### PR TITLE
Additional argument check igraph_bipartite_game_gnm()

### DIFF
--- a/src/bipartite.c
+++ b/src/bipartite.c
@@ -980,6 +980,9 @@ int igraph_bipartite_game_gnm(igraph_t *graph, igraph_vector_bool_t *types,
   }
   
   if (m == 0 || n1 * n2 == 0) {
+    if (m > 0) {
+      IGRAPH_ERROR("Invalid number (too large) of edges", IGRAPH_EINVAL);
+    }  	
     IGRAPH_CHECK(retval=igraph_empty(graph, n1 + n2, directed));
   } else {
     


### PR DESCRIPTION
igraph_bipartite_game_gnm() should report an error when n1 == 0 or n2 == 0 and m > 0.