### PR TITLE
A portability fix for configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -197,7 +197,7 @@ tls_support=no
 HAVE_TLS=0
 THREAD_LOCAL=
 AC_ARG_ENABLE(tls, AC_HELP_STRING([--enable-tls], [Compile with thread-local storage]))
-if test "x$enable_tls" == "xyes"; then
+if test "x$enable_tls" = "xyes"; then
   keywords="__thread __declspec(thread)"
   for kw in $keywords ; do
       AC_TRY_COMPILE([int $kw test;], [], ac_cv_tls=$kw)


### PR DESCRIPTION
The "`test`" command, as well as the "`[`" command, are not required to
know the "`==`" operator. Only a few implementations like bash and some
versions of ksh support it.

When you run "`test foo == foo`" on a platform that does not support the
"`==`" operator, the result will be `false` instead of `true`. This can
lead to unexpected behavior.