### PR TITLE
Limited warning when disconnected graph has actually been discovered.

### DIFF
--- a/src/centrality.c
+++ b/src/centrality.c
@@ -2588,11 +2588,11 @@ int igraph_i_closeness_estimate_weighted(const igraph_t *graph,
 
     while (!igraph_2wheap_empty(&Q)) {
       igraph_integer_t minnei=(igraph_integer_t) igraph_2wheap_max_index(&Q);
-      mindist=-igraph_2wheap_delete_max(&Q);
-      
       /* Now check all neighbors of minnei for a shorter path */
       igraph_vector_t *neis=igraph_lazy_inclist_get(&inclist, minnei);
       long int nlen=igraph_vector_size(neis);
+
+      mindist=-igraph_2wheap_delete_max(&Q);
 
       VECTOR(*res)[i] += (mindist - 1.0);
       nodes_reached++;


### PR DESCRIPTION
This fixes #1197, by only issuing a warning when it is actually discovered that a graph is disconnected. So, if `cutoff > 0` , but we still failed to find all nodes within the cutoff, it will issue the warning. If we fail to find all the nodes, but we have reached the cutoff, no warning will be issued.