### PR TITLE
Documentation fixes and reshuffling

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -147,7 +147,7 @@ foreign.xml: foreign.xxml $(SRCDIR)/foreign.c $(SRCDIR)/foreign-graphml.c
 	$(SRCDIR)/foreign-graphml.c
 
 nongraph.xml: nongraph.xxml $(SRCDIR)/other.c $(SRCDIR)/random.c $(SRCDIR)/version.c $(INCLUDEDIR)/igraph_nongraph.h
-	$(DOXROX) -t $< -e $(REGEX) -o $@ $(INCLUDEDIR)/igraph_nongraph.h $(SRCDIR)/other.c $(SRCDIR)/random.c $(SRCDIR)/version.c
+	$(DOXROX) -t $< -e $(REGEX) -o $@ $(INCLUDEDIR)/igraph_nongraph.h $(SRCDIR)/other.c $(SRCDIR)/random.c $(SRCDIR)/version.c $(SRCDIR)/dotproduct.c
 
 isomorphism.xml: isomorphism.xxml $(SRCDIR)/topology.c $(INCLUDEDIR)/igraph_topology.h $(SRCDIR)/bliss.cc $(SRCDIR)/lad.c
 	$(DOXROX) -c -t $< -e $(REGEX) -o $@ $(SRCDIR)/topology.c $(INCLUDEDIR)/igraph_topology.h $(SRCDIR)/bliss.cc $(SRCDIR)/lad.c

--- a/doc/community.xxml
+++ b/doc/community.xxml
@@ -9,6 +9,7 @@
 
 <section><title>Common functions related to community structure</title>
 <!-- doxrox-include igraph_modularity -->
+<!-- doxrox-include igraph_modularity_matrix -->
 <!-- doxrox-include igraph_community_optimal_modularity -->
 <!-- doxrox-include igraph_community_to_membership -->
 <!-- doxrox-include igraph_reindex_membership -->

--- a/doc/embedding.xxml
+++ b/doc/embedding.xxml
@@ -9,7 +9,8 @@
 
 <section><title>Functions</title>
 <!-- doxrox-include igraph_adjacency_spectral_embedding -->
-<!-- doxroc-include igraph_dim_select -->
+<!-- doxrox-include igraph_laplacian_spectral_embedding -->
+<!-- doxrox-include igraph_dim_select -->
 </section>
 
 </chapter>

--- a/doc/flows.xxml
+++ b/doc/flows.xxml
@@ -21,6 +21,7 @@
 <!-- doxrox-include igraph_all_st_mincuts -->
 <!-- doxrox-include igraph_mincut -->
 <!-- doxrox-include igraph_mincut_value -->
+<!-- doxrox-include igraph_gomory_hu_tree -->
 </section>
 
 <section><title>Connectivity</title>

--- a/doc/generators.xxml
+++ b/doc/generators.xxml
@@ -55,7 +55,7 @@
 <!-- doxrox-include igraph_recent_degree_game -->
 <!-- doxrox-include igraph_barabasi_aging_game -->
 <!-- doxrox-include igraph_recent_degree_aging_game -->
-<!---doxrox-include igraph_lastcit_game -->
+<!-- doxrox-include igraph_lastcit_game -->
 <!-- doxrox-include igraph_cited_type_game -->
 <!-- doxrox-include igraph_citing_cited_type_game -->
 <!-- doxrox-include igraph_sbm_game -->
@@ -63,11 +63,9 @@
 <!-- doxrox-include igraph_hsbm_list_game -->
 <!-- doxrox-include igraph_dot_product_game -->
 <!-- doxrox-include igraph_tree_game -->
-<!-- doxrox-include igraph_sample_sphere_surface -->
-<!-- doxrox-include igraph_sample_sphere_volume -->
-<!-- doxrox-include igraph_sample_dirichlet -->
 <!-- doxrox-include igraph_correlated_game -->
 <!-- doxrox-include igraph_correlated_pair_game -->
+<!-- doxrox-include igraph_simple_interconnected_islands_game -->
 </section>
 
 </chapter>

--- a/doc/nongraph.xxml
+++ b/doc/nongraph.xxml
@@ -7,7 +7,7 @@
 <chapter id="igraph-Nongraph">
 <title>Not Graph Related Functions </title>
 
-<section><title>Igraph version number</title>
+<section><title>Igraph Version Number</title>
 <!-- doxrox-include igraph_version -->
 </section>
 
