### PR TITLE
Clarify documentation on mean geodesic lengths

### DIFF
--- a/src/structural_properties.c
+++ b/src/structural_properties.c
@@ -204,10 +204,10 @@ int igraph_diameter(const igraph_t *graph, igraph_integer_t *pres,
  * \param directed Boolean, whether to consider directed
  *        paths. Ignored for undirected graphs.
  * \param unconn What to do if the graph is not connected. If
- *        \c TRUE the average of the geodesics
- *        within the components 
- *        will be returned, otherwise the number of vertices is
- *        used for the length of non-existing geodesics. (The rationale
+ *        \c TRUE the average of the geodesic lengths between connected
+ *        vertex pairs will be returned and unconnected pairs are ignored.
+ *        Otherwise the number of vertices is
+ *        used for the length between unconnected pairs. (The rationale
  *        behind this is that this is always longer than the longest
  *        possible geodesic in a graph.) 
  * \return Error code:

--- a/src/structural_properties.c
+++ b/src/structural_properties.c
@@ -197,19 +197,18 @@ int igraph_diameter(const igraph_t *graph, igraph_integer_t *pres,
 /**
  * \ingroup structural
  * \function igraph_average_path_length
- * \brief Calculates the average geodesic length in a graph.
+ * \brief Calculates the average shortest path length between all vertex pairs.
  *
  * \param graph The graph object.
  * \param res Pointer to a real number, this will contain the result.
  * \param directed Boolean, whether to consider directed
  *        paths. Ignored for undirected graphs.
  * \param unconn What to do if the graph is not connected. If
- *        \c TRUE the average of the geodesic lengths between connected
- *        vertex pairs will be returned and unconnected pairs are ignored.
- *        Otherwise the number of vertices is
- *        used for the length between unconnected pairs. (The rationale
- *        behind this is that this is always longer than the longest
- *        possible geodesic in a graph.) 
+ *        \c TRUE, only those vertex pairs will be included in the calculation
+ *        between which there is a path. If \c FALSE, the number of vertices is
+ *        used as the distance between vertices unreachable from each other. 
+ *        The rationale behind this is that this is always longer than the longest
+ *        possible geodesic in a graph.
  * \return Error code:
  *         \c IGRAPH_ENOMEM, not enough memory for
  *         data structures 


### PR DESCRIPTION
This is based on user feedback (for IGraph/M).

For a directed graph, it is not true that the mean shortest paths within connected components will be taken.  Consider the two-vertex directed graph `1 -> 2`.  The two components are `{1}` and `{2}` and the `1 -> 2` edge is not part of either component.  Yet it is taken into account during the calculation of the average.

It also doesn't exactly compute the average geodesic length, i.e. average of the lengths of all geodesics. There may be more than one geodesic between the same two vertices.

Yes, this is splitting hairs, but useful when one is in doubt about what exactly gets calculated.