### PR TITLE
Python: optimal_count now returns consistently

### DIFF
--- a/interfaces/python/igraph/clustering.py
+++ b/interfaces/python/igraph/clustering.py
@@ -982,6 +982,7 @@ class VertexDendrogram(Dendrogram):
                 optimal_count = n-step
                 max_q = q
         self._optimal_count = optimal_count
+        return self._optimal_count
 
     @optimal_count.setter
     def optimal_count(self, value):


### PR DESCRIPTION
Previously, `optimal_count` returned `None` when it had not previously been calculated, but `self._optimal_count` when it had already been set. This causes `VertexDendrogram.as_clustering()` to fail when `optimal_count` has not been called and no hint has been provided.
