### PR TITLE
PLOT BACKGROUND COLOR

### DIFF
--- a/interfaces/python/igraph/drawing/__init__.py
+++ b/interfaces/python/igraph/drawing/__init__.py
@@ -457,7 +457,10 @@ def plot(obj, target=None, bbox=(0, 0, 600, 600), *args, **kwds):
     if not isinstance(bbox, BoundingBox):
         bbox = BoundingBox(bbox)
 
-    result = Plot(target, bbox, background="white")
+    if "background" in kwds:
+        result = Plot(target, bbox, background=kwds["background"])
+    else:
+        result = Plot(target, bbox, background="white")
 
     if "margin" in kwds:
         bbox = bbox.contract(kwds["margin"])


### PR DESCRIPTION
For the Python interface, drawing/**init**.py is modified so that
an arbitrary  background color can be chosen for a plot. This color
can be specified using a "background" option to igraph.plot().
