### PR TITLE
igraph_edge_connectivity: fix for singleton graph

### DIFF
--- a/src/flow.c
+++ b/src/flow.c
@@ -2140,6 +2140,16 @@ int igraph_st_edge_connectivity(const igraph_t *graph, igraph_integer_t *res,
 int igraph_edge_connectivity(const igraph_t *graph, igraph_integer_t *res,
 			     igraph_bool_t checks) {
   igraph_bool_t ret=0;
+  igraph_integer_t number_of_nodes = igraph_vcount(graph);
+
+  /* igraph_mincut_value returns infinity for the singleton graph,
+   * which cannot be cast to an integer. We catch this case early
+   * and postulate the edge-connectivity of this graph to be 0.
+   * This is consistent with what other software packages return. */
+  if (number_of_nodes <= 1) {
+      *res = 0;
+      return 0;
+  }
   
   /* Use that vertex.connectivity(G) <= edge.connectivity(G) <= min(degree(G)) */
   if (checks) {


### PR DESCRIPTION
Fixes #1163 by postulating the edge connectivity of K_1 to be 0. See discussion there.