### PR TITLE
Update auto NCV selection for ARPACK

### DIFF
--- a/src/arpack.c
+++ b/src/arpack.c
@@ -794,9 +794,9 @@ void igraph_i_arpack_auto_ncv(igraph_arpack_options_t* options) {
   if (options->ncv < min_ncv) {
     options->ncv = min_ncv;
   }
-  /* ...but at most n-1 */
-  if (options->ncv > options->n - 1) {
-    options->ncv = options->n - 1;
+  /* ...but at most n */
+  if (options->ncv > options->n) {
+    options->ncv = options->n;
   }
 }
 


### PR DESCRIPTION
Maximum NCV should be N and not N-1, otherwise it may happen that NCV - NEV < 2, which causes ARPACK to fail.

Fixes #1119

I am unsure why the cap on NCV was N-1 previously. I am going by the error message issued by ARPACK, 

> NCV must be greater than NEV and less than or equal to N (and for the non-symmetric solver NCV-NEV >=2 must also hold)

