### PR TITLE
Add igraph_random_edge_walk()

### DIFF
--- a/doc/visitors.xxml
+++ b/doc/visitors.xxml
@@ -19,6 +19,7 @@
 
 <section><title>Random walks</title>
 <!-- doxrox-include igraph_random_walk -->
+<!-- doxrox-include igraph_random_edge_walk -->
 </section>
 
 </chapter>

--- a/examples/benchmarks/igraph_random_walk.c
+++ b/examples/benchmarks/igraph_random_walk.c
@@ -1,0 +1,91 @@
+
+#include <igraph.h>
+#include "bench.h"
+
+int main() {
+    igraph_t graph;
+    igraph_vector_t walk, weights;
+    igraph_integer_t ec, i;
+
+    igraph_rng_seed(igraph_rng_default(), 137);
+
+    igraph_vector_init(&walk, 0);
+    igraph_vector_init(&weights, 0);
+
+    /* create a small graph, and a compatible weight vector */
+    igraph_de_bruijn(&graph, 3, 2); /* 9 vertices, 27 edges, average degree: 6 */
+    ec = igraph_ecount(&graph);
+
+    igraph_vector_resize(&weights, ec);
+    for (i=0; i < ec; ++i)
+        VECTOR(weights)[i] = igraph_rng_get_unif01(igraph_rng_default());
+
+    BENCH(" 1 Random edge walk,   directed,   unweighted, small graph  ",
+        igraph_random_edge_walk(&graph, NULL, &walk, 0, IGRAPH_OUT, 50000000, IGRAPH_RANDOM_WALK_STUCK_RETURN)
+    );
+
+    BENCH(" 2 Random edge walk,   directed,   weighted,   small graph  ",
+        igraph_random_edge_walk(&graph, &weights, &walk, 0, IGRAPH_OUT, 50000000, IGRAPH_RANDOM_WALK_STUCK_RETURN)
+    );
+
+    BENCH(" 3 Random vertex walk, directed,   unweighted, small graph  ",
+        igraph_random_walk(&graph, &walk, 0, IGRAPH_OUT, 50000000, IGRAPH_RANDOM_WALK_STUCK_RETURN)
+    );
+
+    igraph_to_undirected(&graph, IGRAPH_TO_UNDIRECTED_EACH, NULL);
+
+    BENCH(" 4 Random edge walk,   undirected, unweighted, small graph  ",
+        igraph_random_edge_walk(&graph, NULL, &walk, 0, IGRAPH_OUT, 50000000, IGRAPH_RANDOM_WALK_STUCK_RETURN)
+    );
+
+    BENCH(" 5 Random edge walk,   undirected, weighted,   small graph  ",
+        igraph_random_edge_walk(&graph, &weights, &walk, 0, IGRAPH_OUT, 50000000, IGRAPH_RANDOM_WALK_STUCK_RETURN)
+    );
+
+    BENCH(" 6 Random vertex walk, undirected, unweighted, small graph  ",
+        igraph_random_walk(&graph, &walk, 0, IGRAPH_OUT, 50000000, IGRAPH_RANDOM_WALK_STUCK_RETURN)
+    );
+
+    igraph_destroy(&graph);
+
+    /* create a big graph, and a compatible weight vector */
+    igraph_de_bruijn(&graph, 8, 5); /* 32768 vertices, 262144 edges, average degree: 16 */
+    ec = igraph_ecount(&graph);
+
+    igraph_vector_resize(&weights, ec);
+    for (i=0; i < ec; ++i)
+        VECTOR(weights)[i] = igraph_rng_get_unif01(igraph_rng_default());
+
+    BENCH(" 7 Random edge walk,   directed,   unweighted, large graph  ",
+        igraph_random_edge_walk(&graph, NULL, &walk, 0, IGRAPH_OUT, 50000000, IGRAPH_RANDOM_WALK_STUCK_RETURN)
+    );
+
+    BENCH(" 8 Random edge walk,   directed,   weighted,   large graph  ",
+        igraph_random_edge_walk(&graph, &weights, &walk, 0, IGRAPH_OUT, 50000000, IGRAPH_RANDOM_WALK_STUCK_RETURN)
+    );
+
+    BENCH(" 9 Random vertex walk, directed,   unweighted, large graph  ",
+        igraph_random_walk(&graph, &walk, 0, IGRAPH_OUT, 50000000, IGRAPH_RANDOM_WALK_STUCK_RETURN)
+    );
+
+    igraph_to_undirected(&graph, IGRAPH_TO_UNDIRECTED_EACH, NULL);
+
+    BENCH("10 Random edge walk,   undirected, unweighted, large graph  ",
+        igraph_random_edge_walk(&graph, NULL, &walk, 0, IGRAPH_OUT, 50000000, IGRAPH_RANDOM_WALK_STUCK_RETURN)
+    );
+
+    BENCH("11 Random edge walk,   undirected, weighted,   large graph  ",
+        igraph_random_edge_walk(&graph, &weights, &walk, 0, IGRAPH_OUT, 50000000, IGRAPH_RANDOM_WALK_STUCK_RETURN)
+    );
+
+    BENCH("12 Random vertex walk, undirected, unweighted, large graph  ",
+        igraph_random_walk(&graph, &walk, 0, IGRAPH_OUT, 50000000, IGRAPH_RANDOM_WALK_STUCK_RETURN)
+    );
+
+    igraph_destroy(&graph);
+
+    igraph_vector_destroy(&weights);
+    igraph_vector_destroy(&walk);
+
+    return 0;
+}

