### PR TITLE
pajek: optional time interval info of vertices and edges added to reader grammar 

### DIFF
--- a/src/cs/cs_amd.c
+++ b/src/cs/cs_amd.c
@@ -18,8 +18,10 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#ifdef __clang__
 #pragma clang diagnostic ignored "-Wconversion"
 #pragma clang diagnostic ignored "-Wsign-conversion"
+#endif
 
 #include "cs.h"
 /* clear w */

--- a/src/cs/cs_lu.c
+++ b/src/cs/cs_lu.c
@@ -18,7 +18,9 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#ifdef __clang__
 #pragma clang diagnostic ignored "-Wconversion"
+#endif // __clang__
 
 #include "cs.h"
 /* [L,U,pinv]=lu(A, [q lnz unz]). lnz and unz can be guess */

--- a/src/foreign-gml-lexer.l
+++ b/src/foreign-gml-lexer.l
@@ -67,7 +67,7 @@
 #  undef stdout
 #endif
 #define stdout 0
-#define exit(code) igraph_error("Fatal error in DL parser", __FILE__, \
+#define exit(code) igraph_error("Fatal error in GML parser", __FILE__, \
 				__LINE__, IGRAPH_PARSEERROR);
 %}
 

--- a/src/foreign-lgl-lexer.l
+++ b/src/foreign-lgl-lexer.l
@@ -67,7 +67,7 @@
 #  undef stdout
 #endif
 #define stdout 0
-#define exit(code) igraph_error("Fatal error in DL parser", __FILE__, \
+#define exit(code) igraph_error("Fatal error in LGL parser", __FILE__, \
 				__LINE__, IGRAPH_PARSEERROR);
 %}
 

--- a/src/foreign-ncol-lexer.l
+++ b/src/foreign-ncol-lexer.l
@@ -67,7 +67,7 @@
 #  undef stdout
 #endif
 #define stdout 0
-#define exit(code) igraph_error("Fatal error in DL parser", __FILE__, \
+#define exit(code) igraph_error("Fatal error in NCOL parser", __FILE__, \
 				__LINE__, IGRAPH_PARSEERROR);
 %}
 

--- a/src/foreign-pajek-lexer.l
+++ b/src/foreign-pajek-lexer.l
@@ -67,7 +67,7 @@
 #  undef stdout
 #endif
 #define stdout 0
-#define exit(code) igraph_error("Fatal error in DL parser", __FILE__, \
+#define exit(code) igraph_error("Fatal error in PAJEK parser", __FILE__, \
 				__LINE__, IGRAPH_PARSEERROR);
 %}
 

--- a/src/foreign-pajek-lexer.l
+++ b/src/foreign-pajek-lexer.l
@@ -80,8 +80,10 @@
 %option bison-bridge
 %option bison-locations
 
+%x LEX_PAJEK_INTERVAL
+
 digit [0-9]
-word [^ \t\r\n]
+word [[:alnum:]]
 
 %%
 
@@ -99,7 +101,17 @@ word [^ \t\r\n]
 \n\r|\r\n|\n|\r   { yyextra->mode=0; return NEWLINE; }
 \"[^\"]*\"        { return QSTR; }
 \([^\)]*\)        { return PSTR; }
-\-?{digit}+(\.{digit}+)?([eE](\+|\-)?{digit}+)? { 
+
+"," |
+"*" |
+\[  |
+\]                                                      return yytext[0];
+<LEX_PAJEK_INTERVAL>{
+"-"                                                     return yytext[0];
+{digit}+                    BEGIN(INITIAL);             return INTEGER;
+}
+{digit}+/[[:blank:]]*"-"    BEGIN(LEX_PAJEK_INTERVAL);  return INTEGER;
+\-?{digit}+(\.{digit}+)?([eE](\+|\-)?{digit}+)? {
                     return NUM; }
 
 [Xx]_[Ff][Aa][Cc][Tt]/[ \t\n\r]  { if (yyextra->mode==1) { return VP_X_FACT; } else { return ALNUM; } }


### PR DESCRIPTION
I added optional time interval tags to the Pajek grammar together with implied fixes in the pajek lexer. An issue recently raised in the [userlist](https://lists.gnu.org/archive/html/igraph-help/2017-07/msg00004.html). I tried to make as little adjustments as possible.

 @ntamas & @gaborcsardi  With that Pajek data conforming with the [Pajek manual](http://vlado.fmf.uni-lj.si/pub/networks/pajek/doc/pajekman.pdf) should be parsable (works for the example provided by the user from the userlist) and can thus be fed into graph objects. Implementation of the latter I better leave with you guys.


Separately, two additional innocent commits on guarding `__clang__ #pragma`'s and on error messages glued to the grammar patch. Still a bit struggling with git here, but getting better.

HTH ... just let me know.