### PR TITLE
Corrected include files

### DIFF
--- a/examples/simple/2wheap.c
+++ b/examples/simple/2wheap.c
@@ -22,7 +22,7 @@
 */
 
 #include <igraph.h>
-#include <igraph_types_internal.h>
+#include "igraph_types_internal.h"
 #include <time.h>
 #include <stdlib.h>
 

--- a/examples/simple/biguint.c
+++ b/examples/simple/biguint.c
@@ -22,8 +22,8 @@
 */
 
 #include <igraph.h>
-#include <igraph_types_internal.h>
-#include <bigint.h>
+#include "igraph_types_internal.h"
+#include "bigint.h"
 
 #include <limits.h>
 

--- a/examples/simple/d_indheap.c
+++ b/examples/simple/d_indheap.c
@@ -22,7 +22,7 @@
 */
 
 #include <igraph.h>
-#include <igraph_types_internal.h>
+#include "igraph_types_internal.h"
 
 int main() {
   

--- a/examples/simple/dqueue.c
+++ b/examples/simple/dqueue.c
@@ -22,7 +22,6 @@
 */
 
 #include <igraph.h>
-#include <igraph_dqueue.h>
 
 int main() {
   

--- a/examples/simple/igraph_all_st_cuts.c
+++ b/examples/simple/igraph_all_st_cuts.c
@@ -22,8 +22,8 @@
 */
 
 #include <igraph.h>
-#include <igraph_marked_queue.h>
-#include <igraph_estack.h>
+#include "igraph_marked_queue.h"
+#include "igraph_estack.h"
 
 int igraph_i_all_st_cuts_pivot(const igraph_t *graph,
 			       const igraph_marked_queue_t *S,

--- a/examples/simple/igraph_hashtable.c
+++ b/examples/simple/igraph_hashtable.c
@@ -22,7 +22,7 @@
 */
 
 #include <igraph.h>
-#include <igraph_types_internal.h>
+#include "igraph_types_internal.h"
 
 int main() {
 

--- a/examples/simple/igraph_i_cutheap.c
+++ b/examples/simple/igraph_i_cutheap.c
@@ -22,7 +22,7 @@
 */
 
 #include <igraph.h>
-#include <igraph_types_internal.h>
+#include "igraph_types_internal.h"
 
 void print_vector(igraph_vector_t *v, FILE *f) {
   long int i;

--- a/examples/simple/igraph_layout_merge.c
+++ b/examples/simple/igraph_layout_merge.c
@@ -22,7 +22,7 @@
 */
 
 #include <igraph.h>
-#include <igraph_types_internal.h>
+#include "igraph_types_internal.h"
 #include <stdlib.h>
 #include <time.h>
 

--- a/examples/simple/igraph_psumtree.c
+++ b/examples/simple/igraph_psumtree.c
@@ -23,7 +23,6 @@
 */
 
 #include <igraph.h>
-#include <igraph_psumtree.h>
 #include <stdlib.h>
 
 int print_vector(igraph_vector_t *v) {

--- a/examples/simple/igraph_set.c
+++ b/examples/simple/igraph_set.c
@@ -22,7 +22,7 @@
 */
 
 #include <igraph.h>
-#include <igraph_types_internal.h>
+#include "igraph_types_internal.h"
 #include <stdlib.h>
 
 void print_set(igraph_set_t *set, FILE *f) {

--- a/examples/simple/igraph_sparsemat.c
+++ b/examples/simple/igraph_sparsemat.c
@@ -22,7 +22,6 @@
 */
 
 #include <igraph.h>
-#include <igraph_sparsemat.h>
 
 int main() {
   

--- a/examples/simple/igraph_sparsemat2.c
+++ b/examples/simple/igraph_sparsemat2.c
@@ -23,9 +23,8 @@
 
 #include <cs/cs.h>
 #include <igraph.h>
-#include <igraph_sparsemat.h>
-#include <igraph_blas_internal.h>
-#include <igraph_arpack_internal.h>
+#include "igraph_blas_internal.h"
+#include "igraph_arpack_internal.h"
 
 int igraph_matrix_dgemv(const igraph_matrix_t *m,
                         const igraph_vector_t *v,

--- a/examples/simple/igraph_sparsemat3.c
+++ b/examples/simple/igraph_sparsemat3.c
@@ -23,7 +23,6 @@
 
 #include <cs/cs.h>
 #include <igraph.h>
-#include <igraph_sparsemat.h>
 
 int permute(const igraph_matrix_t *M, 
 	    const igraph_vector_int_t *p,

--- a/examples/simple/igraph_sparsemat4.c
+++ b/examples/simple/igraph_sparsemat4.c
@@ -23,7 +23,6 @@
 
 #include <cs/cs.h>
 #include <igraph.h>
-#include <igraph_sparsemat.h>
 
 igraph_bool_t check_solution(const igraph_sparsemat_t *A,
 			     const igraph_vector_t *x,

--- a/examples/simple/igraph_sparsemat5.c
+++ b/examples/simple/igraph_sparsemat5.c
@@ -22,7 +22,6 @@
 */
 
 #include <igraph.h>
-#include <igraph_sparsemat.h>
 
 #define EPS 1e-13
 

--- a/examples/simple/igraph_sparsemat6.c
+++ b/examples/simple/igraph_sparsemat6.c
@@ -22,7 +22,6 @@
 */
 
 #include <igraph.h>
-#include <igraph_sparsemat.h>
 
 int main() {
   igraph_matrix_t mat, mat2, mat3;

--- a/examples/simple/igraph_trie.c
+++ b/examples/simple/igraph_trie.c
@@ -23,7 +23,7 @@
 
 #include <stdio.h>
 #include <igraph.h>
-#include <igraph_types_internal.h>
+#include "igraph_types_internal.h"
 
 int main() {
   

--- a/examples/simple/stack.c
+++ b/examples/simple/stack.c
@@ -22,7 +22,6 @@
 */
 
 #include <igraph.h>
-#include <igraph_stack.h>
 
 int main() {
 

--- a/include/igraph.h
+++ b/include/igraph.h
@@ -28,6 +28,10 @@
 # define _GNU_SOURCE 1
 #endif
 
+#ifdef __cplusplus
+extern "C"{
+#endif
+
 #include "igraph_version.h"
 #include "igraph_memory.h"
 #include "igraph_error.h"
@@ -96,5 +100,9 @@
 #include "igraph_epidemics.h"
 #include "igraph_lsap.h"
 #include "igraph_coloring.h"
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif


### PR DESCRIPTION
This PR changes `igraph.h` so that it can be included directly in `C++` without necessitating `extern "C"` (see #1242). 

I have also changed the example/test files to ensure that only `igraph.h` is included instead of any separate headers such as `igraph_sparsemat.h` since they are already included in `igraph.h`. I also changed any non-public headers (e.g. `igraph_types_internal.h`) to be included using `"..."` instead of `<...>` to clarify the difference.