### PR TITLE
Update __init__.py

### DIFF
--- a/interfaces/python/igraph/__init__.py
+++ b/interfaces/python/igraph/__init__.py
@@ -959,6 +959,8 @@ class Graph(GraphBase):
         @return: an appropriate L{VertexClustering} object with an extra attribute
           called C{codelength} that stores the code length determined by the
           algorithm.
+          
+        Note the graph must not contain isolated vertices.
         
         @newfield ref: Reference
         @ref: M. Rosvall and C. T. Bergstrom: Maps of information flow reveal


### PR DESCRIPTION
Added note that graphs passed to infomap cannot contain isolated vertices (included in C documentation, not in Python documentation).