### PR TITLE
Corrected all s-t mincuts

### DIFF
--- a/examples/simple/igraph_all_st_mincuts.c
+++ b/examples/simple/igraph_all_st_mincuts.c
@@ -23,16 +23,30 @@
 
 #include <igraph.h>
 
-int print_and_destroy(igraph_real_t value, 
+int print_and_destroy(igraph_t *g,
+          igraph_real_t value,
 		      igraph_vector_ptr_t *partitions, 
 		      igraph_vector_ptr_t *cuts) {
-  long int i, n=igraph_vector_ptr_size(partitions);
+  long int i,e,m,n=igraph_vector_ptr_size(partitions);
   printf("Found %li cuts, value: %g\n", n, value);
   for (i=0; i<n; i++) {
     igraph_vector_t *vec=VECTOR(*partitions)[i];
     igraph_vector_t *vec2=cuts ? VECTOR(*cuts)[i] : 0;
-    printf("Partition: "); igraph_vector_print(vec);
-    if (vec2) { printf("Cut: "); igraph_vector_print(vec2); }
+    printf("Partition %li: ", i); igraph_vector_print(vec);
+    if (vec2) {
+      printf("Cut %li:\n", i);
+      m = igraph_vector_size(vec2);
+      for (e = 0; e < m; e++)
+      {
+        igraph_integer_t from, to;
+        igraph_edge(g, VECTOR(*vec2)[e], &from, &to);
+        if (igraph_is_directed(g))
+          printf("  %i -> %i\n", from, to);
+        else
+          printf("  %i -- %i\n", from, to);
+      }
+    }
+
     igraph_vector_destroy(vec);
     if (vec2) { igraph_vector_destroy(vec2); }
     igraph_free(vec);
@@ -62,7 +76,7 @@ int main() {
   			/*source=*/ 0, /*target=*/ 4,
   			/*capacity=*/ 0);
   
-  print_and_destroy(value, &partitions, &cuts);
+  print_and_destroy(&g, value, &partitions, &cuts);
   igraph_destroy(&g);
 
   /* ---------------------------------------------------------------- */
@@ -73,7 +87,7 @@ int main() {
   igraph_all_st_mincuts(&g, &value, &cuts, &partitions,
   			/*source=*/ 0, /*target=*/ 5, /*capacity=*/ 0);
 
-  print_and_destroy(value, &partitions, &cuts);
+  print_and_destroy(&g, value, &partitions, &cuts);
   igraph_destroy(&g);
 
   /* ---------------------------------------------------------------- */
@@ -84,7 +98,7 @@ int main() {
   igraph_all_st_mincuts(&g, &value, &cuts, &partitions,
   			/*source=*/ 0, /*target=*/ 4, /*capacity=*/ 0);
 
-  print_and_destroy(value, &partitions, &cuts);
+  print_and_destroy(&g, value, &partitions, &cuts);
   igraph_destroy(&g);
 
   /* ---------------------------------------------------------------- */
@@ -97,7 +111,7 @@ int main() {
   igraph_all_st_mincuts(&g, &value, &cuts, &partitions,
   			/*source=*/ 0, /*target=*/ 3, /*capacity=*/ 0);
 
-  print_and_destroy(value, &partitions, &cuts);
+  print_and_destroy(&g, value, &partitions, &cuts);
   igraph_destroy(&g);
 
   /* ---------------------------------------------------------------- */
@@ -110,7 +124,7 @@ int main() {
   igraph_all_st_mincuts(&g, &value, &cuts, &partitions,
                         /*source=*/ 2, /*target=*/ 0, /*capacity=*/ 0);
 
-  print_and_destroy(value, &partitions, &cuts);
+  print_and_destroy(&g, value, &partitions, &cuts);
   igraph_destroy(&g);
 
   /* ---------------------------------------------------------------- */
@@ -123,8 +137,23 @@ int main() {
   igraph_all_st_mincuts(&g, &value, &cuts, &partitions,
                         /*source=*/ 2, /*target=*/ 0, /*capacity=*/ 0);
 
-  print_and_destroy(value, &partitions, &cuts);
+  print_and_destroy(&g, value, &partitions, &cuts);
+  igraph_destroy(&g);
+
+  /* ---------------------------------------------------------------- */
+  igraph_small(&g, 9, IGRAPH_DIRECTED,
+    0,4,  0,7,  1,6,  2,1,  3,8,  4,0,  4,2,
+    4,5,  5,0,  5,3,  6,7,  7,8,
+    -1);
+
+  igraph_vector_ptr_init(&partitions, 0);
+  igraph_vector_ptr_init(&cuts, 0);
+  igraph_all_st_mincuts(&g, &value, &cuts, &partitions,
+                        /*source=*/ 0, /*target=*/ 8, /*capacity=*/ 0);
+
+  print_and_destroy(&g, value, &partitions, &cuts);
   igraph_destroy(&g);
 
   return 0;
 }
+

--- a/examples/simple/igraph_all_st_mincuts.c
+++ b/examples/simple/igraph_all_st_mincuts.c
@@ -27,7 +27,7 @@ int print_and_destroy(igraph_real_t value,
 		      igraph_vector_ptr_t *partitions, 
 		      igraph_vector_ptr_t *cuts) {
   long int i, n=igraph_vector_ptr_size(partitions);
-  printf("Value: %g\n", value);
+  printf("Found %li cuts, value: %g\n", n, value);
   for (i=0; i<n; i++) {
     igraph_vector_t *vec=VECTOR(*partitions)[i];
     igraph_vector_t *vec2=cuts ? VECTOR(*cuts)[i] : 0;
@@ -40,6 +40,7 @@ int print_and_destroy(igraph_real_t value,
   }  
   igraph_vector_ptr_destroy(partitions);
   if (cuts) { igraph_vector_ptr_destroy(cuts); }
+  printf("\n");
   
   return 0;
 }
@@ -99,6 +100,31 @@ int main() {
   print_and_destroy(value, &partitions, &cuts);
   igraph_destroy(&g);
 
- 
+  /* ---------------------------------------------------------------- */
+  igraph_small(&g, 4, IGRAPH_DIRECTED,
+    1,0, 2,0, 2,1, 3,2,
+    -1);
+
+  igraph_vector_ptr_init(&partitions, 0);
+  igraph_vector_ptr_init(&cuts, 0);
+  igraph_all_st_mincuts(&g, &value, &cuts, &partitions,
+                        /*source=*/ 2, /*target=*/ 0, /*capacity=*/ 0);
+
+  print_and_destroy(value, &partitions, &cuts);
+  igraph_destroy(&g);
+
+  /* ---------------------------------------------------------------- */
+  igraph_small(&g, 4, IGRAPH_DIRECTED,
+    1,0, 2,0, 2,1, 2,3,
+    -1);
+
+  igraph_vector_ptr_init(&partitions, 0);
+  igraph_vector_ptr_init(&cuts, 0);
+  igraph_all_st_mincuts(&g, &value, &cuts, &partitions,
+                        /*source=*/ 2, /*target=*/ 0, /*capacity=*/ 0);
+
+  print_and_destroy(value, &partitions, &cuts);
+  igraph_destroy(&g);
+
   return 0;
 }

--- a/examples/simple/igraph_all_st_mincuts.out
+++ b/examples/simple/igraph_all_st_mincuts.out
@@ -1,42 +1,99 @@
 Found 4 cuts, value: 1
-Partition: 0
-Cut: 0
-Partition: 0 1
-Cut: 1
-Partition: 0 1 2
-Cut: 2
-Partition: 0 1 2 3
-Cut: 3
+Partition 0: 0
+Cut 0:
+  0 -> 1
+Partition 1: 0 1
+Cut 1:
+  1 -> 2
+Partition 2: 0 1 2
+Cut 2:
+  2 -> 3
+Partition 3: 0 1 2 3
+Cut 3:
+  3 -> 4
 
 Found 2 cuts, value: 1
-Partition: 0
-Cut: 0
-Partition: 0 4 3 2 1
-Cut: 5
+Partition 0: 0
+Cut 0:
+  0 -> 1
+Partition 1: 0 4 3 2 1
+Cut 1:
+  4 -> 5
 
 Found 1 cuts, value: 1
-Partition: 0
-Cut: 0
+Partition 0: 0
+Cut 0:
+  0 -> 1
 
 Found 4 cuts, value: 2
-Partition: 0
-Cut: 0 1
-Partition: 0 1 8 7 6 5 4 2
-Cut: 2 3
-Partition: 0 2
-Cut: 0 3
-Partition: 0 2 1 8 7 6 5 4
-Cut: 2 3
+Partition 0: 0
+Cut 0:
+  0 -> 1
+  0 -> 2
+Partition 1: 0 1 8 7 6 5 4
+Cut 1:
+  0 -> 2
+  1 -> 3
+Partition 2: 0 2
+Cut 2:
+  0 -> 1
+  2 -> 3
+Partition 3: 0 2 1 8 7 6 5 4
+Cut 3:
+  1 -> 3
+  2 -> 3
 
 Found 2 cuts, value: 2
-Partition: 2
-Cut: 1 2
-Partition: 2 1
-Cut: 0 1
+Partition 0: 2
+Cut 0:
+  2 -> 0
+  2 -> 1
+Partition 1: 2 1
+Cut 1:
+  1 -> 0
+  2 -> 0
 
 Found 2 cuts, value: 2
-Partition: 2 3
-Cut: 1 2
-Partition: 2 3 1
-Cut: 0 1
+Partition 0: 2 3
+Cut 0:
+  2 -> 0
+  2 -> 1
+Partition 1: 2 3 1
+Cut 1:
+  1 -> 0
+  2 -> 0
+
+Found 8 cuts, value: 2
+Partition 0: 0
+Cut 0:
+  0 -> 4
+  0 -> 7
+Partition 1: 0 4 2 1 6
+Cut 1:
+  0 -> 7
+  4 -> 5
+Partition 2: 0 4 2 1 6 5
+Cut 2:
+  0 -> 7
+  5 -> 3
+Partition 3: 0 4 2 1 6 5 3
+Cut 3:
+  0 -> 7
+  3 -> 8
+Partition 4: 0 7
+Cut 4:
+  0 -> 4
+  7 -> 8
+Partition 5: 0 7 4 2 1 6
+Cut 5:
+  4 -> 5
+  7 -> 8
+Partition 6: 0 7 4 2 1 6 5
+Cut 6:
+  5 -> 3
+  7 -> 8
+Partition 7: 0 7 4 2 1 6 5 3
+Cut 7:
+  3 -> 8
+  7 -> 8
 

--- a/examples/simple/igraph_all_st_mincuts.out
+++ b/examples/simple/igraph_all_st_mincuts.out
@@ -1,4 +1,4 @@
-Value: 1
+Found 4 cuts, value: 1
 Partition: 0
 Cut: 0
 Partition: 0 1
@@ -7,18 +7,36 @@ Partition: 0 1 2
 Cut: 2
 Partition: 0 1 2 3
 Cut: 3
-Value: 1
+
+Found 2 cuts, value: 1
 Partition: 0
 Cut: 0
 Partition: 0 4 3 2 1
 Cut: 5
-Value: 1
+
+Found 1 cuts, value: 1
 Partition: 0
 Cut: 0
-Value: 2
+
+Found 4 cuts, value: 2
 Partition: 0
 Cut: 0 1
+Partition: 0 1 8 7 6 5 4 2
+Cut: 2 3
 Partition: 0 2
 Cut: 0 3
 Partition: 0 2 1 8 7 6 5 4
 Cut: 2 3
+
+Found 2 cuts, value: 2
+Partition: 2
+Cut: 1 2
+Partition: 2 1
+Cut: 0 1
+
+Found 2 cuts, value: 2
+Partition: 2 3
+Cut: 1 2
+Partition: 2 3 1
+Cut: 0 1
+

--- a/src/st-cuts.c
+++ b/src/st-cuts.c
@@ -1185,7 +1185,7 @@ int igraph_i_all_st_mincuts_pivot(const igraph_t *graph,
   const igraph_vector_bool_t *active=data->active;
 
   long int no_of_nodes=igraph_vcount(graph);
-  long int i;
+  long int i,j;
   igraph_vector_t Sbar_map, Sbar_invmap;
   igraph_vector_t keep;
   igraph_t Sbar;
@@ -1239,21 +1239,21 @@ int igraph_i_all_st_mincuts_pivot(const igraph_t *graph,
     /* OK, we found a pivot element. I(S,v) contains all elements
        that can reach the pivot element */
     igraph_vector_t Isv_min;
-    long int isvlen;
     IGRAPH_VECTOR_INIT_FINALLY(&Isv_min, 0);
     *v=(long int) VECTOR(Sbar_invmap)[ (long int) VECTOR(M)[i] ];
     /* TODO: restricted == keep ? */
     IGRAPH_CHECK(igraph_bfs(graph, /*root=*/ (igraph_integer_t) *v,/*roots=*/ 0,
-			    /*mode=*/ IGRAPH_IN, /*unreachable=*/ 0,
-			    /*restricted=*/ &keep, /*order=*/ &Isv_min,
-			    /*rank=*/ 0, /*father=*/ 0, /*pred=*/ 0,
-			    /*succ=*/ 0, /*dist=*/ 0, /*callback=*/ 0,
-			    /*extra=*/ 0));
-    for (isvlen=0; isvlen<no_of_nodes; isvlen++) {
-      if (!IGRAPH_FINITE(VECTOR(Isv_min)[isvlen])) { break; }
+          /*mode=*/ IGRAPH_IN, /*unreachable=*/ 0,
+          /*restricted=*/ &keep, /*order=*/ &Isv_min,
+          /*rank=*/ 0, /*father=*/ 0, /*pred=*/ 0,
+          /*succ=*/ 0, /*dist=*/ 0, /*callback=*/ 0,
+          /*extra=*/ 0));
+    for (j=0; j<no_of_nodes; j++) {
+      igraph_real_t u = VECTOR(Isv_min)[j];
+      if (!IGRAPH_FINITE(u)) { break; }
+      if (!igraph_estack_iselement(T, u))
+        igraph_vector_push_back(Isv, u);
     }
-    igraph_vector_resize(&Isv_min, isvlen);
-    igraph_vector_update(Isv, &Isv_min);
     igraph_vector_destroy(&Isv_min);
     IGRAPH_FINALLY_CLEAN(1);
   }

--- a/src/st-cuts.c
+++ b/src/st-cuts.c
@@ -1232,7 +1232,8 @@ int igraph_i_all_st_mincuts_pivot(const igraph_t *graph,
   nomin=igraph_vector_size(&M);
   for (i=0; i<nomin; i++) {
     long int min=(long int) VECTOR(Sbar_invmap)[ (long int) VECTOR(M)[i] ];
-    if (!igraph_estack_iselement(T, min)) { break; }
+    if (min != target)
+      if (!igraph_estack_iselement(T, min)) { break; }
   }
   if (i!=nomin) {
     /* OK, we found a pivot element. I(S,v) contains all elements

--- a/src/st-cuts.c
+++ b/src/st-cuts.c
@@ -1120,12 +1120,9 @@ int igraph_i_all_st_mincuts_minimal(const igraph_t *Sbar,
   igraph_vector_t indeg;
   long int i, minsize;
   igraph_vector_t neis;
-  igraph_dqueue_t to_visit;
   
   IGRAPH_VECTOR_INIT_FINALLY(&neis, 0);
   IGRAPH_VECTOR_INIT_FINALLY(&indeg, no_of_nodes);
-  IGRAPH_CHECK(igraph_dqueue_init(&to_visit, 0));
-  IGRAPH_FINALLY(igraph_dqueue_destroy, &to_visit);
 
   IGRAPH_CHECK(igraph_degree(Sbar, &indeg, igraph_vss_all(), 
 			     IGRAPH_IN, /*loops=*/ 1));
@@ -1133,22 +1130,18 @@ int igraph_i_all_st_mincuts_minimal(const igraph_t *Sbar,
 #define ACTIVE(x) (VECTOR(*active)[(long int)VECTOR(*invmap)[(x)]])
 #define ZEROIN(x) (VECTOR(indeg)[(x)]==0)
 
-  for (i=0; i<no_of_nodes; i++) {
-    if (!ACTIVE(i) && ZEROIN(i)) {
-      IGRAPH_CHECK(igraph_dqueue_push(&to_visit, i));
-    }
-    while (!igraph_dqueue_empty(&to_visit)) {
-      long int rv=(long int) igraph_dqueue_pop(&to_visit);
+  for (i=0; i<no_of_nodes; i++)
+  {
+    if (!ACTIVE(i))
+    {
       long int j, n;
-      IGRAPH_CHECK(igraph_neighbors(Sbar, &neis, (igraph_integer_t) rv,
-				    IGRAPH_OUT));
+      IGRAPH_CHECK(igraph_neighbors(Sbar, &neis, (igraph_integer_t) i,
+            IGRAPH_OUT));
       n=igraph_vector_size(&neis);
-      for (j=0; j<n; j++) {
-	long int nei=(long int) VECTOR(neis)[j];
-	VECTOR(indeg)[nei] -= 1;
-	if (VECTOR(indeg)[nei] == 0) {
-	  IGRAPH_CHECK(igraph_dqueue_push(&to_visit, nei));
-	}
+      for (j=0; j<n; j++)
+      {
+        long int nei=(long int) VECTOR(neis)[j];
+        VECTOR(indeg)[nei] -= 1;
       }
     }
   }
@@ -1168,7 +1161,6 @@ int igraph_i_all_st_mincuts_minimal(const igraph_t *Sbar,
 #undef ACTIVE
 #undef ZEROIN
   
-  igraph_dqueue_destroy(&to_visit);
   igraph_vector_destroy(&indeg);
   igraph_vector_destroy(&neis);
   IGRAPH_FINALLY_CLEAN(3);

--- a/src/st-cuts.c
+++ b/src/st-cuts.c
@@ -1252,7 +1252,7 @@ int igraph_i_all_st_mincuts_pivot(const igraph_t *graph,
       igraph_real_t u = VECTOR(Isv_min)[j];
       if (!IGRAPH_FINITE(u)) { break; }
       if (!igraph_estack_iselement(T, u))
-        igraph_vector_push_back(Isv, u);
+        IGRAPH_CHECK(igraph_vector_push_back(Isv, u));
     }
     igraph_vector_destroy(&Isv_min);
     IGRAPH_FINALLY_CLEAN(1);

--- a/src/st-cuts.c
+++ b/src/st-cuts.c
@@ -1443,6 +1443,7 @@ int igraph_all_st_mincuts(const igraph_t *graph, igraph_real_t *value,
     VECTOR(revmap_ptr)[id]=i+1;
   }
   
+  /* Create partitions in original graph */
   nocuts=igraph_vector_ptr_size(&closedsets);
   igraph_vector_ptr_clear(mypartition1s);
   IGRAPH_CHECK(igraph_vector_ptr_reserve(mypartition1s, nocuts));
@@ -1473,6 +1474,7 @@ int igraph_all_st_mincuts(const igraph_t *graph, igraph_real_t *value,
   igraph_vector_ptr_destroy(&closedsets);
   IGRAPH_FINALLY_CLEAN(3);
 
+  /* Create cuts in original graph */
   if (cuts) {
     igraph_vector_long_t memb;
     IGRAPH_CHECK(igraph_vector_long_init(&memb, no_of_nodes));
@@ -1492,11 +1494,13 @@ int igraph_all_st_mincuts(const igraph_t *graph, igraph_real_t *value,
 	VECTOR(memb)[vtx]=i+1;
       }
       for (j=0; j<no_of_edges; j++) {
-	long int from=IGRAPH_FROM(graph, j);
-	long int to=IGRAPH_TO(graph, j);
-	if (VECTOR(memb)[from] == i+1 && VECTOR(memb)[to] != i+1) {
-	  IGRAPH_CHECK(igraph_vector_push_back(v, j)); /* TODO: allocation */
-	}
+        if (VECTOR(flow)[j] > 0) {
+          long int from=IGRAPH_FROM(graph, j);
+          long int to=IGRAPH_TO(graph, j);
+          if (VECTOR(memb)[from] == i+1 && VECTOR(memb)[to] != i+1) {
+            IGRAPH_CHECK(igraph_vector_push_back(v, j)); /* TODO: allocation */
+          }
+        }
       }
       VECTOR(*cuts)[i] = v;
       IGRAPH_FINALLY_CLEAN(1);


### PR DESCRIPTION
This fixes #1235 I believe.

There seemed to have been two problems. In [Provan & Shier (1996)](10.1007/s004539900020) there are two ingredients that seemed to have gone wrong in the implementation.
1. In Eq. (3.8a) effectively the target node `t` is excluded as a pivot element `v`. This was not implemented. I must admit that Eq. (3.8a) is also a bit strangely written, since only pivot elements `v` of indegree 0 are admitted, and so `t` can never reach `v`, hence the latter condition of (3.8a) only holds for the case that `v==t`.
2. It seemed that the following sentence was wrongly interpreted: "After this preprocessing has been done, the set M0 can be found by successively removing vertices of indegree 0 in G3" (p. 365). I believe the "succesive" here refers to the fact that we repeatedly need to find the set M0. It was now programmed to succesively remove vertices of indegree 0 for simply finding M0. I have corrected this.

Finally, it seemed that for one example included in the test, the results were actually already incorrect. Because the expected output was incorrect, this was of course not noted previously. I believe this is now also corrected.