### PR TITLE
Handle incorrect types supplied to bipartite matching.

### DIFF
--- a/src/matching.c
+++ b/src/matching.c
@@ -362,6 +362,8 @@ int igraph_i_maximum_bipartite_matching_unweighted(const igraph_t* graph,
     n = igraph_vector_size(&neis);
     for (j = 0; j < n; j++) {
       k = (long int) VECTOR(neis)[j];
+      if (VECTOR(*types)[k] == VECTOR(*types)[i])
+        IGRAPH_ERROR("Graph is not bipartite with supplied types vector", IGRAPH_EINVAL);
       if (UNMATCHED(k)) {
         /* We match vertex i to vertex VECTOR(neis)[j] */
         VECTOR(match)[k] = i;
@@ -611,10 +613,12 @@ int igraph_i_maximum_bipartite_matching_weighted(const igraph_t* graph,
     neis = igraph_inclist_get(&inclist, i);
     n = igraph_vector_int_size(neis);
     for (j = 0, k = 0; j < n; j++) {
-      if (VECTOR(*weights)[(long int)VECTOR(*neis)[j]] > max_weight) {
-        k = (long int) VECTOR(*neis)[j];
+      k = (long int) VECTOR(*neis)[j];
+      u = IGRAPH_OTHER(graph, k, i);
+      if (VECTOR(*types)[u] == VECTOR(*types)[i])
+        IGRAPH_ERROR("Graph is not bipartite with supplied types vector", IGRAPH_EINVAL);
+      if (VECTOR(*weights)[k] > max_weight)
         max_weight = VECTOR(*weights)[k];
-      }
     }
 
     VECTOR(labels)[i] = max_weight;

--- a/src/matching.c
+++ b/src/matching.c
@@ -297,8 +297,9 @@ int igraph_maximum_bipartite_matching(const igraph_t* graph,
     }
     return IGRAPH_SUCCESS;
   } else {
-    return igraph_i_maximum_bipartite_matching_weighted(graph, types,
-        matching_size, matching_weight, matching, weights, eps);
+    IGRAPH_CHECK(igraph_i_maximum_bipartite_matching_weighted(graph, types,
+        matching_size, matching_weight, matching, weights, eps));
+    return IGRAPH_SUCCESS;
   }
 }
 


### PR DESCRIPTION
This fixes #1110, by checking whether the graph is correctly bipartite with the supplied labelling. The check is done while performing the matching, instead of checking whether the types are correct beforehand.

I now just realise that this solution goes against our philosophy of doing checks in internal functions (i.e. #1219). Perhaps we should then do a check before passing over to the internal function? The standard `is_bipartite` is not usable, because it actually finds the correct types (if possible), instead of checking whether the supplied types are valid. Perhaps we should then create a `is_valid_bipartite` function instead, to check whether the supplied types are valid?