### PR TITLE
Correcting make dist

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -36,7 +36,7 @@ install-info:
 dist-hook:
 	rm -rf `find $(distdir)/examples -type d -name .arch-ids`
 
-MAINTAINERCLEANFILES = Makefile.in
+MAINTAINERCLEANFILES = Makefile.in aclocal.m4
 
 ## to make sure make deb will generate Debian packages
 .PHONY: framework msvc parsersources

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -281,7 +281,8 @@ HEADERS_PRIVATE = atlas-edges.h \
 		scg_headers.h igraph_hacks_internal.h triangles_template.h \
 		triangles_template1.h maximal_cliques_template.h prpack.h \
 		igraph_cliquer.h cliquer/graph.h cliquer/cliquer.h cliquer/misc.h \
-		cliquer/cliquerconf.h cliquer/reorder.h cliquer/set.h
+		cliquer/cliquerconf.h cliquer/reorder.h cliquer/set.h \
+		structural_properties_internal.h
 
 HEADERS_PUBLIC =../include/igraph.h 		../include/igraph_memory.h    \
 		../include/igraph_random.h 	../include/igraph_types.h     \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -23,7 +23,7 @@ TESTSUITE_AT = \
 	other.at foreign.at conversion.at flow.at community.at eigen.at \
 	cliques.at attributes.at arpack.at bipartite.at centralization.at \
 	version.at separators.at hrg.at microscopic.at mt.at random.at scg.at \
-	matching.at qsort.at
+	matching.at qsort.at coloring.at embedding.at
 
 TESTSUITE = testsuite
 


### PR DESCRIPTION
This fixes #1240, that is, the second problem that was noticed, the missing `structural_properties_internal.h` file when running `make dist`.