### PR TITLE
Corrected cleaning

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -36,7 +36,7 @@ install-info:
 dist-hook:
 	rm -rf `find $(distdir)/examples -type d -name .arch-ids`
 
-MAINTAINERCLEANFILES = Makefile.in aclocal.m4
+MAINTAINERCLEANFILES = Makefile.in
 
 ## to make sure make deb will generate Debian packages
 .PHONY: framework msvc parsersources


### PR DESCRIPTION
This reverts commit f777ea7b320faefccda2c3cc703cdbe25bfe80c1.

It turns out that it is not necessary to explicitly add `aclocal.m4` to be removed. One has to run `make maintainer-clean` before regenerating all necessary files using `bootstrap.sh`. This correctly regenerates a configure script that is correctly versioned.