### PR TITLE
Made vector_binsearch_slice public

### DIFF
--- a/doc/vector.xxml
+++ b/doc/vector.xxml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN" 
+<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
                "http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd" [
 <!ENTITY igraph "igraph">
 ]>
@@ -91,6 +91,7 @@
 <!-- doxrox-include igraph_vector_contains -->
 <!-- doxrox-include igraph_vector_search -->
 <!-- doxrox-include igraph_vector_binsearch -->
+<!-- doxrox-include igraph_vector_binsearch_slice -->
 <!-- doxrox-include igraph_vector_binsearch2 -->
 </section>
 

--- a/include/igraph_vector_pmt.h
+++ b/include/igraph_vector_pmt.h
@@ -177,6 +177,9 @@ DECLDIR igraph_bool_t FUNCTION(igraph_vector, contains)(const TYPE(igraph_vector
 DECLDIR igraph_bool_t FUNCTION(igraph_vector, search)(const TYPE(igraph_vector) *v,
         long int from, BASE what,
         long int *pos);
+DECLDIR igraph_bool_t FUNCTION(igraph_vector, binsearch_slice)(const TYPE(igraph_vector) *v,
+        BASE what, long int *pos,
+        long int start, long int end);
 DECLDIR igraph_bool_t FUNCTION(igraph_vector, binsearch)(const TYPE(igraph_vector) *v,
         BASE what, long int *pos);
 DECLDIR igraph_bool_t FUNCTION(igraph_vector, binsearch2)(const TYPE(igraph_vector) *v,

--- a/src/community_leiden.c
+++ b/src/community_leiden.c
@@ -420,7 +420,7 @@ int igraph_i_community_leiden_mergenodes(const igraph_t *graph,
             if (total_cum_trans_diff < IGRAPH_INFINITY) {
                 igraph_real_t r = igraph_rng_get_unif(igraph_rng_default(), 0, total_cum_trans_diff);
                 long int chosen_idx;
-                igraph_i_vector_binsearch_slice(&cum_trans_diff, r, &chosen_idx, 0, nb_neigh_clusters);
+                igraph_vector_binsearch_slice(&cum_trans_diff, r, &chosen_idx, 0, nb_neigh_clusters);
                 chosen_cluster = VECTOR(neighbor_clusters)[chosen_idx];
             } else {
                 chosen_cluster = best_cluster;

--- a/src/vector.pmt
+++ b/src/vector.pmt
@@ -1710,6 +1710,51 @@ igraph_bool_t FUNCTION(igraph_vector, binsearch)(const TYPE(igraph_vector) *v,
             0, FUNCTION(igraph_vector, size)(v));
 }
 
+/**
+ * \ingroup vector
+ * \function igraph_vector_binsearch_slice
+ * \brief Finds an element by binary searching a sorted slice of a vector.
+ *
+ * </para><para>
+
+ * It is assumed that the indicated slice of the vector, from \p start to \p end,
+ * is sorted. If the specified element (\p what) is not in the slice of the
+ * vector, then the position of where it should be inserted (to keep the vector
+ * sorted) is returned.
+ * \param v The \type igraph_vector_t object.
+ * \param what The element to search for.
+ * \param pos Pointer to a \type long int. This is set to the position of an
+ *        instance of \p what in the slice of the vector if it is present. If \p
+ *        v does not contain \p what then \p pos is set to the position to which
+ *        it should be inserted (to keep the the vector sorted).
+ * \param start The start position of the slice to search (inclusive).
+ * \param end The end position of the slice to search (exclusive).
+ * \return Positive integer (true) if \p what is found in the vector,
+ *         zero (false) otherwise.
+ *
+ * Time complexity: O(log(n)),
+ * n is the number of elements in the slice of \p v, i.e. \p end - \p start.
+ */
+
+igraph_bool_t FUNCTION(igraph_vector, binsearch_slice)(const TYPE(igraph_vector) *v,
+        BASE what, long int *pos,
+        long int start, long int end) {
+    long int left  = start;
+    long int right = end - 1;
+
+    if (left < 0)
+        IGRAPH_ERROR("Invalid start position.", IGRAPH_EINVAL);
+
+    if (right >= FUNCTION(igraph_vector, size)(v))
+        IGRAPH_ERROR("Invalid end position.", IGRAPH_EINVAL);
+
+    if (left > right)
+        IGRAPH_ERROR("Invalid slice, start position must be smaller than end position.",
+                     IGRAPH_EINVAL);
+
+    return FUNCTION(igraph_i_vector, binsearch_slice)(v, what, pos, start, end);
+}
+
 igraph_bool_t FUNCTION(igraph_i_vector, binsearch_slice)(const TYPE(igraph_vector) *v,
         BASE what, long int *pos,
         long int start, long int end) {
@@ -2008,7 +2053,7 @@ igraph_real_t FUNCTION(igraph_vector, maxdifference)(const TYPE(igraph_vector) *
  * \brief Update a vector from another one.
  *
  * After this operation the contents of \p to will be exactly the same
- * as that of \p from. The vector \p to will be resized if it was originally 
+ * as that of \p from. The vector \p to will be resized if it was originally
  * shorter or longer than \p from.
  * \param to The vector to update.
  * \param from The vector to update from.


### PR DESCRIPTION
As discussed in https://github.com/igraph/igraph/issues/981#issuecomment-592440175, we decided to make `igraph_vector_binsearch_slice` properly public, because the `igraph_community_leiden` was improperly relying on the `igraph_i_vector_binsearch_slice` function.

In accordance with our earlier discussion in https://github.com/igraph/igraph/issues/1219#issuecomment-512514619, I made an internal version, `igraph_i_vector_binsearch_slice` (which is used by `igraph_vector_intersect_sorted`, for which it is properly defined) which does not perform any argument checking, and a public version `igraph_vector_binsearch_slice`, which checks arguments. From the perspective of `igraph` as a whole, `igraph_community_leiden` should be allowed to use "internal" functions that perform no argument checking. This then in turn begs the question of how to deal exactly with these type of internal functions that should be included in a proper (internal) header. For now `igraph_community_leiden` simply uses the public `igraph_vector_binsearch_slice` to keep it simple.