### PR TITLE
igraph_rewire_directed_edges

### DIFF
--- a/doc/generators.xxml
+++ b/doc/generators.xxml
@@ -38,6 +38,7 @@
 <!-- doxrox-include igraph_erdos_renyi_game -->
 <!-- doxrox-include igraph_watts_strogatz_game -->
 <!-- doxrox-include igraph_rewire_edges -->
+<!-- doxrox-include igraph_rewire_directed_edges -->
 <!-- doxrox-include igraph_degree_sequence_game -->
 <!-- doxrox-include igraph_k_regular_game -->
 <!-- doxrox-include igraph_static_fitness_game -->

--- a/include/igraph_games.h
+++ b/include/igraph_games.h
@@ -128,6 +128,9 @@ DECLDIR int igraph_asymmetric_preference_game(igraph_t *graph, igraph_integer_t 
 
 DECLDIR int igraph_rewire_edges(igraph_t *graph, igraph_real_t prob, 
                 igraph_bool_t loops, igraph_bool_t multiple);
+DECLDIR int igraph_rewire_directed_edges(igraph_t *graph, igraph_real_t prob,
+                igraph_bool_t loops, igraph_neimode_t mode);
+
 DECLDIR int igraph_watts_strogatz_game(igraph_t *graph, igraph_integer_t dim,
                 igraph_integer_t size, igraph_integer_t nei,
                 igraph_real_t p, igraph_bool_t loops, 


### PR DESCRIPTION
This is a pull request for the feature described in #999 

The function is modelled after igraph_rewire_edges and borrows some code from it.  Please review especially the part that handles attributes, as I am not very familiar with this part of igraph, and the code has simply been borrowed from `igraph_rewire_edges`.