### PR TITLE
Documentation: Spell check intro

### DIFF
--- a/doc/basicigraph.xxml
+++ b/doc/basicigraph.xxml
@@ -21,7 +21,7 @@ the graph is directed or undirected.
 
 <para>
 Like the edges, the &igraph; vertices are also
-labeled by number between zero and the number of vertices minus one. 
+labeled by numbers between zero and the number of vertices minus one. 
 So, to summarize, a directed graph can be imagined like this:
 <informalexample>
 <programlisting>

--- a/doc/introduction.xml
+++ b/doc/introduction.xml
@@ -8,28 +8,27 @@
 <title>Introduction</title>
 
 <para>
-This is another library for creating and manipulating graphs.
-You can look at it two ways: first, igraph contains the implementation
-of quite a lot graph algorithms. These include classic graph
+igraph is a library for creating and manipulating graphs.
+You can look at it in two ways: first, igraph contains the implementation
+of quite a lot of graph algorithms. These include classic graph
 algorithms like graph isomorphism, graph girth and connectivity and
 also the new wave graph algorithms like transitivity, graph motifs and 
 community structure detection. Skim through the table of contents
-or the index of this book to get an impression.</para>
+or the index of this book to get an impression of what is available.</para>
 
 <para>
-Second, igraph provides a platform for the developing and/or
-implementing graph algorithms. It has a quite efficient data structure
-for representing graphs and a number of other data structures like
-flexible vectors, stacks, heaps, queues, adjacency lists to accomplish
-this. In fact these data structures evolved along the
+Second, igraph provides a platform for developing and/or
+implementing graph algorithms. It has an efficient data structure
+for representing graphs, and a number of other data structures like
+flexible vectors, stacks, heaps, queues, adjacency lists that are useful for implementing graph algorthms. In fact these data structures evolved along with the
 implementation of the classic and non-classic graph algorithms which
-make up the major part of the igraph library. This way they were fine tuned
+make up the major part of the igraph library. This way, they were fine-tuned
 and checked for correctness several times.
 </para>
 
 <para>
 Our main goal with developing igraph was to create a graph library
-which is efficient on large but not extremely large graphs. More
+which is efficient on large, but not extremely large graphs. More
 precisely, it is assumed that the graph(s) fit into the physical
 memory of the computer. Nowadays this means graphs with
 several million vertices and/or edges. Our definition of efficient is
@@ -38,18 +37,17 @@ that it runs fast, both in theory and (more importantly) in practice.
 
 <para>
 We believe that one of the big strengths of igraph is that it can be
-embedded into a higher level language or environment. Two such
-embeddings (or interfaces if you look at them the other way)
-are currently being developed by us: igraph as a GNU R
-package and igraph as a Python extension module. A third embedding,
-being developed by another developer is a Ruby extension. Other are
-likely to come. The high level languages as R or Python make it
-possible to do use graph routines with mush greater comfort, without
+embedded into a higher-level language or environment. Three such
+embeddings (or interfaces if you look at them another way)
+are currently being developed by us: an R
+package, a Python extension module, and a Mathematica (Wolfram Language) package. Others are
+likely to come. High level languages such as R or Python make it
+possible to use graph routines with much greater comfort, without
 actually writing a single line of C code. They have some, usually very
-small, speed penalty compared to the C version, but add ease and much
-flexibility. This manual however covers only the C library. If you 
-want to use Python or GNU R, please see the documentation written
-specifically for these interfaces and come back here only if you're
+small, speed penalty compared to the C version, but add ease of use and much
+flexibility. This manual, however, covers only the C library. If you 
+want to use Python, R or the Wolfram Language, please see the documentation written
+specifically for these interfaces and come back here only if you are
 interested in some detail which is not covered in those documents.
 </para>
 
@@ -64,7 +62,7 @@ to add and what to improve.
 <para>
 igraph is open source and distributed under the terms of the GNU GPL.
 We strongly believe that all the algorithms used in science, let that
-be graph theory or not, should have an efficient open source
+be graph theory or not, should have an efficient open-source
 implementation allowing use and modification for anyone.
 </para>
 
