### PR TITLE
Fix CXSparse link in docs

### DIFF
--- a/src/sparsemat.c
+++ b/src/sparsemat.c
@@ -45,7 +45,7 @@
  *
  * <para>The data type is essentially a wrapper to some of the
  * functions in the CXSparse library, by Tim Davis, see
- * http://www.cise.ufl.edu/research/sparse/CXSparse/
+ * http://faculty.cse.tamu.edu/davis/suitesparse.html
  * </para>
  * 
  * <para>


### PR DESCRIPTION
The old link is broken. The new link is not directly to CXSparse but to SparseSuite, which includes CXSparse