### PR TITLE
igraph_colored_simple_graph

### DIFF
--- a/doc/isomorphism.xxml
+++ b/doc/isomorphism.xxml
@@ -49,7 +49,7 @@
 
 <section><title>Utility functions</title>
 <!-- doxrox-include igraph_permute_vertices -->
-<!-- doxrox-include igraph_colored_simple_graph -->
+<!-- doxrox-include igraph_simplify_and_colorize -->
 </section>
 
 </chapter>

--- a/doc/isomorphism.xxml
+++ b/doc/isomorphism.xxml
@@ -9,7 +9,6 @@
 
 <section><title>The simple interface</title>
 <!-- doxrox-include about_graph_isomorphism -->
-<!-- doxrox-include igraph_permute_vertices -->
 <!-- doxrox-include igraph_isomorphic -->
 <!-- doxrox-include igraph_subisomorphic -->
 </section>
@@ -46,6 +45,11 @@
 <!-- doxrox-include igraph_isoclass -->
 <!-- doxrox-include igraph_isoclass_subgraph -->
 <!-- doxrox-include igraph_isoclass_create -->
+</section>
+
+<section><title>Utility functions</title>
+<!-- doxrox-include igraph_permute_vertices -->
+<!-- doxrox-include igraph_colored_simple_graph -->
 </section>
 
 </chapter>

--- a/examples/tests/simplify_and_colorize.c
+++ b/examples/tests/simplify_and_colorize.c
@@ -1,0 +1,58 @@
+
+#include <igraph.h>
+
+#include "test_utilities.inc"
+
+#define SIMPLIFY_PRINT_DESTROY(name) \
+    printf(name "\n"); \
+    igraph_simplify_and_colorize(&graph, &res, &vcol, &ecol); \
+    print_graph(&res, stdout); \
+    print_vector_int(&vcol, stdout); \
+    print_vector_int(&ecol, stdout); \
+    printf("\n"); \
+    igraph_destroy(&graph);
+
+int main() {
+    igraph_t graph, res;
+    igraph_vector_int_t vcol, ecol;
+
+    igraph_vector_int_init(&vcol, 0);
+    igraph_vector_int_init(&ecol, 0);
+
+    /* null graph */
+    igraph_empty(&graph, 0, 0);
+    SIMPLIFY_PRINT_DESTROY("K0");
+
+    /* singleton graph */
+    igraph_empty(&graph, 1, 0);
+    SIMPLIFY_PRINT_DESTROY("K1");
+
+    /* 4-cycle-graph */   
+    igraph_ring(&graph, 4, 0, 0, 1);
+    SIMPLIFY_PRINT_DESTROY("C4");
+
+    /* both multi-edges and self loops */
+    igraph_small(&graph, 2, 0,
+                 0,1, 0,1, 1,1, -1);
+    SIMPLIFY_PRINT_DESTROY("Undirected graph 1");
+
+    /* parallel edges specified with different vertex orderings */   
+    igraph_small(&graph, 3, 0,
+                 0,1, 1,2, 2,0, 2,2, 2,2, 2,1, -1);
+    SIMPLIFY_PRINT_DESTROY("Undirected graph 2");
+
+    /* directed version of the same as above */
+    igraph_small(&graph, 3, 1,
+                 0,1, 1,2, 2,0, 2,2, 2,2, 2,1, -1);
+    SIMPLIFY_PRINT_DESTROY("Directed graph 1");
+
+    /* isolated vertices */
+    igraph_small(&graph, 4, 1,
+                 0,1, 0,1, 1,0, 1,0, 1,0, 1,1, 1,1, -1);
+    SIMPLIFY_PRINT_DESTROY("Directed graph 2");
+
+    igraph_vector_int_destroy(&vcol);
+    igraph_vector_int_destroy(&ecol);
+
+    return 0;
+}