@@ -19,11 +19,17 @@
 <!-- doxrox-include igraph_random_sample -->
 </section>
 
-<section><title>Convex hull of a set of points on a plane</title>
+<section><title>Random Sampling of Spatial Points</title>
+<!-- doxrox-include igraph_sample_sphere_surface -->
+<!-- doxrox-include igraph_sample_sphere_volume -->
+<!-- doxrox-include igraph_sample_dirichlet -->
+</section>
+
+<section><title>Convex Hull of A Set of Points on A Plane</title>
 <!-- doxrox-include igraph_convex_hull -->
 </section>
 
-<section><title>Fitting power-law distributions to empirical data</title>
+<section><title>Fitting Power-law Distributions to Empirical Data</title>
 <!-- doxrox-include igraph_plfit_result_t -->
 <!-- doxrox-include igraph_power_law_fit -->
 </section>

--- a/doc/random.xxml
+++ b/doc/random.xxml
@@ -30,6 +30,7 @@
 <!-- doxrox-include igraph_rng_get_normal -->
 <!-- doxrox-include igraph_rng_get_geom -->
 <!-- doxrox-include igraph_rng_get_binom -->
+<!-- doxrox-include igraph_rng_get_gamma -->
 </section>
 
 <section><title>Supported random number generators</title>

--- a/src/dotproduct.c
+++ b/src/dotproduct.c
@@ -117,10 +117,10 @@ int igraph_dot_product_game(igraph_t *graph, const igraph_matrix_t *vecs,
  * \param n The number of vectors to sample.
  * \param radius Radius of the sphere, it must be positive.
  * \param positive Whether to restrict sampling to the positive
- *    orthant.}
+ *    orthant.
  * \param res Pointer to an initialized matrix, the result is
  *    stored here, each column will be a sampled vector. The matrix is
- *    resized, as needed.}
+ *    resized, as needed.
  * \return Error code.
  *
  * Time complexity: O(n*dim*g), where g is the time complexity of
@@ -184,10 +184,10 @@ int igraph_sample_sphere_surface(igraph_integer_t dim, igraph_integer_t n,
  * \param n The number of vectors to sample.
  * \param radius Radius of the sphere, it must be positive.
  * \param positive Whether to restrict sampling to the positive
- *    orthant.}
+ *    orthant.
  * \param res Pointer to an initialized matrix, the result is
  *    stored here, each column will be a sampled vector. The matrix is
- *    resized, as needed.}
+ *    resized, as needed.
  * \return Error code.
  *
  * Time complexity: O(n*dim*g), where g is the time complexity of

--- a/src/embedding.c
+++ b/src/embedding.c
@@ -987,7 +987,7 @@ int igraph_i_lse_dir(const igraph_t *graph,
  *
  * This function essentially does the same as
  * \ref igraph_adjacency_spectral_embedding, but works on the Laplacian
- * of the graph, instead of the adjacncy matrix.
+ * of the graph, instead of the adjacency matrix.
  * \param graph The input graph.
  * \param no The number of eigenvectors (or singular vectors if the graph
  *        is directed) to use for the embedding.
@@ -1006,7 +1006,7 @@ int igraph_i_lse_dir(const igraph_t *graph,
  *        between them with this argument. Possible values:
  *        <code>IGRAPH_EMBEDDING_D_A</code> means D - A where D is the
  *        degree matrix and A is the adjacency matrix;
- *        <code>IGRAPH_EMBEDDING_DAD<code> means Di times A times Di,
+ *        <code>IGRAPH_EMBEDDING_DAD</code> means Di times A times Di,
  *        where Di is the inverse of the square root of the degree matrix;
  *        <code>IGRAPH_EMBEDDING_I_DAD</code> means I - Di A Di, where I
  *        is the identity matrix.

--- a/src/random.c
+++ b/src/random.c
@@ -892,8 +892,8 @@ igraph_real_t igraph_rng_get_binom(igraph_rng_t *rng, long int n,
  *
  * \param rng Pointer to the RNG to use. Use \ref igraph_rng_default()
  *        here to use the default igraph RNG.
- * \param a
- * \param scale
+ * \param shape Shape parameter.
+ * \param scale Scale parameter.
  * \return The generated sample
  *
  * Time complexity: depends on RNG.


### PR DESCRIPTION
Adds some functions to the docs, see #1297 

Moves spatial point sampling form Generators to Non-graph chapter