### PR TITLE
timeb.h deprecated, removed on some platforms, causes build failures

### DIFF
--- a/src/prpack/prpack_utils.cpp
+++ b/src/prpack/prpack_utils.cpp
@@ -29,7 +29,6 @@ double prpack_utils::get_time() {
 }
 #else
 #include <sys/types.h>
-#include <sys/timeb.h>
 #include <sys/time.h>
 double prpack_utils::get_time() {
     struct timeval t;


### PR DESCRIPTION
Hello,

I was just tracking down a build failure on OpenBSD, and tracked it down to the removal of timeb.h from that platform. From what I can tell, timeb has been deprecated on posix systems (including Linux). Its inclusion will likely cause build errors over time as more platforms remove it. My understanding is that it's not needed on systems that implement gettimeofday, which you use anyway. So, I think this should be safe to remove. Removing it seems to result in a working igraph/rigraph, however, I've only tested on OpenBSD... caveat emptor.

