### PR TITLE
igraph_vector_init_copy: Add const to the source pointer

### DIFF
--- a/include/igraph_vector_pmt.h
+++ b/include/igraph_vector_pmt.h
@@ -27,7 +27,7 @@
 
 DECLDIR int FUNCTION(igraph_vector,init)(TYPE(igraph_vector)* v, long int size);
 DECLDIR int FUNCTION(igraph_vector,init_copy)(TYPE(igraph_vector)* v, 
-				       BASE* data, long int length);
+				       const BASE* data, long int length);
 DECLDIR int FUNCTION(igraph_vector,init_seq)(TYPE(igraph_vector)*v, BASE from, BASE to);
 DECLDIR int FUNCTION(igraph_vector,copy)(TYPE(igraph_vector) *to, 
 				 const TYPE(igraph_vector) *from);

--- a/src/vector.pmt
+++ b/src/vector.pmt
@@ -1063,7 +1063,7 @@ long int FUNCTION(igraph_vector,which_min)(const TYPE(igraph_vector)* v) {
  */
 
 int FUNCTION(igraph_vector,init_copy)(TYPE(igraph_vector) *v, 
-				      BASE *data, long int length) {
+				      const BASE *data, long int length) {
   v->stor_begin=igraph_Calloc(length, BASE);
   if (v->stor_begin==0) {
     IGRAPH_ERROR("cannot init vector from array", IGRAPH_ENOMEM);


### PR DESCRIPTION
The copy source should be passed to `igraph_vector_init_copy()` via `const` pointer.