### PR TITLE
Add igraph_malloc()

### DIFF
--- a/doc/memory.xxml
+++ b/doc/memory.xxml
@@ -7,6 +7,7 @@
 <chapter id="igraph-Memory">
 <title>Memory (de)allocation</title>
 
+<!-- doxrox-include igraph_malloc -->
 <!-- doxrox-include igraph_free -->
 
 </chapter>

--- a/include/igraph_memory.h
+++ b/include/igraph_memory.h
@@ -49,6 +49,7 @@ __BEGIN_DECLS
 /* #endif */
 
 int igraph_free(void *p);
+void *igraph_malloc(size_t n);
 
 __END_DECLS
 

--- a/include/igraph_topology.h
+++ b/include/igraph_topology.h
@@ -230,7 +230,7 @@ int igraph_get_subisomorphisms_vf2(const igraph_t *graph1,
  * \member max_level Maximum level.
  * \member group_size The size of the automorphism group of the graph,
  *    given as a string. It should be deallocated via
- *    <function>free()</function> if not needed any more.
+ *    \ref igraph_free() if not needed any more.
  * 
  * See http://www.tcs.hut.fi/Software/bliss/index.html
  * for details about the algorithm and these parameters.

--- a/src/memory.c
+++ b/src/memory.c
@@ -67,9 +67,33 @@
  * \return Error code, currently always zero, meaning success.
  * 
  * Time complexity: platform dependent, ideally it should be O(1).
+ *
+ * \sa \ref igraph_malloc()
  */
 
 int igraph_free(void *p) {
   igraph_Free(p);
   return 0;
+}
+
+
+/**
+ * \function igraph_malloc
+ * Allocate memory that can be safely deallocated by igraph functions
+ *
+ * Some igraph functions, such as \ref igraph_vector_ptr_free_all() and
+ * \ref igraph_vector_ptr_destroy_all() can free memory that may have been
+ * allocated by the user.  \c igraph_malloc() works exactly like \c malloc()
+ * from the C standard library, but it is guaranteed that it can be safely
+ * paired with the \c free() function used by igraph internally (which is
+ * also user-accessible through \ref igraph_free()).
+ *
+ * \param n Number of bytes to be allocated.
+ * \return Pointer to the piece of allocated memory.
+ *
+ * \sa \ref igraph_free()
+ */
+
+void *igraph_malloc(size_t n) {
+    return malloc(n);
 }


### PR DESCRIPTION
### Summary

This pull request adds `igraph_malloc()`, a function that works exactly like the standard `malloc()`, but it calls the same `malloc` that igraph was compiled with.  This is useful (and necessary) if igraph is compiled as a DLL with compiler *A* but then the DLL is used from a program compiled with compiler *B*, and the two do not have compatible malloc/free implementations.

`igraph_free()` is also necessary in this case, but this function already exists so I didn't need to add it.

### Motivation

We had a short discussion about this on the mailing list, but at that time the problem did not come up in a practical situation for me.

https://lists.gnu.org/archive/html/igraph-help/2015-12/msg00027.html


>> Finally, I notice that some examples use free() and not igraph_free()
>> to free memory. Do I need to worry about this and the potential
>> differences between the two if igraph itself and my program use
>> different compilers?  Shouldn't igraph provide an igraph_malloc in
>> addition to igraph_free to make sure that memory I might allocate will
>> be correctly freed by igraph_vector_ptr_free_all()? This last one is
>> so far a theoretical question as I don't yet need this.
>
>Don't worry about free and igraph_free. AFAIR igraph_free is newer,
>and the idea was that we could use different allocators, but in the
>end we never did this.
>
>I guess we could still convert all free() to igraph_free()
>
>GAbor

It turns out that my worry was not unfounded.  If I compile igraph with MinGW-w64 as a DLL, but then use that DLL with the Visual Studio compiler, I run into problems.  The MinGW and MSVC free/malloc are incompatible.  Memory allocated by one cannot be freed with the other (it crashes).

This problem is also mentioned here: http://www.mingw.org/wiki/Interoperability_of_Libraries_Created_by_Different_Compiler_Brands

> A new/delete or malloc/free in a MSVC DLL will not co-operate with a Cygwin newlib new/delete or malloc/free. One cannot free space which was allocated in a function using a different new/malloc at all.

The same page also agrees that despite these problems, it is not necessarily an absolutely atrocious idea to mix compilers like this for as long as its done across DLL boundaries (not static linking) and for as long as the DLL is called through a simple C (not C++) interface.

> Dll's are slightly different. Sometimes you can link a DLL built with one compiler to an application compiled with another. This works well if the DLL is written in C, even if the application is written in C++.

The problems can be avoided if the user is very careful to only use malloc/free in matching pairs.  Always use MSVC-free on MSVC-malloc'd memory and always use MinGW-free on MinGW-malloc'd memory.  To be able to do this, the user needs access to both sets of functions, i.e. he needs access to the malloc/free pair that igraph (the igraph DLL) uses internally.  Hence this pull request.

Now let me show practical scenarios which force the user to allocate memory which will be freed by igraph internally, or the reverse, deallocate memory which was allocated by igraph internally.

Some Bliss functions allocate memory which must be explicitly deallocated by the user using `free()`.  To avoid trouble it should in fact be done using `igraph_free()`.

http://igraph.org/c/doc/igraph-Isomorphism.html#igraph_bliss_info_t

What about the reverse?  `igraph_vector_ptr_free_all` and `igraph_vector_ptr_destroy_all` will free memory which may have been allocated by the user.  When is this memory likely allocated by the user directly and not an igraph function?  One example is when preparing the `domain` argument of [igraph_subisomorphic_lad](http://igraph.org/c/doc/igraph-Isomorphism.html#igraph_subisomorphic_lad).

Can the user just _not use `igraph_vector_ptr_free_all`_ but use their own (matching) `free()` to manually deallocate each element instead?  Yes, in principle this is possible.  But in my case it is very inconvenient.  The reason is that I have a C++ class wrapping `igraph_vector_ptr_t` and the class destructor does not know which malloc was used to allocate elements.  They may have been allocated by an igraph function internally (typical) or they may have been allocated by me manually (rare, prime example being `domain` in LAD functions).

Now I will understand if this pull request gets rejected on the basis that mixing compilers is just a bad idea anyway.  But given my practical constraints, I am going to use this patch either way.  So I might as well submit it as a pull request.

I compile igraph using MinGW because I am unable to get it to work using MSVC (I spent a lot of time on this without success).  But I compile my Mathematica package using MSVC because using MinGW with Mathematica is risky and troublesome, partly for the same compatibility worries mentioned above.  I cannot control the library-Mathematica interface and how they might malloc/free things.  But I *can* control the igraph-library interface and I can take care to avoid trouble there.  So at least until the dev version (0.8) of igraph becomes easy to compile with MSVC, I am going to stick to this solution.