### PR TITLE
Added missing DECLDIR

### DIFF
--- a/include/igraph_cohesive_blocks.h
+++ b/include/igraph_cohesive_blocks.h
@@ -30,7 +30,7 @@
 
 __BEGIN_DECLS
 
-int igraph_cohesive_blocks(const igraph_t *graph,
+DECLDIR int igraph_cohesive_blocks(const igraph_t *graph,
                            igraph_vector_ptr_t *blocks,
                            igraph_vector_t *cohesion,
                            igraph_vector_t *parent,

--- a/include/igraph_visitor.h
+++ b/include/igraph_visitor.h
@@ -75,7 +75,7 @@ typedef igraph_bool_t igraph_bfshandler_t(const igraph_t *graph,
         igraph_integer_t dist,
         void *extra);
 
-int igraph_bfs(const igraph_t *graph,
+DECLDIR int igraph_bfs(const igraph_t *graph,
                igraph_integer_t root, const igraph_vector_t *roots,
                igraph_neimode_t mode, igraph_bool_t unreachable,
                const igraph_vector_t *restricted,
@@ -85,7 +85,7 @@ int igraph_bfs(const igraph_t *graph,
                igraph_vector_t *dist, igraph_bfshandler_t *callback,
                void *extra);
 
-int igraph_i_bfs(igraph_t *graph, igraph_integer_t vid, igraph_neimode_t mode,
+DECLDIR int igraph_i_bfs(igraph_t *graph, igraph_integer_t vid, igraph_neimode_t mode,
                  igraph_vector_t *vids, igraph_vector_t *layers,
                  igraph_vector_t *parents);
 
@@ -119,7 +119,7 @@ typedef igraph_bool_t igraph_dfshandler_t(const igraph_t *graph,
         igraph_integer_t dist,
         void *extra);
 
-int igraph_dfs(const igraph_t *graph, igraph_integer_t root,
+DECLDIR int igraph_dfs(const igraph_t *graph, igraph_integer_t root,
                igraph_neimode_t mode, igraph_bool_t unreachable,
                igraph_vector_t *order,
                igraph_vector_t *order_out, igraph_vector_t *father,

--- a/include/igraph_visitor.h
+++ b/include/igraph_visitor.h
@@ -85,7 +85,7 @@ DECLDIR int igraph_bfs(const igraph_t *graph,
                igraph_vector_t *dist, igraph_bfshandler_t *callback,
                void *extra);
 
-DECLDIR int igraph_i_bfs(igraph_t *graph, igraph_integer_t vid, igraph_neimode_t mode,
+int igraph_i_bfs(igraph_t *graph, igraph_integer_t vid, igraph_neimode_t mode,
                  igraph_vector_t *vids, igraph_vector_t *layers,
                  igraph_vector_t *parents);
 


### PR DESCRIPTION
Some existing functions did not yet have a proper `DECLDIR` to ensure proper export under Windows.