### PR TITLE
Fix compile error with -Werror-format-security.

### DIFF
--- a/src/f2c/arithchk.c
+++ b/src/f2c/arithchk.c
@@ -110,7 +110,8 @@ icheck(void)
 	return 0;
 	}
 
-char *emptyfmt = "";	/* avoid possible warning message with printf("") */
+/* avoid possible warning message with printf("") */
+const char *const emptyfmt = "";
 
  static Akind *
 ccheck(void)


### PR DESCRIPTION
This patch was originally written for the Mageia Linux package, where
the GCC flag is enforced.