### PR TITLE
Docs: Warning for case when MDS collapses vertices into the same point

### DIFF
--- a/src/layout.c
+++ b/src/layout.c
@@ -2044,6 +2044,12 @@ int igraph_i_layout_mds_single(const igraph_t* graph, igraph_matrix_t *res,
  * Since \ref igraph_layout_merge_dla works for 2D layouts only,
  * you cannot run the MDS layout on disconnected graphs for
  * more than two dimensions.
+ * 
+ * </para><para>
+ * Warning: if the graph is symmetric to the exchange of two vertices
+ * (as is the case with leaves of a tree connecting to the same parent),
+ * classical multidimensional scaling may assign the same coordinates to
+ * these vertices.
  *
  * \param graph A graph object.
  * \param res Pointer to an initialized matrix object. This will


### PR DESCRIPTION
This happens because two such vertices are the same number of hops away from any other vertex.  Thus classical MDS will not distinguish them along the first few axes. I think the documentation warning is important because the output from this layout algorithm can be very misleading.