### PR TITLE
Isomorphism tests: set a fixed seed for Bliss and VF2

### DIFF
--- a/examples/simple/igraph_isomorphic_bliss.c
+++ b/examples/simple/igraph_isomorphic_bliss.c
@@ -24,7 +24,6 @@
 #include <igraph.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <time.h>
 
 int main() {
   
@@ -34,7 +33,7 @@ int main() {
   igraph_vector_t perm;
   igraph_bool_t iso;
 
-  srand(12345);
+  igraph_rng_seed(igraph_rng_default(), 54321);
 
   igraph_ring(&ring1, 100, /*directed=*/ 0, /*mutual=*/ 0, /*circular=*/1);
   igraph_vector_init_seq(&perm, 0, igraph_vcount(&ring1)-1);

--- a/examples/simple/igraph_isomorphic_vf2.c
+++ b/examples/simple/igraph_isomorphic_vf2.c
@@ -24,7 +24,6 @@
 #include <igraph.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <time.h>
 
 int main() {
   
@@ -35,7 +34,7 @@ int main() {
   igraph_integer_t count;
   long int i;
 
-  srand(12345);
+  igraph_rng_seed(igraph_rng_default(), 12345);
 
   igraph_ring(&ring1, 100, /*directed=*/ 0, /*mutual=*/ 0, /*circular=*/1);
   igraph_vector_init_seq(&perm, 0, igraph_vcount(&ring1)-1);


### PR DESCRIPTION
Occasionally, _and randomly_, I was getting failures from the tests isomorphic_bliss and isomorphic_vf2, in both case with "Second negative test failed".

To make a long story short:

In both cases, this test is about vertex-coloured isomorphism. The colour vector contains all zeros, except for precisely two 1s.  The result of the isomorphism test is expected to be "false" because the colour vectors are set to be different. _However, this is not generally true._  Whether it is true depends on the specific vertex reordering done at the beginning of the test. If we're unlucky, this reordering makes the colour vectors equivalent too.

And this is exactly what was happening.  The tests has an `srand(1234)`, but it was igraph's RNG that was being used. It's igraph's RNG that needs to be seeded.

This PR does that.

Actually, if we use the seed 12345 in the Bliss test, we get a special permutation that makes the test "fail" exactly how I described it. I verified manually that this is really what happens.  I chose 54321 instead, for this reason.