### PR TITLE
Add missing includes and other small fixes

### DIFF
--- a/include/igraph_lapack.h
+++ b/include/igraph_lapack.h
@@ -21,8 +21,8 @@
 
 */
 
-#ifndef LAPACK_H
-#define LAPACK_H
+#ifndef IGRAPH_LAPACK_H
+#define IGRAPH_LAPACK_H
 
 #include "igraph_vector.h"
 #include "igraph_matrix.h"

--- a/include/igraph_neighborhood.h
+++ b/include/igraph_neighborhood.h
@@ -25,6 +25,9 @@
 #define IGRAPH_NEIGHBORHOOD_H
 
 #include "igraph_decls.h"
+#include "igraph_datatype.h"
+#include "igraph_iterators.h"
+#include "igraph_vector_ptr.h"
 
 __BEGIN_DECLS
 

--- a/include/igraph_qsort.h
+++ b/include/igraph_qsort.h
@@ -26,6 +26,8 @@
 
 #include "igraph_decls.h"
 
+#include <stddef.h>
+
 __BEGIN_DECLS
 
 DECLDIR void igraph_qsort(void *base, size_t nel, size_t width,

--- a/src/NetDataTypes.cpp
+++ b/src/NetDataTypes.cpp
@@ -21,7 +21,7 @@
 
 */
 
-/* The original version of this file was written by Jörg Reichardt 
+/* The original version of this file was written by JÃ¶rg Reichardt 
    The original copyright notice follows here */
 
 /***************************************************************************

--- a/src/NetDataTypes.h
+++ b/src/NetDataTypes.h
@@ -21,7 +21,7 @@
 
 */
 
-/* The original version of this file was written by Jörg Reichardt 
+/* The original version of this file was written by JÃ¶rg Reichardt 
    The original copyright notice follows here */
 
 /***************************************************************************

--- a/src/NetRoutines.cpp
+++ b/src/NetRoutines.cpp
@@ -21,7 +21,7 @@
 
 */
 
-/* The original version of this file was written by Jörg Reichardt 
+/* The original version of this file was written by JÃ¶rg Reichardt 
    The original copyright notice follows here */
 
 /***************************************************************************

--- a/src/NetRoutines.h
+++ b/src/NetRoutines.h
@@ -21,7 +21,7 @@
 
 */
 
-/* The original version of this file was written by Jörg Reichardt 
+/* The original version of this file was written by JÃ¶rg Reichardt 
    The original copyright notice follows here */
 
 /***************************************************************************

--- a/src/bigint.h
+++ b/src/bigint.h
@@ -49,6 +49,8 @@
 #include "igraph_pmt_off.h"
 #undef BASE_LIMB
 
+__BEGIN_DECLS
+
 typedef struct igraph_biguint_t {
   igraph_vector_limb_t v;
 } igraph_biguint_t;

--- a/src/community.c
+++ b/src/community.c
@@ -40,6 +40,7 @@
 #include "igraph_types_internal.h"
 #include "igraph_conversion.h"
 #include "igraph_centrality.h"
+#include "igraph_structural.h"
 #include "config.h"
 
 #include <string.h>

--- a/src/community_leiden.c
+++ b/src/community_leiden.c
@@ -30,6 +30,7 @@
 #include "igraph_memory.h"
 #include "igraph_random.h"
 #include "igraph_stack.h"
+#include "igraph_constructors.h"
 
 /* Move nodes in order to improve the quality of a partition.
  *

--- a/src/hrg_graph_simp.h
+++ b/src/hrg_graph_simp.h
@@ -65,6 +65,7 @@
 #include <cstdlib>
 
 #include "hrg_rbtree.h"
+#include "hrg_dendro.h"
 
 using namespace std;
 

--- a/src/igraph_flow_internal.h
+++ b/src/igraph_flow_internal.h
@@ -27,6 +27,7 @@
 #include "igraph_types.h"
 #include "igraph_marked_queue.h"
 #include "igraph_estack.h"
+#include "igraph_datatype.h"
 
 typedef int igraph_provan_shier_pivot_t(const igraph_t *graph,
 					const igraph_marked_queue_t *S,

--- a/src/igraph_gml_tree.h
+++ b/src/igraph_gml_tree.h
@@ -33,11 +33,11 @@
 # define __END_DECLS /* empty */
 #endif
 
-__BEGIN_DECLS
-
 #include "igraph_types.h"
 #include "igraph_vector.h"
 #include "igraph_vector_ptr.h"
+
+__BEGIN_DECLS
 
 typedef enum { IGRAPH_I_GML_TREE_TREE=0, 
 	       IGRAPH_I_GML_TREE_INTEGER,
@@ -84,4 +84,7 @@ const char *igraph_gml_tree_get_string(const igraph_gml_tree_t *t,
 
 igraph_gml_tree_t *igraph_gml_tree_get_tree(const igraph_gml_tree_t *t,
 					    long int pos);
+
+__END_DECLS
+
 #endif

--- a/src/random.c
+++ b/src/random.c
@@ -238,7 +238,8 @@ const igraph_rng_type_t igraph_rngtype_glibc2 = {
   /* get_norm= */  0,
   /* get_geom= */  0,
   /* get_binom= */ 0,
-  /* get_exp= */   0
+  /* get_exp= */   0,
+  /* get_gamma= */ 0
 };
 
 /* ------------------------------------ */
@@ -314,7 +315,8 @@ const igraph_rng_type_t igraph_rngtype_rand = {
   /* get_norm= */  0,
   /* get_geom= */  0,
   /* get_binom= */ 0,
-  /* get_exp= */   0
+  /* get_exp= */   0,
+  /* get_gamma= */ 0
 };
 
 /* ------------------------------------ */
@@ -467,7 +469,8 @@ const igraph_rng_type_t igraph_rngtype_mt19937 = {
   /* get_norm= */  0,
   /* get_geom= */  0,
   /* get_binom= */ 0,
-  /* get_exp= */   0
+  /* get_exp= */   0,
+  /* get_gamma= */ 0
 };
 
 #undef N

--- a/src/structural_properties_internal.h
+++ b/src/structural_properties_internal.h
@@ -26,6 +26,7 @@
 
 #include "igraph_constants.h"
 #include "igraph_types.h"
+#include "igraph_iterators.h"
 
 int igraph_i_induced_subgraph_suggest_implementation(
     const igraph_t *graph, const igraph_vs_t vids,


### PR DESCRIPTION
This PR adds some missing includes to get rid of `implicit-function-declaration` warnings and to make IDEs be happier when editing igraph source files.

There are also a few other minor changes:

 - re-encode some files to UTF-8 from ISO-Latin-1
 - change `LAPACK_H` header guard to `IGRAPH_LAPACK_H` (as `LAPACK_H` is too likely to be encountered in other projects)
 - Add some missing `__BEGIN_DECL` or `__END_DECL`
 - Add missing entries for `igraph_rng_type_t` structs