### PR TITLE
Added support for personalization vector for dangling nodes

### DIFF
--- a/examples/simple/igraph_pagerank.c
+++ b/examples/simple/igraph_pagerank.c
@@ -122,11 +122,13 @@ int main() {
   /* Check personalized PageRank */
   igraph_personalized_pagerank_vs(&g, IGRAPH_PAGERANK_ALGO_ARPACK, &res, 0,
 				  igraph_vss_all(), 0, 0.5,
-				  igraph_vss_1(1), 0, &arpack_options);
+				  igraph_vss_1(1),
+				  0, &arpack_options);
   print_vector(&res, stdout);
   igraph_personalized_pagerank_vs(&g, IGRAPH_PAGERANK_ALGO_PRPACK, &res, 0,
 				  igraph_vss_all(), 0, 0.5,
-				  igraph_vss_1(1), 0, 0);
+				  igraph_vss_1(1),
+				  0, 0);
   print_vector(&res, stdout);
 
   /* Errors */
@@ -158,13 +160,13 @@ int main() {
 
   igraph_vector_init(&reset, 2);
   ret=igraph_personalized_pagerank(&g, IGRAPH_PAGERANK_ALGO_ARPACK, &res, 0,
-				   igraph_vss_all(), 0, 0.85, &reset, 0,
+				   igraph_vss_all(), 0, 0.85, &reset, &reset, 0,
 				   &arpack_options);
   if (ret != IGRAPH_EINVAL) {
     return 4;
   }
   ret=igraph_personalized_pagerank(&g, IGRAPH_PAGERANK_ALGO_PRPACK, &res, 0,
-				   igraph_vss_all(), 0, 0.85, &reset, 0, 0);
+				   igraph_vss_all(), 0, 0.85, &reset, &reset, 0, 0);
   if (ret != IGRAPH_EINVAL) {
     return 4;
   }
@@ -172,13 +174,13 @@ int main() {
   igraph_vector_fill(&reset, 0);
   ret=igraph_personalized_pagerank(&g, IGRAPH_PAGERANK_ALGO_ARPACK,
 				   &res, 0, igraph_vss_all(), 0, 0.85,
-				   &reset, 0, &arpack_options);
+				   &reset, &reset, 0, &arpack_options);
   if (ret != IGRAPH_EINVAL) {
     return 5;
   }
   ret=igraph_personalized_pagerank(&g, IGRAPH_PAGERANK_ALGO_PRPACK,
 				   &res, 0, igraph_vss_all(), 0, 0.85,
-				   &reset, 0, 0);
+				   &reset, &reset, 0, 0);
   if (ret != IGRAPH_EINVAL) {
     return 5;
   }

--- a/include/igraph_centrality.h
+++ b/include/igraph_centrality.h
@@ -118,7 +118,7 @@ int igraph_personalized_pagerank(const igraph_t *graph,
 		    igraph_pagerank_algo_t algo, igraph_vector_t *vector,
 		    igraph_real_t *value, const igraph_vs_t vids,
 		    igraph_bool_t directed, igraph_real_t damping, 
-		    igraph_vector_t *reset,
+		    igraph_vector_t *reset, igraph_vector_t *reset_dangling,
 		    const igraph_vector_t *weights, void *options);
 int igraph_personalized_pagerank_vs(const igraph_t *graph, 
 		    igraph_pagerank_algo_t algo,

--- a/interfaces/R/igraph/man/page.rank.Rd
+++ b/interfaces/R/igraph/man/page.rank.Rd
@@ -8,7 +8,7 @@
 \usage{
 page.rank (graph, algo = c("prpack", "arpack", "power"),
     vids = V(graph), directed = TRUE, damping = 0.85,
-    personalized = NULL, weights = NULL, options = NULL) 
+    personalized = NULL, personalizeddangling=personalized, weights = NULL, options = NULL) 
 page.rank.old (graph, vids = V(graph), directed = TRUE, niter = 1000, 
     eps = 0.001, damping = 0.85, old = FALSE) 
 }
@@ -34,6 +34,12 @@ page.rank.old (graph, vids = V(graph), directed = TRUE, niter = 1000,
     not uniform, but it is given by this vector. The vector should
     contains an entry for each vertex and it will be rescaled to sum up
     to one.}
