### PR TITLE
Included NONE again to make a non-MSVC build.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,17 @@
 
-[![](https://travis-ci.org/igraph/igraph.svg?branch=master)](https://travis-ci.org/igraph/igraph)
+[![Build status Linux](https://travis-ci.org/igraph/igraph.svg?branch=master)](https://travis-ci.org/igraph/igraph)
+[![Build status Windows](https://ci.appveyor.com/api/projects/status/github/igraph/igraph?branch=master&svg=true)](https://ci.appveyor.com/project/ntamas/igraph/branch/master)
+
 
 The igraph library
 ------------------
 
-igraph is a library for creating and manipulating graphs. 
+igraph is a library for creating and manipulating graphs.
 It is intended to be as powerful (ie. fast) as possible to enable the
-analysis of large graphs. 
+analysis of large graphs.
 
-See http://igraph.org for installation instructions, 
-and documentation. 
+See http://igraph.org for installation instructions,
+and documentation.
 
 Igraph can also be used from R, see https://github.com/igraph/rigraph,
 and from Python, see https://github.com/igraph/python-igraph

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,6 +21,9 @@ environment:
     -
       PYTHON_VERSION: "3.7"
       CONDA_INSTALL_LOCN: "C:\\Miniconda37-x64"
+    -
+      PYTHON_VERSION: "NONE"
+      CONDA_INSTALL_LOCN: "C:\\Miniconda37-x64"
 
 # We always use a 64-bit machine, but can build x86 distributions
 # with the PYTHON_ARCH variable (which is used by CMD_IN_ENV).


### PR DESCRIPTION
Previously, in #1230 the python environment was renamed. However, the NONE environment was used to create an ordinary build of the source code, i.e. not using MSVC. 

I just wanted to note here that MSVC builds are only necessary for a few versions, as the same MSVC compiler is used for Python 3.5, 3.6 and 3.7. Hence, it is only actually build for Python 3.5, this is correct.