### PR TITLE
Make all tests deterministic

### DIFF
--- a/examples/simple/2wheap.c
+++ b/examples/simple/2wheap.c
@@ -23,7 +23,6 @@
 
 #include <igraph.h>
 #include "igraph_types_internal.h"
-#include <time.h>
 #include <stdlib.h>
 
 int main() {
@@ -33,7 +32,7 @@ int main() {
     long int i;
     igraph_real_t prev = IGRAPH_INFINITY;
 
-    srand(time(0));
+    srand(42); /* make tests deterministic */
 
     igraph_vector_init(&elems, 100);
     for (i = 0; i < igraph_vector_size(&elems); i++) {

--- a/examples/simple/igraph_are_connected.c
+++ b/examples/simple/igraph_are_connected.c
@@ -21,7 +21,6 @@
 
 #include <igraph.h>
 #include <stdio.h>
-#include <time.h>
 
 #define R_INTEGER(a,b) (igraph_rng_get_integer(igraph_rng_default(), (a), (b)))
 
@@ -33,7 +32,7 @@ int error_test() {
     igraph_integer_t nvert, u, v;
     int ret;
 
-    igraph_rng_seed(igraph_rng_default(), time(0));
+    igraph_rng_seed(igraph_rng_default(), 42); /* make tests deterministic */
     igraph_small(&g, /*nvert*/ 0, IGRAPH_UNDIRECTED, 0, 1, 1, 2, 2, 0, -1);
     nvert = igraph_vcount(&g);
     u = (igraph_integer_t)R_INTEGER(-100 * nvert, 100 * nvert);
@@ -57,7 +56,7 @@ int connected_test() {
     igraph_bool_t connected;
     igraph_integer_t nvert, u, v;
 
-    igraph_rng_seed(igraph_rng_default(), time(0));
+    igraph_rng_seed(igraph_rng_default(), 57); /* make tests deterministic */
 
     /* A complete graph on n vertices. Any two distinct vertices are connected */
     /* by an edge. Hence we expect the test to return true for any given pair */

--- a/examples/simple/igraph_eigen_matrix_symmetric.c
+++ b/examples/simple/igraph_eigen_matrix_symmetric.c
@@ -22,7 +22,6 @@
 */
 
 #include <igraph.h>
-#include <time.h>
 
 #define DIM 10
 

--- a/examples/simple/igraph_eigen_matrix_symmetric_arpack.c
+++ b/examples/simple/igraph_eigen_matrix_symmetric_arpack.c
@@ -22,7 +22,6 @@
 */
 
 #include <igraph.h>
-#include <time.h>
 
 #define DIM 10
 

--- a/examples/simple/igraph_es_path.c
+++ b/examples/simple/igraph_es_path.c
@@ -22,7 +22,6 @@
 */
 
 #include <igraph.h>
-#include <time.h>
 #include <stdlib.h>
 
 int main() {

--- a/examples/simple/igraph_fisher_yates_shuffle.c
+++ b/examples/simple/igraph_fisher_yates_shuffle.c
@@ -20,7 +20,6 @@
 */
 
 #include <igraph.h>
-#include <time.h>
 
 #define R_INTEGER(a,b) (igraph_rng_get_integer(igraph_rng_default(), (a), (b)))
 #define R_UNIF(a,b) (igraph_rng_get_unif(igraph_rng_default(), (a), (b)))
@@ -41,7 +40,7 @@ int main() {
      */
     n = 1;
     igraph_vector_init(&v, n);
-    igraph_rng_seed(igraph_rng_default(), time(0));
+    igraph_rng_seed(igraph_rng_default(), 42); /* make tests deterministic */
     k = R_INTEGER(-1000, 1000);
     VECTOR(v)[0] = k;
     igraph_vector_shuffle(&v);

--- a/examples/simple/igraph_get_eids.c
+++ b/examples/simple/igraph_get_eids.c
@@ -42,7 +42,7 @@ int check_simple() {
     long int r, e, ecount;
     igraph_vector_t eids, pairs, path;
 
-    srand(time(0));
+    igraph_rng_seed(igraph_rng_default(), 42); /* make tests deterministic */
 
     igraph_vector_init(&pairs, edges * 2);
     igraph_vector_init(&path, 0);

--- a/examples/simple/igraph_i_layout_sphere.c
+++ b/examples/simple/igraph_i_layout_sphere.c
@@ -22,7 +22,6 @@
 */
 
 #include <igraph.h>
-#include <time.h>
 #include <stdlib.h>
 #include <math.h>
 
@@ -36,7 +35,7 @@ int main () {
     igraph_matrix_t m;
     igraph_real_t x, y, z, r;
 
-    srand(time(0));
+    srand(42); /* make tests deterministic */
 
     /* 2D */
     igraph_matrix_init(&m, 1000, 2);

--- a/examples/simple/igraph_lapack_dgeev.c
+++ b/examples/simple/igraph_lapack_dgeev.c
@@ -22,7 +22,6 @@
 */
 
 #include <igraph.h>
-#include <time.h>
 #include <stdio.h>
 
 #define DIM 10

--- a/examples/simple/igraph_lapack_dgeevx.c
+++ b/examples/simple/igraph_lapack_dgeevx.c
@@ -22,7 +22,6 @@
 */
 
 #include <igraph.h>
-#include <time.h>
 #include <stdio.h>
 
 #define DIM 10

--- a/examples/simple/igraph_lapack_dgesv.c
+++ b/examples/simple/igraph_lapack_dgesv.c
@@ -22,7 +22,6 @@
 */
 
 #include <igraph.h>
-#include <time.h>
 #include <stdio.h>
 
 #define DIM 10

--- a/examples/simple/igraph_lapack_dsyevr.c
+++ b/examples/simple/igraph_lapack_dsyevr.c
@@ -22,7 +22,6 @@
 */
 
 #include <igraph.h>
-#include <time.h>
 
 #define DIM 10
 

--- a/examples/simple/igraph_layout_mds.c
+++ b/examples/simple/igraph_layout_mds.c
@@ -32,7 +32,8 @@ int main() {
     igraph_matrix_t coords, dist_mat;
     igraph_arpack_options_t options;
     int i, j;
-    srand(time(0));
+
+    srand(42); /* make tests deterministic */
 
     igraph_arpack_options_init(&options);
 

--- a/examples/simple/igraph_layout_merge.c
+++ b/examples/simple/igraph_layout_merge.c
@@ -24,7 +24,6 @@
 #include <igraph.h>
 #include "igraph_types_internal.h"
 #include <stdlib.h>
-#include <time.h>
 
 int igraph_i_layout_merge_dla(igraph_i_layout_mergegrid_t *grid,
                               long int actg, igraph_real_t *x, igraph_real_t *y, igraph_real_t r,

--- a/examples/simple/igraph_random_sample.c
+++ b/examples/simple/igraph_random_sample.c
@@ -23,7 +23,6 @@
 #include <igraph.h>
 #include <math.h>
 #include <stdio.h>
-#include <time.h>
 
 #define R_INTEGER(a,b) (igraph_rng_get_integer(igraph_rng_default(), (a), (b)))
 
@@ -42,7 +41,7 @@ int error_test() {
     int i, n, ret;
     sampling_test_t *test;
 
-    igraph_rng_seed(igraph_rng_default(), time(0));
+    igraph_rng_seed(igraph_rng_default(), 42); /* make tests deterministic */
     igraph_vector_init(&V, /*size*/ 0);
 
     /* test parameters */
@@ -87,7 +86,7 @@ int random_sample_test() {
     igraph_vector_t V;
     int i;
 
-    igraph_rng_seed(igraph_rng_default(), time(0));
+    igraph_rng_seed(igraph_rng_default(), 57); /* make tests deterministic */
 
     /* The generated sequence of numbers must be in increasing order. */
     igraph_vector_init(&V, /*size*/ 0);

--- a/examples/simple/igraph_roulette_wheel_imitation.c
+++ b/examples/simple/igraph_roulette_wheel_imitation.c
@@ -21,7 +21,6 @@
 
 #include <igraph.h>
 #include <stdio.h>
-#include <time.h>
 
 #define R_INTEGER(a,b) (igraph_rng_get_integer(igraph_rng_default(), (a), (b)))
 
@@ -222,7 +221,7 @@ int retain_strategy_test() {
     /* random vertex */
     min = 0;
     max = 5;
-    igraph_rng_seed(igraph_rng_default(), time(0));
+    igraph_rng_seed(igraph_rng_default(), 42); /* make tests deterministic */
     v = R_INTEGER(min, max);  /* min <= v <= max */
     /* Ensure that it is possible for v to retain its current strategy. We */
     /* will try to do this at most ntry times. As there are at most 6 vertices */


### PR DESCRIPTION
This PR tries to make all tests deterministic by setting a fixed random seed. Some tests use igraph's own RNG, some use the one from the C standard library.

This was motivated by this spurious failure which may have happened because of numerical precision issues:

https://travis-ci.org/igraph/igraph/jobs/648828440

I am not sure how to get the full build state from Travis (if it's even possible).