### PR TITLE
Corrected all s-t cuts

### DIFF
--- a/examples/simple/igraph_all_st_cuts.c
+++ b/examples/simple/igraph_all_st_cuts.c
@@ -32,6 +32,37 @@ int igraph_i_all_st_cuts_pivot(const igraph_t *graph,
 			       long int target,
 			       long int *v,
 			       igraph_vector_t *Isv);
+int test_all_st_cuts(const igraph_t *graph,
+             long int source,
+             long int target)
+{
+  igraph_vector_ptr_t cuts, partition1s;
+  long int n, i;
+
+  igraph_vector_ptr_init(&cuts, 0);
+  igraph_vector_ptr_init(&partition1s, 0);
+  igraph_all_st_cuts(graph, &cuts, &partition1s,
+                     source, target);
+
+  n=igraph_vector_ptr_size(&partition1s);
+  printf("Partitions and cuts:\n");
+  for (i=0; i<n; i++) {
+    igraph_vector_t *v=VECTOR(partition1s)[i];
+    igraph_vector_t *v2=VECTOR(cuts)[i];
+    printf("P: ");
+    igraph_vector_print(v);
+    igraph_vector_destroy(v);
+    igraph_free(v);
+    printf("C: ");
+    igraph_vector_print(v2);
+    igraph_vector_destroy(v2);
+    igraph_free(v2);
+  }
+  igraph_vector_ptr_destroy(&partition1s);
+  igraph_vector_ptr_destroy(&cuts);
+
+  return 0;
+}
 
 int main() {
   igraph_t g;
@@ -388,6 +419,23 @@ int main() {
   igraph_vector_ptr_destroy(&cuts);
 
   igraph_destroy(&g);  
+
+  /* -----------------------------------------------------------
+   * Check problematic cases in issue #1102
+   * ----------------------------------------------------------- */
+
+  igraph_small(&g, 4, IGRAPH_DIRECTED,
+          0,1, 1,2, 2,3,
+	       -1);
+  test_all_st_cuts(&g, 0, 2);
+  igraph_destroy(&g);
+
+  igraph_small(&g, 5, IGRAPH_DIRECTED,
+          0,1, 1,2, 2,3, 3,4,
+	       -1);
+  test_all_st_cuts(&g, 0, 2);
+  test_all_st_cuts(&g, 1, 3);
+  igraph_destroy(&g);
 
   return 0;
 }

--- a/examples/simple/igraph_all_st_cuts.out
+++ b/examples/simple/igraph_all_st_cuts.out
@@ -77,3 +77,18 @@ C: 1 2 5 7 9
 C: 1 2 6 7 8
 C: 1 2 7 8 9
 C: 2 3
+Partitions and cuts:
+P: 0
+C: 0
+P: 0 1
+C: 1
+Partitions and cuts:
+P: 0
+C: 0
+P: 0 1
+C: 1
+Partitions and cuts:
+P: 1
+C: 1
+P: 1 2
+C: 2

--- a/src/st-cuts.c
+++ b/src/st-cuts.c
@@ -699,7 +699,7 @@ int igraph_i_all_st_cuts_pivot(const igraph_t *graph,
   igraph_vector_t keep;
   igraph_t domtree;
   igraph_vector_t leftout;
-  long int i, nomin;
+  long int i, nomin, n;
   long int root;
   igraph_vector_t M;
   igraph_vector_bool_t GammaS;
@@ -742,6 +742,12 @@ int igraph_i_all_st_cuts_pivot(const igraph_t *graph,
 				     &leftout, IGRAPH_IN));
   IGRAPH_FINALLY(igraph_destroy, &domtree);
 
+  /* Relabel left out vertices (set K in Provan & Shier) to
+     correspond to node labelling of graph instead of SBar. */
+  n = igraph_vector_size(&leftout);
+  for (i = 0; i < n; i++)
+    VECTOR(leftout)[i] = VECTOR(Sbar_invmap)[(long int)VECTOR(leftout)[i]];
+
   /* -------------------------------------------------------------*/
   /* Identify the set M of minimal elements of Gamma(S) with respect
      to the dominator relation. */
@@ -756,7 +762,7 @@ int igraph_i_all_st_cuts_pivot(const igraph_t *graph,
     for (i=0; i<no_of_nodes; i++) {
       if (igraph_marked_queue_iselement(S, i)) {
 	igraph_vector_t neis;
-	long int j, n;
+	long int j;
 	IGRAPH_VECTOR_INIT_FINALLY(&neis, 0);
 	IGRAPH_CHECK(igraph_neighbors(graph, &neis, (igraph_integer_t) i,
 				      IGRAPH_OUT));


### PR DESCRIPTION
This should fix #1102. The problem was that some vertices were not relabeled while working on a subgraph. I've also added tests to demonstrate that it functions correctly, I believe.

Potentially a similar problem plays also in some of the other `_pivot` functions, I'll have to check. Please wait until I've done so. I just wanted to share this, so that you can check whether this solution works.