--- a/examples/tests/simplify_and_colorize.out
+++ b/examples/tests/simplify_and_colorize.out
@@ -1,0 +1,70 @@
+K0
+directed: false
+vcount: 0
+edges: {
+}
+( )
+( )
+
+K1
+directed: false
+vcount: 1
+edges: {
+}
+( 0 )
+( )
+
+C4
+directed: false
+vcount: 4
+edges: {
+1 0
+3 0
+2 1
+3 2
+}
+( 0 0 0 0 )
+( 1 1 1 1 )
+
+Undirected graph 1
+directed: false
+vcount: 2
+edges: {
+1 0
+}
+( 0 1 )
+( 2 )
+
+Undirected graph 2
+directed: false
+vcount: 3
+edges: {
+1 0
+2 0
+2 1
+}
+( 0 0 2 )
+( 1 1 2 )
+
+Directed graph 1
+directed: true
+vcount: 3
+edges: {
+0 1
+1 2
+2 0
+2 1
+}
+( 0 0 2 )
+( 1 1 1 1 )
+
+Directed graph 2
+directed: true
+vcount: 4
+edges: {
+0 1
+1 0
+}
+( 0 2 0 0 )
+( 2 3 )
+

--- a/examples/tests/test_utilities.inc
+++ b/examples/tests/test_utilities.inc
@@ -1,0 +1,60 @@
+#ifndef TEST_UTILITIES_INC
+#define TEST_UTILITIES_INC
+
+/*
+ * This file contains functions that are useful when writing tests.
+ * Include it in the test program using #include "test_utilities.inc"
+ */
+
+#include <igraph.h>
+#include <stdio.h>
+
+/* Print elements of a vector. Use parentheses to make it clear when a vector has size zero. */
+void print_vector(const igraph_vector_t *v, FILE *f) {
+  long i;
+  fprintf(f, "(");
+  for (i=0; i < igraph_vector_size(v); i++) {
+    fprintf(f, " %f", VECTOR(*v)[i]);
+  }
+  fprintf(f, " )\n");
+}
+
+
+/* Round elements of a vector to integers and print them. */
+/* This is meant to be used when the elements of a vector are integer values. */
+void print_vector_round(const igraph_vector_t *v, FILE *f) {
+  long i;
+  fprintf(f, "(");
+  for (i=0; i < igraph_vector_size(v); i++) {
+    fprintf(f, " %li", (long int) VECTOR(*v)[i]);
+  }
+  fprintf(f, " )\n");
+}
+
+
+/* Print elements of an integer vector */
+void print_vector_int(const igraph_vector_int_t *v, FILE *f) {
+  long i;
+  fprintf(f, "(");
+  for (i=0; i < igraph_vector_int_size(v); i++) {
+    fprintf(f, " %d", VECTOR(*v)[i]);
+  }
+  fprintf(f, " )\n");
+}
+
+
+/* Print a graph. Use brackets to make it obvious when the edge list is empty. */
+void print_graph(const igraph_t *graph, FILE *f) {
+    long ecount = igraph_ecount(graph);
+    long vcount = igraph_vcount(graph);
+    long i;
+
+    fprintf(f, "directed: %s\n", igraph_is_directed(graph) ? "true" : "false");
+    fprintf(f, "vcount: %ld\n", vcount);
+    fprintf(f, "edges: {\n");
+    for (i=0; i < ecount; ++i)
+        fprintf(f, "%d %d\n", IGRAPH_FROM(graph, i), IGRAPH_TO(graph, i));
+    fprintf(f, "}\n");
+}
+
+#endif /* TEST_UTILITIES_INC */

