### PR TITLE
Fix bug in igraph_is_tree

### DIFF
--- a/examples/simple/igraph_is_tree.c
+++ b/examples/simple/igraph_is_tree.c
@@ -109,5 +109,17 @@ int main() {
 
     igraph_destroy(&g);
 
+    /* Regression test, see:
+     * https://github.com/szhorvat/IGraphM/issues/90
+     * https://github.com/igraph/igraph/pull/1160
+     */
+    igraph_small(&g, 5, 0,
+                 0,3, 0,4, 1,3, 1,4, -1);
+
+    igraph_is_tree(&g, &res, &root, IGRAPH_ALL);
+    assert(! res);
+
+    igraph_destroy(&g);
+
     return 0;
 }

--- a/src/structural_properties.c
+++ b/src/structural_properties.c
@@ -6885,8 +6885,10 @@ static int igraph_i_is_tree_visitor(igraph_integer_t root, const igraph_adjlist_
 
         /* take a vertex from the stack, mark it as visited */
         u = igraph_stack_int_pop(&stack);
-        VECTOR(visited)[u] = 1;
-        *visited_count += 1;
+        if (IGRAPH_LIKELY(! VECTOR(visited)[u])) {
+            VECTOR(visited)[u] = 1;
+            *visited_count += 1;
+        }
 
         /* register all its yet-unvisited neighbours for future processing */
         neighbors = igraph_adjlist_get(al, u);


### PR DESCRIPTION
There was a bug in `igraph_is_tree`.  See here: https://github.com/szhorvat/IGraphM/issues/90

I contributed this code originally.

The `igraph_i_is_tree_visitor` function is effectively measuring the size of a connected component that contains `root`.  It worked like this: it pushed neighbours of the current version onto a stack. It popped off vertices from the stack and pushed their neighbours, etc.

A counter was incremented every time a vertex was popped. I did not think about the case when a vertex may be pushed more than once before it gets visited. This is exactly what happened here.

Now we only increment the counter if the popped vertex has no yet been visited.

