### PR TITLE
Fix igraph_lcf_vector

### DIFF
--- a/examples/simple/igraph_lcf.c
+++ b/examples/simple/igraph_lcf.c
@@ -28,6 +28,7 @@ int main() {
   igraph_t g, g2;
   igraph_bool_t iso;
   
+  // Franklin graph
   igraph_lcf(&g, 12, 5, -5, 6, 0);
   igraph_famous(&g2, "franklin");
   
@@ -36,12 +37,42 @@ int main() {
 			/*edge.color1=*/ 0, /*edge.color2=*/ 0,
 			&iso, 0, 0, 0, 0, 0);
   if (!iso) {
-    printf("OOOPS!\n");
+    printf("Failure: Franklin\n");
     return 1;
   }
   
   igraph_destroy(&g);
   igraph_destroy(&g2);
+
+  // [3, -2]^4, n=8
+  igraph_lcf(&g, 8, 3, -2, 4, 0);
+
+  if (igraph_ecount(&g) != 16) {
+    printf("Failure: [3, -2]^4, n=8\n");
+    return 1;
+  }
+
+  igraph_destroy(&g);
   
+  // [2, -2]^2, n=2
+  igraph_lcf(&g, 2, 2, -2, 2, 0);
+
+  if (igraph_ecount(&g) != 1) {
+    printf("Failure: [2, -2]^2, n=2\n");
+    return 1;
+  }
+
+  igraph_destroy(&g);
+
+  // [2]^2, n=2
+  igraph_lcf(&g, 2, 2, 2, 0);
+
+  if (igraph_ecount(&g) != 1) {
+    printf("Failure: [2]^2, n=2\n");
+    return 1;
+  }
+
+  igraph_destroy(&g);
+
   return 0;
 }

--- a/src/structure_generators.c
+++ b/src/structure_generators.c
@@ -22,6 +22,7 @@
 */
 
 #include "igraph_constructors.h"
+#include "igraph_structural.h"
 #include "igraph_memory.h"
 #include "igraph_interface.h"
 #include "igraph_attributes.h"
@@ -1621,9 +1622,9 @@ int igraph_lcf_vector(igraph_t *graph, igraph_integer_t n,
   long int no_of_shifts=igraph_vector_size(shifts);
   long int ptr=0, i, sptr=0;
   long int no_of_nodes=n;
-  long int no_of_edges=n+no_of_shifts*repeats/2;
+  long int no_of_edges=n+no_of_shifts*repeats;
 
-	if (repeats<0) IGRAPH_ERROR("number of repeats must be positive", IGRAPH_EINVAL);
+  if (repeats<0) IGRAPH_ERROR("number of repeats must be positive", IGRAPH_EINVAL);
   IGRAPH_VECTOR_INIT_FINALLY(&edges, 2*no_of_edges);
 
   /* Create a ring first */
@@ -1638,15 +1639,14 @@ int igraph_lcf_vector(igraph_t *graph, igraph_integer_t n,
     long int sh=(long int) VECTOR(*shifts)[sptr % no_of_shifts];
     long int from=sptr % no_of_nodes;
     long int to=(no_of_nodes+sptr+sh) % no_of_nodes;
-    if (from < to) {
-      VECTOR(edges)[ptr++]=from;
-      VECTOR(edges)[ptr++]=to;
-    }
+    VECTOR(edges)[ptr++]=from;
+    VECTOR(edges)[ptr++]=to;
     sptr++;
   }
   
   IGRAPH_CHECK(igraph_create(graph, &edges, (igraph_integer_t) no_of_nodes, 
 			     IGRAPH_UNDIRECTED));
+  IGRAPH_CHECK(igraph_simplify(graph, 1 /* true */, 1 /* true */, NULL));
   igraph_vector_destroy(&edges);
   IGRAPH_FINALLY_CLEAN(1);
   


### PR DESCRIPTION
For some inputs, `igraph_lcf_vector` was returning results that did not agree with the description at [MathWorld](http://mathworld.wolfram.com/LCFNotation.html), or with networkx's implementation.  One example is `shifts=[3,-2]`, `repeats=4`, `n=8`.  It also crashed for some inputs, see #880 

This patch fixes these problems and ensures that no multiple or loop edges are returned.