@@ -72,7 +70,7 @@ implementation allowing use and modification for anyone.
 <para>
     igraph library
 </para><para>
-    Copyright (C) 2003-2012  Gabor Csardi &lt;csardi.gabor@gmail.com>
+    Copyright (C) 2003-2012  Gábor Csardi &lt;csardi.gabor@gmail.com>
     334 Harvard st, Cambridge MA, 02139, USA
 </para><para>
     This program is free software; you can redistribute it and/or modify

--- a/doc/tutorial.xml
+++ b/doc/tutorial.xml
@@ -65,7 +65,7 @@ library file itself, usually a file called
 <filename>libigraph.so</filename>, <filename>libigraph.a</filename> or
 <filename>igraph.dll</filename>. 
 It your system has the <command>pkg-config</command> utility you are
-likely to get the neccessary compile options by issuing the command
+likely to get the necessary compile options by issuing the command
 <programlisting>
 pkg-config --libs --cflags igraph
 </programlisting>
@@ -94,7 +94,7 @@ LD_PRELOAD=/home/user/libs/igraph/libigraph.so ./igraph_test
 Please note that <envar>LD_PRELOAD</envar> and
 <envar>LD_LIBRARY_PATH</envar> are usually available only on
 Un*x-like systems. On Windows using Cygwin it is usually enough to set the
-<envar>PATH</envar> enviroment variable to include the folder in which
+<envar>PATH</envar> environment variable to include the folder in which
 the <command>igraph</command> library is installed, look for the 
 <filename>cygigraph-0.dll</filename> or similar file.
 </para>
@@ -104,7 +104,7 @@ the <command>igraph</command> library is installed, look for the
 
 <para>
 The functions generating graph objects are called graph
-generators. Stochastic (=randomized) graph generators are called
+generators. Stochastic (i.e. randomized) graph generators are called
 <quote>games</quote>.
 </para>
 
@@ -114,7 +114,7 @@ generators are able to create both types of graphs and most other
 functions are usually also capable of handling
 both. Eg. <link linkend="igraph_shortest_paths"><function>igraph_shortest_paths()</function></link>
 which (surprisingly) calculates
-shortest paths from a vertex to another vertices can calculate
+shortest paths from a vertex to other vertices can calculate
 directed or undirected paths.
 </para>
 
@@ -176,7 +176,7 @@ This example illustrates some new points. <command>igraph</command> uses
 instead of plain C arrays. <type>igraph_vector_t</type> is superior to
 regular arrays in almost every sense. Vectors are created by the
 <link linkend="igraph_vector_init"><function>igraph_vector_init()</function></link>
-function and like graphs they should be destroyed if not 
+function and, like graphs, they should be destroyed if not 
 needed any more by calling 
 <link linkend="igraph_vector_destroy"><function>igraph_vector_destroy()</function></link>
 on them. A vector can be indexed by the 
@@ -189,7 +189,7 @@ vector resize it to the size of the result.
 <para>
 <link linkend="igraph_lattice"><function>igraph_lattice()</function></link>
 takes a vector argument specifying the dimensions of 
-the lattice, in this example we generate a 30x30 two dimensional
+the lattice. In this example we generate a 30x30 two dimensional
 lattice. See the documentation of
 <link linkend="igraph_lattice"><function>igraph_lattice()</function></link> in
 the reference manual for the other arguments.
@@ -305,7 +305,7 @@ it to be able to hold the result.
 The <constant>igraph_vss_all()</constant> argument tells the functions to
 calculate the property for every vertex in the graph, it is shorthand
 for a <emphasis>vertex selector</emphasis> (<type>igraph_vs_t</type>). 
-Vertex selectors help performing operations on a subset of vertices,
+Vertex selectors help to perform operations on a subset of vertices,
 you can read more about them in <link linkend="igraph-Iterators">one
 of the following chapters.</link>
 </para>


### PR DESCRIPTION
Fixed some language/spelling in the introduction to the documentation.

Removed mention of the Ruby interface, as it seems dead.

Added mention of the Mathematica interface.

