### PR TITLE
plfit: ensure math.h defines are present with MSVC

### DIFF
--- a/src/plfit/hzeta.c
+++ b/src/plfit/hzeta.c
@@ -42,8 +42,13 @@
 
 /* Author:  Jerome G. Benoit < jgmbenoit _at_ rezozer _dot_ net > */
 
+#ifdef _MSC_VER
+#define _USE_MATH_DEFINES
+#endif
+
 #include <math.h>
 #include <stdio.h>
+#include "hzeta.h"
 #include "error.h"
 #include "platform.h"
 


### PR DESCRIPTION
Hopefully this will fix the missing `M_LN2`. See this test failure:

https://ci.appveyor.com/project/ntamas/igraph/builds/31127044/job/rpktetnh87thu4x3#L4306