### PR TITLE
igraph_destroy should be void (not return anything)

### DIFF
--- a/include/igraph_interface.h
+++ b/include/igraph_interface.h
@@ -37,7 +37,7 @@ __BEGIN_DECLS
 
 DECLDIR int igraph_empty(igraph_t *graph, igraph_integer_t n, igraph_bool_t directed);
 DECLDIR int igraph_empty_attrs(igraph_t *graph, igraph_integer_t n, igraph_bool_t directed, void *attr);
-DECLDIR int igraph_destroy(igraph_t *graph);
+DECLDIR void igraph_destroy(igraph_t *graph);
 DECLDIR int igraph_copy(igraph_t *to, const igraph_t *from);
 DECLDIR int igraph_add_edges(igraph_t *graph, const igraph_vector_t *edges, 
                 void *attr);

--- a/src/type_indexededgelist.c
+++ b/src/type_indexededgelist.c
@@ -157,11 +157,10 @@ int igraph_empty_attrs(igraph_t *graph, igraph_integer_t n, igraph_bool_t direct
  * iterators of a graph should be destroyed before the graph itself
  * anyway. 
  * \param graph Pointer to the graph to free.
- * \return Error code.
  * 
  * Time complexity: operating system specific.
  */
-int igraph_destroy(igraph_t *graph) {
+void igraph_destroy(igraph_t *graph) {
 
   IGRAPH_I_ATTRIBUTE_DESTROY(graph);
 
@@ -170,9 +169,7 @@ int igraph_destroy(igraph_t *graph) {
   igraph_vector_destroy(&graph->oi);
   igraph_vector_destroy(&graph->ii);
   igraph_vector_destroy(&graph->os);
-  igraph_vector_destroy(&graph->is);
-  
-  return 0;
+  igraph_vector_destroy(&graph->is);  
 }
 
 /**


### PR DESCRIPTION
Changed `int igraph_destroy(igraph_t *)` to `void igraph_destroy(igraph_t *)`.

No other changes were necessary. Test pass on Mac.

Fixes #1142 