### PR TITLE
Add Zenodo DOI to docs

### DIFF
--- a/doc/introduction.xml
+++ b/doc/introduction.xml
@@ -96,6 +96,8 @@ reference:
 </para><para>
 Gábor Csárdi, Tamás Nepusz: The igraph software package for complex network
 research. InterJournal Complex Systems, 1695, 2006.
+</para><para>
+The igraph C library is assigned the DOI <ulink url="https://doi.org/10.5281/zenodo.3630268">10.5281/zenodo.3630268</ulink> on Zenodo.
 </para>
 
 </section>


### PR DESCRIPTION
This PR adds the master DOI from Zenodo to the Citing igraph section of the docs.

Zenodo assigns a separate DOI to each release. This is the master DOI that refers to all of them at once.