### PR TITLE
Correctly ensure C++ inclusion for each separate header files

### DIFF
--- a/include/igraph.h
+++ b/include/igraph.h
@@ -28,10 +28,6 @@
 # define _GNU_SOURCE 1
 #endif
 
-#ifdef __cplusplus
-extern "C"{
-#endif
-
 #include "igraph_version.h"
 #include "igraph_memory.h"
 #include "igraph_error.h"
@@ -100,9 +96,5 @@ extern "C"{
 #include "igraph_epidemics.h"
 #include "igraph_lsap.h"
 #include "igraph_coloring.h"
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/igraph_cohesive_blocks.h
+++ b/include/igraph_cohesive_blocks.h
@@ -28,10 +28,14 @@
 #include "igraph_vector.h"
 #include "igraph_vector_ptr.h"
 
+__BEGIN_DECLS
+
 int igraph_cohesive_blocks(const igraph_t *graph,
 			   igraph_vector_ptr_t *blocks,
 			   igraph_vector_t *cohesion,
 			   igraph_vector_t *parent,
 			   igraph_t *block_tree);
+
+__END_DECLS
 
 #endif

--- a/include/igraph_lsap.h
+++ b/include/igraph_lsap.h
@@ -6,7 +6,11 @@
 #include "igraph_vector.h"
 #include "igraph_matrix.h"
 
+__BEGIN_DECLS
+
 int igraph_solve_lsap(igraph_matrix_t *c, igraph_integer_t n,
 		      igraph_vector_int_t *p);
+
+__END_DECLS
 
 #endif

--- a/include/igraph_scg.h
+++ b/include/igraph_scg.h
@@ -29,6 +29,8 @@
 #include "igraph_matrix.h"
 #include "igraph_sparsemat.h"
 
+__BEGIN_DECLS
+
 typedef enum { IGRAPH_SCG_SYMMETRIC=1, IGRAPH_SCG_LAPLACIAN=2,
 	       IGRAPH_SCG_STOCHASTIC=3 } igraph_scg_matrix_t;
 
@@ -131,5 +133,7 @@ int igraph_scg_laplacian(const igraph_t *graph,
 			 igraph_matrix_t *R,
 			 igraph_sparsemat_t *Lsparse,
 			 igraph_sparsemat_t *Rsparse);
+
+__END_DECLS
 
 #endif

--- a/include/igraph_sparsemat.h
+++ b/include/igraph_sparsemat.h
@@ -31,6 +31,8 @@
 
 #include <stdio.h>
 
+__BEGIN_DECLS
+
 struct cs_di_sparse;
 struct cs_di_symbolic;
 struct cs_di_numeric;
@@ -277,5 +279,7 @@ int igraph_sparsemat_iterator_idx(const igraph_sparsemat_iterator_t *it);
 igraph_real_t 
 igraph_sparsemat_iterator_get(const igraph_sparsemat_iterator_t *it);
 int igraph_sparsemat_iterator_next(igraph_sparsemat_iterator_t *it);
+
+__END_DECLS
 
 #endif


### PR DESCRIPTION
Previously, in #1244, the entire `igraph.h` was enclosed in `extern C` to ensure that the library could be correctly included in `C++` projects. However, this was not the proper way to solve the issue. The problem (in #1242) was that some include files (among others `igraph_sparsemat.h`) were missing `__BEGIN_DECLS` and `__END_DECLS`. This has now been corrected.