### PR TITLE
degree_sequence_game: make DEGSEQ_SIMPLE_NO_MULTIPLE interruptible

### DIFF
--- a/src/games.c
+++ b/src/games.c
@@ -965,6 +965,8 @@ int igraph_degree_sequence_game_no_multiple_undirected(
      * until it finally succeeds. */
     finished = 0;
     while (!finished) {
+        IGRAPH_ALLOW_INTERRUPTION();
+
         /* Be optimistic :) */
         failed = 0;
 
@@ -1111,6 +1113,8 @@ int igraph_degree_sequence_game_no_multiple_directed(igraph_t *graph,
      * until it finally succeeds. */
     finished = 0;
     while (!finished) {
+        IGRAPH_ALLOW_INTERRUPTION();
+
         /* Be optimistic :) */
         failed = 0;
 


### PR DESCRIPTION
`degree_sequence_game` with `DEGSEQ_SIMPLE_NO_MULTIPLE` does not do well with some degree sequence (e.g. power-law distributed) and will in practice keep running forever.

This makes it interruptible.