--- a/examples/simple/igraph_random_walk.c
+++ b/examples/simple/igraph_random_walk.c
@@ -1,0 +1,52 @@
+
+#include <igraph.h>
+#include <assert.h>
+
+int main() {
+    igraph_t graph;
+    igraph_vector_t walk, weights;
+    igraph_integer_t ec, i;
+
+    igraph_rng_seed(igraph_rng_default(), 137);
+
+    igraph_vector_init(&walk, 0);
+    igraph_vector_init(&weights, 0);
+
+    /* This directed graph has loop edges.
+       It also has multi-edges when considered as undirected. */
+    igraph_de_bruijn(&graph, 3, 2);
+    ec = igraph_ecount(&graph);
+
+    /* unweighted, directed */
+    igraph_random_edge_walk(&graph, NULL, &walk, 0, IGRAPH_OUT, 1000, IGRAPH_RANDOM_WALK_STUCK_RETURN);
+    assert(igraph_vector_size(&walk) == 1000);
+
+    /* unweighted, undirected */
+    igraph_random_edge_walk(&graph, NULL, &walk, 0, IGRAPH_ALL, 1000, IGRAPH_RANDOM_WALK_STUCK_RETURN);
+    assert(igraph_vector_size(&walk) == 1000);
+
+    igraph_vector_resize(&weights, ec);
+    for (i=0; i < ec; ++i)
+        VECTOR(weights)[i] = igraph_rng_get_unif01(igraph_rng_default());
+
+    /* weighted, directed */
+    igraph_random_edge_walk(&graph, &weights, &walk, 0, IGRAPH_OUT, 1000, IGRAPH_RANDOM_WALK_STUCK_RETURN);
+    assert(igraph_vector_size(&walk) == 1000);
+
+    /* weighted, undirecetd */
+    igraph_random_edge_walk(&graph, &weights, &walk, 0, IGRAPH_ALL, 1000, IGRAPH_RANDOM_WALK_STUCK_RETURN);
+    assert(igraph_vector_size(&walk) == 1000);
+
+    igraph_destroy(&graph);
+
+    /* 1-vertex graph, should get stuck */
+    igraph_empty(&graph, 1, /* directed = */ 0);
+    igraph_random_edge_walk(&graph, NULL, &walk, 0, IGRAPH_OUT, 1000, IGRAPH_RANDOM_WALK_STUCK_RETURN);
+    assert(igraph_vector_size(&walk) == 0);
+    igraph_destroy(&graph);
+
+    igraph_vector_destroy(&weights);
+    igraph_vector_destroy(&walk);
+
+    return 0;
+}

