### PR TITLE
Corrected test code and example code for Leiden algorithm.

### DIFF
--- a/examples/simple/igraph_community_leiden.c
+++ b/examples/simple/igraph_community_leiden.c
@@ -39,14 +39,19 @@ int main() {
 	       5,6,5,7,5,8,5,9, 6,7,6,8,6,9, 7,8,7,9, 8,9,
            0,5, -1);
 
-  /* Initialize with singleton partition. */
-  igraph_vector_init_seq(&membership, 0, igraph_vcount(&graph) - 1);  
-  nb_clusters = igraph_vcount(&graph);
-
   /* Perform Leiden algorithm using CPM */
-  igraph_community_leiden(&graph, NULL, NULL, 0.05, 0.01, &membership, &nb_clusters, &quality);
+  igraph_vector_init(&membership, igraph_vcount(&graph));
+  igraph_community_leiden(&graph, NULL, NULL, 0.05, 0.01, 0, &membership, &nb_clusters, &quality);
 
   printf("Leiden found %i clusters using CPM (resolution parameter 0.05), quality is %.4f.\n", nb_clusters, quality);
+  printf("Membership: ");
+  igraph_vector_print(&membership);
+  printf("\n");
+
+  /* Start from existing membership to improve it further */
+  igraph_community_leiden(&graph, NULL, NULL, 0.05, 0.01, 1, &membership, &nb_clusters, &quality);
+
+  printf("Iterated Leiden, using CPM (resolution parameter 0.05), quality is %.4f.\n", nb_clusters, quality);
   printf("Membership: ");
   igraph_vector_print(&membership);
   printf("\n");
@@ -54,14 +59,9 @@ int main() {
   /* Initialize degree vector to use for optimizing modularity */
   igraph_vector_init(&degree, igraph_vcount(&graph));
   igraph_degree(&graph, &degree, igraph_vss_all(), IGRAPH_ALL, 1);
-  
-  /* Initialize with singleton partition. */
-  for (i = 0; i < igraph_vcount(&graph); i++)
-    VECTOR(membership)[i] = i;
-  nb_clusters = igraph_vcount(&graph);
 
   /* Perform Leiden algorithm using modularity */
-  igraph_community_leiden(&graph, NULL, &degree, 1.0/(2*igraph_ecount(&graph)), 0.01, &membership, &nb_clusters, &quality);
+  igraph_community_leiden(&graph, NULL, &degree, 1.0/(2*igraph_ecount(&graph)), 0.01, 0, &membership, &nb_clusters, &quality);
 
   printf("Leiden found %i clusters using modularity, quality is %.4f.\n", nb_clusters, quality);
   printf("Membership: ");

--- a/examples/tests/igraph_community_leiden.c
+++ b/examples/tests/igraph_community_leiden.c
@@ -48,17 +48,24 @@ void run_leiden_modularity(igraph_t *graph, igraph_vector_t *edge_weights) {
   igraph_vector_t membership, degree;
   igraph_integer_t nb_clusters = igraph_vcount(graph);
   igraph_real_t quality;
+  igraph_real_t m;
 
   igraph_vector_init(&degree, igraph_vcount(graph));
   if (edge_weights)
+  {
     igraph_strength(graph, &degree, igraph_vss_all(), IGRAPH_ALL, 1, edge_weights);
+    m = igraph_vector_sum(edge_weights);
+  }
   else
+  {
     igraph_degree(graph, &degree, igraph_vss_all(), IGRAPH_ALL, 1);
+    m = (igraph_real_t)igraph_ecount(graph);
+  }
   
   /* Initialize with singleton partition. */
   igraph_vector_init(&membership, igraph_vcount(graph));
 
-  igraph_community_leiden(graph, edge_weights, &degree, 1.0/(2*igraph_ecount(graph)), 0.01, 0, &membership, &nb_clusters, &quality);
+  igraph_community_leiden(graph, edge_weights, &degree, 1.0/(2*m), 0.01, 0, &membership, &nb_clusters, &quality);
 
   if(isnan(quality))
     printf("Leiden found %i clusters using modularity, quality is nan.\n", nb_clusters);

--- a/examples/tests/igraph_community_leiden.out
+++ b/examples/tests/igraph_community_leiden.out
@@ -1,14 +1,14 @@
 Leiden found 2 clusters using modularity, quality is 0.4524.
 Membership: 0 0 0 0 0 1 1 1 1 1
 
-Leiden found 2 clusters using modularity, quality is -0.0476.
+Leiden found 2 clusters using modularity, quality is 0.4524.
 Membership: 0 0 0 0 0 1 1 1 1 1
 
 Leiden found 2 clusters using modularity, quality is 0.1797.
 Membership: 0 0 1 1 1 1
 
-Leiden found 4 clusters using modularity, quality is -0.7861.
-Membership: 0 1 2 3 3 3
+Leiden found 2 clusters using modularity, quality is 0.1709.
+Membership: 0 0 0 1 1 1
 
 Leiden found 4 clusters using modularity, quality is 0.4188.
 Membership: 0 0 0 0 1 1 1 0 2 0 1 0 0 0 2 2 1 0 2 0 2 0 2 3 3 3 2 3 3 2 2 3 2 2
@@ -19,8 +19,8 @@ Membership: 0 0 0 0 0 0 0 0 1 0 0 0 0 0 1 1 0 0 1 0 1 0 1 1 1 1 1 1 1 1 1 1 1 1
 Leiden found 3 clusters using modularity, quality is 0.5000.
 Membership: 0 0 0 0 1 1 1 1 2
 
-Leiden found 4 clusters using modularity, quality is 0.5500.
-Membership: 0 0 0 0 0 1 1 1 1 1 2 2 3 3 3 3 3 2 2 2
+Leiden found 4 clusters using modularity, quality is 0.5450.
+Membership: 0 0 0 0 0 1 1 1 1 1 2 2 2 3 3 3 3 2 2 2
 
 Leiden found 2 clusters using CPM (resolution parameter=0.05), quality is 0.7500.
 Membership: 0 0 0 0 0 0 0 0 0 0 1 1 1 1 1 1 1 1 1 1


### PR DESCRIPTION
This addresses the remark by @szhorvat in https://github.com/igraph/igraph/pull/1259#issuecomment-568579654. The `start` parameter also was not yet properly implemented in the example in the documentation.