### PR TITLE
Add missing break; in igraph_layout_drl_options_init()

### DIFF
--- a/src/drl_layout.cpp
+++ b/src/drl_layout.cpp
@@ -416,6 +416,7 @@ int igraph_layout_drl_options_init(igraph_layout_drl_options_t *options,
     options->simmer_attraction   = .5;
     options->simmer_damping_mult = 0;
     
+    break;
   default:
     IGRAPH_ERROR("Unknown DrL template", IGRAPH_EINVAL);
     break;


### PR DESCRIPTION
Without this, using `IGRAPH_LAYOUT_DRL_FINAL` causes an error.