### PR TITLE
remove some GCC warnings about unused variables

### DIFF
--- a/src/cs/cs_qr.c
+++ b/src/cs/cs_qr.c
@@ -26,12 +26,12 @@ csn *cs_qr (const cs *A, const css *S)
 {
     CS_ENTRY *Rx, *Vx, *Ax, *x ;
     double *Beta ;
-    CS_INT i, k, p, m, n, vnz, p1, top, m2, len, col, rnz, *s, *leftmost, *Ap, *Ai,
+    CS_INT i, k, p, n, vnz, p1, top, m2, len, col, rnz, *s, *leftmost, *Ap, *Ai,
         *parent, *Rp, *Ri, *Vp, *Vi, *w, *pinv, *q ;
     cs *R, *V ;
     csn *N ;
     if (!CS_CSC (A) || !S) return (NULL) ;
-    m = A->m ; n = A->n ; Ap = A->p ; Ai = A->i ; Ax = A->x ;
+    n = A->n ; Ap = A->p ; Ai = A->i ; Ax = A->x ;
     q = S->q ; parent = S->parent ; pinv = S->pinv ; m2 = S->m2 ;
     vnz = S->lnz ; rnz = S->unz ; leftmost = S->leftmost ;
     w = cs_malloc (m2+n, sizeof (CS_INT)) ;            /* get CS_INT workspace */

--- a/src/scg.c
+++ b/src/scg.c
@@ -898,7 +898,6 @@ int igraph_scg_norm_eps(const igraph_matrix_t *V,
 			igraph_scg_norm_t norm) {
 
   int no_of_nodes=(int) igraph_vector_size(groups);
-  int no_of_groups;
   int no_of_vectors=(int) igraph_matrix_ncol(V);
   igraph_real_t min, max;
   igraph_sparsemat_t Lsparse, Rsparse, Lsparse2, Rsparse2, Rsparse3, proj;
@@ -911,7 +910,6 @@ int igraph_scg_norm_eps(const igraph_matrix_t *V,
   }
 
   igraph_vector_minmax(groups, &min, &max);
-  no_of_groups=(int) max+1;
   
   if (min < 0 || max >= no_of_nodes) {
     IGRAPH_ERROR("Invalid membership vector", IGRAPH_EINVAL);


### PR DESCRIPTION
Fix some GCC warnings about unused variables in `src/cs/cs_qr.c` and `src/scg.c`.  This addresses some part of issue #297.  The specific GCC warnings that this patch fixes are:

```
cs/cs_qr.c:29:21: warning: variable 'm' set but not used [-Wunused-but-set-variable]
     CS_INT i, k, p, m, n, vnz, p1, top, m2, len, col, rnz, *s, *leftmost, *Ap, *Ai,
                     ^

scg.c:901:7: warning: variable 'no_of_groups' set but not used [-Wunused-but-set-variable]
   int no_of_groups;
       ^
```

I have another bunch of warning fixes for files under `src/CHOLMOD` if you're interested.
