### PR TITLE
Motifs: check size of cut probability vector

### DIFF
--- a/src/motifs.c
+++ b/src/motifs.c
@@ -222,6 +222,12 @@ int igraph_motifs_randesu_callback(const igraph_t *graph, int size,
     IGRAPH_ERROR("Only 3 and 4 vertex motifs are implemented",
 		 IGRAPH_EINVAL);
   }
+
+  if (igraph_vector_size(cut_prob) < size) {
+    IGRAPH_ERROR("The size of the cut probability vector must not be smaller than the motif size.",
+                 IGRAPH_EINVAL);
+  }
+
   if (size==3) {
     mul=3;
     if (igraph_is_directed(graph)) {


### PR DESCRIPTION
This will check that the size of the cut probability vector is not smaller than the motif size (which, as far as I could tell, would result in an out-of-bounds access even though it never crashed for me).

For convenience reason, and also so that we do not have to modify the tests, I still allow longer `cut_prob` vectors than the motif size.

I opted not to check that the probabilities are all `0 <= p <= 1`. Values < 0 or > 1 are effectively treated as 0 and 1, but I think they won't cause trouble.