### PR TITLE
Create .zenodo.json

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,13 @@
+{
+    "title": "igraph",
+    "upload_type": "software",
+    "keywords": [
+        "graph theory",
+        "network analysis"
+    ],
+    "creators": [
+        {
+            "name": "The igraph Development Team"
+        }
+    ]
+}


### PR DESCRIPTION
Zenodo automatically extracts metadata about repositories from GitHub APIs. For example, the authors are determined from the repository's contributor statistics. This automatic extraction is solely a best guess. Therefore it is useful to set certain values explicitly in a `.zenodo.json` files.

This is in preparation for requesting a DOI from Zenodo, which should be set up *before* we create a release. It is creating a release that triggers auto-archiving on Zenodo. At that point Zenodo will take some of the data from this file.