### PR TITLE
fontsize px bug.

### DIFF
--- a/interfaces/python/igraph/__init__.py
+++ b/interfaces/python/igraph/__init__.py
@@ -1980,7 +1980,7 @@ class Graph(GraphBase):
                 print >> f, '      <rect ry="5" rx="5" x="-{0}" y="-{1}" width="{2}" height="{3}" id="rect{4}" style="fill:{5};fill-opacity:1" />'.\
                     format(vertex_width / 2., vertex_height / 2., vertex_width, vertex_height, vidx, colors[vidx])
             
-            print >> f, '      <text sodipodi:linespacing="125%" y="{0}" x="0" id="text{1}" style="font-size:{2}px;font-style:normal;font-weight:normal;text-align:center;line-height:125%;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans">'.format(vertex_size / 2.,vidx, font_size)
+            print >> f, '      <text sodipodi:linespacing="125%" y="{0}" x="0" id="text{1}" style="font-size:{2};font-style:normal;font-weight:normal;text-align:center;line-height:125%;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans">'.format(vertex_size / 2.,vidx, font_size)
             print >> f, '<tspan y="{0}" x="0" id="tspan{1}" sodipodi:role="line">{2}</tspan></text>'.format(vertex_size / 2.,vidx, str(labels[vidx]))
             print >> f, '    </g>'
 


### PR DESCRIPTION
write_svg had a duplicated "pxpx" in the fontsize, so that the font did not appear at all. 

Further improvements could be done here:
- allow fname to be either a string or a file handle, so that one can pass sys.stdout. This is generically a nice thing to do, if you want pipe the output somewhere, say to imagemagick  "display".
- allow for stroke width of the edges.