+  \item{personalizeddangling}{Optional vector giving a probability distribution
+    for dangling nodes to calculate personalized PageRank. The vector should
+    contains an entry for each vertex and it will be rescaled to sum up
+    to one. Default is to use the same distribution as the version
+    used for non-dangling nodes. Dangling nodes become self connected
+    for numerical stability.}
   \item{weights}{A numerical vector or \code{NULL}. This argument can be
     used to give edge weights for calculating the weighted PageRank of
     vertices. If this is \code{NULL} and the graph has a \code{weight}

--- a/interfaces/functions.def
+++ b/interfaces/functions.def
@@ -482,6 +482,7 @@ igraph_personalized_pagerank:
                 OUT VERTEXINDEX vector, OUT REALPTR value, \
                 VERTEXSET vids=ALL, BOOLEAN directed=True, \
                 REAL damping=0.85, VECTOR_OR_0 personalized=NULL, \
+		VECTOR_OR_0 personalizeddangling=personalized, \
                 EDGEWEIGHTS weights=NULL, \
                 INOUT PAGERANKOPT options=NULL
         DEPS: vids ON graph, weights ON graph, vector ON graph vids, \

--- a/src/centrality.c
+++ b/src/centrality.c
@@ -46,7 +46,7 @@ int igraph_personalized_pagerank_arpack(const igraph_t *graph,
 		    igraph_vector_t *vector,
 		    igraph_real_t *value, const igraph_vs_t vids,
 		    igraph_bool_t directed, igraph_real_t damping, 
-		    igraph_vector_t *reset,
+		    igraph_vector_t *reset, 
 		    const igraph_vector_t *weights,
 		    igraph_arpack_options_t *options);
 
@@ -1119,7 +1119,7 @@ int igraph_pagerank(const igraph_t *graph, igraph_pagerank_algo_t algo,
 		    igraph_bool_t directed, igraph_real_t damping, 
 		    const igraph_vector_t *weights, void *options) {
   return igraph_personalized_pagerank(graph, algo, vector, value, vids, 
-				      directed, damping, 0, weights, 
+				      directed, damping, 0, 0, weights, 
 				      options);
 }
 
@@ -1199,6 +1199,8 @@ int igraph_personalized_pagerank_vs(const igraph_t *graph,
 	igraph_vector_t reset;
 	igraph_vit_t vit;
 
+	igraph_vector_t *reset_dangling = 0;
+
 	IGRAPH_VECTOR_INIT_FINALLY(&reset, igraph_vcount(graph));
 	IGRAPH_CHECK(igraph_vit_create(graph, reset_vids, &vit));
 	IGRAPH_FINALLY(igraph_vit_destroy, &vit);
@@ -1212,7 +1214,7 @@ int igraph_personalized_pagerank_vs(const igraph_t *graph,
 	
 	IGRAPH_CHECK(igraph_personalized_pagerank(graph, algo, vector, 
 						  value, vids, directed, 
-						  damping, &reset, weights,
+						  damping, &reset, reset_dangling, weights,
 						  options));
 
 	igraph_vector_destroy(&reset);
@@ -1285,7 +1287,7 @@ int igraph_personalized_pagerank(const igraph_t *graph,
 		    igraph_pagerank_algo_t algo, igraph_vector_t *vector,
 		    igraph_real_t *value, const igraph_vs_t vids,
 		    igraph_bool_t directed, igraph_real_t damping, 
-		    igraph_vector_t *reset,
+		    igraph_vector_t *reset, igraph_vector_t *reset_dangling,
 		    const igraph_vector_t *weights,
 		    void *options) {
 
@@ -1306,7 +1308,7 @@ int igraph_personalized_pagerank(const igraph_t *graph,
 					       weights, o);
   } else if (algo == IGRAPH_PAGERANK_ALGO_PRPACK) {
     return igraph_personalized_pagerank_prpack(graph, vector, value, vids,
-					       directed, damping, reset, 
+					       directed, damping, reset, reset_dangling,
 					       weights);
   } else {
     IGRAPH_ERROR("Unknown PageRank algorithm", IGRAPH_EINVAL);

--- a/src/prpack.cpp
+++ b/src/prpack.cpp
@@ -37,7 +37,7 @@ using namespace std;
 int igraph_personalized_pagerank_prpack(const igraph_t *graph, igraph_vector_t *vector,
             igraph_real_t *value, const igraph_vs_t vids,
             igraph_bool_t directed, igraph_real_t damping, 
-            igraph_vector_t *reset,
+	    igraph_vector_t *reset, igraph_vector_t *resetdangling,
             const igraph_vector_t *weights) {
     long int i, no_of_nodes = igraph_vcount(graph), nodes_to_calc;
     igraph_vit_t vit;
@@ -59,6 +59,31 @@ int igraph_personalized_pagerank_prpack(const igraph_t *graph, igraph_vector_t *
         v = new double[no_of_nodes];
         for (i = 0; i < no_of_nodes; i++) {
             v[i] = VECTOR(*reset)[i] / reset_sum;
+        }
+#if 0
+	if (!resetdangling) {
+	  // create a default u - should this be done in R instead?
+	  u = new double[no_of_nodes];
+	  for (i = 0; i < no_of_nodes; i++) {
+            u[i] = v[i];
+	  }
+	}
+#endif
+    }
+    if (resetdangling) {
+        /* Normalize reset vector so the sum is 1 */
+        double reset_sum = igraph_vector_sum(resetdangling);
+        if (igraph_vector_min(resetdangling) < 0) {
+            IGRAPH_ERROR("the reset vector for dangling nodes must not contain negative elements", IGRAPH_EINVAL);
+        }
+        if (reset_sum == 0) {
+            IGRAPH_ERROR("the sum of the elements in the reset vector for dangling nodes must not be zero", IGRAPH_EINVAL);
+        }
+
+        // Construct the personalization vector
+        u = new double[no_of_nodes];
+        for (i = 0; i < no_of_nodes; i++) {
+            u[i] = VECTOR(*resetdangling)[i] / reset_sum;
         }
     }
 

--- a/src/prpack.h
+++ b/src/prpack.h
@@ -45,7 +45,7 @@ __BEGIN_DECLS
 int igraph_personalized_pagerank_prpack(const igraph_t *graph, igraph_vector_t *vector,
 		    igraph_real_t *value, const igraph_vs_t vids,
 		    igraph_bool_t directed, igraph_real_t damping, 
-		    igraph_vector_t *reset,
+		    igraph_vector_t *reset, igraph_vector_t *reset_dangling,
 		    const igraph_vector_t *weights);
 
 __END_DECLS


### PR DESCRIPTION
Hi,
Here is my attempt at adding the support for personalization vectors for dangling nodes. The default behaviour is implemented via R default function flags, although there is also some #ifdef code in prpack.cpp to provide a copy of the reset vector if the resetdangling vector is absent.

Testing is not yet thorough, but everything compiles and installs, checks pass and documentation updated.

Thanks for your help, and I hope this patch makes life easier for you.