### PR TITLE
Compiles with musl libc

### DIFF
--- a/src/f2c/sysdep1.h
+++ b/src/f2c/sysdep1.h
@@ -15,8 +15,13 @@
 
 #ifdef __linux__
 #define USE_LARGEFILE
+
+#ifdef __GLIBC__
 #define OFF_T __off64_t
-#endif
+#else
+#define OFF_T off64_t
+#endif /* __GLIBC__ */
+#endif /* __linux__ */
 
 #ifdef _AIX43
 #define _LARGE_FILES

--- a/src/f2c/uninit.c
+++ b/src/f2c/uninit.c
@@ -250,9 +250,11 @@ ieee0(Void)
  */
 
 
-#if (defined(__GLIBC__)&& ( __GLIBC__>=2) && (__GLIBC_MINOR__>=2) )
-#define _GNU_SOURCE 1
+#ifdef __GLIBC__
 #define IEEE0_done
+
+#if ((__GLIBC__>=2) && (__GLIBC_MINOR__>=2))
+#define _GNU_SOURCE 1
 #include <fenv.h>
  static void
   ieee0(Void)
@@ -265,14 +267,11 @@ ieee0(Void)
          unsupported_error();
 }
 
-#endif /* Glibc control */
-
 /* Many linux cases will be treated through GLIBC.  Note that modern
  * linux runs on many non-i86 plaforms and as a result the following code
  * must be processor dependent rather than simply OS specific */
 
-#if (defined(__linux__)&&(!defined(IEEE0_done)))
-#define IEEE0_done
+#else /* __GLIBC__<2.2 */
 #include <fpu_control.h>
 
 
@@ -401,7 +400,8 @@ static void ieee0(Void)
 
 #endif /* _FPU_IEEE */
 	}
-#endif /* __linux__ */
+#endif /* __GLIBC__>2.2 */
+#endif /* __GLIBC__ */
 
 /* Specific to OSF/1 */
 #if (defined(__alpha)&&defined(__osf__))


### PR DESCRIPTION
Fixes #1066

I’m not sure which of the branches is hit, but I assume the fallback branch (empty ieee0 function).

This fits with the [musl FAQ entry](https://wiki.musl-libc.org/functional-differences-from-glibc.html#Floating-point-exceptions) explaining that there is no standards compliant behavior that enables floating point exceptions.

If we really need the behavior specified [here](https://github.com/igraph/igraph/blob/02005680aebb4281f2964c6d2d8d98851fce63b9/src/f2c/uninit.c#L298-L299) and feel adventurous, we could try the assembler code [here](https://github.com/iXit/Mesa-3D/pull/214/files) on x86 and x86_64.