### PR TITLE
Add missing include to atlas-edges.h

### DIFF
--- a/src/atlas-edges.h
+++ b/src/atlas-edges.h
@@ -33,6 +33,8 @@
 
 __BEGIN_DECLS
 
+#include "igraph_types.h"
+
 const igraph_real_t igraph_i_atlas_edges[]={
 	0,0,
 	1,0,


### PR DESCRIPTION
This makes no difference at compilation time, it's only about making IDEs happy and not complain that `igraph_real_t` is an unknown type