### PR TITLE
Limited maximum cardinality search to undirected simple graphs.

### DIFF
--- a/src/decomposition.c
+++ b/src/decomposition.c
@@ -37,7 +37,7 @@
  * hypergraphs, and selectively reduce acyclic hypergraphs.
  * SIAM Journal of Computation 13, 566--579, 1984.
  * 
- * \param graph The input graph. Can be directed, but the direction
+ * \param graph The input graph, which should be undirected and simple.
  *   of the edges is ignored.
  * \param alpha Pointer to an initialized vector, the result is stored here. 
  *   It will be resized, as needed. Upon return it contains
@@ -63,6 +63,18 @@ int igraph_maximum_cardinality_search(const igraph_t *graph,
   long int i;
   igraph_adjlist_t adjlist;
   
+  igraph_bool_t simple;
+
+  if (igraph_is_directed(graph))
+  {
+    IGRAPH_ERROR("Maximum cardinality search works on undirected graphs only", IGRAPH_EINVAL);
+  }
+
+  igraph_is_simple(graph, &simple);
+  if (!simple) {
+    IGRAPH_ERROR("Maximum cardinality search works on simple graphs only", IGRAPH_EINVAL);
+  }
+
   /***************/
   /* local j, v; */
   /***************/

--- a/src/decomposition.c
+++ b/src/decomposition.c
@@ -62,8 +62,13 @@ int igraph_maximum_cardinality_search(const igraph_t *graph,
   igraph_vector_long_t head, next, prev; /* doubly linked list with head */
   long int i;
   igraph_adjlist_t adjlist;
-  
   igraph_bool_t simple;
+
+  /***************/
+  /* local j, v; */
+  /***************/
+  
+  long int j, v;
 
   if (igraph_is_directed(graph))
   {
@@ -74,12 +79,6 @@ int igraph_maximum_cardinality_search(const igraph_t *graph,
   if (!simple) {
     IGRAPH_ERROR("Maximum cardinality search works on simple graphs only", IGRAPH_EINVAL);
   }
-
-  /***************/
-  /* local j, v; */
-  /***************/
-  
-  long int j, v;
   
   if (no_of_nodes == 0) {
     igraph_vector_clear(alpha);


### PR DESCRIPTION
This partially fixes #1029, that is, it ensures that only undirected simple graphs are accepted as input. The underlying problem itself should still be addressed, but this should then be done for 0.9.0.