--- a/include/igraph_paths.h
+++ b/include/igraph_paths.h
@@ -133,6 +133,13 @@ DECLDIR int igraph_random_walk(const igraph_t *graph, igraph_vector_t *walk,
                 igraph_integer_t steps,
                 igraph_random_walk_stuck_t stuck);
 
+DECLDIR int igraph_random_edge_walk(const igraph_t *graph,
+                            const igraph_vector_t *weights,
+                            igraph_vector_t *edgewalk,
+                            igraph_integer_t start, igraph_neimode_t mode,
+                            igraph_integer_t steps,
+                            igraph_random_walk_stuck_t stuck);
+
 __END_DECLS
 
 #endif

--- a/src/random_walk.c
+++ b/src/random_walk.c
@@ -26,6 +26,7 @@
 #include "igraph_interface.h"
 #include "igraph_random.h"
 #include "igraph_memory.h"
+#include "igraph_interrupt_internal.h"
 
 /**
  * \function igraph_random_walk
@@ -268,6 +269,8 @@ int igraph_random_edge_walk(const igraph_t *graph,
             }
             break;
         }
+
+        IGRAPH_ALLOW_INTERRUPTION();
     }
 
     RNG_END();

--- a/src/random_walk.c
+++ b/src/random_walk.c
@@ -230,6 +230,8 @@ int igraph_random_edge_walk(const igraph_t *graph,
                 long j;
 
                 *cd = igraph_malloc(sizeof(igraph_vector_t));
+                if (*cd == NULL)
+                    IGRAPH_ERROR("random edge walk failed", IGRAPH_ENOMEM);
                 IGRAPH_CHECK(igraph_vector_init(*cd, degree));
 
                 IGRAPH_CHECK(igraph_vector_resize(&weight_temp, degree));

--- a/src/random_walk.c
+++ b/src/random_walk.c
@@ -111,3 +111,118 @@ int igraph_random_walk(const igraph_t *graph, igraph_vector_t *walk,
 
   return 0;
 }
+
+
+/**
+ * \function igraph_random_edge_walk
+ * \brief Perform a random walk on a graph and return the traversed edges
+ *
+ * Performs a random walk with a given length on a graph, from the given
+ * start vertex. Edge directions are (potentially) considered, depending on
+ * the \p mode argument.
+ *
+ * \param graph The input graph, it can be directed or undirected.
+ *   Multiple edges are respected, so are loop edges.
+ * \param weights A vector of non-negative edge weights.
+ *   It is assumed that at least one strictly positive weight is found among the
+ *   outgoing edges of each vertex.  If it is a NULL pointer, all edges are considered
+ *   to have equal weight.
+ * \param edgewalk An initialized vector; the indices of traversed edges are stored here.
+ *   It will be resized as needed.
+ * \param start The start vertex for the walk.
+ * \param steps The number of steps to take. If the random walk gets
+ *   stuck, then the \p stuck argument specifies what happens.
+ * \param mode How to walk along the edges in direted graphs.
+ *   \c IGRAPH_OUT means following edge directions, \c IGRAPH_IN means
+ *   going opposite the edge directions, \c IGRAPH_ALL means ignoring
+ *   edge directions. This argument is ignored for undirected graphs.
+ * \param stuck What to do if the random walk gets stuck.
+ *   \c IGRAPH_RANDOM_WALK_STUCK_RETURN means that the function returns
+ *   with a shorter walk; \c IGRAPH_RANDOM_WALK_STUCK_ERROR means
+ *   that an error is reported. In both cases, \p edgewalk is truncated
+ *   to contain the actual interrupted walk.
+ *
+ * \return Error code.
+ *
+ */
+int igraph_random_edge_walk(const igraph_t *graph,
+                            const igraph_vector_t *weights,
+                            igraph_vector_t *edgewalk,
+                            igraph_integer_t start, igraph_neimode_t mode,
+                            igraph_integer_t steps,
+                            igraph_random_walk_stuck_t stuck)
+{
+    igraph_integer_t vc = igraph_vcount(graph);
+    igraph_integer_t ec = igraph_ecount(graph);
+    igraph_integer_t i;
+    igraph_inclist_t il;
+    igraph_vector_t ws, cs;
+
+    if (start < 0 || start >= vc)
+        IGRAPH_ERROR("Invalid start vertex", IGRAPH_EINVAL);
+
+    if (steps < 0)
+        IGRAPH_ERROR("Invalid number of steps", IGRAPH_EINVAL);
+
+    if (weights) {
+        if (igraph_vector_size(weights) != ec)
+            IGRAPH_ERROR("Invalid weight vector length", IGRAPH_EINVAL);
+        if (igraph_vector_min(weights) < 0)
+            IGRAPH_ERROR("Weights must be non-negative", IGRAPH_EINVAL);
+    }
+
+    IGRAPH_CHECK(igraph_vector_resize(edgewalk, steps));
+
+    IGRAPH_CHECK(igraph_inclist_init(graph, &il, mode));
+    IGRAPH_FINALLY(igraph_inclist_destroy, &il);
+
+    IGRAPH_VECTOR_INIT_FINALLY(&ws, 0);
+    IGRAPH_VECTOR_INIT_FINALLY(&cs, 0);
+
+    RNG_BEGIN();
+
+    for (i=0; i < steps; ++i) {
+        long degree, edge, idx;
+        igraph_vector_int_t *edges = igraph_inclist_get(&il, start);
+
+        degree = igraph_vector_int_size(edges);
+
+        /* Are we stuck? */
+        if (IGRAPH_UNLIKELY(degree == 0)) {
+            igraph_vector_resize(edgewalk, i); /* can't fail since size is reduced, skip IGRAPH_CHECK */
+            if (stuck == IGRAPH_RANDOM_WALK_STUCK_RETURN)
+                break;
+            else
+                IGRAPH_ERROR("Random walk got stuck", IGRAPH_ERWSTUCK);
+        }
+
+        if (weights) { /* weighted: choose an out-edge with probability proportional to its weight */
+            igraph_real_t r;
+            long j;
+
+            IGRAPH_CHECK(igraph_vector_resize(&ws, degree));
+            for (j=0; j < degree; ++j)
+                VECTOR(ws)[j] = VECTOR(*weights)[ VECTOR(*edges)[j] ];
+
+            IGRAPH_CHECK(igraph_vector_cumsum(&cs, &ws));
+
+            r = RNG_UNIF(0, VECTOR(cs)[degree-1]);
+            igraph_vector_binsearch(&cs, r, &idx);
+        } else { /* unweighted: choose an out-edge at random */
+            idx = RNG_INTEGER(0, degree-1);
+        }
+
+        edge = VECTOR(*edges)[idx];
+        VECTOR(*edgewalk)[i] = edge;
+        start = IGRAPH_TO(graph, edge);
+    }
+
+    RNG_END();
+
+    igraph_vector_destroy(&cs);
+    igraph_vector_destroy(&ws);
+    igraph_inclist_destroy(&il);
+    IGRAPH_FINALLY_CLEAN(3);
+
+    return IGRAPH_SUCCESS;
+}

--- a/tests/visitors.at
+++ b/tests/visitors.at
@@ -31,3 +31,7 @@ AT_KEYWORDS([igraph_bfs bfs breadth-first visitor])
 AT_COMPILE_CHECK([simple/igraph_bfs2.c], [simple/igraph_bfs2.out])
 AT_CLEANUP
 
+AT_SETUP([Random walk (igraph_random_edge_walk):])
+AT_KEYWORDS([igraph_random_edge_walk random_walk])
+AT_COMPILE_CHECK([simple/igraph_random_walk.c])
+AT_CLEANUP


### PR DESCRIPTION
This pull request adds the function `igraph_random_edge_walk()`.

It is analogous to `igraph_random_walk()` with the following differences:

 - it returns a list of edge indices
 - it supports edge weights

Related bug: #981 

There I asked if `random_walk()` should be changed to return an edge list instead of a vertex list. It is probably best to have both variants. Obtaining an edge list from a vertex list is not possible when multiple edges are present between the same vertices.  Obtaining a vertex list from an edge list is possible, but it is inconvenient for undirected graphs (because it is not clear in which direction the edge was traversed).

Still missing:

 - [x] Unit tests
 - [ ] Update `igraph_random_walk()` to also handle weights

I will do these after the review.