--- a/include/igraph_topology.h
+++ b/include/igraph_topology.h
@@ -59,7 +59,7 @@ DECLDIR int igraph_transitive_closure_dag(const igraph_t *graph,
 DECLDIR int igraph_permute_vertices(const igraph_t *graph, igraph_t *res,
 			    const igraph_vector_t *permutation);
 
-DECLDIR int igraph_colored_simple_graph(
+DECLDIR int igraph_simplify_and_colorize(
                       const igraph_t *graph, igraph_t *res,
                       igraph_vector_int_t *vertex_color, igraph_vector_int_t *edge_color);
 

--- a/include/igraph_topology.h
+++ b/include/igraph_topology.h
@@ -59,6 +59,10 @@ DECLDIR int igraph_transitive_closure_dag(const igraph_t *graph,
 DECLDIR int igraph_permute_vertices(const igraph_t *graph, igraph_t *res,
 			    const igraph_vector_t *permutation);
 
+DECLDIR int igraph_colored_simple_graph(
+                      const igraph_t *graph, igraph_t *res,
+                      igraph_vector_int_t *vertex_color, igraph_vector_int_t *edge_color);
+
 /* Generic interface */
 DECLDIR int igraph_isomorphic(const igraph_t *graph1, const igraph_t *graph2,
 		      igraph_bool_t *iso);

--- a/src/topology.c
+++ b/src/topology.c
@@ -2980,3 +2980,91 @@ int igraph_isomorphic_bliss(const igraph_t *graph1, const igraph_t *graph2,
   
   return 0;
 }
+
+
+/**
+ * \function igraph_colored_simple_graph
+ * \brief Simplify the graph and compute self-loop and edge multiplicities.
+ *
+ * </para><para>
+ * This function computes a vertex and edge colored simple graph from the input
+ * graph. The vertex colors are computed as the number of incident self-loops in
+ * the input graph. The edge colors are computed as the number of
+ * parallel edges that were merged to create each edge in the simple graph.
+ *
+ * </para><para>
+ * The resulting colored simple graph is suitable for use by isomorphism checking
+ * algorithms such as VF2, which only support simple graphs, but can consider
+ * vertex and edge colors.
+ *
+ * \param graph The graph object, typically having self-loops or multi-edges.
+ * \param res An uninitialized graph object. The result will be stored here
+ * \param vertex_color Computed vertex colors corresponding to self-loop multiplicities.
+ * \param edge_color Computed edge colors corresponding to edge multiplicities
+ * \return Error code.
+ *
+ * \sa \ref igraph_simplify(), \ref igraph_isomorphic_vf2(), \ref igraph_subisomorphic_vf2()
+ *
+ */
+int igraph_colored_simple_graph(
+        const igraph_t *graph, igraph_t *res,
+        igraph_vector_int_t *vertex_color, igraph_vector_int_t *edge_color)
+{
+  igraph_es_t es;
+  igraph_eit_t eit;
+  igraph_vector_t edges;
+  long int no_of_nodes = igraph_vcount(graph);
+  long int no_of_edges = igraph_ecount(graph);
+  long int pto = -1, pfrom = -1;
+  long int i;
+
+  IGRAPH_CHECK(igraph_es_all(&es, IGRAPH_EDGEORDER_FROM));
+  IGRAPH_FINALLY(igraph_es_destroy, &es);
+  IGRAPH_CHECK(igraph_eit_create(graph, es, &eit));
+  IGRAPH_FINALLY(igraph_eit_destroy, &eit);
+
+  IGRAPH_VECTOR_INIT_FINALLY(&edges, 0);
+  IGRAPH_CHECK(igraph_vector_reserve(&edges, no_of_edges*2));
+
+  IGRAPH_CHECK(igraph_vector_int_resize(vertex_color, no_of_nodes));
+  igraph_vector_int_null(vertex_color);
+
+  IGRAPH_CHECK(igraph_vector_int_resize(edge_color, no_of_edges));
+  igraph_vector_int_null(edge_color);
+
+  i = -1;
+  for (; !IGRAPH_EIT_END(eit); IGRAPH_EIT_NEXT(eit)) {
+    long int edge = IGRAPH_EIT_GET(eit);
+    long int from = IGRAPH_FROM(graph, edge);
+    long int to   = IGRAPH_TO(graph, edge);
+
+    if (to == from) {
+      VECTOR(*vertex_color)[to]++;
+      continue;
+    }
+
+    if (to == pto && from == pfrom) {
+      VECTOR(*edge_color)[i]++;
+    } else {
+      igraph_vector_push_back(&edges, from);
+      igraph_vector_push_back(&edges, to);
+      i++;
+      VECTOR(*edge_color)[i] = 1;      
+    }
+
+    pfrom=from; pto=to;
+  }
+
+  igraph_vector_int_resize(edge_color, i+1);
+
+  igraph_eit_destroy(&eit);
+  igraph_es_destroy(&es);
+  IGRAPH_FINALLY_CLEAN(2);
+
+  IGRAPH_CHECK(igraph_create(res, &edges, no_of_nodes, igraph_is_directed(graph)));
+
+  igraph_vector_destroy(&edges);
+  IGRAPH_FINALLY_CLEAN(1);
+
+  return IGRAPH_SUCCESS;
+}

--- a/src/topology.c
+++ b/src/topology.c
@@ -2983,14 +2983,15 @@ int igraph_isomorphic_bliss(const igraph_t *graph1, const igraph_t *graph2,
 
 
 /**
- * \function igraph_colored_simple_graph
+ * \function igraph_simplify_and_colorize
  * \brief Simplify the graph and compute self-loop and edge multiplicities.
  *
  * </para><para>
- * This function computes a vertex and edge colored simple graph from the input
- * graph. The vertex colors are computed as the number of incident self-loops in
- * the input graph. The edge colors are computed as the number of
- * parallel edges that were merged to create each edge in the simple graph.
+ * This function creates a vertex and edge colored simple graph from the input
+ * graph. The vertex colors are computed as the number of incident self-loops
+ * to each vertex in the input graph. The edge colors are computed as the number of
+ * parallel edges in the input graph that were merged to create each edge
+ * in the simple graph.
  *
  * </para><para>
  * The resulting colored simple graph is suitable for use by isomorphism checking
@@ -3006,7 +3007,7 @@ int igraph_isomorphic_bliss(const igraph_t *graph1, const igraph_t *graph2,
  * \sa \ref igraph_simplify(), \ref igraph_isomorphic_vf2(), \ref igraph_subisomorphic_vf2()
  *
  */
-int igraph_colored_simple_graph(
+int igraph_simplify_and_colorize(
         const igraph_t *graph, igraph_t *res,
         igraph_vector_int_t *vertex_color, igraph_vector_int_t *edge_color)
 {

--- a/tests/topology.at
+++ b/tests/topology.at
@@ -54,6 +54,11 @@ AT_COMPILE_CHECK([simple/isomorphism_test.c],
 		 [simple/isomorphism_test.out])
 AT_CLEANUP
 
+AT_SETUP([Simplify and colorize])
+AT_KEYWORDS([simplify multigraph colorize isomorphism])
+AT_COMPILE_CHECK([tests/simplify_and_colorize.c], [tests/simplify_and_colorize.out])
+AT_CLEANUP
+
 AT_SETUP([Graphical degree sequences])
 AT_KEYWORDS([degree sequence graphical])
 AT_COMPILE_CHECK([simple/igraph_is_degree_sequence.c])


### PR DESCRIPTION
Currently, no included isomorphism algorithm supports multigraphs.

VF2 does not seem to support either self loops (#1166, please verify) or multigraphs (#815)

We can still theoretically deal with multigraphs like so:

 - simplify the graph (no self-loops / multi-edges)
 - colour edges based on their original multiplicity (simple edges get 1, edges merged from two parallel ones get 2, etc.)
 - colour vertices based on how many incident self-loops they had

Now we can use coloured-graph isomorphism (using VF2) to handle the multigraph.

This PR adds a function to do this graph simplification while counting self-loops and multi-edges.

It also rearranges the Isomorphism documentation sections a bit.

Please verify before merging!  It closely follows `igraph_simplify` in its implementation.

Question: In undirected graphs, do edges always appear sorted, i.e. always 1-2 and not 2-1?  `igraph_simplify` seems to rely on this where it checks `to == pto && from == pfrom` but not `to == pfrom && from == pto`.  I did the same in this function