### PR TITLE
GCC not tolerating empty variadic argument without ## token before __VA_ARGS__

### DIFF
--- a/src/foreign-dl-lexer.l
+++ b/src/foreign-dl-lexer.l
@@ -57,8 +57,13 @@
 #define YY_EXTRA_TYPE igraph_i_dl_parsedata_t*
 #define YY_USER_ACTION yylloc->first_line = yylineno;
 /* We assume that 'file' is 'stderr' here. */
-#define fprintf(file, msg, ...) \
-  igraph_warningf(msg, __FILE__, __LINE__, 0, __VA_ARGS__)
+#ifdef __GNUC__
+	#define fprintf(file, msg, ...) \
+	  igraph_warningf(msg, __FILE__, __LINE__, 0, ##__VA_ARGS__)
+#else
+	#define fprintf(file, msg, ...) \
+	  igraph_warningf(msg, __FILE__, __LINE__, 0, __VA_ARGS__)
+#endif
 #ifdef stdout 
 #  undef stdout
 #endif

--- a/src/foreign-gml-lexer.l
+++ b/src/foreign-gml-lexer.l
@@ -56,8 +56,13 @@
 #define YY_EXTRA_TYPE igraph_i_gml_parsedata_t*
 #define YY_USER_ACTION yylloc->first_line = yylineno;
 /* We assume that 'file' is 'stderr' here. */
-#define fprintf(file, msg, ...) \
-  igraph_warningf(msg, __FILE__, __LINE__, 0, __VA_ARGS__)
+#ifdef __GNUC__
+	#define fprintf(file, msg, ...) \
+	  igraph_warningf(msg, __FILE__, __LINE__, 0, ##__VA_ARGS__)
+#else
+	#define fprintf(file, msg, ...) \
+	  igraph_warningf(msg, __FILE__, __LINE__, 0, __VA_ARGS__)
+#endif
 #ifdef stdout 
 #  undef stdout
 #endif

--- a/src/foreign-lgl-lexer.l
+++ b/src/foreign-lgl-lexer.l
@@ -56,8 +56,13 @@
 #define YY_EXTRA_TYPE igraph_i_lgl_parsedata_t*
 #define YY_USER_ACTION yylloc->first_line = yylineno;
 /* We assume that 'file' is 'stderr' here. */
-#define fprintf(file, msg, ...) \
-  igraph_warningf(msg, __FILE__, __LINE__, 0, __VA_ARGS__)
+#ifdef __GNUC__
+	#define fprintf(file, msg, ...) \
+	  igraph_warningf(msg, __FILE__, __LINE__, 0, ##__VA_ARGS__)
+#else
+	#define fprintf(file, msg, ...) \
+	  igraph_warningf(msg, __FILE__, __LINE__, 0, __VA_ARGS__)
+#endif
 #ifdef stdout 
 #  undef stdout
 #endif

--- a/src/foreign-ncol-lexer.l
+++ b/src/foreign-ncol-lexer.l
@@ -56,8 +56,13 @@
 #define YY_EXTRA_TYPE igraph_i_ncol_parsedata_t*
 #define YY_USER_ACTION yylloc->first_line = yylineno;
 /* We assume that 'file' is 'stderr' here. */
-#define fprintf(file, msg, ...) \
-  igraph_warningf(msg, __FILE__, __LINE__, 0, __VA_ARGS__)
+#ifdef __GNUC__
+	#define fprintf(file, msg, ...) \
+	  igraph_warningf(msg, __FILE__, __LINE__, 0, ##__VA_ARGS__)
+#else
+	#define fprintf(file, msg, ...) \
+	  igraph_warningf(msg, __FILE__, __LINE__, 0, __VA_ARGS__)
+#endif
 #ifdef stdout 
 #  undef stdout
 #endif

--- a/src/foreign-pajek-lexer.l
+++ b/src/foreign-pajek-lexer.l
@@ -56,8 +56,13 @@
 #define YY_EXTRA_TYPE igraph_i_pajek_parsedata_t*
 #define YY_USER_ACTION yylloc->first_line = yylineno;
 /* We assume that 'file' is 'stderr' here. */
-#define fprintf(file, msg, ...) \
-  igraph_warningf(msg, __FILE__, __LINE__, 0, __VA_ARGS__)
+#ifdef __GNUC__
+	#define fprintf(file, msg, ...) \
+	  igraph_warningf(msg, __FILE__, __LINE__, 0, ##__VA_ARGS__)
+#else
+	#define fprintf(file, msg, ...) \
+	  igraph_warningf(msg, __FILE__, __LINE__, 0, __VA_ARGS__)
+#endif
 #ifdef stdout 
 #  undef stdout
 #endif


### PR DESCRIPTION
In preprocessor macros [GCC](https://gcc.gnu.org/onlinedocs/cpp/Variadic-Macros.html#Variadic-Macros) does not tolerate an __empty__ variadic argument `__VA_ARGS__` without a preceding `##` token, since in this case the preceding comma is **not** removed.

The proposed patch singles out GCC compliant compilers to add the required `##` token. In case this syntax is fine for any other compiler, then clearly the `#ifdef` branches can be removed and only the `##` token before `__VA_ARGS__` can be added. I checked that MSVC does not complain about the additional `##`. 