### PR TITLE
Correct compilation on Windows, including test

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -65,9 +65,9 @@ msvc: parsersources
 	cp -r $(top_srcdir)/include/*.h $(top_builddir)/igraph-$(VERSION)-msvc/include
 	if [ "x$(top_srcdir)" != "x$(top_builddir)" ]; then cp -r $(top_builddir)/include $(top_builddir)/src $(top_builddir)/igraph-$(VERSION)-msvc; fi
 	cp -r $(top_srcdir)/msvc/include $(top_builddir)/igraph-$(VERSION)-msvc/winclude
-	find $(top_builddir)/igraph-$(VERSION)-msvc/src -type d \( -name .deps -o -name .libs \) | xargs rm -rf
-	find $(top_builddir)/igraph-$(VERSION)-msvc/src -type f \( -name '*.o' -o -name '*.lo' -o -name '*.la' \) | xargs rm
-	find $(top_builddir)/igraph-$(VERSION)-msvc/src -type f \( -name 'Makefile*' -o -name '.dirstamp' \) | xargs rm
+	find $(top_builddir)/igraph-$(VERSION)-msvc/src -type d \( -name .deps -o -name .libs \) | xargs -r rm -rf
+	find $(top_builddir)/igraph-$(VERSION)-msvc/src -type f \( -name '*.o' -o -name '*.lo' -o -name '*.la' \) | xargs -r rm
+	find $(top_builddir)/igraph-$(VERSION)-msvc/src -type f \( -name 'Makefile*' -o -name '.dirstamp' \) | xargs -r rm
 	rm -rf $(top_builddir)/igraph-$(VERSION)-msvc/src/config.h
 	rm -rf $(top_builddir)/igraph-$(VERSION)-msvc/src/*~
 	rm -rf $(top_builddir)/igraph-$(VERSION)-msvc/include/*~
@@ -80,5 +80,5 @@ msvc: parsersources
 	cp -r $(top_srcdir)/msvc/igraphtest $(top_builddir)/igraph-$(VERSION)-msvc/test
 	rm -rf igraph-$(VERSION)-msvc.zip
 	zip -q -r igraph-$(VERSION)-msvc.zip igraph-$(VERSION)-msvc
-    
+
 CLEANFILES=


### PR DESCRIPTION
This is intended to fix #1287. This corrects some aspects related to the `make msvc` command, which failed if there were no files yet in the `igraph-*-msvc` directory.

I still intend to look at compiling with `libxml` support, so please do not merge yet.

Another issue that I preferably would like to correct in this PR is to automatically include the `-DMSDOS` flag when compiling using MinGW.
