### PR TITLE
Make functions 'static' when appropriate

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -56,7 +56,8 @@ AC_HEADER_STDC
 AC_CHECK_HEADERS([stdarg.h stdlib.h string.h time.h unistd.h stdint.h sys/int_types.h])
 LIBS_SAVE=$LIBS
 LIBS="$LIBS -lm"
-AC_CHECK_FUNCS([expm1 rint rintf finite log2 snprintf log1p round fabsl fmin strcasecmp isfinite isnan strdup _strdup ftruncate stpcpy])
+AC_CHECK_FUNCS([expm1 rint rintf finite log2 snprintf log1p round fabsl fmin strcasecmp isnan strdup _strdup ftruncate stpcpy])
+AC_CHECK_DECLS(isfinite,,,[#include <math.h>])
 AC_CHECK_DECL([stpcpy],
     [AC_DEFINE([HAVE_STPCPY_SIGNATURE], [1], [Define to 1 if the stpcpy function has a signature])])
 LIBS=$LIBS_SAVE

--- a/src/arpack.c
+++ b/src/arpack.c
@@ -32,7 +32,7 @@
 
 /* The ARPACK example file dssimp.f is used as a template */
 
-int igraph_i_arpack_err_dsaupd(int error) {
+static int igraph_i_arpack_err_dsaupd(int error) {
     switch (error) {
     case  1:      return IGRAPH_ARPACK_MAXIT;
     case  3:      return IGRAPH_ARPACK_NOSHIFT;
@@ -54,7 +54,7 @@ int igraph_i_arpack_err_dsaupd(int error) {
     }
 }
 
-int igraph_i_arpack_err_dseupd(int error) {
+static int igraph_i_arpack_err_dseupd(int error) {
     switch (error) {
     case -1:      return IGRAPH_ARPACK_NPOS;
     case -2:      return IGRAPH_ARPACK_NEVNPOS;
@@ -76,7 +76,7 @@ int igraph_i_arpack_err_dseupd(int error) {
 
 }
 
-int igraph_i_arpack_err_dnaupd(int error) {
+static int igraph_i_arpack_err_dnaupd(int error) {
     switch (error) {
     case  1:      return IGRAPH_ARPACK_MAXIT;
     case  3:      return IGRAPH_ARPACK_NOSHIFT;
@@ -97,7 +97,7 @@ int igraph_i_arpack_err_dnaupd(int error) {
     }
 }
 
-int igraph_i_arpack_err_dneupd(int error) {
+static int igraph_i_arpack_err_dneupd(int error) {
     switch (error) {
     case  1:      return IGRAPH_ARPACK_REORDER;
     case -1:      return IGRAPH_ARPACK_NPOS;
@@ -258,9 +258,9 @@ void igraph_arpack_storage_destroy(igraph_arpack_storage_t *s) {
  * "Solver" for 1x1 eigenvalue problems since ARPACK sometimes blows up with
  * these.
  */
-int igraph_i_arpack_rssolve_1x1(igraph_arpack_function_t *fun, void *extra,
-                                igraph_arpack_options_t* options,
-                                igraph_vector_t* values, igraph_matrix_t* vectors) {
+static int igraph_i_arpack_rssolve_1x1(igraph_arpack_function_t *fun, void *extra,
+                                       igraph_arpack_options_t* options,
+                                       igraph_vector_t* values, igraph_matrix_t* vectors) {
     igraph_real_t a, b;
     int nev = options->nev;
 
@@ -294,9 +294,9 @@ int igraph_i_arpack_rssolve_1x1(igraph_arpack_function_t *fun, void *extra,
  * "Solver" for 1x1 eigenvalue problems since ARPACK sometimes blows up with
  * these.
  */
-int igraph_i_arpack_rnsolve_1x1(igraph_arpack_function_t *fun, void *extra,
-                                igraph_arpack_options_t* options,
-                                igraph_matrix_t* values, igraph_matrix_t* vectors) {
+static int igraph_i_arpack_rnsolve_1x1(igraph_arpack_function_t *fun, void *extra,
+                                       igraph_arpack_options_t* options,
+                                       igraph_matrix_t* values, igraph_matrix_t* vectors) {
     igraph_real_t a, b;
     int nev = options->nev;
 
@@ -330,9 +330,9 @@ int igraph_i_arpack_rnsolve_1x1(igraph_arpack_function_t *fun, void *extra,
  * "Solver" for 2x2 nonsymmetric eigenvalue problems since ARPACK sometimes
  * blows up with these.
  */
-int igraph_i_arpack_rnsolve_2x2(igraph_arpack_function_t *fun, void *extra,
-                                igraph_arpack_options_t* options, igraph_matrix_t* values,
-                                igraph_matrix_t* vectors) {
+static int igraph_i_arpack_rnsolve_2x2(igraph_arpack_function_t *fun, void *extra,
+                                       igraph_arpack_options_t* options, igraph_matrix_t* values,
+                                       igraph_matrix_t* vectors) {
     igraph_real_t vec[2], mat[4];
     igraph_real_t a, b, c, d;
     igraph_real_t trace, det, tsq4_minus_d;
@@ -484,9 +484,9 @@ int igraph_i_arpack_rnsolve_2x2(igraph_arpack_function_t *fun, void *extra,
  * "Solver" for symmetric 2x2 eigenvalue problems since ARPACK sometimes blows
  * up with these.
  */
-int igraph_i_arpack_rssolve_2x2(igraph_arpack_function_t *fun, void *extra,
-                                igraph_arpack_options_t* options, igraph_vector_t* values,
-                                igraph_matrix_t* vectors) {
+static int igraph_i_arpack_rssolve_2x2(igraph_arpack_function_t *fun, void *extra,
+                                       igraph_arpack_options_t* options, igraph_vector_t* values,
+                                       igraph_matrix_t* vectors) {
     igraph_real_t vec[2], mat[4];
     igraph_real_t a, b, c, d;
     igraph_real_t trace, det, tsq4_minus_d;
@@ -778,7 +778,7 @@ int igraph_arpack_rnsort(igraph_matrix_t *values, igraph_matrix_t *vectors,
  * \brief Tries to set up the value of \c ncv in an \c igraph_arpack_options_t
  *        automagically.
  */
-void igraph_i_arpack_auto_ncv(igraph_arpack_options_t* options) {
+static void igraph_i_arpack_auto_ncv(igraph_arpack_options_t* options) {
     /* This is similar to how Octave determines the value of ncv, with some
      * modifications. */
     int min_ncv = options->nev * 2 + 1;
@@ -811,7 +811,7 @@ void igraph_i_arpack_auto_ncv(igraph_arpack_options_t* options) {
  * \brief Prints a warning that informs the user that the ARPACK solver
  *        did not converge.
  */
-void igraph_i_arpack_report_no_convergence(const igraph_arpack_options_t* options) {
+static void igraph_i_arpack_report_no_convergence(const igraph_arpack_options_t* options) {
     char buf[1024];
     snprintf(buf, sizeof(buf), "ARPACK solver failed to converge (%d iterations, "
              "%d/%d eigenvectors converged)", options->iparam[2],

--- a/src/bipartite.c
+++ b/src/bipartite.c
@@ -150,11 +150,11 @@ int igraph_bipartite_projection_size(const igraph_t *graph,
     return 0;
 }
 
-int igraph_i_bipartite_projection(const igraph_t *graph,
-                                  const igraph_vector_bool_t *types,
-                                  igraph_t *proj,
-                                  int which,
-                                  igraph_vector_t *multiplicity) {
+static int igraph_i_bipartite_projection(const igraph_t *graph,
+                                         const igraph_vector_bool_t *types,
+                                         igraph_t *proj,
+                                         int which,
+                                         igraph_vector_t *multiplicity) {
 
     long int no_of_nodes = igraph_vcount(graph);
     long int i, j, k;

--- a/src/centrality.c
+++ b/src/centrality.c
@@ -50,7 +50,7 @@ int igraph_personalized_pagerank_arpack(const igraph_t *graph,
                                         const igraph_vector_t *weights,
                                         igraph_arpack_options_t *options);
 
-igraph_bool_t igraph_i_vector_mostly_negative(const igraph_vector_t *vector) {
+static igraph_bool_t igraph_i_vector_mostly_negative(const igraph_vector_t *vector) {
     /* Many of the centrality measures correspond to the eigenvector of some
      * matrix. When v is an eigenvector, c*v is also an eigenvector, therefore
      * it may happen that all the scores in the eigenvector are negative, in which
@@ -89,8 +89,8 @@ igraph_bool_t igraph_i_vector_mostly_negative(const igraph_vector_t *vector) {
     return (mi < 1e-5) ? 1 : 0;
 }
 
-int igraph_i_eigenvector_centrality(igraph_real_t *to, const igraph_real_t *from,
-                                    int n, void *extra) {
+static int igraph_i_eigenvector_centrality(igraph_real_t *to, const igraph_real_t *from,
+                                           int n, void *extra) {
     igraph_adjlist_t *adjlist = extra;
     igraph_vector_int_t *neis;
     long int i, j, nlen;
@@ -115,8 +115,8 @@ typedef struct igraph_i_eigenvector_centrality_t {
     const igraph_vector_t *weights;
 } igraph_i_eigenvector_centrality_t;
 
-int igraph_i_eigenvector_centrality2(igraph_real_t *to, const igraph_real_t *from,
-                                     int n, void *extra) {
+static int igraph_i_eigenvector_centrality2(igraph_real_t *to, const igraph_real_t *from,
+                                            int n, void *extra) {
 
     igraph_i_eigenvector_centrality_t *data = extra;
     const igraph_t *graph = data->graph;
@@ -140,7 +140,7 @@ int igraph_i_eigenvector_centrality2(igraph_real_t *to, const igraph_real_t *fro
     return 0;
 }
 
-int igraph_i_eigenvector_centrality_loop(igraph_adjlist_t *adjlist) {
+static int igraph_i_eigenvector_centrality_loop(igraph_adjlist_t *adjlist) {
 
     long int i, j, k, nlen, n = igraph_adjlist_size(adjlist);
     igraph_vector_int_t *neis;
@@ -591,9 +591,9 @@ typedef struct igraph_i_kleinberg_data2_t {
 } igraph_i_kleinberg_data2_t;
 
 /* ARPACK auxiliary routine for the unweighted HITS algorithm */
-int igraph_i_kleinberg_unweighted(igraph_real_t *to,
-                                  const igraph_real_t *from,
-                                  int n, void *extra) {
+static int igraph_i_kleinberg_unweighted(igraph_real_t *to,
+                                         const igraph_real_t *from,
+                                         int n, void *extra) {
     igraph_i_kleinberg_data_t *data = (igraph_i_kleinberg_data_t*)extra;
     igraph_adjlist_t *in = data->in;
     igraph_adjlist_t *out = data->out;
@@ -625,9 +625,9 @@ int igraph_i_kleinberg_unweighted(igraph_real_t *to,
 }
 
 /* ARPACK auxiliary routine for the weighted HITS algorithm */
-int igraph_i_kleinberg_weighted(igraph_real_t *to,
-                                const igraph_real_t *from,
-                                int n, void *extra) {
+static int igraph_i_kleinberg_weighted(igraph_real_t *to,
+                                       const igraph_real_t *from,
+                                       int n, void *extra) {
 
     igraph_i_kleinberg_data2_t *data = (igraph_i_kleinberg_data2_t*)extra;
     igraph_inclist_t *in = data->in;
@@ -663,10 +663,10 @@ int igraph_i_kleinberg_weighted(igraph_real_t *to,
     return 0;
 }
 
-int igraph_i_kleinberg(const igraph_t *graph, igraph_vector_t *vector,
-                       igraph_real_t *value, igraph_bool_t scale,
-                       const igraph_vector_t *weights,
-                       igraph_arpack_options_t *options, int inout) {
+static int igraph_i_kleinberg(const igraph_t *graph, igraph_vector_t *vector,
+                              igraph_real_t *value, igraph_bool_t scale,
+                              const igraph_vector_t *weights,
+                              igraph_arpack_options_t *options, int inout) {
 
     igraph_adjlist_t myinadjlist, myoutadjlist;
     igraph_inclist_t myininclist, myoutinclist;
@@ -934,8 +934,8 @@ typedef struct igraph_i_pagerank_data2_t {
     igraph_vector_t *reset;
 } igraph_i_pagerank_data2_t;
 
-int igraph_i_pagerank(igraph_real_t *to, const igraph_real_t *from,
-                      int n, void *extra) {
+static int igraph_i_pagerank(igraph_real_t *to, const igraph_real_t *from,
+                             int n, void *extra) {
 
     igraph_i_pagerank_data_t *data = extra;
     igraph_adjlist_t *adjlist = data->adjlist;
@@ -996,8 +996,8 @@ int igraph_i_pagerank(igraph_real_t *to, const igraph_real_t *from,
     return 0;
 }
 
-int igraph_i_pagerank2(igraph_real_t *to, const igraph_real_t *from,
-                       int n, void *extra) {
+static int igraph_i_pagerank2(igraph_real_t *to, const igraph_real_t *from,
+                              int n, void *extra) {
 
     igraph_i_pagerank_data2_t *data = extra;
     const igraph_t *graph = data->graph;
@@ -1608,7 +1608,8 @@ int igraph_betweenness(const igraph_t *graph, igraph_vector_t *res,
                                        nobigint);
 }
 
-int igraph_i_betweenness_estimate_weighted(const igraph_t *graph,
+static int igraph_i_betweenness_estimate_weighted(
+        const igraph_t *graph,
         igraph_vector_t *res,
         const igraph_vs_t vids,
         igraph_bool_t directed,
@@ -1784,7 +1785,7 @@ int igraph_i_betweenness_estimate_weighted(const igraph_t *graph,
     return 0;
 }
 
-void igraph_i_destroy_biguints(igraph_biguint_t *p) {
+static void igraph_i_destroy_biguints(igraph_biguint_t *p) {
     igraph_biguint_t *p2 = p;
     while ( *((long int*)(p)) ) {
         igraph_biguint_destroy(p);
@@ -2079,7 +2080,8 @@ int igraph_betweenness_estimate(const igraph_t *graph, igraph_vector_t *res,
     return 0;
 }
 
-int igraph_i_edge_betweenness_estimate_weighted(const igraph_t *graph,
+static int igraph_i_edge_betweenness_estimate_weighted(
+        const igraph_t *graph,
         igraph_vector_t *result,
         igraph_bool_t directed,
         igraph_real_t cutoff,
@@ -2563,13 +2565,13 @@ int igraph_closeness(const igraph_t *graph, igraph_vector_t *res,
                                      normalized);
 }
 
-int igraph_i_closeness_estimate_weighted(const igraph_t *graph,
-        igraph_vector_t *res,
-        const igraph_vs_t vids,
-        igraph_neimode_t mode,
-        igraph_real_t cutoff,
-        const igraph_vector_t *weights,
-        igraph_bool_t normalized) {
+static int igraph_i_closeness_estimate_weighted(const igraph_t *graph,
+                                                igraph_vector_t *res,
+                                                const igraph_vs_t vids,
+                                                igraph_neimode_t mode,
+                                                igraph_real_t cutoff,
+                                                const igraph_vector_t *weights,
+                                                igraph_bool_t normalized) {
 
     /* See igraph_shortest_paths_dijkstra() for the implementation
        details and the dirty tricks. */

--- a/src/cliques.c
+++ b/src/cliques.c
@@ -37,7 +37,7 @@
 #include <assert.h>
 #include <string.h>    /* memset */
 
-void igraph_i_cliques_free_res(igraph_vector_ptr_t *res) {
+static void igraph_i_cliques_free_res(igraph_vector_ptr_t *res) {
     long i, n;
 
     n = igraph_vector_ptr_size(res);
@@ -50,14 +50,15 @@ void igraph_i_cliques_free_res(igraph_vector_ptr_t *res) {
     igraph_vector_ptr_clear(res);
 }
 
-int igraph_i_find_k_cliques(const igraph_t *graph,
-                            long int size,
-                            const igraph_real_t *member_storage,
-                            igraph_real_t **new_member_storage,
-                            long int old_clique_count,
-                            long int *clique_count,
-                            igraph_vector_t *neis,
-                            igraph_bool_t independent_vertices) {
+static int igraph_i_find_k_cliques(
+        const igraph_t *graph,
+        long int size,
+        const igraph_real_t *member_storage,
+        igraph_real_t **new_member_storage,
+        long int old_clique_count,
+        long int *clique_count,
+        igraph_vector_t *neis,
+        igraph_bool_t independent_vertices) {
 
     long int j, k, l, m, n, new_member_storage_size;
     const igraph_real_t *c1, *c2;
@@ -188,9 +189,9 @@ int igraph_i_find_k_cliques(const igraph_t *graph,
  * They are practically the same except that the complementer of the graph
  * should be used in the latter case.
  */
-int igraph_i_cliques(const igraph_t *graph, igraph_vector_ptr_t *res,
-                     igraph_integer_t min_size, igraph_integer_t max_size,
-                     igraph_bool_t independent_vertices) {
+static int igraph_i_cliques(const igraph_t *graph, igraph_vector_ptr_t *res,
+                            igraph_integer_t min_size, igraph_integer_t max_size,
+                            igraph_bool_t independent_vertices) {
 
     igraph_integer_t no_of_nodes;
     igraph_vector_t neis;
@@ -524,9 +525,10 @@ typedef struct {
     igraph_integer_t max_size;
 } igraph_i_maximal_clique_data_t;
 
-int igraph_i_maximal_cliques(const igraph_t *graph, igraph_i_maximal_clique_func_t func, void* data);
+static int igraph_i_maximal_cliques(const igraph_t *graph, igraph_i_maximal_clique_func_t func, void* data);
 
-int igraph_i_maximal_or_largest_cliques_or_indsets(const igraph_t *graph,
+static int igraph_i_maximal_or_largest_cliques_or_indsets(
+        const igraph_t *graph,
         igraph_vector_ptr_t *res,
         igraph_integer_t *clique_number,
         igraph_bool_t keep_only_largest,
@@ -619,7 +621,8 @@ typedef struct igraph_i_max_ind_vsets_data_t {
     igraph_bool_t keep_only_largest;     /* True if we keep only the largest sets */
 } igraph_i_max_ind_vsets_data_t;
 
-int igraph_i_maximal_independent_vertex_sets_backtrack(const igraph_t *graph,
+static int igraph_i_maximal_independent_vertex_sets_backtrack(
+        const igraph_t *graph,
         igraph_vector_ptr_t *res,
         igraph_i_max_ind_vsets_data_t *clqdata,
         igraph_integer_t level) {
@@ -763,7 +766,7 @@ int igraph_i_maximal_independent_vertex_sets_backtrack(const igraph_t *graph,
     return 0;
 }
 
-void igraph_i_free_set_array(igraph_set_t* array) {
+static void igraph_i_free_set_array(igraph_set_t* array) {
     long int i = 0;
     while (igraph_set_inited(array + i)) {
         igraph_set_destroy(array + i);
@@ -943,8 +946,8 @@ int igraph_independence_number(const igraph_t *graph, igraph_integer_t *no) {
 /* MAXIMAL CLIQUES, LARGEST CLIQUES                                      */
 /*************************************************************************/
 
-int igraph_i_maximal_cliques_store_max_size(const igraph_vector_t* clique, void* data,
-        igraph_bool_t* cont) {
+static int igraph_i_maximal_cliques_store_max_size(const igraph_vector_t* clique, void* data,
+                                                   igraph_bool_t* cont) {
     igraph_integer_t* result = (igraph_integer_t*)data;
     IGRAPH_UNUSED(cont);
     if (*result < igraph_vector_size(clique)) {
@@ -953,7 +956,7 @@ int igraph_i_maximal_cliques_store_max_size(const igraph_vector_t* clique, void*
     return IGRAPH_SUCCESS;
 }
 
-int igraph_i_maximal_cliques_store(const igraph_vector_t* clique, void* data, igraph_bool_t* cont) {
+static int igraph_i_maximal_cliques_store(const igraph_vector_t* clique, void* data, igraph_bool_t* cont) {
     igraph_vector_ptr_t* result = (igraph_vector_ptr_t*)data;
     igraph_vector_t* vec;
 
@@ -969,7 +972,7 @@ int igraph_i_maximal_cliques_store(const igraph_vector_t* clique, void* data, ig
     return IGRAPH_SUCCESS;
 }
 
-int igraph_i_maximal_cliques_store_size_check(const igraph_vector_t* clique, void* data_, igraph_bool_t* cont) {
+static int igraph_i_maximal_cliques_store_size_check(const igraph_vector_t* clique, void* data_, igraph_bool_t* cont) {
     igraph_i_maximal_clique_data_t* data = (igraph_i_maximal_clique_data_t*)data_;
     igraph_vector_t* vec;
     igraph_integer_t size = (igraph_integer_t) igraph_vector_size(clique);
@@ -990,7 +993,7 @@ int igraph_i_maximal_cliques_store_size_check(const igraph_vector_t* clique, voi
     return IGRAPH_SUCCESS;
 }
 
-int igraph_i_largest_cliques_store(const igraph_vector_t* clique, void* data, igraph_bool_t* cont) {
+static int igraph_i_largest_cliques_store(const igraph_vector_t* clique, void* data, igraph_bool_t* cont) {
     igraph_vector_ptr_t* result = (igraph_vector_ptr_t*)data;
     igraph_vector_t* vec;
     long int i, n;
@@ -1091,13 +1094,13 @@ typedef struct {
     igraph_vector_int_t cand_filtered;
 } igraph_i_maximal_cliques_stack_frame;
 
-void igraph_i_maximal_cliques_stack_frame_destroy(igraph_i_maximal_cliques_stack_frame *frame) {
+static void igraph_i_maximal_cliques_stack_frame_destroy(igraph_i_maximal_cliques_stack_frame *frame) {
     igraph_vector_int_destroy(&frame->cand);
     igraph_vector_int_destroy(&frame->fini);
     igraph_vector_int_destroy(&frame->cand_filtered);
 }
 
-void igraph_i_maximal_cliques_stack_destroy(igraph_stack_ptr_t *stack) {
+static void igraph_i_maximal_cliques_stack_destroy(igraph_stack_ptr_t *stack) {
     igraph_i_maximal_cliques_stack_frame *frame;
 
     while (!igraph_stack_ptr_empty(stack)) {
@@ -1109,7 +1112,7 @@ void igraph_i_maximal_cliques_stack_destroy(igraph_stack_ptr_t *stack) {
     igraph_stack_ptr_destroy(stack);
 }
 
-int igraph_i_maximal_cliques(const igraph_t *graph, igraph_i_maximal_clique_func_t func, void* data) {
+static int igraph_i_maximal_cliques(const igraph_t *graph, igraph_i_maximal_clique_func_t func, void* data) {
     int directed = igraph_is_directed(graph);
     long int i, j, k, l;
     igraph_integer_t no_of_nodes, nodes_to_check, nodes_done;
@@ -1331,7 +1334,7 @@ int igraph_i_maximal_cliques(const igraph_t *graph, igraph_i_maximal_clique_func
     return IGRAPH_SUCCESS;
 }
 
-int igraph_i_maximal_or_largest_cliques_or_indsets(const igraph_t *graph,
+static int igraph_i_maximal_or_largest_cliques_or_indsets(const igraph_t *graph,
         igraph_vector_ptr_t *res,
         igraph_integer_t *clique_number,
         igraph_bool_t keep_only_largest,

--- a/src/clustertool.cpp
+++ b/src/clustertool.cpp
@@ -62,21 +62,23 @@
 #include "igraph_components.h"
 #include "igraph_interrupt_internal.h"
 
-int igraph_i_community_spinglass_orig(const igraph_t *graph,
-                                      const igraph_vector_t *weights,
-                                      igraph_real_t *modularity,
-                                      igraph_real_t *temperature,
-                                      igraph_vector_t *membership,
-                                      igraph_vector_t *csize,
-                                      igraph_integer_t spins,
-                                      igraph_bool_t parupdate,
-                                      igraph_real_t starttemp,
-                                      igraph_real_t stoptemp,
-                                      igraph_real_t coolfact,
-                                      igraph_spincomm_update_t update_rule,
-                                      igraph_real_t gamma);
+static int igraph_i_community_spinglass_orig(
+        const igraph_t *graph,
+        const igraph_vector_t *weights,
+        igraph_real_t *modularity,
+        igraph_real_t *temperature,
+        igraph_vector_t *membership,
+        igraph_vector_t *csize,
+        igraph_integer_t spins,
+        igraph_bool_t parupdate,
+        igraph_real_t starttemp,
+        igraph_real_t stoptemp,
+        igraph_real_t coolfact,
+        igraph_spincomm_update_t update_rule,
+        igraph_real_t gamma);
 
-int igraph_i_community_spinglass_negative(const igraph_t *graph,
+static int igraph_i_community_spinglass_negative(
+        const igraph_t *graph,
         const igraph_vector_t *weights,
         igraph_real_t *modularity,
         igraph_real_t *temperature,
@@ -89,9 +91,9 @@ int igraph_i_community_spinglass_negative(const igraph_t *graph,
         igraph_real_t coolfact,
         igraph_spincomm_update_t update_rule,
         igraph_real_t gamma,
-        /*                    igraph_matrix_t *adhesion, */
-        /*                    igraph_matrix_t *normalised_adhesion, */
-        /*                    igraph_real_t *polarization, */
+        /* igraph_matrix_t *adhesion, */
+        /* igraph_matrix_t *normalised_adhesion, */
+        /* igraph_real_t *polarization, */
         igraph_real_t gamma_minus);
 
 /**
@@ -231,19 +233,20 @@ int igraph_community_spinglass(const igraph_t *graph,
     return 0;
 }
 
-int igraph_i_community_spinglass_orig(const igraph_t *graph,
-                                      const igraph_vector_t *weights,
-                                      igraph_real_t *modularity,
-                                      igraph_real_t *temperature,
-                                      igraph_vector_t *membership,
-                                      igraph_vector_t *csize,
-                                      igraph_integer_t spins,
-                                      igraph_bool_t parupdate,
-                                      igraph_real_t starttemp,
-                                      igraph_real_t stoptemp,
-                                      igraph_real_t coolfact,
-                                      igraph_spincomm_update_t update_rule,
-                                      igraph_real_t gamma) {
+static int igraph_i_community_spinglass_orig(
+        const igraph_t *graph,
+        const igraph_vector_t *weights,
+        igraph_real_t *modularity,
+        igraph_real_t *temperature,
+        igraph_vector_t *membership,
+        igraph_vector_t *csize,
+        igraph_integer_t spins,
+        igraph_bool_t parupdate,
+        igraph_real_t starttemp,
+        igraph_real_t stoptemp,
+        igraph_real_t coolfact,
+        igraph_spincomm_update_t update_rule,
+        igraph_real_t gamma) {
 
     unsigned long changes, runs;
     igraph_bool_t use_weights = 0;
@@ -535,7 +538,8 @@ int igraph_community_spinglass_single(const igraph_t *graph,
     return 0;
 }
 
-int igraph_i_community_spinglass_negative(const igraph_t *graph,
+static int igraph_i_community_spinglass_negative(
+        const igraph_t *graph,
         const igraph_vector_t *weights,
         igraph_real_t *modularity,
         igraph_real_t *temperature,
@@ -548,9 +552,9 @@ int igraph_i_community_spinglass_negative(const igraph_t *graph,
         igraph_real_t coolfact,
         igraph_spincomm_update_t update_rule,
         igraph_real_t gamma,
-        /*                    igraph_matrix_t *adhesion, */
-        /*                    igraph_matrix_t *normalised_adhesion, */
-        /*                    igraph_real_t *polarization, */
+        /* igraph_matrix_t *adhesion, */
+        /* igraph_matrix_t *normalised_adhesion, */
+        /* igraph_real_t *polarization, */
         igraph_real_t gamma_minus) {
 
     unsigned long changes, runs;

--- a/src/cocitation.c
+++ b/src/cocitation.c
@@ -460,7 +460,7 @@ int igraph_similarity_jaccard_pairs(const igraph_t *graph, igraph_vector_t *res,
         if (seen == 0) {
             IGRAPH_ERROR("cannot calculate Jaccard similarity", IGRAPH_ENOMEM);
         }
-        IGRAPH_FINALLY(free, seen);
+        IGRAPH_FINALLY(igraph_free, seen);
 
         for (i = 0; i < k; i++) {
             j = (long int) VECTOR(*pairs)[i];
@@ -474,7 +474,7 @@ int igraph_similarity_jaccard_pairs(const igraph_t *graph, igraph_vector_t *res,
             }
         }
 
-        free(seen);
+        igraph_Free(seen);
         IGRAPH_FINALLY_CLEAN(1);
     }
 

--- a/src/cocitation.c
+++ b/src/cocitation.c
@@ -254,13 +254,10 @@ int igraph_cocitation_real(const igraph_t *graph, igraph_matrix_t *res,
     return 0;
 }
 
-int igraph_i_neisets_intersect(const igraph_vector_t *v1,
-                               const igraph_vector_t *v2, long int *len_union,
-                               long int *len_intersection);
 
-int igraph_i_neisets_intersect(const igraph_vector_t *v1,
-                               const igraph_vector_t *v2, long int *len_union,
-                               long int *len_intersection) {
+static int igraph_i_neisets_intersect(const igraph_vector_t *v1,
+                                      const igraph_vector_t *v2, long int *len_union,
+                                      long int *len_intersection) {
     /* ASSERT: v1 and v2 are sorted */
     long int i, j, i0, jj0;
     i0 = igraph_vector_size(v1); jj0 = igraph_vector_size(v2);

--- a/src/cohesive_blocks.c
+++ b/src/cohesive_blocks.c
@@ -33,7 +33,7 @@
 #include "igraph_interrupt_internal.h"
 #include "igraph_statusbar.h"
 
-void igraph_i_cohesive_blocks_free(igraph_vector_ptr_t *ptr) {
+static void igraph_i_cohesive_blocks_free(igraph_vector_ptr_t *ptr) {
     long int i, n = igraph_vector_ptr_size(ptr);
 
     for (i = 0; i < n; i++) {
@@ -45,7 +45,7 @@ void igraph_i_cohesive_blocks_free(igraph_vector_ptr_t *ptr) {
     }
 }
 
-void igraph_i_cohesive_blocks_free2(igraph_vector_ptr_t *ptr) {
+static void igraph_i_cohesive_blocks_free2(igraph_vector_ptr_t *ptr) {
     long int i, n = igraph_vector_ptr_size(ptr);
 
     for (i = 0; i < n; i++) {
@@ -57,7 +57,7 @@ void igraph_i_cohesive_blocks_free2(igraph_vector_ptr_t *ptr) {
     }
 }
 
-void igraph_i_cohesive_blocks_free3(igraph_vector_ptr_t *ptr) {
+static void igraph_i_cohesive_blocks_free3(igraph_vector_ptr_t *ptr) {
     long int i, n = igraph_vector_ptr_size(ptr);
 
     for (i = 0; i < n; i++) {
@@ -75,14 +75,14 @@ void igraph_i_cohesive_blocks_free3(igraph_vector_ptr_t *ptr) {
  * all neighboring components.
  */
 
-int igraph_i_cb_components(igraph_t *graph,
-                           const igraph_vector_bool_t *excluded,
-                           igraph_vector_long_t *components,
-                           long int *no,
-                           /* working area follows */
-                           igraph_vector_long_t *compid,
-                           igraph_dqueue_t *Q,
-                           igraph_vector_t *neis) {
+static int igraph_i_cb_components(igraph_t *graph,
+                                  const igraph_vector_bool_t *excluded,
+                                  igraph_vector_long_t *components,
+                                  long int *no,
+                                  /* working area follows */
+                                  igraph_vector_long_t *compid,
+                                  igraph_dqueue_t *Q,
+                                  igraph_vector_t *neis) {
 
     long int no_of_nodes = igraph_vcount(graph);
     long int i;
@@ -137,8 +137,8 @@ int igraph_i_cb_components(igraph_t *graph,
     return 0;
 }
 
-igraph_bool_t igraph_i_cb_isin(const igraph_vector_t *needle,
-                               const igraph_vector_t *haystack) {
+static igraph_bool_t igraph_i_cb_isin(const igraph_vector_t *needle,
+                                      const igraph_vector_t *haystack) {
     long int nlen = igraph_vector_size(needle);
     long int hlen = igraph_vector_size(haystack);
     long int np = 0, hp = 0;

--- a/src/coloring.c
+++ b/src/coloring.c
@@ -6,7 +6,7 @@
 #include "igraph_types_internal.h"
 
 
-int igraph_i_vertex_coloring_greedy_cn(const igraph_t *graph, igraph_vector_int_t *colors) {
+static int igraph_i_vertex_coloring_greedy_cn(const igraph_t *graph, igraph_vector_int_t *colors) {
     long i, vertex, maxdeg;
     long vc = igraph_vcount(graph);
     igraph_2wheap_t cn; /* indexed heap storing number of already coloured neighbours */

--- a/src/community.c
+++ b/src/community.c
@@ -50,7 +50,7 @@
     #include <R.h>
 #endif
 
-int igraph_i_rewrite_membership_vector(igraph_vector_t *membership) {
+static int igraph_i_rewrite_membership_vector(igraph_vector_t *membership) {
     long int no = (long int) igraph_vector_max(membership) + 1;
     igraph_vector_t idx;
     long int realno = 0;
@@ -73,13 +73,13 @@ int igraph_i_rewrite_membership_vector(igraph_vector_t *membership) {
     return 0;
 }
 
-int igraph_i_community_eb_get_merges2(const igraph_t *graph,
-                                      const igraph_vector_t *edges,
-                                      const igraph_vector_t *weights,
-                                      igraph_matrix_t *res,
-                                      igraph_vector_t *bridges,
-                                      igraph_vector_t *modularity,
-                                      igraph_vector_t *membership) {
+static int igraph_i_community_eb_get_merges2(const igraph_t *graph,
+                                             const igraph_vector_t *edges,
+                                             const igraph_vector_t *weights,
+                                             igraph_matrix_t *res,
+                                             igraph_vector_t *bridges,
+                                             igraph_vector_t *modularity,
+                                             igraph_vector_t *membership) {
 
     igraph_vector_t mymembership;
     long int no_of_nodes = igraph_vcount(graph);
@@ -293,8 +293,8 @@ int igraph_community_eb_get_merges(const igraph_t *graph,
 }
 
 /* Find the smallest active element in the vector */
-long int igraph_i_vector_which_max_not_null(const igraph_vector_t *v,
-        const char *passive) {
+static long int igraph_i_vector_which_max_not_null(const igraph_vector_t *v,
+                                                   const char *passive) {
     long int which, i = 0, size = igraph_vector_size(v);
     igraph_real_t max;
     while (passive[i]) {
@@ -1178,9 +1178,9 @@ typedef struct igraph_i_community_leading_eigenvector_data_t {
     igraph_real_t sumweights;
 } igraph_i_community_leading_eigenvector_data_t;
 
-int igraph_i_community_leading_eigenvector(igraph_real_t *to,
-        const igraph_real_t *from,
-        int n, void *extra) {
+static int igraph_i_community_leading_eigenvector(igraph_real_t *to,
+                                                  const igraph_real_t *from,
+                                                  int n, void *extra) {
 
     igraph_i_community_leading_eigenvector_data_t *data = extra;
     long int j, k, nlen, size = n;
@@ -1239,9 +1239,9 @@ int igraph_i_community_leading_eigenvector(igraph_real_t *to,
     return 0;
 }
 
-int igraph_i_community_leading_eigenvector2(igraph_real_t *to,
-        const igraph_real_t *from,
-        int n, void *extra) {
+static int igraph_i_community_leading_eigenvector2(igraph_real_t *to,
+                                                   const igraph_real_t *from,
+                                                   int n, void *extra) {
 
     igraph_i_community_leading_eigenvector_data_t *data = extra;
     long int j, k, nlen, size = n;
@@ -1305,9 +1305,9 @@ int igraph_i_community_leading_eigenvector2(igraph_real_t *to,
     return 0;
 }
 
-int igraph_i_community_leading_eigenvector_weighted(igraph_real_t *to,
-        const igraph_real_t *from,
-        int n, void *extra) {
+static int igraph_i_community_leading_eigenvector_weighted(igraph_real_t *to,
+                                                           const igraph_real_t *from,
+                                                           int n, void *extra) {
 
     igraph_i_community_leading_eigenvector_data_t *data = extra;
     long int j, k, nlen, size = n;
@@ -1369,9 +1369,9 @@ int igraph_i_community_leading_eigenvector_weighted(igraph_real_t *to,
     return 0;
 }
 
-int igraph_i_community_leading_eigenvector2_weighted(igraph_real_t *to,
-        const igraph_real_t *from,
-        int n, void *extra) {
+static int igraph_i_community_leading_eigenvector2_weighted(igraph_real_t *to,
+                                                            const igraph_real_t *from,
+                                                            int n, void *extra) {
 
     igraph_i_community_leading_eigenvector_data_t *data = extra;
     long int j, k, nlen, size = n;
@@ -1438,7 +1438,7 @@ int igraph_i_community_leading_eigenvector2_weighted(igraph_real_t *to,
     return 0;
 }
 
-void igraph_i_levc_free(igraph_vector_ptr_t *ptr) {
+static void igraph_i_levc_free(igraph_vector_ptr_t *ptr) {
     long int i, n = igraph_vector_ptr_size(ptr);
     for (i = 0; i < n; i++) {
         igraph_vector_t *v = VECTOR(*ptr)[i];
@@ -1449,8 +1449,8 @@ void igraph_i_levc_free(igraph_vector_ptr_t *ptr) {
     }
 }
 
-void igraph_i_error_handler_none(const char *reason, const char *file,
-                                 int line, int igraph_errno) {
+static void igraph_i_error_handler_none(const char *reason, const char *file,
+                                        int line, int igraph_errno) {
     IGRAPH_UNUSED(reason);
     IGRAPH_UNUSED(file);
     IGRAPH_UNUSED(line);
@@ -2684,7 +2684,7 @@ typedef struct {
 } igraph_i_multilevel_community_list;
 
 /* Computes the modularity of a community partitioning */
-igraph_real_t igraph_i_multilevel_community_modularity(
+static igraph_real_t igraph_i_multilevel_community_modularity(
     const igraph_i_multilevel_community_list *communities) {
     igraph_real_t result = 0;
     long int i;
@@ -2705,7 +2705,7 @@ typedef struct {
     long int id;
 } igraph_i_multilevel_link;
 
-int igraph_i_multilevel_link_cmp(const void *a, const void *b) {
+static int igraph_i_multilevel_link_cmp(const void *a, const void *b) {
     long int r = (((igraph_i_multilevel_link*)a)->from -
                   ((igraph_i_multilevel_link*)b)->from);
     if (r != 0) {
@@ -2717,7 +2717,7 @@ int igraph_i_multilevel_link_cmp(const void *a, const void *b) {
 }
 
 /* removes multiple edges and returns new edge id's for each edge in |E|log|E| */
-int igraph_i_multilevel_simplify_multiple(igraph_t *graph, igraph_vector_t *eids) {
+static int igraph_i_multilevel_simplify_multiple(igraph_t *graph, igraph_vector_t *eids) {
     long int ecount = igraph_ecount(graph);
     long int i, l = -1, last_from = -1, last_to = -1;
     igraph_bool_t directed = igraph_is_directed(graph);
@@ -2779,7 +2779,7 @@ typedef struct {
     igraph_real_t weight;
 } igraph_i_multilevel_community_link;
 
-int igraph_i_multilevel_community_link_cmp(const void *a, const void *b) {
+static int igraph_i_multilevel_community_link_cmp(const void *a, const void *b) {
     return (int) (((igraph_i_multilevel_community_link*)a)->community -
                   ((igraph_i_multilevel_community_link*)b)->community);
 }
@@ -2797,11 +2797,12 @@ int igraph_i_multilevel_community_link_cmp(const void *a, const void *b) {
  *   communities incident on this vertex and the total weight of edges
  *   pointing to these communities
  */
-int igraph_i_multilevel_community_links(const igraph_t *graph,
-                                        const igraph_i_multilevel_community_list *communities,
-                                        igraph_integer_t vertex, igraph_vector_t *edges,
-                                        igraph_real_t *weight_all, igraph_real_t *weight_inside, igraph_real_t *weight_loop,
-                                        igraph_vector_t *links_community, igraph_vector_t *links_weight) {
+static int igraph_i_multilevel_community_links(
+        const igraph_t *graph,
+        const igraph_i_multilevel_community_list *communities,
+        igraph_integer_t vertex, igraph_vector_t *edges,
+        igraph_real_t *weight_all, igraph_real_t *weight_inside, igraph_real_t *weight_loop,
+        igraph_vector_t *links_community, igraph_vector_t *links_weight) {
 
     long int i, n, last = -1, c = -1;
     igraph_real_t weight = 1;
@@ -2871,10 +2872,10 @@ int igraph_i_multilevel_community_links(const igraph_t *graph,
     return 0;
 }
 
-igraph_real_t igraph_i_multilevel_community_modularity_gain(
-    const igraph_i_multilevel_community_list *communities,
-    igraph_integer_t community, igraph_integer_t vertex,
-    igraph_real_t weight_all, igraph_real_t weight_inside) {
+static igraph_real_t igraph_i_multilevel_community_modularity_gain(
+        const igraph_i_multilevel_community_list *communities,
+        igraph_integer_t community, igraph_integer_t vertex,
+        igraph_real_t weight_all, igraph_real_t weight_inside) {
     IGRAPH_UNUSED(vertex);
     return weight_inside -
            communities->item[(long int)community].weight_all * weight_all / communities->weight_sum;
@@ -2886,7 +2887,7 @@ igraph_real_t igraph_i_multilevel_community_modularity_gain(
  * detection where a copy of the original graph is used anyway.
  * The membership vector will also be rewritten by the underlying
  * igraph_membership_reindex call */
-int igraph_i_multilevel_shrink(igraph_t *graph, igraph_vector_t *membership) {
+static int igraph_i_multilevel_shrink(igraph_t *graph, igraph_vector_t *membership) {
     igraph_vector_t edges;
     long int no_of_nodes = igraph_vcount(graph);
     long int no_of_edges = igraph_ecount(graph);
@@ -2957,9 +2958,11 @@ int igraph_i_multilevel_shrink(igraph_t *graph, igraph_vector_t *membership) {
  *
  * Time complexity: in average near linear on sparse graphs.
  */
-int igraph_i_community_multilevel_step(igraph_t *graph,
-                                       igraph_vector_t *weights, igraph_vector_t *membership,
-                                       igraph_real_t *modularity) {
+static int igraph_i_community_multilevel_step(
+        igraph_t *graph,
+        igraph_vector_t *weights,
+        igraph_vector_t *membership,
+        igraph_real_t *modularity) {
 
     long int i, j;
     long int vcount = igraph_vcount(graph);
@@ -3318,15 +3321,15 @@ int igraph_community_multilevel(const igraph_t *graph,
 }
 
 
-int igraph_i_compare_communities_vi(const igraph_vector_t *v1,
-                                    const igraph_vector_t *v2, igraph_real_t* result);
-int igraph_i_compare_communities_nmi(const igraph_vector_t *v1,
-                                     const igraph_vector_t *v2, igraph_real_t* result);
-int igraph_i_compare_communities_rand(const igraph_vector_t *v1,
-                                      const igraph_vector_t *v2, igraph_real_t* result, igraph_bool_t adjust);
-int igraph_i_split_join_distance(const igraph_vector_t *v1,
-                                 const igraph_vector_t *v2, igraph_integer_t* distance12,
-                                 igraph_integer_t* distance21);
+static int igraph_i_compare_communities_vi(const igraph_vector_t *v1,
+                                           const igraph_vector_t *v2, igraph_real_t* result);
+static int igraph_i_compare_communities_nmi(const igraph_vector_t *v1,
+                                            const igraph_vector_t *v2, igraph_real_t* result);
+static int igraph_i_compare_communities_rand(const igraph_vector_t *v1,
+                                             const igraph_vector_t *v2, igraph_real_t* result, igraph_bool_t adjust);
+static int igraph_i_split_join_distance(const igraph_vector_t *v1,
+                                        const igraph_vector_t *v2, igraph_integer_t* distance12,
+                                        igraph_integer_t* distance21);
 
 /**
  * \ingroup communities
@@ -3520,7 +3523,7 @@ int igraph_split_join_distance(const igraph_vector_t *comm1,
  * membership vectors v1 and v2. This is needed by both Meila's and Danon's
  * community comparison measure.
  */
-int igraph_i_entropy_and_mutual_information(const igraph_vector_t* v1,
+static int igraph_i_entropy_and_mutual_information(const igraph_vector_t* v1,
         const igraph_vector_t* v2, double* h1, double* h2, double* mut_inf) {
     long int i, n = igraph_vector_size(v1);
     long int k1 = (long int)igraph_vector_max(v1) + 1;
@@ -3605,7 +3608,7 @@ int igraph_i_entropy_and_mutual_information(const igraph_vector_t* v1,
  * </para><para>
  * Time complexity: O(n log(n))
  */
-int igraph_i_compare_communities_nmi(const igraph_vector_t *v1, const igraph_vector_t *v2,
+static int igraph_i_compare_communities_nmi(const igraph_vector_t *v1, const igraph_vector_t *v2,
                                      igraph_real_t* result) {
     double h1, h2, mut_inf;
 
@@ -3635,7 +3638,7 @@ int igraph_i_compare_communities_nmi(const igraph_vector_t *v1, const igraph_vec
  * </para><para>
  * Time complexity: O(n log(n))
  */
-int igraph_i_compare_communities_vi(const igraph_vector_t *v1, const igraph_vector_t *v2,
+static int igraph_i_compare_communities_vi(const igraph_vector_t *v1, const igraph_vector_t *v2,
                                     igraph_real_t* result) {
     double h1, h2, mut_inf;
 
@@ -3656,7 +3659,7 @@ int igraph_i_compare_communities_vi(const igraph_vector_t *v1, const igraph_vect
  * Time complexity: O(n log(max(k1, k2))), where n is the number of vertices, k1
  * and k2 are the number of clusters in each of the clusterings.
  */
-int igraph_i_confusion_matrix(const igraph_vector_t *v1, const igraph_vector_t *v2,
+static int igraph_i_confusion_matrix(const igraph_vector_t *v1, const igraph_vector_t *v2,
                               igraph_spmatrix_t *m) {
     long int k1 = (long int)igraph_vector_max(v1) + 1;
     long int k2 = (long int)igraph_vector_max(v2) + 1;
@@ -3687,7 +3690,7 @@ int igraph_i_confusion_matrix(const igraph_vector_t *v1, const igraph_vector_t *
  * Time complexity: O(n log(max(k1, k2))), where n is the number of vertices, k1
  * and k2 are the number of clusters in each of the clusterings.
  */
-int igraph_i_split_join_distance(const igraph_vector_t *v1, const igraph_vector_t *v2,
+static int igraph_i_split_join_distance(const igraph_vector_t *v1, const igraph_vector_t *v2,
                                  igraph_integer_t* distance12, igraph_integer_t* distance21) {
     long int n = igraph_vector_size(v1);
     igraph_vector_t rowmax, colmax;
@@ -3752,8 +3755,9 @@ int igraph_i_split_join_distance(const igraph_vector_t *v1, const igraph_vector_
  * Time complexity: O(n log(max(k1, k2))), where n is the number of vertices, k1
  * and k2 are the number of clusters in each of the clusterings.
  */
-int igraph_i_compare_communities_rand(const igraph_vector_t *v1,
-                                      const igraph_vector_t *v2, igraph_real_t *result, igraph_bool_t adjust) {
+static int igraph_i_compare_communities_rand(
+        const igraph_vector_t *v1, const igraph_vector_t *v2,
+        igraph_real_t *result, igraph_bool_t adjust) {
     igraph_spmatrix_t m;
     igraph_spmatrix_iter_t mit;
     igraph_vector_t rowsums, colsums;

--- a/src/community.c
+++ b/src/community.c
@@ -721,7 +721,7 @@ int igraph_community_edge_betweenness(const igraph_t *graph,
 
     if (result_owned) {
         igraph_vector_destroy(result);
-        free(result);
+        igraph_Free(result);
         IGRAPH_FINALLY_CLEAN(2);
     }
 
@@ -1516,7 +1516,7 @@ void igraph_i_error_handler_none(const char *reason, const char *file,
  *    \ref igraph_vector_t object. The user is responsible of
  *    deallocating the memory that belongs to the individual vectors,
  *    by calling first \ref igraph_vector_destroy(), and then
- *    <code>free()</code> on them.
+ *    \ref igraph_free() on them.
  * \param history Pointer to an initialized vector or a null pointer.
  *    If not a null pointer, then a trace of the algorithm is stored
  *    here, encoded numerically. The various operations:
@@ -2732,7 +2732,7 @@ int igraph_i_multilevel_simplify_multiple(igraph_t *graph, igraph_vector_t *eids
     if (links == 0) {
         IGRAPH_ERROR("multi-level community structure detection failed", IGRAPH_ENOMEM);
     }
-    IGRAPH_FINALLY(free, links);
+    IGRAPH_FINALLY(igraph_free, links);
 
     for (i = 0; i < ecount; i++) {
         igraph_edge(graph, (igraph_integer_t) i, &from, &to);
@@ -2762,7 +2762,7 @@ int igraph_i_multilevel_simplify_multiple(igraph_t *graph, igraph_vector_t *eids
         VECTOR(*eids)[links[i].id] = l;
     }
 
-    free(links);
+    igraph_Free(links);
     IGRAPH_FINALLY_CLEAN(1);
 
     igraph_destroy(graph);
@@ -3533,12 +3533,12 @@ int igraph_i_entropy_and_mutual_information(const igraph_vector_t* v1,
     if (p1 == 0) {
         IGRAPH_ERROR("igraph_i_entropy_and_mutual_information failed", IGRAPH_ENOMEM);
     }
-    IGRAPH_FINALLY(free, p1);
+    IGRAPH_FINALLY(igraph_free, p1);
     p2 = igraph_Calloc(k2, double);
     if (p2 == 0) {
         IGRAPH_ERROR("igraph_i_entropy_and_mutual_information failed", IGRAPH_ENOMEM);
     }
-    IGRAPH_FINALLY(free, p2);
+    IGRAPH_FINALLY(igraph_free, p2);
 
     /* Calculate the entropy of v1 */
     *h1 = 0.0;
@@ -3586,7 +3586,7 @@ int igraph_i_entropy_and_mutual_information(const igraph_vector_t* v1,
 
     igraph_spmatrix_iter_destroy(&mit);
     igraph_spmatrix_destroy(&m);
-    free(p1); free(p2);
+    igraph_Free(p1); igraph_Free(p2);
 
     IGRAPH_FINALLY_CLEAN(4);
 

--- a/src/community_leiden.c
+++ b/src/community_leiden.c
@@ -46,7 +46,8 @@
  * and is updated in-place.
  *
  */
-int igraph_i_community_leiden_fastmovenodes(const igraph_t *graph,
+static int igraph_i_community_leiden_fastmovenodes(
+        const igraph_t *graph,
         const igraph_inclist_t *edges_per_node,
         const igraph_vector_t *edge_weights, const igraph_vector_t *node_weights,
         const igraph_real_t resolution_parameter,
@@ -215,7 +216,10 @@ int igraph_i_community_leiden_fastmovenodes(const igraph_t *graph,
  * resulting \c nb_refined_clusters, then nodes in \c node_subset are numbered
  * C, C + 1, ..., C' - 1.
  */
-int igraph_i_community_leiden_clean_refined_membership(const igraph_vector_t* node_subset, igraph_vector_t *refined_membership, igraph_integer_t* nb_refined_clusters) {
+static int igraph_i_community_leiden_clean_refined_membership(
+        const igraph_vector_t* node_subset,
+        igraph_vector_t *refined_membership,
+        igraph_integer_t* nb_refined_clusters) {
     long int i, n = igraph_vector_size(node_subset);
     igraph_vector_t new_cluster;
 
@@ -280,7 +284,8 @@ int igraph_i_community_leiden_clean_refined_membership(const igraph_vector_t* no
  * igraph_i_community_leiden_clean_refined_membership for more information about
  * this aspect.
  */
-int igraph_i_community_leiden_mergenodes(const igraph_t *graph,
+static int igraph_i_community_leiden_mergenodes(
+        const igraph_t *graph,
         const igraph_inclist_t *edges_per_node,
         const igraph_vector_t *edge_weights, const igraph_vector_t *node_weights,
         const igraph_vector_t *node_subset,
@@ -479,7 +484,7 @@ int igraph_i_community_leiden_mergenodes(const igraph_t *graph,
  * should be ensured that all clusters are always properly empty (or
  * non-existing) before calling this function.
  */
-int igraph_i_community_get_clusters(const igraph_vector_t *membership, igraph_vector_ptr_t *clusters) {
+static int igraph_i_community_get_clusters(const igraph_vector_t *membership, igraph_vector_ptr_t *clusters) {
     long int i, c, n = igraph_vector_size(membership);
     igraph_vector_t *cluster;
     for (i = 0; i < n; i++) {
@@ -518,7 +523,7 @@ int igraph_i_community_get_clusters(const igraph_vector_t *membership, igraph_ve
  * aggregated_membership are all expected to be initialized.
  *
  */
-int igraph_i_community_leiden_aggregate(
+static int igraph_i_community_leiden_aggregate(
     const igraph_t *graph, const igraph_inclist_t *edges_per_node, const igraph_vector_t *edge_weights, const igraph_vector_t *node_weights,
     const igraph_vector_t *membership, const igraph_vector_t *refined_membership, const igraph_integer_t nb_refined_clusters,
     igraph_t *aggregated_graph, igraph_vector_t *aggregated_edge_weights, igraph_vector_t *aggregated_node_weights, igraph_vector_t *aggregated_membership) {
@@ -641,9 +646,10 @@ int igraph_i_community_leiden_aggregate(
  * weights inside cluster c. This is how the quality is calculated in practice.
  *
  */
-int igraph_i_community_leiden_quality(const igraph_t *graph, const igraph_vector_t *edge_weights, const igraph_vector_t *node_weights,
-                                      const igraph_vector_t *membership, const igraph_integer_t nb_comms, const igraph_real_t resolution_parameter,
-                                      igraph_real_t *quality) {
+static int igraph_i_community_leiden_quality(
+        const igraph_t *graph, const igraph_vector_t *edge_weights, const igraph_vector_t *node_weights,
+        const igraph_vector_t *membership, const igraph_integer_t nb_comms, const igraph_real_t resolution_parameter,
+        igraph_real_t *quality) {
     igraph_vector_t cluster_weights;
     igraph_real_t total_edge_weight = 0.0;
     igraph_eit_t eit;
@@ -696,10 +702,11 @@ int igraph_i_community_leiden_quality(const igraph_t *graph, const igraph_vector
  * refined partition, using the non-refined partition to create an initial
  * partition for the aggregate network.
  */
-int igraph_i_community_leiden(const igraph_t *graph,
-                              const igraph_vector_t *edge_weights, const igraph_vector_t *node_weights,
-                              const igraph_real_t resolution_parameter, const igraph_real_t beta,
-                              igraph_vector_t *membership, igraph_integer_t *nb_clusters, igraph_real_t *quality) {
+static int igraph_i_community_leiden(
+        const igraph_t *graph,
+        const igraph_vector_t *edge_weights, const igraph_vector_t *node_weights,
+        const igraph_real_t resolution_parameter, const igraph_real_t beta,
+        igraph_vector_t *membership, igraph_integer_t *nb_clusters, igraph_real_t *quality) {
     igraph_integer_t nb_refined_clusters;
     long int i, c, n = igraph_vcount(graph);
     igraph_t *aggregated_graph, *tmp_graph;

--- a/src/community_leiden.c
+++ b/src/community_leiden.c
@@ -531,7 +531,7 @@ int igraph_i_community_leiden_aggregate(
 
     /* Get refined clusters */
     IGRAPH_CHECK(igraph_vector_ptr_init(&refined_clusters, nb_refined_clusters));
-    igraph_vector_ptr_set_item_destructor(&refined_clusters, igraph_vector_destroy);
+    IGRAPH_VECTOR_PTR_SET_ITEM_DESTRUCTOR(&refined_clusters, igraph_vector_destroy);
     IGRAPH_FINALLY(igraph_vector_ptr_destroy_all, &refined_clusters);
     IGRAPH_CHECK(igraph_i_community_get_clusters(refined_membership, &refined_clusters));
 
@@ -722,7 +722,7 @@ int igraph_i_community_leiden(const igraph_t *graph,
 
     /* Initialize clusters */
     IGRAPH_CHECK(igraph_vector_ptr_init(&clusters, n));
-    igraph_vector_ptr_set_item_destructor(&clusters, igraph_vector_destroy);
+    IGRAPH_VECTOR_PTR_SET_ITEM_DESTRUCTOR(&clusters, igraph_vector_destroy);
     IGRAPH_FINALLY(igraph_vector_ptr_destroy_all, &clusters);
     /* Initialize aggregate nodes, which initially is identical to simply the
      * nodes in the graph. */

--- a/src/community_leiden.c
+++ b/src/community_leiden.c
@@ -815,7 +815,7 @@ int igraph_i_community_leiden(const igraph_t *graph,
             if (tmp_graph == 0) {
                 IGRAPH_ERROR("Leiden algorithm failed, could not allocate memory for aggregate graph", IGRAPH_ENOMEM);
             }
-            IGRAPH_FINALLY(free, tmp_graph);
+            IGRAPH_FINALLY(igraph_free, tmp_graph);
 
             IGRAPH_CHECK(igraph_i_community_leiden_aggregate(
                              aggregated_graph, &edges_per_node, aggregated_edge_weights, aggregated_node_weights,
@@ -845,7 +845,7 @@ int igraph_i_community_leiden(const igraph_t *graph,
                 if (aggregated_edge_weights == 0) {
                     IGRAPH_ERROR("Leiden algorithm failed, could not allocate memory for aggregate edge weights", IGRAPH_ENOMEM);
                 }
-                IGRAPH_FINALLY(free, aggregated_edge_weights);
+                IGRAPH_FINALLY(igraph_free, aggregated_edge_weights);
                 IGRAPH_CHECK(igraph_vector_init(aggregated_edge_weights, 0));
                 IGRAPH_FINALLY(igraph_vector_destroy, aggregated_edge_weights);
 
@@ -853,7 +853,7 @@ int igraph_i_community_leiden(const igraph_t *graph,
                 if (aggregated_node_weights == 0) {
                     IGRAPH_ERROR("Leiden algorithm failed, could not allocate memory for aggregate node weights", IGRAPH_ENOMEM);
                 }
-                IGRAPH_FINALLY(free, aggregated_node_weights);
+                IGRAPH_FINALLY(igraph_free, aggregated_node_weights);
                 IGRAPH_CHECK(igraph_vector_init(aggregated_node_weights, 0));
                 IGRAPH_FINALLY(igraph_vector_destroy, aggregated_node_weights);
 
@@ -861,7 +861,7 @@ int igraph_i_community_leiden(const igraph_t *graph,
                 if (aggregated_membership == 0) {
                     IGRAPH_ERROR("Leiden algorithm failed, could not allocate memory for aggregate membership", IGRAPH_ENOMEM);
                 }
-                IGRAPH_FINALLY(free, aggregated_membership);
+                IGRAPH_FINALLY(igraph_free, aggregated_membership);
                 IGRAPH_CHECK(igraph_vector_init(aggregated_membership, 0));
                 IGRAPH_FINALLY(igraph_vector_destroy, aggregated_membership);
             }
@@ -1037,7 +1037,7 @@ int igraph_community_leiden(const igraph_t *graph,
             IGRAPH_ERROR("Leiden algorithm failed, could not allocate memory for edge weights", IGRAPH_ENOMEM);
         }
         IGRAPH_CHECK(igraph_vector_init(i_edge_weights, igraph_ecount(graph)));
-        IGRAPH_FINALLY(free, i_edge_weights);
+        IGRAPH_FINALLY(igraph_free, i_edge_weights);
         IGRAPH_FINALLY(igraph_vector_destroy, i_edge_weights);
         igraph_vector_fill(i_edge_weights, 1);
     } else {
@@ -1051,7 +1051,7 @@ int igraph_community_leiden(const igraph_t *graph,
             IGRAPH_ERROR("Leiden algorithm failed, could not allocate memory for node weights", IGRAPH_ENOMEM);
         }
         IGRAPH_CHECK(igraph_vector_init(i_node_weights, n));
-        IGRAPH_FINALLY(free, i_node_weights);
+        IGRAPH_FINALLY(igraph_free, i_node_weights);
         IGRAPH_FINALLY(igraph_vector_destroy, i_node_weights);
         igraph_vector_fill(i_node_weights, 1);
     } else {

--- a/src/components.c
+++ b/src/components.c
@@ -410,7 +410,7 @@ int igraph_is_connected_weak(const igraph_t *graph, igraph_bool_t *res) {
     if (already_added == 0) {
         IGRAPH_ERROR("is connected (weak) failed", IGRAPH_ENOMEM);
     }
-    IGRAPH_FINALLY(free, already_added); /* TODO: hack */
+    IGRAPH_FINALLY(igraph_free, already_added);
 
     IGRAPH_DQUEUE_INIT_FINALLY(&q, 10);
     IGRAPH_VECTOR_INIT_FINALLY(&neis, 0);
@@ -616,7 +616,7 @@ static int igraph_i_decompose_weak(const igraph_t *graph,
     igraph_vector_destroy(&neis);
     igraph_vector_destroy(&verts);
     igraph_dqueue_destroy(&q);
-    igraph_free(already_added);
+    igraph_Free(already_added);
     IGRAPH_FINALLY_CLEAN(5);  /* + components */
 
     return 0;
@@ -889,7 +889,7 @@ void igraph_i_free_vectorlist(igraph_vector_ptr_t *list) {
  *     a spanning tree of the biconnected component is returned.
  *     Note you'll have to
  *     destroy each vector first by calling \ref igraph_vector_destroy()
- *     and then <code>free()</code> on it, plus you need to call
+ *     and then \ref igraph_free() on it, plus you need to call
  *     \ref igraph_vector_ptr_destroy() on the list to regain all
  *     allocated memory.
  * \param component_edges If not a NULL pointer, then the edges of the

--- a/src/conversion.c
+++ b/src/conversion.c
@@ -782,8 +782,6 @@ int igraph_get_stochastic(const igraph_t *graph,
 
     return 0;
 }
-int igraph_i_normalize_sparsemat(igraph_sparsemat_t *sparsemat,
-                                 igraph_bool_t column_wise);
 
 
 int igraph_i_normalize_sparsemat(igraph_sparsemat_t *sparsemat,

--- a/src/distances.c
+++ b/src/distances.c
@@ -30,11 +30,11 @@
 #include "igraph_interface.h"
 #include "igraph_adjlist.h"
 
-int igraph_i_eccentricity(const igraph_t *graph,
-                          igraph_vector_t *res,
-                          igraph_vs_t vids,
-                          igraph_neimode_t mode,
-                          const igraph_adjlist_t *adjlist) {
+static int igraph_i_eccentricity(const igraph_t *graph,
+                                 igraph_vector_t *res,
+                                 igraph_vs_t vids,
+                                 igraph_neimode_t mode,
+                                 const igraph_adjlist_t *adjlist) {
 
     int no_of_nodes = igraph_vcount(graph);
     igraph_dqueue_long_t q;

--- a/src/eigen.c
+++ b/src/eigen.c
@@ -30,7 +30,7 @@
 #include <math.h>
 #include <float.h>
 
-int igraph_i_eigen_arpackfun_to_mat(igraph_arpack_function_t *fun,
+static int igraph_i_eigen_arpackfun_to_mat(igraph_arpack_function_t *fun,
                                     int n, void *extra,
                                     igraph_matrix_t *res) {
 
@@ -55,7 +55,7 @@ int igraph_i_eigen_arpackfun_to_mat(igraph_arpack_function_t *fun,
     return 0;
 }
 
-int igraph_i_eigen_matrix_symmetric_lapack_lm(const igraph_matrix_t *A,
+static int igraph_i_eigen_matrix_symmetric_lapack_lm(const igraph_matrix_t *A,
         const igraph_eigen_which_t *which,
         igraph_vector_t *values,
         igraph_matrix_t *vectors) {
@@ -133,7 +133,7 @@ int igraph_i_eigen_matrix_symmetric_lapack_lm(const igraph_matrix_t *A,
     return 0;
 }
 
-int igraph_i_eigen_matrix_symmetric_lapack_sm(const igraph_matrix_t *A,
+static int igraph_i_eigen_matrix_symmetric_lapack_sm(const igraph_matrix_t *A,
         const igraph_eigen_which_t *which,
         igraph_vector_t *values,
         igraph_matrix_t *vectors) {
@@ -209,7 +209,7 @@ int igraph_i_eigen_matrix_symmetric_lapack_sm(const igraph_matrix_t *A,
     return 0;
 }
 
-int igraph_i_eigen_matrix_symmetric_lapack_la(const igraph_matrix_t *A,
+static int igraph_i_eigen_matrix_symmetric_lapack_la(const igraph_matrix_t *A,
         const igraph_eigen_which_t *which,
         igraph_vector_t *values,
         igraph_matrix_t *vectors) {
@@ -226,7 +226,7 @@ int igraph_i_eigen_matrix_symmetric_lapack_la(const igraph_matrix_t *A,
     return 0;
 }
 
-int igraph_i_eigen_matrix_symmetric_lapack_sa(const igraph_matrix_t *A,
+static int igraph_i_eigen_matrix_symmetric_lapack_sa(const igraph_matrix_t *A,
         const igraph_eigen_which_t *which,
         igraph_vector_t *values,
         igraph_matrix_t *vectors) {
@@ -242,7 +242,7 @@ int igraph_i_eigen_matrix_symmetric_lapack_sa(const igraph_matrix_t *A,
     return 0;
 }
 
-int igraph_i_eigen_matrix_symmetric_lapack_be(const igraph_matrix_t *A,
+static int igraph_i_eigen_matrix_symmetric_lapack_be(const igraph_matrix_t *A,
         const igraph_eigen_which_t *which,
         igraph_vector_t *values,
         igraph_matrix_t *vectors) {
@@ -321,7 +321,7 @@ int igraph_i_eigen_matrix_symmetric_lapack_be(const igraph_matrix_t *A,
     return 0;
 }
 
-int igraph_i_eigen_matrix_symmetric_lapack_all(const igraph_matrix_t *A,
+static int igraph_i_eigen_matrix_symmetric_lapack_all(const igraph_matrix_t *A,
         igraph_vector_t *values,
         igraph_matrix_t *vectors) {
 
@@ -334,7 +334,7 @@ int igraph_i_eigen_matrix_symmetric_lapack_all(const igraph_matrix_t *A,
     return 0;
 }
 
-int igraph_i_eigen_matrix_symmetric_lapack_iv(const igraph_matrix_t *A,
+static int igraph_i_eigen_matrix_symmetric_lapack_iv(const igraph_matrix_t *A,
         const igraph_eigen_which_t *which,
         igraph_vector_t *values,
         igraph_matrix_t *vectors) {
@@ -349,7 +349,7 @@ int igraph_i_eigen_matrix_symmetric_lapack_iv(const igraph_matrix_t *A,
     return 0;
 }
 
-int igraph_i_eigen_matrix_symmetric_lapack_sel(const igraph_matrix_t *A,
+static int igraph_i_eigen_matrix_symmetric_lapack_sel(const igraph_matrix_t *A,
         const igraph_eigen_which_t *which,
         igraph_vector_t *values,
         igraph_matrix_t *vectors) {
@@ -363,7 +363,7 @@ int igraph_i_eigen_matrix_symmetric_lapack_sel(const igraph_matrix_t *A,
     return 0;
 }
 
-int igraph_i_eigen_matrix_symmetric_lapack(const igraph_matrix_t *A,
+static int igraph_i_eigen_matrix_symmetric_lapack(const igraph_matrix_t *A,
         const igraph_sparsemat_t *sA,
         igraph_arpack_function_t *fun,
         int n, void *extra,
@@ -444,7 +444,7 @@ typedef struct igraph_i_eigen_matrix_sym_arpack_data_t {
     const igraph_sparsemat_t *sA;
 } igraph_i_eigen_matrix_sym_arpack_data_t;
 
-int igraph_i_eigen_matrix_sym_arpack_cb(igraph_real_t *to,
+static int igraph_i_eigen_matrix_sym_arpack_cb(igraph_real_t *to,
                                         const igraph_real_t *from,
                                         int n, void *extra) {
 
@@ -464,7 +464,7 @@ int igraph_i_eigen_matrix_sym_arpack_cb(igraph_real_t *to,
     return 0;
 }
 
-int igraph_i_eigen_matrix_symmetric_arpack_be(const igraph_matrix_t *A,
+static int igraph_i_eigen_matrix_symmetric_arpack_be(const igraph_matrix_t *A,
         const igraph_sparsemat_t *sA,
         igraph_arpack_function_t *fun,
         int n, void *extra,
@@ -535,7 +535,7 @@ int igraph_i_eigen_matrix_symmetric_arpack_be(const igraph_matrix_t *A,
     return 0;
 }
 
-int igraph_i_eigen_matrix_symmetric_arpack(const igraph_matrix_t *A,
+static int igraph_i_eigen_matrix_symmetric_arpack(const igraph_matrix_t *A,
         const igraph_sparsemat_t *sA,
         igraph_arpack_function_t *fun,
         int n, void *extra,
@@ -637,7 +637,7 @@ typedef struct igraph_i_eml_cmp_t {
    3 Larger real part
    4 Larger imaginary part */
 
-int igraph_i_eigen_matrix_lapack_cmp_lm(void *extra, const void *a,
+static int igraph_i_eigen_matrix_lapack_cmp_lm(void *extra, const void *a,
                                         const void *b) {
     igraph_i_eml_cmp_t *myextra = (igraph_i_eml_cmp_t *) extra;
     int *aa = (int*) a, *bb = (int*) b;
@@ -682,7 +682,7 @@ int igraph_i_eigen_matrix_lapack_cmp_lm(void *extra, const void *a,
    4 Smaller imaginary part
    This ensures that lm has exactly the opposite order to sm */
 
-int igraph_i_eigen_matrix_lapack_cmp_sm(void *extra, const void *a,
+static int igraph_i_eigen_matrix_lapack_cmp_sm(void *extra, const void *a,
                                         const void *b) {
     igraph_i_eml_cmp_t *myextra = (igraph_i_eml_cmp_t *) extra;
     int *aa = (int*) a, *bb = (int*) b;
@@ -725,7 +725,7 @@ int igraph_i_eigen_matrix_lapack_cmp_sm(void *extra, const void *a,
    2 Real eigenvalues come before complex ones
    3 Larger complex part */
 
-int igraph_i_eigen_matrix_lapack_cmp_lr(void *extra, const void *a,
+static int igraph_i_eigen_matrix_lapack_cmp_lr(void *extra, const void *a,
                                         const void *b) {
 
     igraph_i_eml_cmp_t *myextra = (igraph_i_eml_cmp_t *) extra;
@@ -764,7 +764,7 @@ int igraph_i_eigen_matrix_lapack_cmp_lr(void *extra, const void *a,
    This is opposite to LR
 */
 
-int igraph_i_eigen_matrix_lapack_cmp_sr(void *extra, const void *a,
+static int igraph_i_eigen_matrix_lapack_cmp_sr(void *extra, const void *a,
                                         const void *b) {
 
     igraph_i_eml_cmp_t *myextra = (igraph_i_eml_cmp_t *) extra;
@@ -801,7 +801,7 @@ int igraph_i_eigen_matrix_lapack_cmp_sr(void *extra, const void *a,
    2 Real eigenvalues before complex ones
    3 Larger real part */
 
-int igraph_i_eigen_matrix_lapack_cmp_li(void *extra, const void *a,
+static int igraph_i_eigen_matrix_lapack_cmp_li(void *extra, const void *a,
                                         const void *b) {
 
     igraph_i_eml_cmp_t *myextra = (igraph_i_eml_cmp_t *) extra;
@@ -839,7 +839,7 @@ int igraph_i_eigen_matrix_lapack_cmp_li(void *extra, const void *a,
    3 Smaller real part
    Order is opposite to LI */
 
-int igraph_i_eigen_matrix_lapack_cmp_si(void *extra, const void *a,
+static int igraph_i_eigen_matrix_lapack_cmp_si(void *extra, const void *a,
                                         const void *b) {
 
     igraph_i_eml_cmp_t *myextra = (igraph_i_eml_cmp_t *) extra;
@@ -888,7 +888,7 @@ int igraph_i_eigen_matrix_lapack_cmp_si(void *extra, const void *a,
         }                                   \
     } while (0)
 
-int igraph_i_eigen_matrix_lapack_reorder(const igraph_vector_t *real,
+static int igraph_i_eigen_matrix_lapack_reorder(const igraph_vector_t *real,
         const igraph_vector_t *imag,
         const igraph_matrix_t *compressed,
         const igraph_eigen_which_t *which,
@@ -1006,7 +1006,7 @@ int igraph_i_eigen_matrix_lapack_reorder(const igraph_vector_t *real,
     return 0;
 }
 
-int igraph_i_eigen_matrix_lapack_common(const igraph_matrix_t *A,
+static int igraph_i_eigen_matrix_lapack_common(const igraph_matrix_t *A,
                                         const igraph_eigen_which_t *which,
                                         igraph_vector_complex_t *values,
                                         igraph_matrix_complex_t *vectors) {
@@ -1042,21 +1042,21 @@ int igraph_i_eigen_matrix_lapack_common(const igraph_matrix_t *A,
 
 }
 
-int igraph_i_eigen_matrix_lapack_lm(const igraph_matrix_t *A,
+static int igraph_i_eigen_matrix_lapack_lm(const igraph_matrix_t *A,
                                     const igraph_eigen_which_t *which,
                                     igraph_vector_complex_t *values,
                                     igraph_matrix_complex_t *vectors) {
     return igraph_i_eigen_matrix_lapack_common(A, which, values, vectors);
 }
 
-int igraph_i_eigen_matrix_lapack_sm(const igraph_matrix_t *A,
+static int igraph_i_eigen_matrix_lapack_sm(const igraph_matrix_t *A,
                                     const igraph_eigen_which_t *which,
                                     igraph_vector_complex_t *values,
                                     igraph_matrix_complex_t *vectors) {
     return igraph_i_eigen_matrix_lapack_common(A, which, values, vectors);
 }
 
-int igraph_i_eigen_matrix_lapack_lr(const igraph_matrix_t *A,
+static int igraph_i_eigen_matrix_lapack_lr(const igraph_matrix_t *A,
                                     const igraph_eigen_which_t *which,
                                     igraph_vector_complex_t *values,
                                     igraph_matrix_complex_t *vectors) {
@@ -1064,42 +1064,42 @@ int igraph_i_eigen_matrix_lapack_lr(const igraph_matrix_t *A,
 }
 
 
-int igraph_i_eigen_matrix_lapack_sr(const igraph_matrix_t *A,
+static int igraph_i_eigen_matrix_lapack_sr(const igraph_matrix_t *A,
                                     const igraph_eigen_which_t *which,
                                     igraph_vector_complex_t *values,
                                     igraph_matrix_complex_t *vectors) {
     return igraph_i_eigen_matrix_lapack_common(A, which, values, vectors);
 }
 
-int igraph_i_eigen_matrix_lapack_li(const igraph_matrix_t *A,
+static int igraph_i_eigen_matrix_lapack_li(const igraph_matrix_t *A,
                                     const igraph_eigen_which_t *which,
                                     igraph_vector_complex_t *values,
                                     igraph_matrix_complex_t *vectors) {
     return igraph_i_eigen_matrix_lapack_common(A, which, values, vectors);
 }
 
-int igraph_i_eigen_matrix_lapack_si(const igraph_matrix_t *A,
+static int igraph_i_eigen_matrix_lapack_si(const igraph_matrix_t *A,
                                     const igraph_eigen_which_t *which,
                                     igraph_vector_complex_t *values,
                                     igraph_matrix_complex_t *vectors) {
     return igraph_i_eigen_matrix_lapack_common(A, which, values, vectors);
 }
 
-int igraph_i_eigen_matrix_lapack_select(const igraph_matrix_t *A,
+static int igraph_i_eigen_matrix_lapack_select(const igraph_matrix_t *A,
                                         const igraph_eigen_which_t *which,
                                         igraph_vector_complex_t *values,
                                         igraph_matrix_complex_t *vectors) {
     return igraph_i_eigen_matrix_lapack_common(A, which, values, vectors);
 }
 
-int igraph_i_eigen_matrix_lapack_all(const igraph_matrix_t *A,
+static int igraph_i_eigen_matrix_lapack_all(const igraph_matrix_t *A,
                                      const igraph_eigen_which_t *which,
                                      igraph_vector_complex_t *values,
                                      igraph_matrix_complex_t *vectors) {
     return igraph_i_eigen_matrix_lapack_common(A, which, values, vectors);
 }
 
-int igraph_i_eigen_matrix_lapack(const igraph_matrix_t *A,
+static int igraph_i_eigen_matrix_lapack(const igraph_matrix_t *A,
                                  const igraph_sparsemat_t *sA,
                                  igraph_arpack_function_t *fun,
                                  int n, void *extra,
@@ -1172,7 +1172,7 @@ int igraph_i_eigen_matrix_lapack(const igraph_matrix_t *A,
     return 0;
 }
 
-int igraph_i_eigen_checks(const igraph_matrix_t *A,
+static int igraph_i_eigen_checks(const igraph_matrix_t *A,
                           const igraph_sparsemat_t *sA,
                           igraph_arpack_function_t *fun, int n) {
 
@@ -1322,7 +1322,7 @@ int igraph_eigen_matrix(const igraph_matrix_t *A,
     return 0;
 }
 
-int igraph_i_eigen_adjacency_arpack_sym_cb(igraph_real_t *to,
+static int igraph_i_eigen_adjacency_arpack_sym_cb(igraph_real_t *to,
         const igraph_real_t *from,
         int n, void *extra) {
     igraph_adjlist_t *adjlist = (igraph_adjlist_t *) extra;
@@ -1342,7 +1342,7 @@ int igraph_i_eigen_adjacency_arpack_sym_cb(igraph_real_t *to,
     return 0;
 }
 
-int igraph_i_eigen_adjacency_arpack(const igraph_t *graph,
+static int igraph_i_eigen_adjacency_arpack(const igraph_t *graph,
                                     const igraph_eigen_which_t *which,
                                     igraph_arpack_options_t *options,
                                     igraph_arpack_storage_t* storage,

--- a/src/embedding.c
+++ b/src/embedding.c
@@ -40,7 +40,7 @@ typedef struct {
 
 /* Adjacency matrix, unweighted, undirected.
    Eigendecomposition is used */
-int igraph_i_asembeddingu(igraph_real_t *to, const igraph_real_t *from,
+static int igraph_i_asembeddingu(igraph_real_t *to, const igraph_real_t *from,
                           int n, void *extra) {
     igraph_i_asembedding_data_t *data = extra;
     igraph_adjlist_t *outlist = data->outlist;
@@ -65,7 +65,7 @@ int igraph_i_asembeddingu(igraph_real_t *to, const igraph_real_t *from,
 
 /* Adjacency matrix, weighted, undirected.
    Eigendecomposition is used. */
-int igraph_i_asembeddinguw(igraph_real_t *to, const igraph_real_t *from,
+static int igraph_i_asembeddinguw(igraph_real_t *to, const igraph_real_t *from,
                            int n, void *extra) {
     igraph_i_asembedding_data_t *data = extra;
     igraph_inclist_t *outlist = data->eoutlist;
@@ -93,7 +93,7 @@ int igraph_i_asembeddinguw(igraph_real_t *to, const igraph_real_t *from,
 }
 
 /* Adjacency matrix, unweighted, directed. SVD. */
-int igraph_i_asembedding(igraph_real_t *to, const igraph_real_t *from,
+static int igraph_i_asembedding(igraph_real_t *to, const igraph_real_t *from,
                          int n, void *extra) {
     igraph_i_asembedding_data_t *data = extra;
     igraph_adjlist_t *outlist = data->outlist;
@@ -131,7 +131,7 @@ int igraph_i_asembedding(igraph_real_t *to, const igraph_real_t *from,
 }
 
 /* Adjacency matrix, unweighted, directed. SVD, right eigenvectors */
-int igraph_i_asembedding_right(igraph_real_t *to, const igraph_real_t *from,
+static int igraph_i_asembedding_right(igraph_real_t *to, const igraph_real_t *from,
                                int n, void *extra) {
     igraph_i_asembedding_data_t *data = extra;
     igraph_adjlist_t *inlist = data->inlist;
@@ -155,7 +155,7 @@ int igraph_i_asembedding_right(igraph_real_t *to, const igraph_real_t *from,
 }
 
 /* Adjacency matrix, weighted, directed. SVD. */
-int igraph_i_asembeddingw(igraph_real_t *to, const igraph_real_t *from,
+static int igraph_i_asembeddingw(igraph_real_t *to, const igraph_real_t *from,
                           int n, void *extra) {
     igraph_i_asembedding_data_t *data = extra;
     igraph_inclist_t *outlist = data->eoutlist;
@@ -199,7 +199,7 @@ int igraph_i_asembeddingw(igraph_real_t *to, const igraph_real_t *from,
 }
 
 /* Adjacency matrix, weighted, directed. SVD, right eigenvectors. */
-int igraph_i_asembeddingw_right(igraph_real_t *to, const igraph_real_t *from,
+static int igraph_i_asembeddingw_right(igraph_real_t *to, const igraph_real_t *from,
                                 int n, void *extra) {
     igraph_i_asembedding_data_t *data = extra;
     igraph_inclist_t *inlist = data->einlist;
@@ -227,7 +227,7 @@ int igraph_i_asembeddingw_right(igraph_real_t *to, const igraph_real_t *from,
 }
 
 /* Laplacian D-A, unweighted, undirected. Eigendecomposition. */
-int igraph_i_lsembedding_da(igraph_real_t *to, const igraph_real_t *from,
+static int igraph_i_lsembedding_da(igraph_real_t *to, const igraph_real_t *from,
                             int n, void *extra) {
     igraph_i_asembedding_data_t *data = extra;
     igraph_adjlist_t *outlist = data->outlist;
@@ -251,7 +251,7 @@ int igraph_i_lsembedding_da(igraph_real_t *to, const igraph_real_t *from,
 }
 
 /* Laplacian D-A, weighted, undirected. Eigendecomposition. */
-int igraph_i_lsembedding_daw(igraph_real_t *to, const igraph_real_t *from,
+static int igraph_i_lsembedding_daw(igraph_real_t *to, const igraph_real_t *from,
                              int n, void *extra) {
     igraph_i_asembedding_data_t *data = extra;
     igraph_inclist_t *outlist = data->eoutlist;
@@ -279,7 +279,7 @@ int igraph_i_lsembedding_daw(igraph_real_t *to, const igraph_real_t *from,
 }
 
 /* Laplacian DAD, unweighted, undirected. Eigendecomposition. */
-int igraph_i_lsembedding_dad(igraph_real_t *to, const igraph_real_t *from,
+static int igraph_i_lsembedding_dad(igraph_real_t *to, const igraph_real_t *from,
                              int n, void *extra) {
 
     igraph_i_asembedding_data_t *data = extra;
@@ -313,7 +313,7 @@ int igraph_i_lsembedding_dad(igraph_real_t *to, const igraph_real_t *from,
     return 0;
 }
 
-int igraph_i_lsembedding_dadw(igraph_real_t *to, const igraph_real_t *from,
+static int igraph_i_lsembedding_dadw(igraph_real_t *to, const igraph_real_t *from,
                               int n, void *extra) {
 
     igraph_i_asembedding_data_t *data = extra;
@@ -370,7 +370,7 @@ int igraph_i_lsembedding_dadw(igraph_real_t *to, const igraph_real_t *from,
 }
 
 /* Laplacian I-DAD, unweighted, undirected. Eigendecomposition. */
-int igraph_i_lsembedding_idad(igraph_real_t *to, const igraph_real_t *from,
+static int igraph_i_lsembedding_idad(igraph_real_t *to, const igraph_real_t *from,
                               int n, void *extra) {
 
     int i;
@@ -383,7 +383,7 @@ int igraph_i_lsembedding_idad(igraph_real_t *to, const igraph_real_t *from,
     return 0;
 }
 
-int igraph_i_lsembedding_idadw(igraph_real_t *to, const igraph_real_t *from,
+static int igraph_i_lsembedding_idadw(igraph_real_t *to, const igraph_real_t *from,
                                int n, void *extra) {
     int i;
 
@@ -396,7 +396,7 @@ int igraph_i_lsembedding_idadw(igraph_real_t *to, const igraph_real_t *from,
 }
 
 /* Laplacian OAP, unweighted, directed. SVD. */
-int igraph_i_lseembedding_oap(igraph_real_t *to, const igraph_real_t *from,
+static int igraph_i_lseembedding_oap(igraph_real_t *to, const igraph_real_t *from,
                               int n, void *extra) {
 
     igraph_i_asembedding_data_t *data = extra;
@@ -454,7 +454,7 @@ int igraph_i_lseembedding_oap(igraph_real_t *to, const igraph_real_t *from,
 }
 
 /* Laplacian OAP, unweighted, directed. SVD, right eigenvectors. */
-int igraph_i_lseembedding_oap_right(igraph_real_t *to,
+static int igraph_i_lseembedding_oap_right(igraph_real_t *to,
                                     const igraph_real_t *from,
                                     int n, void *extra) {
     igraph_i_asembedding_data_t *data = extra;
@@ -490,7 +490,7 @@ int igraph_i_lseembedding_oap_right(igraph_real_t *to,
 }
 
 /* Laplacian OAP, weighted, directed. SVD. */
-int igraph_i_lseembedding_oapw(igraph_real_t *to, const igraph_real_t *from,
+static int igraph_i_lseembedding_oapw(igraph_real_t *to, const igraph_real_t *from,
                                int n, void *extra) {
 
     igraph_i_asembedding_data_t *data = extra;
@@ -554,7 +554,7 @@ int igraph_i_lseembedding_oapw(igraph_real_t *to, const igraph_real_t *from,
 }
 
 /* Laplacian OAP, weighted, directed. SVD, right eigenvectors. */
-int igraph_i_lseembedding_oapw_right(igraph_real_t *to,
+static int igraph_i_lseembedding_oapw_right(igraph_real_t *to,
                                      const igraph_real_t *from,
                                      int n, void *extra) {
     igraph_i_asembedding_data_t *data = extra;
@@ -593,7 +593,7 @@ int igraph_i_lseembedding_oapw_right(igraph_real_t *to,
     return 0;
 }
 
-int igraph_i_spectral_embedding(const igraph_t *graph,
+static int igraph_i_spectral_embedding(const igraph_t *graph,
                                 igraph_integer_t no,
                                 const igraph_vector_t *weights,
                                 igraph_eigen_which_position_t which,
@@ -876,7 +876,7 @@ int igraph_adjacency_spectral_embedding(const igraph_t *graph,
                                        /*eigen=*/ !directed, /*zapsmall=*/ 1);
 }
 
-int igraph_i_lse_und(const igraph_t *graph,
+static int igraph_i_lse_und(const igraph_t *graph,
                      igraph_integer_t no,
                      const igraph_vector_t *weights,
                      igraph_eigen_which_position_t which,
@@ -937,7 +937,7 @@ int igraph_i_lse_und(const igraph_t *graph,
     return 0;
 }
 
-int igraph_i_lse_dir(const igraph_t *graph,
+static int igraph_i_lse_dir(const igraph_t *graph,
                      igraph_integer_t no,
                      const igraph_vector_t *weights,
                      igraph_eigen_which_position_t which,

--- a/src/fast_community.c
+++ b/src/fast_community.c
@@ -147,12 +147,12 @@ void igraph_i_fastgreedy_community_list_destroy(
     for (i = 0; i < list->n; i++) {
         igraph_vector_ptr_destroy(&list->e[i].neis);
     }
-    free(list->e);
+    igraph_Free(list->e);
     if (list->heapindex != 0) {
-        free(list->heapindex);
+        igraph_Free(list->heapindex);
     }
     if (list->heap != 0) {
-        free(list->heap);
+        igraph_Free(list->heap);
     }
 }
 
@@ -698,12 +698,12 @@ int igraph_community_fastgreedy(const igraph_t *graph,
     if (communities.e == 0) {
         IGRAPH_ERROR("can't run fast greedy community detection", IGRAPH_ENOMEM);
     }
-    IGRAPH_FINALLY(free, communities.e);
+    IGRAPH_FINALLY(igraph_free, communities.e);
     communities.heap = (igraph_i_fastgreedy_community**)calloc((size_t) no_of_nodes, sizeof(igraph_i_fastgreedy_community*));
     if (communities.heap == 0) {
         IGRAPH_ERROR("can't run fast greedy community detection", IGRAPH_ENOMEM);
     }
-    IGRAPH_FINALLY(free, communities.heap);
+    IGRAPH_FINALLY(igraph_free, communities.heap);
     communities.heapindex = (igraph_integer_t*)calloc((size_t)no_of_nodes, sizeof(igraph_integer_t));
     if (communities.heapindex == 0) {
         IGRAPH_ERROR("can't run fast greedy community detection", IGRAPH_ENOMEM);
@@ -722,7 +722,7 @@ int igraph_community_fastgreedy(const igraph_t *graph,
     if (dq == 0) {
         IGRAPH_ERROR("can't run fast greedy community detection", IGRAPH_ENOMEM);
     }
-    IGRAPH_FINALLY(free, dq);
+    IGRAPH_FINALLY(igraph_free, dq);
     debug("Creating community pair list\n");
     IGRAPH_CHECK(igraph_eit_create(graph, igraph_ess_all(0), &edgeit));
     IGRAPH_FINALLY(igraph_eit_destroy, &edgeit);
@@ -730,7 +730,7 @@ int igraph_community_fastgreedy(const igraph_t *graph,
     if (pairs == 0) {
         IGRAPH_ERROR("can't run fast greedy community detection", IGRAPH_ENOMEM);
     }
-    IGRAPH_FINALLY(free, pairs);
+    IGRAPH_FINALLY(igraph_free, pairs);
     loop_weight_sum = 0;
     for (i = 0, j = 0; !IGRAPH_EIT_END(edgeit); i += 2, j++, IGRAPH_EIT_NEXT(edgeit)) {
         long int eidx = IGRAPH_EIT_GET(edgeit);
@@ -1022,12 +1022,12 @@ int igraph_community_fastgreedy(const igraph_t *graph,
         if (ivec == 0) {
             IGRAPH_ERROR("can't run fast greedy community detection", IGRAPH_ENOMEM);
         }
-        IGRAPH_FINALLY(free, ivec);
+        IGRAPH_FINALLY(igraph_free, ivec);
         for (i = 0; i < no_of_joins; i++) {
             ivec[i] = i + 1;
         }
         igraph_matrix_permdelete_rows(merges, ivec, total_joins - no_of_joins);
-        free(ivec);
+        igraph_Free(ivec);
         IGRAPH_FINALLY_CLEAN(1);
     }
     IGRAPH_PROGRESS("fast greedy community detection", 100.0, 0);
@@ -1038,8 +1038,8 @@ int igraph_community_fastgreedy(const igraph_t *graph,
     }
 
     debug("Freeing memory\n");
-    free(pairs);
-    free(dq);
+    igraph_Free(pairs);
+    igraph_Free(dq);
     igraph_i_fastgreedy_community_list_destroy(&communities);
     igraph_vector_destroy(&a);
     IGRAPH_FINALLY_CLEAN(4);

--- a/src/fast_community.c
+++ b/src/fast_community.c
@@ -109,8 +109,8 @@ typedef struct {
 /* Scans the community neighborhood list for the new maximal dq value.
  * Returns 1 if the maximum is different from the previous one,
  * 0 otherwise. */
-int igraph_i_fastgreedy_community_rescan_max(
-    igraph_i_fastgreedy_community* comm) {
+static int igraph_i_fastgreedy_community_rescan_max(
+        igraph_i_fastgreedy_community* comm) {
     long int i, n;
     igraph_i_fastgreedy_commpair *p, *best;
     igraph_real_t bestdq, currdq;
@@ -141,8 +141,8 @@ int igraph_i_fastgreedy_community_rescan_max(
 }
 
 /* Destroys the global community list object */
-void igraph_i_fastgreedy_community_list_destroy(
-    igraph_i_fastgreedy_community_list* list) {
+static void igraph_i_fastgreedy_community_list_destroy(
+        igraph_i_fastgreedy_community_list* list) {
     long int i;
     for (i = 0; i < list->n; i++) {
         igraph_vector_ptr_destroy(&list->e[i].neis);
@@ -157,8 +157,8 @@ void igraph_i_fastgreedy_community_list_destroy(
 }
 
 /* Community list heap maintenance: sift down */
-void igraph_i_fastgreedy_community_list_sift_down(
-    igraph_i_fastgreedy_community_list* list, long int idx) {
+static void igraph_i_fastgreedy_community_list_sift_down(
+        igraph_i_fastgreedy_community_list* list, long int idx) {
     long int root, child, c1, c2;
     igraph_i_fastgreedy_community* dummy;
     igraph_integer_t dummy2;
@@ -192,8 +192,8 @@ void igraph_i_fastgreedy_community_list_sift_down(
 }
 
 /* Community list heap maintenance: sift up */
-void igraph_i_fastgreedy_community_list_sift_up(
-    igraph_i_fastgreedy_community_list* list, long int idx) {
+static void igraph_i_fastgreedy_community_list_sift_up(
+        igraph_i_fastgreedy_community_list* list, long int idx) {
     long int root, parent, c1, c2;
     igraph_i_fastgreedy_community* dummy;
     igraph_integer_t dummy2;
@@ -223,8 +223,8 @@ void igraph_i_fastgreedy_community_list_sift_up(
 }
 
 /* Builds the community heap for the first time */
-void igraph_i_fastgreedy_community_list_build_heap(
-    igraph_i_fastgreedy_community_list* list) {
+static void igraph_i_fastgreedy_community_list_build_heap(
+        igraph_i_fastgreedy_community_list* list) {
     long int i;
     for (i = list->no_of_communities / 2 - 1; i >= 0; i--) {
         igraph_i_fastgreedy_community_list_sift_down(list, i);
@@ -236,8 +236,8 @@ void igraph_i_fastgreedy_community_list_build_heap(
 #define igraph_i_fastgreedy_community_list_find_in_heap(list, idx) (list)->heapindex[idx]
 
 /* Dumps the heap - for debugging purposes */
-void igraph_i_fastgreedy_community_list_dump_heap(
-    igraph_i_fastgreedy_community_list* list) {
+static void igraph_i_fastgreedy_community_list_dump_heap(
+        igraph_i_fastgreedy_community_list* list) {
     long int i;
     debug("Heap:\n");
     for (i = 0; i < list->no_of_communities; i++) {
@@ -258,8 +258,8 @@ void igraph_i_fastgreedy_community_list_dump_heap(
 
 /* Checks if the community heap satisfies the heap property.
  * Only useful for debugging. */
-void igraph_i_fastgreedy_community_list_check_heap(
-    igraph_i_fastgreedy_community_list* list) {
+static void igraph_i_fastgreedy_community_list_check_heap(
+        igraph_i_fastgreedy_community_list* list) {
     long int i;
     for (i = 0; i < list->no_of_communities / 2; i++) {
         if ((2 * i + 1 < list->no_of_communities && *list->heap[i]->maxdq->dq < *list->heap[2 * i + 1]->maxdq->dq) ||
@@ -272,8 +272,8 @@ void igraph_i_fastgreedy_community_list_check_heap(
 }
 
 /* Removes a given element from the heap */
-void igraph_i_fastgreedy_community_list_remove(
-    igraph_i_fastgreedy_community_list* list, long int idx) {
+static void igraph_i_fastgreedy_community_list_remove(
+        igraph_i_fastgreedy_community_list* list, long int idx) {
     igraph_real_t old;
     long int commidx;
 
@@ -298,8 +298,8 @@ void igraph_i_fastgreedy_community_list_remove(
 
 /* Removes a given element from the heap when there are no more neighbors
  * for it (comm->maxdq is NULL) */
-void igraph_i_fastgreedy_community_list_remove2(
-    igraph_i_fastgreedy_community_list* list, long int idx, long int comm) {
+static void igraph_i_fastgreedy_community_list_remove2(
+        igraph_i_fastgreedy_community_list* list, long int idx, long int comm) {
     long int i;
 
     if (idx == list->no_of_communities - 1) {
@@ -327,8 +327,8 @@ void igraph_i_fastgreedy_community_list_remove2(
 
 /* Removes the pair belonging to community k from the neighborhood list
  * of community c (that is, clist[c]) and recalculates maxdq */
-void igraph_i_fastgreedy_community_remove_nei(
-    igraph_i_fastgreedy_community_list* list, long int c, long int k) {
+static void igraph_i_fastgreedy_community_remove_nei(
+        igraph_i_fastgreedy_community_list* list, long int c, long int k) {
     long int i, n;
     igraph_bool_t rescan = 0;
     igraph_i_fastgreedy_commpair *p;
@@ -371,7 +371,7 @@ void igraph_i_fastgreedy_community_remove_nei(
 
 /* Auxiliary function to sort a community pair list with respect to the
  * `second` field */
-int igraph_i_fastgreedy_commpair_cmp(const void* p1, const void* p2) {
+static int igraph_i_fastgreedy_commpair_cmp(const void* p1, const void* p2) {
     igraph_i_fastgreedy_commpair *cp1, *cp2;
     cp1 = *(igraph_i_fastgreedy_commpair**)p1;
     cp2 = *(igraph_i_fastgreedy_commpair**)p2;
@@ -381,9 +381,9 @@ int igraph_i_fastgreedy_commpair_cmp(const void* p1, const void* p2) {
 /* Sorts the neighbor list of the community with the given index, optionally
  * optimizing the process if we know that the list is nearly sorted and only
  * a given pair is in the wrong place. */
-void igraph_i_fastgreedy_community_sort_neighbors_of(
-    igraph_i_fastgreedy_community_list* list, long int index,
-    igraph_i_fastgreedy_commpair* changed_pair) {
+static void igraph_i_fastgreedy_community_sort_neighbors_of(
+        igraph_i_fastgreedy_community_list* list, long int index,
+        igraph_i_fastgreedy_commpair* changed_pair) {
     igraph_vector_ptr_t* vec;
     long int i, n;
     igraph_bool_t can_skip_sort = 0;
@@ -453,9 +453,9 @@ void igraph_i_fastgreedy_community_sort_neighbors_of(
  * of the community list clist to newdq and restores the heap property
  * in community c if necessary. Returns 1 if the maximum in the row had
  * to be updated, zero otherwise */
-int igraph_i_fastgreedy_community_update_dq(
-    igraph_i_fastgreedy_community_list* list,
-    igraph_i_fastgreedy_commpair* p, igraph_real_t newdq) {
+static int igraph_i_fastgreedy_community_update_dq(
+        igraph_i_fastgreedy_community_list* list,
+        igraph_i_fastgreedy_commpair* p, igraph_real_t newdq) {
     long int i, j, to, from;
     igraph_real_t olddq;
     igraph_i_fastgreedy_community *comm_to, *comm_from;

--- a/src/feedback_arc_set.c
+++ b/src/feedback_arc_set.c
@@ -475,7 +475,7 @@ int igraph_i_feedback_arc_set_ip(const igraph_t *graph, igraph_vector_t *result,
         if (vptr == 0) {
             IGRAPH_ERROR("cannot calculate feedback arc set using IP", IGRAPH_ENOMEM);
         }
-        IGRAPH_FINALLY(free, vptr);
+        IGRAPH_FINALLY(igraph_free, vptr);
         IGRAPH_CHECK(igraph_vector_init(vptr, 0));
         IGRAPH_FINALLY_CLEAN(1);
         VECTOR(vertices_by_components)[i] = vptr;
@@ -487,7 +487,7 @@ int igraph_i_feedback_arc_set_ip(const igraph_t *graph, igraph_vector_t *result,
         if (vptr == 0) {
             IGRAPH_ERROR("cannot calculate feedback arc set using IP", IGRAPH_ENOMEM);
         }
-        IGRAPH_FINALLY(free, vptr);
+        IGRAPH_FINALLY(igraph_free, vptr);
         IGRAPH_CHECK(igraph_vector_init(vptr, 0));
         IGRAPH_FINALLY_CLEAN(1);
         VECTOR(edges_by_components)[i] = vptr;

--- a/src/flow.c
+++ b/src/flow.c
@@ -156,16 +156,16 @@
  * undirected edge.
  */
 
-int igraph_i_maxflow_undirected(const igraph_t *graph,
-                                igraph_real_t *value,
-                                igraph_vector_t *flow,
-                                igraph_vector_t *cut,
-                                igraph_vector_t *partition,
-                                igraph_vector_t *partition2,
-                                igraph_integer_t source,
-                                igraph_integer_t target,
-                                const igraph_vector_t *capacity,
-                                igraph_maxflow_stats_t *stats) {
+static int igraph_i_maxflow_undirected(const igraph_t *graph,
+                                       igraph_real_t *value,
+                                       igraph_vector_t *flow,
+                                       igraph_vector_t *cut,
+                                       igraph_vector_t *partition,
+                                       igraph_vector_t *partition2,
+                                       igraph_integer_t source,
+                                       igraph_integer_t target,
+                                       const igraph_vector_t *capacity,
+                                       igraph_maxflow_stats_t *stats) {
     igraph_integer_t no_of_edges = (igraph_integer_t) igraph_ecount(graph);
     igraph_integer_t no_of_nodes = (igraph_integer_t) igraph_vcount(graph);
     igraph_vector_t edges;
@@ -253,10 +253,10 @@ int igraph_i_maxflow_undirected(const igraph_t *graph,
                                         &first, &current, &to, &excess,       \
                                         &rescap, &rev))
 
-void igraph_i_mf_gap(long int b, igraph_maxflow_stats_t *stats,
-                     igraph_buckets_t *buckets, igraph_dbuckets_t *ibuckets,
-                     long int no_of_nodes,
-                     igraph_vector_long_t *distance) {
+static void igraph_i_mf_gap(long int b, igraph_maxflow_stats_t *stats,
+                            igraph_buckets_t *buckets, igraph_dbuckets_t *ibuckets,
+                            long int no_of_nodes,
+                            igraph_vector_long_t *distance) {
 
     long int bo;
     (stats->nogap)++;
@@ -269,12 +269,12 @@ void igraph_i_mf_gap(long int b, igraph_maxflow_stats_t *stats,
     }
 }
 
-void igraph_i_mf_relabel(long int v, long int no_of_nodes,
-                         igraph_vector_long_t *distance,
-                         igraph_vector_long_t *first,
-                         igraph_vector_t *rescap, igraph_vector_long_t *to,
-                         igraph_vector_long_t *current,
-                         igraph_maxflow_stats_t *stats, int *nrelabelsince) {
+static void igraph_i_mf_relabel(long int v, long int no_of_nodes,
+                                igraph_vector_long_t *distance,
+                                igraph_vector_long_t *first,
+                                igraph_vector_t *rescap, igraph_vector_long_t *to,
+                                igraph_vector_long_t *current,
+                                igraph_maxflow_stats_t *stats, int *nrelabelsince) {
 
     long int min = no_of_nodes;
     long int k, l, min_edge = 0;
@@ -293,14 +293,14 @@ void igraph_i_mf_relabel(long int v, long int no_of_nodes,
     }
 }
 
-void igraph_i_mf_push(long int v, long int e, long int n,
-                      igraph_vector_long_t *current,
-                      igraph_vector_t *rescap, igraph_vector_t *excess,
-                      long int target, long int source,
-                      igraph_buckets_t *buckets, igraph_dbuckets_t *ibuckets,
-                      igraph_vector_long_t *distance,
-                      igraph_vector_long_t *rev, igraph_maxflow_stats_t *stats,
-                      int *npushsince) {
+static void igraph_i_mf_push(long int v, long int e, long int n,
+                             igraph_vector_long_t *current,
+                             igraph_vector_t *rescap, igraph_vector_t *excess,
+                             long int target, long int source,
+                             igraph_buckets_t *buckets, igraph_dbuckets_t *ibuckets,
+                             igraph_vector_long_t *distance,
+                             igraph_vector_long_t *rev, igraph_maxflow_stats_t *stats,
+                             int *npushsince) {
     igraph_real_t delta =
         RESCAP(e) < EXCESS(v) ? RESCAP(e) : EXCESS(v);
     (stats->nopush)++; (*npushsince)++;
@@ -314,19 +314,19 @@ void igraph_i_mf_push(long int v, long int e, long int n,
     EXCESS(v) -= delta;
 }
 
-void igraph_i_mf_discharge(long int v,
-                           igraph_vector_long_t *current,
-                           igraph_vector_long_t *first,
-                           igraph_vector_t *rescap,
-                           igraph_vector_long_t *to,
-                           igraph_vector_long_t *distance,
-                           igraph_vector_t *excess,
-                           long int no_of_nodes, long int source,
-                           long int target, igraph_buckets_t *buckets,
-                           igraph_dbuckets_t *ibuckets,
-                           igraph_vector_long_t *rev,
-                           igraph_maxflow_stats_t *stats,
-                           int *npushsince, int *nrelabelsince) {
+static void igraph_i_mf_discharge(long int v,
+                                  igraph_vector_long_t *current,
+                                  igraph_vector_long_t *first,
+                                  igraph_vector_t *rescap,
+                                  igraph_vector_long_t *to,
+                                  igraph_vector_long_t *distance,
+                                  igraph_vector_t *excess,
+                                  long int no_of_nodes, long int source,
+                                  long int target, igraph_buckets_t *buckets,
+                                  igraph_dbuckets_t *ibuckets,
+                                  igraph_vector_long_t *rev,
+                                  igraph_maxflow_stats_t *stats,
+                                  int *npushsince, int *nrelabelsince) {
     do {
         long int i;
         long int start = (long int) CURRENT(v);
@@ -360,14 +360,14 @@ void igraph_i_mf_discharge(long int v,
     } while (1);
 }
 
-void igraph_i_mf_bfs(igraph_dqueue_long_t *bfsq,
-                     long int source, long int target,
-                     long int no_of_nodes, igraph_buckets_t *buckets,
-                     igraph_dbuckets_t *ibuckets,
-                     igraph_vector_long_t *distance,
-                     igraph_vector_long_t *first, igraph_vector_long_t *current,
-                     igraph_vector_long_t *to, igraph_vector_t *excess,
-                     igraph_vector_t *rescap, igraph_vector_long_t *rev) {
+static void igraph_i_mf_bfs(igraph_dqueue_long_t *bfsq,
+                            long int source, long int target,
+                            long int no_of_nodes, igraph_buckets_t *buckets,
+                            igraph_dbuckets_t *ibuckets,
+                            igraph_vector_long_t *distance,
+                            igraph_vector_long_t *first, igraph_vector_long_t *current,
+                            igraph_vector_long_t *to, igraph_vector_t *excess,
+                            igraph_vector_t *rescap, igraph_vector_long_t *rev) {
 
     long int k, l;
 
@@ -1212,12 +1212,12 @@ int igraph_st_mincut(const igraph_t *graph, igraph_real_t *value,
  * It can also calculate the cut itself, not just the cut value.
  */
 
-int igraph_i_mincut_undirected(const igraph_t *graph,
-                               igraph_real_t *res,
-                               igraph_vector_t *partition,
-                               igraph_vector_t *partition2,
-                               igraph_vector_t *cut,
-                               const igraph_vector_t *capacity) {
+static int igraph_i_mincut_undirected(const igraph_t *graph,
+                                      igraph_real_t *res,
+                                      igraph_vector_t *partition,
+                                      igraph_vector_t *partition2,
+                                      igraph_vector_t *cut,
+                                      const igraph_vector_t *capacity) {
 
     igraph_integer_t no_of_nodes = (igraph_integer_t) igraph_vcount(graph);
     igraph_integer_t no_of_edges = (igraph_integer_t) igraph_ecount(graph);
@@ -1479,12 +1479,12 @@ int igraph_i_mincut_undirected(const igraph_t *graph,
     return 0;
 }
 
-int igraph_i_mincut_directed(const igraph_t *graph,
-                             igraph_real_t *value,
-                             igraph_vector_t *partition,
-                             igraph_vector_t *partition2,
-                             igraph_vector_t *cut,
-                             const igraph_vector_t *capacity) {
+static int igraph_i_mincut_directed(const igraph_t *graph,
+                                    igraph_real_t *value,
+                                    igraph_vector_t *partition,
+                                    igraph_vector_t *partition2,
+                                    igraph_vector_t *cut,
+                                    const igraph_vector_t *capacity) {
     long int i;
     long int no_of_nodes = igraph_vcount(graph);
     igraph_real_t flow;
@@ -1665,9 +1665,9 @@ int igraph_mincut(const igraph_t *graph,
 }
 
 
-int igraph_i_mincut_value_undirected(const igraph_t *graph,
-                                     igraph_real_t *res,
-                                     const igraph_vector_t *capacity) {
+static int igraph_i_mincut_value_undirected(const igraph_t *graph,
+                                            igraph_real_t *res,
+                                            const igraph_vector_t *capacity) {
     return igraph_i_mincut_undirected(graph, res, 0, 0, 0, capacity);
 }
 
@@ -1747,11 +1747,11 @@ int igraph_mincut_value(const igraph_t *graph, igraph_real_t *res,
     return 0;
 }
 
-int igraph_i_st_vertex_connectivity_directed(const igraph_t *graph,
-        igraph_integer_t *res,
-        igraph_integer_t source,
-        igraph_integer_t target,
-        igraph_vconn_nei_t neighbors) {
+static int igraph_i_st_vertex_connectivity_directed(const igraph_t *graph,
+                                                    igraph_integer_t *res,
+                                                    igraph_integer_t source,
+                                                    igraph_integer_t target,
+                                                    igraph_vconn_nei_t neighbors) {
 
     igraph_integer_t no_of_nodes = (igraph_integer_t) igraph_vcount(graph);
     igraph_integer_t no_of_edges = (igraph_integer_t) igraph_ecount(graph);
@@ -1835,11 +1835,11 @@ int igraph_i_st_vertex_connectivity_directed(const igraph_t *graph,
     return 0;
 }
 
-int igraph_i_st_vertex_connectivity_undirected(const igraph_t *graph,
-        igraph_integer_t *res,
-        igraph_integer_t source,
-        igraph_integer_t target,
-        igraph_vconn_nei_t neighbors) {
+static int igraph_i_st_vertex_connectivity_undirected(const igraph_t *graph,
+                                                      igraph_integer_t *res,
+                                                      igraph_integer_t source,
+                                                      igraph_integer_t target,
+                                                      igraph_vconn_nei_t neighbors) {
 
     igraph_integer_t no_of_nodes = (igraph_integer_t) igraph_vcount(graph);
     igraph_t newgraph;
@@ -1953,8 +1953,8 @@ int igraph_st_vertex_connectivity(const igraph_t *graph,
     return 0;
 }
 
-int igraph_i_vertex_connectivity_directed(const igraph_t *graph,
-        igraph_integer_t *res) {
+static int igraph_i_vertex_connectivity_directed(const igraph_t *graph,
+                                                 igraph_integer_t *res) {
 
     igraph_integer_t no_of_nodes = (igraph_integer_t) igraph_vcount(graph);
     long int i, j;
@@ -1991,8 +1991,8 @@ int igraph_i_vertex_connectivity_directed(const igraph_t *graph,
     return 0;
 }
 
-int igraph_i_vertex_connectivity_undirected(const igraph_t *graph,
-        igraph_integer_t *res) {
+static int igraph_i_vertex_connectivity_undirected(const igraph_t *graph,
+                                                   igraph_integer_t *res) {
     igraph_t newgraph;
 
     IGRAPH_CHECK(igraph_copy(&newgraph, graph));
@@ -2008,9 +2008,9 @@ int igraph_i_vertex_connectivity_undirected(const igraph_t *graph,
 }
 
 /* Use that vertex.connectivity(G) <= edge.connectivity(G) <= min(degree(G)) */
-int igraph_i_connectivity_checks(const igraph_t *graph,
-                                 igraph_integer_t *res,
-                                 igraph_bool_t *found) {
+static int igraph_i_connectivity_checks(const igraph_t *graph,
+                                        igraph_integer_t *res,
+                                        igraph_bool_t *found) {
     igraph_bool_t conn;
     *found = 0;
 

--- a/src/foreign-graphml.c
+++ b/src/foreign-graphml.c
@@ -133,8 +133,8 @@ static void igraph_i_report_unhandled_attribute_target(const char* target,
                     "attribute specifications", file, line, 0, target);
 }
 
-igraph_real_t igraph_i_graphml_parse_numeric(const char* char_data,
-        igraph_real_t default_value) {
+static igraph_real_t igraph_i_graphml_parse_numeric(const char* char_data,
+                                                    igraph_real_t default_value) {
     double result;
 
     if (char_data == 0) {
@@ -148,8 +148,8 @@ igraph_real_t igraph_i_graphml_parse_numeric(const char* char_data,
     return result;
 }
 
-igraph_bool_t igraph_i_graphml_parse_boolean(const char* char_data,
-        igraph_bool_t default_value) {
+static igraph_bool_t igraph_i_graphml_parse_boolean(const char* char_data,
+                                                    igraph_bool_t default_value) {
     int value;
     if (char_data == 0) {
         return default_value;
@@ -172,7 +172,7 @@ igraph_bool_t igraph_i_graphml_parse_boolean(const char* char_data,
     return value != 0;
 }
 
-void igraph_i_graphml_attribute_record_destroy(igraph_i_graphml_attribute_record_t* rec) {
+static void igraph_i_graphml_attribute_record_destroy(igraph_i_graphml_attribute_record_t* rec) {
     if (rec->record.type == IGRAPH_ATTRIBUTE_NUMERIC) {
         if (rec->record.value != 0) {
             igraph_vector_destroy((igraph_vector_t*)rec->record.value);
@@ -200,7 +200,7 @@ void igraph_i_graphml_attribute_record_destroy(igraph_i_graphml_attribute_record
     }
 }
 
-void igraph_i_graphml_destroy_state(struct igraph_i_graphml_parser_state* state) {
+static void igraph_i_graphml_destroy_state(struct igraph_i_graphml_parser_state* state) {
     if (state->destroyed) {
         return;
     }
@@ -231,7 +231,7 @@ void igraph_i_graphml_destroy_state(struct igraph_i_graphml_parser_state* state)
     IGRAPH_FINALLY_CLEAN(1);
 }
 
-void igraph_i_graphml_sax_handler_error(void *state0, const char* msg, ...) {
+static void igraph_i_graphml_sax_handler_error(void *state0, const char* msg, ...) {
     struct igraph_i_graphml_parser_state *state =
         (struct igraph_i_graphml_parser_state*)state0;
     va_list ap;
@@ -249,7 +249,7 @@ void igraph_i_graphml_sax_handler_error(void *state0, const char* msg, ...) {
     va_end(ap);
 }
 
-xmlEntityPtr igraph_i_graphml_sax_handler_get_entity(void *state0,
+static xmlEntityPtr igraph_i_graphml_sax_handler_get_entity(void *state0,
         const xmlChar* name) {
     xmlEntityPtr predef = xmlGetPredefinedEntity(name);
     IGRAPH_UNUSED(state0);
@@ -260,7 +260,7 @@ xmlEntityPtr igraph_i_graphml_sax_handler_get_entity(void *state0,
     return blankEntity;
 }
 
-void igraph_i_graphml_handle_unknown_start_tag(struct igraph_i_graphml_parser_state *state) {
+static void igraph_i_graphml_handle_unknown_start_tag(struct igraph_i_graphml_parser_state *state) {
     if (state->st != UNKNOWN) {
         igraph_vector_int_push_back(&state->prev_state_stack, state->st);
         state->st = UNKNOWN;
@@ -270,7 +270,7 @@ void igraph_i_graphml_handle_unknown_start_tag(struct igraph_i_graphml_parser_st
     }
 }
 
-void igraph_i_graphml_sax_handler_start_document(void *state0) {
+static void igraph_i_graphml_sax_handler_start_document(void *state0) {
     struct igraph_i_graphml_parser_state *state =
         (struct igraph_i_graphml_parser_state*)state0;
     int ret;
@@ -359,7 +359,7 @@ void igraph_i_graphml_sax_handler_start_document(void *state0) {
     IGRAPH_FINALLY(igraph_i_graphml_destroy_state, state);
 }
 
-void igraph_i_graphml_sax_handler_end_document(void *state0) {
+static void igraph_i_graphml_sax_handler_end_document(void *state0) {
     struct igraph_i_graphml_parser_state *state =
         (struct igraph_i_graphml_parser_state*)state0;
     long i, l;
@@ -559,9 +559,9 @@ void igraph_i_graphml_sax_handler_end_document(void *state0) {
 #define XML_ATTR_VALUE_END(it) (*(it+4))
 #define XML_ATTR_VALUE(it) *(it+3), (*(it+4))-(*(it+3))
 
-igraph_i_graphml_attribute_record_t* igraph_i_graphml_add_attribute_key(
-    const xmlChar** attrs, int nb_attrs,
-    struct igraph_i_graphml_parser_state *state) {
+static igraph_i_graphml_attribute_record_t* igraph_i_graphml_add_attribute_key(
+        const xmlChar** attrs, int nb_attrs,
+        struct igraph_i_graphml_parser_state *state) {
     xmlChar **it;
     xmlChar *localname;
     igraph_trie_t *trie = 0;
@@ -749,10 +749,10 @@ igraph_i_graphml_attribute_record_t* igraph_i_graphml_add_attribute_key(
     return rec;
 }
 
-void igraph_i_graphml_attribute_data_setup(struct igraph_i_graphml_parser_state *state,
-        const xmlChar **attrs,
-        int nb_attrs,
-        igraph_attribute_elemtype_t type) {
+static void igraph_i_graphml_attribute_data_setup(struct igraph_i_graphml_parser_state *state,
+                                                  const xmlChar **attrs,
+                                                  int nb_attrs,
+                                                  igraph_attribute_elemtype_t type) {
     xmlChar **it;
     int i;
 
@@ -782,8 +782,8 @@ void igraph_i_graphml_attribute_data_setup(struct igraph_i_graphml_parser_state 
     }
 }
 
-void igraph_i_graphml_append_to_data_char(struct igraph_i_graphml_parser_state *state,
-        const xmlChar *data, int len) {
+static void igraph_i_graphml_append_to_data_char(struct igraph_i_graphml_parser_state *state,
+                                                 const xmlChar *data, int len) {
     long int data_char_new_start = 0;
 
     if (!state->successful) {
@@ -805,7 +805,7 @@ void igraph_i_graphml_append_to_data_char(struct igraph_i_graphml_parser_state *
     state->data_char[data_char_new_start + len] = '\0';
 }
 
-void igraph_i_graphml_attribute_data_finish(struct igraph_i_graphml_parser_state *state) {
+static void igraph_i_graphml_attribute_data_finish(struct igraph_i_graphml_parser_state *state) {
     const char *key = fromXmlChar(state->data_key);
     igraph_attribute_elemtype_t type = state->data_type;
     igraph_trie_t *trie = 0;
@@ -930,8 +930,8 @@ void igraph_i_graphml_attribute_data_finish(struct igraph_i_graphml_parser_state
     }
 }
 
-void igraph_i_graphml_attribute_default_value_finish(
-    struct igraph_i_graphml_parser_state *state) {
+static void igraph_i_graphml_attribute_default_value_finish(
+        struct igraph_i_graphml_parser_state *state) {
     igraph_i_graphml_attribute_record_t *graphmlrec = state->current_attr_record;
 
     if (graphmlrec == 0) {
@@ -971,10 +971,10 @@ void igraph_i_graphml_attribute_default_value_finish(
     }
 }
 
-void igraph_i_graphml_sax_handler_start_element_ns(
-    void *state0, const xmlChar* localname, const xmlChar* prefix,
-    const xmlChar* uri, int nb_namespaces, const xmlChar** namespaces,
-    int nb_attributes, int nb_defaulted, const xmlChar** attributes) {
+static void igraph_i_graphml_sax_handler_start_element_ns(
+        void *state0, const xmlChar* localname, const xmlChar* prefix,
+        const xmlChar* uri, int nb_namespaces, const xmlChar** namespaces,
+        int nb_attributes, int nb_defaulted, const xmlChar** attributes) {
     struct igraph_i_graphml_parser_state *state =
         (struct igraph_i_graphml_parser_state*)state0;
     xmlChar** it;
@@ -1174,7 +1174,8 @@ void igraph_i_graphml_sax_handler_start_element_ns(
     }
 }
 
-void igraph_i_graphml_sax_handler_end_element_ns(void *state0,
+static void igraph_i_graphml_sax_handler_end_element_ns(
+        void *state0,
         const xmlChar* localname, const xmlChar* prefix,
         const xmlChar* uri) {
     struct igraph_i_graphml_parser_state *state =
@@ -1232,7 +1233,7 @@ void igraph_i_graphml_sax_handler_end_element_ns(void *state0,
     }
 }
 
-void igraph_i_graphml_sax_handler_chars(void* state0, const xmlChar* ch, int len) {
+static void igraph_i_graphml_sax_handler_chars(void* state0, const xmlChar* ch, int len) {
     struct igraph_i_graphml_parser_state *state =
         (struct igraph_i_graphml_parser_state*)state0;
 
@@ -1294,7 +1295,7 @@ static xmlSAXHandler igraph_i_graphml_sax_handler = {
 
 #define IS_FORBIDDEN_CONTROL_CHAR(x) ((x) < ' ' && (x) != '\t' && (x) != '\r' && (x) != '\n')
 
-int igraph_i_xml_escape(char* src, char** dest) {
+static int igraph_i_xml_escape(char* src, char** dest) {
     long int destlen = 0;
     char *s, *d;
     unsigned char ch;

--- a/src/foreign-pajek-parser.y
+++ b/src/foreign-pajek-parser.y
@@ -631,7 +631,7 @@ int igraph_i_pajek_add_string_vertex_attribute(const char *name,
   if (tmp==0) {
     IGRAPH_ERROR("cannot add element to hash table", IGRAPH_ENOMEM);
   }
-  IGRAPH_FINALLY(free, tmp);
+  IGRAPH_FINALLY(igraph_free, tmp);
   strncpy(tmp, value, len);
   tmp[len]='\0';
 
@@ -658,7 +658,7 @@ int igraph_i_pajek_add_string_edge_attribute(const char *name,
   if (tmp==0) {
     IGRAPH_ERROR("cannot add element to hash table", IGRAPH_ENOMEM);
   }
-  IGRAPH_FINALLY(free, tmp);
+  IGRAPH_FINALLY(igraph_free, tmp);
   strncpy(tmp, value, len);
   tmp[len]='\0';
   

--- a/src/foreign.c
+++ b/src/foreign.c
@@ -878,7 +878,7 @@ int igraph_read_graph_dimacs(igraph_t *graph, FILE *instream,
     return 0;
 }
 
-int igraph_i_read_graph_graphdb_getword(FILE *instream) {
+static int igraph_i_read_graph_graphdb_getword(FILE *instream) {
     int b1, b2;
     unsigned char c1, c2;
     b1 = fgetc(instream);
@@ -977,7 +977,7 @@ int igraph_gml_yylex_destroy (void *scanner );
 int igraph_gml_yyparse (igraph_i_gml_parsedata_t* context);
 void igraph_gml_yyset_in  (FILE * in_str, void* yyscanner );
 
-void igraph_i_gml_destroy_attrs(igraph_vector_ptr_t **ptr) {
+static void igraph_i_gml_destroy_attrs(igraph_vector_ptr_t **ptr) {
     long int i;
     igraph_vector_ptr_t *vec;
     for (i = 0; i < 3; i++) {
@@ -1005,7 +1005,7 @@ void igraph_i_gml_destroy_attrs(igraph_vector_ptr_t **ptr) {
     }
 }
 
-igraph_real_t igraph_i_gml_toreal(igraph_gml_tree_t *node, long int pos) {
+static igraph_real_t igraph_i_gml_toreal(igraph_gml_tree_t *node, long int pos) {
 
     igraph_real_t value = 0.0;
     int type = igraph_gml_tree_type(node, pos);
@@ -1025,7 +1025,7 @@ igraph_real_t igraph_i_gml_toreal(igraph_gml_tree_t *node, long int pos) {
     return value;
 }
 
-const char *igraph_i_gml_tostring(igraph_gml_tree_t *node, long int pos) {
+static const char *igraph_i_gml_tostring(igraph_gml_tree_t *node, long int pos) {
 
     int type = igraph_gml_tree_type(node, pos);
     char tmp[256];
@@ -1942,7 +1942,7 @@ int igraph_write_graph_lgl(const igraph_t *graph, FILE *outstream,
 #define E_COLOR            22
 #define E_LAST             23
 
-int igraph_i_pajek_escape(char* src, char** dest) {
+static int igraph_i_pajek_escape(char* src, char** dest) {
     long int destlen = 0;
     igraph_bool_t need_escape = 0;
 
@@ -2466,7 +2466,7 @@ int igraph_write_graph_dimacs(const igraph_t *graph, FILE *outstream,
     return 0;
 }
 
-int igraph_i_gml_convert_to_key(const char *orig, char **key) {
+static int igraph_i_gml_convert_to_key(const char *orig, char **key) {
     int no = 1;
     char strno[50];
     size_t i, len = strlen(orig), newlen = 0, plen = 0;
@@ -2741,7 +2741,7 @@ int igraph_write_graph_gml(const igraph_t *graph, FILE *outstream,
     return 0;
 }
 
-int igraph_i_dot_escape(const char *orig, char **result) {
+static int igraph_i_dot_escape(const char *orig, char **result) {
     /* do we have to escape the string at all? */
     long int i, j, len = (long int) strlen(orig), newlen = 0;
     igraph_bool_t need_quote = 0, is_number = 1;

--- a/src/forestfire.c
+++ b/src/forestfire.c
@@ -38,7 +38,7 @@ typedef struct igraph_i_forest_fire_data_t {
 } igraph_i_forest_fire_data_t;
 
 
-void igraph_i_forest_fire_free(igraph_i_forest_fire_data_t *data) {
+static void igraph_i_forest_fire_free(igraph_i_forest_fire_data_t *data) {
     long int i;
     for (i = 0; i < data->no_of_nodes; i++) {
         igraph_vector_destroy(data->inneis + i);

--- a/src/games.c
+++ b/src/games.c
@@ -124,7 +124,7 @@ int igraph_i_barabasi_game_bag(igraph_t *graph, igraph_integer_t n,
     if (bag == 0) {
         IGRAPH_ERROR("barabasi_game failed", IGRAPH_ENOMEM);
     }
-    IGRAPH_FINALLY(free, bag);    /* TODO: hack */
+    IGRAPH_FINALLY(igraph_free, bag);    /* TODO: hack */
 
     /* The first node(s) in the bag */
     if (start_from) {
@@ -860,7 +860,7 @@ int igraph_degree_sequence_game_simple(igraph_t *graph,
     if (bag1 == 0) {
         IGRAPH_ERROR("degree sequence game (simple)", IGRAPH_ENOMEM);
     }
-    IGRAPH_FINALLY(free, bag1);   /* TODO: hack */
+    IGRAPH_FINALLY(igraph_free, bag1);   /* TODO: hack */
 
     for (i = 0; i < no_of_nodes; i++) {
         for (j = 0; j < VECTOR(*out_seq)[i]; j++) {
@@ -872,7 +872,7 @@ int igraph_degree_sequence_game_simple(igraph_t *graph,
         if (bag2 == 0) {
             IGRAPH_ERROR("degree sequence game (simple)", IGRAPH_ENOMEM);
         }
-        IGRAPH_FINALLY(free, bag2);
+        IGRAPH_FINALLY(igraph_free, bag2);
         for (i = 0; i < no_of_nodes; i++) {
             for (j = 0; j < VECTOR(*in_seq)[i]; j++) {
                 bag2[bagp2++] = i;

--- a/src/games.c
+++ b/src/games.c
@@ -47,8 +47,8 @@ typedef struct {
     igraph_psumtree_t *sumtrees;
 } igraph_i_citing_cited_type_game_struct_t;
 
-void igraph_i_citing_cited_type_game_free (
-    igraph_i_citing_cited_type_game_struct_t *s);
+static void igraph_i_citing_cited_type_game_free (
+        igraph_i_citing_cited_type_game_struct_t *s);
 /**
  * \section about_games
  *
@@ -56,39 +56,39 @@ void igraph_i_citing_cited_type_game_free (
  * they generate a different graph every time you call them. </para>
  */
 
-int igraph_i_barabasi_game_bag(igraph_t *graph, igraph_integer_t n,
-                               igraph_integer_t m,
-                               const igraph_vector_t *outseq,
-                               igraph_bool_t outpref,
-                               igraph_bool_t directed,
-                               const igraph_t *start_from);
+static int igraph_i_barabasi_game_bag(igraph_t *graph, igraph_integer_t n,
+                                      igraph_integer_t m,
+                                      const igraph_vector_t *outseq,
+                                      igraph_bool_t outpref,
+                                      igraph_bool_t directed,
+                                      const igraph_t *start_from);
 
-int igraph_i_barabasi_game_psumtree_multiple(igraph_t *graph,
-        igraph_integer_t n,
-        igraph_real_t power,
-        igraph_integer_t m,
-        const igraph_vector_t *outseq,
-        igraph_bool_t outpref,
-        igraph_real_t A,
-        igraph_bool_t directed,
-        const igraph_t *start_from);
+static int igraph_i_barabasi_game_psumtree_multiple(igraph_t *graph,
+                                                    igraph_integer_t n,
+                                                    igraph_real_t power,
+                                                    igraph_integer_t m,
+                                                    const igraph_vector_t *outseq,
+                                                    igraph_bool_t outpref,
+                                                    igraph_real_t A,
+                                                    igraph_bool_t directed,
+                                                    const igraph_t *start_from);
 
-int igraph_i_barabasi_game_psumtree(igraph_t *graph,
-                                    igraph_integer_t n,
-                                    igraph_real_t power,
-                                    igraph_integer_t m,
-                                    const igraph_vector_t *outseq,
-                                    igraph_bool_t outpref,
-                                    igraph_real_t A,
-                                    igraph_bool_t directed,
-                                    const igraph_t *start_from);
+static int igraph_i_barabasi_game_psumtree(igraph_t *graph,
+                                           igraph_integer_t n,
+                                           igraph_real_t power,
+                                           igraph_integer_t m,
+                                           const igraph_vector_t *outseq,
+                                           igraph_bool_t outpref,
+                                           igraph_real_t A,
+                                           igraph_bool_t directed,
+                                           const igraph_t *start_from);
 
-int igraph_i_barabasi_game_bag(igraph_t *graph, igraph_integer_t n,
-                               igraph_integer_t m,
-                               const igraph_vector_t *outseq,
-                               igraph_bool_t outpref,
-                               igraph_bool_t directed,
-                               const igraph_t *start_from) {
+static int igraph_i_barabasi_game_bag(igraph_t *graph, igraph_integer_t n,
+                                      igraph_integer_t m,
+                                      const igraph_vector_t *outseq,
+                                      igraph_bool_t outpref,
+                                      igraph_bool_t directed,
+                                      const igraph_t *start_from) {
 
     long int no_of_nodes = n;
     long int no_of_neighbors = m;
@@ -190,15 +190,15 @@ int igraph_i_barabasi_game_bag(igraph_t *graph, igraph_integer_t n,
     return 0;
 }
 
-int igraph_i_barabasi_game_psumtree_multiple(igraph_t *graph,
-        igraph_integer_t n,
-        igraph_real_t power,
-        igraph_integer_t m,
-        const igraph_vector_t *outseq,
-        igraph_bool_t outpref,
-        igraph_real_t A,
-        igraph_bool_t directed,
-        const igraph_t *start_from) {
+static int igraph_i_barabasi_game_psumtree_multiple(igraph_t *graph,
+                                                    igraph_integer_t n,
+                                                    igraph_real_t power,
+                                                    igraph_integer_t m,
+                                                    const igraph_vector_t *outseq,
+                                                    igraph_bool_t outpref,
+                                                    igraph_real_t A,
+                                                    igraph_bool_t directed,
+                                                    const igraph_t *start_from) {
 
     long int no_of_nodes = n;
     long int no_of_neighbors = m;
@@ -296,15 +296,15 @@ int igraph_i_barabasi_game_psumtree_multiple(igraph_t *graph,
     return 0;
 }
 
-int igraph_i_barabasi_game_psumtree(igraph_t *graph,
-                                    igraph_integer_t n,
-                                    igraph_real_t power,
-                                    igraph_integer_t m,
-                                    const igraph_vector_t *outseq,
-                                    igraph_bool_t outpref,
-                                    igraph_real_t A,
-                                    igraph_bool_t directed,
-                                    const igraph_t *start_from) {
+static int igraph_i_barabasi_game_psumtree(igraph_t *graph,
+                                           igraph_integer_t n,
+                                           igraph_real_t power,
+                                           igraph_integer_t m,
+                                           const igraph_vector_t *outseq,
+                                           igraph_bool_t outpref,
+                                           igraph_real_t A,
+                                           igraph_bool_t directed,
+                                           const igraph_t *start_from) {
 
     long int no_of_nodes = n;
     long int no_of_neighbors = m;
@@ -2410,9 +2410,7 @@ int igraph_grg_game(igraph_t *graph, igraph_integer_t nodes,
 }
 
 
-void igraph_i_preference_game_free_vids_by_type(igraph_vector_ptr_t *vecs);
-
-void igraph_i_preference_game_free_vids_by_type(igraph_vector_ptr_t *vecs) {
+static void igraph_i_preference_game_free_vids_by_type(igraph_vector_ptr_t *vecs) {
     int i = 0, n;
     igraph_vector_t *v;
 
@@ -2954,13 +2952,9 @@ int igraph_asymmetric_preference_game(igraph_t *graph, igraph_integer_t nodes,
     return 0;
 }
 
-int igraph_i_rewire_edges_no_multiple(igraph_t *graph, igraph_real_t prob,
-                                      igraph_bool_t loops,
-                                      igraph_vector_t *edges);
-
-int igraph_i_rewire_edges_no_multiple(igraph_t *graph, igraph_real_t prob,
-                                      igraph_bool_t loops,
-                                      igraph_vector_t *edges) {
+static int igraph_i_rewire_edges_no_multiple(igraph_t *graph, igraph_real_t prob,
+                                             igraph_bool_t loops,
+                                             igraph_vector_t *edges) {
 
     int no_verts = igraph_vcount(graph);
     int no_edges = igraph_ecount(graph);
@@ -3655,7 +3649,7 @@ int igraph_cited_type_game(igraph_t *graph, igraph_integer_t nodes,
     return 0;
 }
 
-void igraph_i_citing_cited_type_game_free(igraph_i_citing_cited_type_game_struct_t *s) {
+static void igraph_i_citing_cited_type_game_free(igraph_i_citing_cited_type_game_struct_t *s) {
     long int i;
     if (!s->sumtrees) {
         return;

--- a/src/glet.c
+++ b/src/glet.c
@@ -75,7 +75,7 @@ typedef struct {
     int nc;
 } igraph_i_subclique_next_free_t;
 
-void igraph_i_subclique_next_free(void *ptr) {
+static void igraph_i_subclique_next_free(void *ptr) {
     igraph_i_subclique_next_free_t *data = ptr;
     int i;
     if (data->resultids) {
@@ -123,15 +123,15 @@ void igraph_i_subclique_next_free(void *ptr) {
  *
  */
 
-int igraph_i_subclique_next(const igraph_t *graph,
-                            const igraph_vector_t *weights,
-                            const igraph_vector_int_t *ids,
-                            const igraph_vector_ptr_t *cliques,
-                            igraph_t **result,
-                            igraph_vector_t **resultweights,
-                            igraph_vector_int_t **resultids,
-                            igraph_vector_t *clique_thr,
-                            igraph_vector_t *next_thr) {
+static int igraph_i_subclique_next(const igraph_t *graph,
+                                   const igraph_vector_t *weights,
+                                   const igraph_vector_int_t *ids,
+                                   const igraph_vector_ptr_t *cliques,
+                                   igraph_t **result,
+                                   igraph_vector_t **resultweights,
+                                   igraph_vector_int_t **resultids,
+                                   igraph_vector_t *clique_thr,
+                                   igraph_vector_t *next_thr) {
 
     /* The input is a set of cliques, that were found at a previous level.
        For each clique, we calculate the next threshold, drop the isolate
@@ -294,7 +294,7 @@ int igraph_i_subclique_next(const igraph_t *graph,
     return 0;
 }
 
-void igraph_i_graphlets_destroy_vectorlist(igraph_vector_ptr_t *vl) {
+static void igraph_i_graphlets_destroy_vectorlist(igraph_vector_ptr_t *vl) {
     int i, n = igraph_vector_ptr_size(vl);
     for (i = 0; i < n; i++) {
         igraph_vector_t *v = (igraph_vector_t*) VECTOR(*vl)[i];
@@ -305,12 +305,12 @@ void igraph_i_graphlets_destroy_vectorlist(igraph_vector_ptr_t *vl) {
     igraph_vector_ptr_destroy(vl);
 }
 
-int igraph_i_graphlets(const igraph_t *graph,
-                       const igraph_vector_t *weights,
-                       igraph_vector_ptr_t *cliques,
-                       igraph_vector_t *thresholds,
-                       const igraph_vector_int_t *ids,
-                       igraph_real_t startthr) {
+static int igraph_i_graphlets(const igraph_t *graph,
+                              const igraph_vector_t *weights,
+                              igraph_vector_ptr_t *cliques,
+                              igraph_vector_t *thresholds,
+                              const igraph_vector_int_t *ids,
+                              igraph_real_t startthr) {
 
     /* This version is different from the main function, and is
        appropriate to use in recursive calls, because it _adds_ the
@@ -401,7 +401,7 @@ typedef struct {
     const igraph_vector_t *thresholds;
 } igraph_i_graphlets_filter_t;
 
-int igraph_i_graphlets_filter_cmp(void *data, const void *a, const void *b) {
+static int igraph_i_graphlets_filter_cmp(void *data, const void *a, const void *b) {
     igraph_i_graphlets_filter_t *ddata = (igraph_i_graphlets_filter_t *) data;
     int *aa = (int*) a;
     int *bb = (int*) b;
@@ -430,8 +430,8 @@ int igraph_i_graphlets_filter_cmp(void *data, const void *a, const void *b) {
     }
 }
 
-int igraph_i_graphlets_filter(igraph_vector_ptr_t *cliques,
-                              igraph_vector_t *thresholds) {
+static int igraph_i_graphlets_filter(igraph_vector_ptr_t *cliques,
+                                     igraph_vector_t *thresholds) {
 
     /* Filter out non-maximal cliques. Every non-maximal clique is
        part of a maximal clique, at the same threshold.
@@ -583,11 +583,11 @@ int igraph_graphlets_candidate_basis(const igraph_t *graph,
     return 0;
 }
 
-int igraph_i_graphlets_project(const igraph_t *graph,
-                               const igraph_vector_t *weights,
-                               const igraph_vector_ptr_t *cliques,
-                               igraph_vector_t *Mu, igraph_bool_t startMu,
-                               int niter, int vid1) {
+static int igraph_i_graphlets_project(const igraph_t *graph,
+                                      const igraph_vector_t *weights,
+                                      const igraph_vector_ptr_t *cliques,
+                                      igraph_vector_t *Mu, igraph_bool_t startMu,
+                                      int niter, int vid1) {
 
     int no_of_nodes = igraph_vcount(graph);
     int no_of_edges = igraph_ecount(graph);
@@ -794,7 +794,7 @@ typedef struct igraph_i_graphlets_order_t {
     const igraph_vector_t *Mu;
 } igraph_i_graphlets_order_t;
 
-int igraph_i_graphlets_order_cmp(void *data, const void *a, const void *b) {
+static int igraph_i_graphlets_order_cmp(void *data, const void *a, const void *b) {
     igraph_i_graphlets_order_t *ddata = (igraph_i_graphlets_order_t*) data;
     int *aa = (int*) a;
     int *bb = (int*) b;

--- a/src/heap.c
+++ b/src/heap.c
@@ -289,12 +289,12 @@ int igraph_indheap_reserve        (igraph_indheap_t* h, long int size) {
     if (tmp1 == 0) {
         IGRAPH_ERROR("indheap reserve failed", IGRAPH_ENOMEM);
     }
-    IGRAPH_FINALLY(free, tmp1);   /* TODO: hack */
+    IGRAPH_FINALLY(igraph_free, tmp1);
     tmp2 = igraph_Calloc(size, long int);
     if (tmp2 == 0) {
         IGRAPH_ERROR("indheap reserve failed", IGRAPH_ENOMEM);
     }
-    IGRAPH_FINALLY(free, tmp2);
+    IGRAPH_FINALLY(igraph_free, tmp2);
     memcpy(tmp1, h->stor_begin, (size_t) actual_size * sizeof(igraph_real_t));
     memcpy(tmp2, h->index_begin, (size_t) actual_size * sizeof(long int));
     igraph_Free(h->stor_begin);
@@ -575,17 +575,17 @@ int igraph_d_indheap_reserve        (igraph_d_indheap_t* h, long int size) {
     if (tmp1 == 0) {
         IGRAPH_ERROR("d_indheap reserve failed", IGRAPH_ENOMEM);
     }
-    IGRAPH_FINALLY(free, tmp1);   /* TODO: hack */
+    IGRAPH_FINALLY(igraph_free, tmp1);
     tmp2 = igraph_Calloc(size, long int);
     if (tmp2 == 0) {
         IGRAPH_ERROR("d_indheap reserve failed", IGRAPH_ENOMEM);
     }
-    IGRAPH_FINALLY(free, tmp2);   /* TODO: hack */
+    IGRAPH_FINALLY(igraph_free, tmp2);
     tmp3 = igraph_Calloc(size, long int);
     if (tmp3 == 0) {
         IGRAPH_ERROR("d_indheap reserve failed", IGRAPH_ENOMEM);
     }
-    IGRAPH_FINALLY(free, tmp3);   /* TODO: hack */
+    IGRAPH_FINALLY(igraph_free, tmp3);
 
     memcpy(tmp1, h->stor_begin, (size_t) actual_size * sizeof(igraph_real_t));
     memcpy(tmp2, h->index_begin, (size_t) actual_size * sizeof(long int));

--- a/src/igraph_hashtable.c
+++ b/src/igraph_hashtable.c
@@ -87,7 +87,7 @@ int igraph_hashtable_addset2(igraph_hashtable_t *ht,
     if (tmp == 0) {
         IGRAPH_ERROR("cannot add element to hash table", IGRAPH_ENOMEM);
     }
-    IGRAPH_FINALLY(free, tmp);
+    IGRAPH_FINALLY(igraph_free, tmp);
     strncpy(tmp, elem, elemlen);
     tmp[elemlen] = '\0';
 

--- a/src/igraph_hrg.cc
+++ b/src/igraph_hrg.cc
@@ -82,7 +82,7 @@ struct pblock {
 };
 }
 
-int markovChainMonteCarlo(dendro *d, unsigned int period,
+static int markovChainMonteCarlo(dendro *d, unsigned int period,
                           igraph_hrg_t *hrg) {
 
     igraph_real_t bestL = d->getLikelihood();
@@ -121,7 +121,7 @@ int markovChainMonteCarlo(dendro *d, unsigned int period,
     return 0;
 }
 
-int markovChainMonteCarlo2(dendro *d, int num_samples) {
+static int markovChainMonteCarlo2(dendro *d, int num_samples) {
     bool flag_taken;
     double dL, ptest = 1.0 / (50.0 * (double)(d->g->numNodes()));
     int sample_num = 0, t = 1, thresh = 200 * d->g->numNodes();
@@ -150,7 +150,7 @@ int markovChainMonteCarlo2(dendro *d, int num_samples) {
     return 0;
 }
 
-int MCMCEquilibrium_Find(dendro *d, igraph_hrg_t *hrg) {
+static int MCMCEquilibrium_Find(dendro *d, igraph_hrg_t *hrg) {
 
     // We want to run the MCMC until we've found equilibrium; we
     // use the heuristic of the average log-likelihood (which is
@@ -187,8 +187,8 @@ int MCMCEquilibrium_Find(dendro *d, igraph_hrg_t *hrg) {
     return 0;
 }
 
-int igraph_i_hrg_getgraph(const igraph_t *igraph,
-                          dendro *d) {
+static int igraph_i_hrg_getgraph(const igraph_t *igraph,
+                                 dendro *d) {
 
     int no_of_nodes = igraph_vcount(igraph);
     int no_of_edges = igraph_ecount(igraph);
@@ -217,9 +217,9 @@ int igraph_i_hrg_getgraph(const igraph_t *igraph,
     return 0;
 }
 
-int igraph_i_hrg_getsimplegraph(const igraph_t *igraph,
-                                dendro *d, simpleGraph **sg,
-                                int num_bins) {
+static int igraph_i_hrg_getsimplegraph(const igraph_t *igraph,
+                                       dendro *d, simpleGraph **sg,
+                                       int num_bins) {
 
     int no_of_nodes = igraph_vcount(igraph);
     int no_of_edges = igraph_ecount(igraph);
@@ -693,7 +693,7 @@ int igraph_hrg_consensus(const igraph_t *graph,
     return 0;
 }
 
-int MCMCEquilibrium_Sample(dendro *d, int num_samples) {
+static int MCMCEquilibrium_Sample(dendro *d, int num_samples) {
 
     // Because moves in the dendrogram space are chosen (Monte
     // Carlo) so that we sample dendrograms with probability
@@ -725,7 +725,7 @@ int MCMCEquilibrium_Sample(dendro *d, int num_samples) {
     return 0;
 }
 
-int QsortPartition (pblock* array, int left, int right, int index) {
+static int QsortPartition (pblock* array, int left, int right, int index) {
     pblock p_value, temp;
     p_value.L = array[index].L;
     p_value.i = array[index].i;
@@ -772,7 +772,7 @@ int QsortPartition (pblock* array, int left, int right, int index) {
     return stored;
 }
 
-void QsortMain (pblock* array, int left, int right) {
+static void QsortMain (pblock* array, int left, int right) {
     if (right > left) {
         int pivot = left;
         int part  = QsortPartition(array, left, right, pivot);
@@ -782,7 +782,7 @@ void QsortMain (pblock* array, int left, int right) {
     return;
 }
 
-int rankCandidatesByProbability(simpleGraph *sg, dendro *d,
+static int rankCandidatesByProbability(simpleGraph *sg, dendro *d,
                                 pblock *br_list, int mk) {
     int mkk = 0;
     int n = sg->getNumNodes();
@@ -804,7 +804,7 @@ int rankCandidatesByProbability(simpleGraph *sg, dendro *d,
     return 0;
 }
 
-int recordPredictions(pblock *br_list, igraph_vector_t *edges,
+static int recordPredictions(pblock *br_list, igraph_vector_t *edges,
                       igraph_vector_t *prob, int mk) {
 
     IGRAPH_CHECK(igraph_vector_resize(edges, mk * 2));

--- a/src/igraph_psumtree.c
+++ b/src/igraph_psumtree.c
@@ -31,7 +31,7 @@
 #include <math.h>
 #include <stdio.h>
 
-double igraph_i_log2(double f) {
+static double igraph_i_log2(double f) {
     return log(f) / log(2.0);
 }
 

--- a/src/igraph_trie.c
+++ b/src/igraph_trie.c
@@ -210,9 +210,9 @@ int igraph_trie_get_node(igraph_trie_node_t *t, const char *key,
                 IGRAPH_ERROR("cannot add to trie", IGRAPH_ENOMEM);
             }
             str2[diff] = '\0';
-            IGRAPH_FINALLY(free, str2);
+            IGRAPH_FINALLY(igraph_free, str2);
             IGRAPH_CHECK(igraph_strvector_set(&t->strs, i, str2));
-            free(str2);
+            igraph_Free(str2);
             IGRAPH_FINALLY_CLEAN(4);
 
             VECTOR(t->values)[i] = newvalue;
@@ -246,9 +246,9 @@ int igraph_trie_get_node(igraph_trie_node_t *t, const char *key,
                 IGRAPH_ERROR("cannot add to trie", IGRAPH_ENOMEM);
             }
             str2[diff] = '\0';
-            IGRAPH_FINALLY(free, str2);
+            IGRAPH_FINALLY(igraph_free, str2);
             IGRAPH_CHECK(igraph_strvector_set(&t->strs, i, str2));
-            free(str2);
+            igraph_Free(str2);
             IGRAPH_FINALLY_CLEAN(4);
 
             VECTOR(t->values)[i] = -1;
@@ -345,7 +345,7 @@ int igraph_trie_get2(igraph_trie_t *t, const char *key, long int length,
 
     strncpy(tmp, key, length);
     tmp[length] = '\0';
-    IGRAPH_FINALLY(free, tmp);
+    IGRAPH_FINALLY(igraph_free, tmp);
     IGRAPH_CHECK(igraph_trie_get(t, tmp, id));
     igraph_Free(tmp);
     IGRAPH_FINALLY_CLEAN(1);

--- a/src/igraph_trie.c
+++ b/src/igraph_trie.c
@@ -39,7 +39,7 @@
  *         igraph_vector_ptr_init() and igraph_vector_init() might be returned.
  */
 
-int igraph_i_trie_init_node(igraph_trie_node_t *t) {
+static int igraph_i_trie_init_node(igraph_trie_node_t *t) {
     IGRAPH_STRVECTOR_INIT_FINALLY(&t->strs, 0);
     IGRAPH_VECTOR_PTR_INIT_FINALLY(&t->children, 0);
     IGRAPH_VECTOR_INIT_FINALLY(&t->values, 0);
@@ -47,7 +47,7 @@ int igraph_i_trie_init_node(igraph_trie_node_t *t) {
     return 0;
 }
 
-void igraph_i_trie_destroy_node(igraph_trie_node_t *t, igraph_bool_t sfree);
+static void igraph_i_trie_destroy_node(igraph_trie_node_t *t, igraph_bool_t sfree);
 
 /**
  * \ingroup igraphtrie
@@ -74,7 +74,7 @@ int igraph_trie_init(igraph_trie_t *t, igraph_bool_t storekeys) {
  * \brief Destroys a node of a trie (not to be called directly).
  */
 
-void igraph_i_trie_destroy_node(igraph_trie_node_t *t, igraph_bool_t sfree) {
+static void igraph_i_trie_destroy_node(igraph_trie_node_t *t, igraph_bool_t sfree) {
     long int i;
     igraph_strvector_destroy(&t->strs);
     for (i = 0; i < igraph_vector_ptr_size(&t->children); i++) {
@@ -108,7 +108,7 @@ void igraph_trie_destroy(igraph_trie_t *t) {
  * \brief Internal helping function for igraph_trie_t
  */
 
-long int igraph_i_strdiff(const char *str, const char *key) {
+static long int igraph_i_strdiff(const char *str, const char *key) {
 
     long int diff = 0;
     while (key[diff] != '\0' && str[diff] != '\0' && str[diff] == key[diff]) {

--- a/src/iterators.c
+++ b/src/iterators.c
@@ -1430,12 +1430,12 @@ int igraph_es_type(const igraph_es_t *es) {
     return es->type;
 }
 
-int igraph_i_es_pairs_size(const igraph_t *graph,
-                           const igraph_es_t *es, igraph_integer_t *result);
-int igraph_i_es_path_size(const igraph_t *graph,
-                          const igraph_es_t *es, igraph_integer_t *result);
-int igraph_i_es_multipairs_size(const igraph_t *graph,
-                                const igraph_es_t *es, igraph_integer_t *result);
+static int igraph_i_es_pairs_size(const igraph_t *graph,
+                                  const igraph_es_t *es, igraph_integer_t *result);
+static int igraph_i_es_path_size(const igraph_t *graph,
+                                 const igraph_es_t *es, igraph_integer_t *result);
+static int igraph_i_es_multipairs_size(const igraph_t *graph,
+                                       const igraph_es_t *es, igraph_integer_t *result);
 
 /**
  * \function igraph_es_size
@@ -1514,8 +1514,8 @@ int igraph_es_size(const igraph_t *graph, const igraph_es_t *es,
     return 0;
 }
 
-int igraph_i_es_pairs_size(const igraph_t *graph,
-                           const igraph_es_t *es, igraph_integer_t *result) {
+static int igraph_i_es_pairs_size(const igraph_t *graph,
+                                  const igraph_es_t *es, igraph_integer_t *result) {
     long int n = igraph_vector_size(es->data.path.ptr);
     long int no_of_nodes = igraph_vcount(graph);
     long int i;
@@ -1542,8 +1542,8 @@ int igraph_i_es_pairs_size(const igraph_t *graph,
     return 0;
 }
 
-int igraph_i_es_path_size(const igraph_t *graph,
-                          const igraph_es_t *es, igraph_integer_t *result) {
+static int igraph_i_es_path_size(const igraph_t *graph,
+                                 const igraph_es_t *es, igraph_integer_t *result) {
     long int n = igraph_vector_size(es->data.path.ptr);
     long int no_of_nodes = igraph_vcount(graph);
     long int i;
@@ -1569,27 +1569,27 @@ int igraph_i_es_path_size(const igraph_t *graph,
     return 0;
 }
 
-int igraph_i_es_multipairs_size(const igraph_t *graph,
-                                const igraph_es_t *es, igraph_integer_t *result) {
+static int igraph_i_es_multipairs_size(const igraph_t *graph,
+                                       const igraph_es_t *es, igraph_integer_t *result) {
     IGRAPH_UNUSED(graph); IGRAPH_UNUSED(es); IGRAPH_UNUSED(result);
     IGRAPH_ERROR("Cannot calculate edge selector length", IGRAPH_UNIMPLEMENTED);
 }
 
 /**************************************************/
 
-int igraph_i_eit_create_allfromto(const igraph_t *graph,
-                                  igraph_eit_t *eit,
-                                  igraph_neimode_t mode);
-int igraph_i_eit_pairs(const igraph_t *graph,
-                       igraph_es_t es, igraph_eit_t *eit);
-int igraph_i_eit_multipairs(const igraph_t *graph,
-                            igraph_es_t es, igraph_eit_t *eit);
-int igraph_i_eit_path(const igraph_t *graph,
-                      igraph_es_t es, igraph_eit_t *eit);
+static int igraph_i_eit_create_allfromto(const igraph_t *graph,
+                                         igraph_eit_t *eit,
+                                         igraph_neimode_t mode);
+static int igraph_i_eit_pairs(const igraph_t *graph,
+                              igraph_es_t es, igraph_eit_t *eit);
+static int igraph_i_eit_multipairs(const igraph_t *graph,
+                                   igraph_es_t es, igraph_eit_t *eit);
+static int igraph_i_eit_path(const igraph_t *graph,
+                             igraph_es_t es, igraph_eit_t *eit);
 
-int igraph_i_eit_create_allfromto(const igraph_t *graph,
-                                  igraph_eit_t *eit,
-                                  igraph_neimode_t mode) {
+static int igraph_i_eit_create_allfromto(const igraph_t *graph,
+                                         igraph_eit_t *eit,
+                                         igraph_neimode_t mode) {
     igraph_vector_t *vec;
     long int no_of_nodes = igraph_vcount(graph);
     long int i;
@@ -1647,8 +1647,8 @@ int igraph_i_eit_create_allfromto(const igraph_t *graph,
     return 0;
 }
 
-int igraph_i_eit_pairs(const igraph_t *graph,
-                       igraph_es_t es, igraph_eit_t *eit) {
+static int igraph_i_eit_pairs(const igraph_t *graph,
+                              igraph_es_t es, igraph_eit_t *eit) {
     long int n = igraph_vector_size(es.data.path.ptr);
     long int no_of_nodes = igraph_vcount(graph);
     long int i;
@@ -1686,8 +1686,8 @@ int igraph_i_eit_pairs(const igraph_t *graph,
     return 0;
 }
 
-int igraph_i_eit_multipairs(const igraph_t *graph,
-                            igraph_es_t es, igraph_eit_t *eit) {
+static int igraph_i_eit_multipairs(const igraph_t *graph,
+                                   igraph_es_t es, igraph_eit_t *eit) {
     long int n = igraph_vector_size(es.data.path.ptr);
     long int no_of_nodes = igraph_vcount(graph);
 
@@ -1718,8 +1718,8 @@ int igraph_i_eit_multipairs(const igraph_t *graph,
     return 0;
 }
 
-int igraph_i_eit_path(const igraph_t *graph,
-                      igraph_es_t es, igraph_eit_t *eit) {
+static int igraph_i_eit_path(const igraph_t *graph,
+                             igraph_es_t es, igraph_eit_t *eit) {
     long int n = igraph_vector_size(es.data.path.ptr);
     long int no_of_nodes = igraph_vcount(graph);
     long int i, len;

--- a/src/lad.c
+++ b/src/lad.c
@@ -169,19 +169,19 @@ typedef struct {
        or -1 if v is not matched */
 } Tdomain;
 
-bool igraph_i_lad_toFilterEmpty(Tdomain* D) {
+static bool igraph_i_lad_toFilterEmpty(Tdomain* D) {
     /* return true if there is no more nodes in toFilter */
     return (D->nextOutToFilter < 0);
 }
 
-void igraph_i_lad_resetToFilter(Tdomain *D) {
+static void igraph_i_lad_resetToFilter(Tdomain *D) {
     /* empty to filter and unmark the vertices that are marked to be filtered */
     igraph_vector_char_null(&D->markedToFilter);
     D->nextOutToFilter = -1;
 }
 
 
-int igraph_i_lad_nextToFilter(Tdomain* D, int size) {
+static int igraph_i_lad_nextToFilter(Tdomain* D, int size) {
     /* precondition: emptyToFilter = false
        remove a node from toFilter (FIFO)
        unmark this node and return it */
@@ -198,7 +198,7 @@ int igraph_i_lad_nextToFilter(Tdomain* D, int size) {
     return u;
 }
 
-void igraph_i_lad_addToFilter(int u, Tdomain* D, int size) {
+static void igraph_i_lad_addToFilter(int u, Tdomain* D, int size) {
     /* if u is not marked, then add it to toFilter and mark it */
     if (VECTOR(D->markedToFilter)[u]) {
         return;
@@ -215,13 +215,13 @@ void igraph_i_lad_addToFilter(int u, Tdomain* D, int size) {
     VECTOR(D->toFilter)[D->lastInToFilter] = u;
 }
 
-bool igraph_i_lad_isInD(int u, int v, Tdomain* D) {
+static bool igraph_i_lad_isInD(int u, int v, Tdomain* D) {
     /* returns true if v belongs to D(u); false otherwise */
     return (MATRIX(D->posInVal, u, v) <
             VECTOR(D->firstVal)[u] + VECTOR(D->nbVal)[u]);
 }
 
-int igraph_i_lad_augmentingPath(int u, Tdomain* D, int nbV, bool* result) {
+static int igraph_i_lad_augmentingPath(int u, Tdomain* D, int nbV, bool* result) {
     /* return true if there exists an augmenting path starting from u and
        ending on a free vertex v in the bipartite directed graph G=(U,
        V, E) such that U=pattern nodes, V=target nodes, and
@@ -289,7 +289,7 @@ cleanup:
     return 0;
 }
 
-int igraph_i_lad_removeAllValuesButOne(int u, int v, Tdomain* D, Tgraph* Gp,
+static int igraph_i_lad_removeAllValuesButOne(int u, int v, Tdomain* D, Tgraph* Gp,
                                        Tgraph* Gt, bool* result) {
     /* remove all values but v from D(u) and add all successors of u in
        toFilter return false if an inconsistency is detected wrt to
@@ -323,7 +323,7 @@ int igraph_i_lad_removeAllValuesButOne(int u, int v, Tdomain* D, Tgraph* Gp,
 }
 
 
-int igraph_i_lad_removeValue(int u, int v, Tdomain* D, Tgraph* Gp,
+static int igraph_i_lad_removeValue(int u, int v, Tdomain* D, Tgraph* Gp,
                              Tgraph* Gt, bool* result) {
     /* remove v from D(u) and add all successors of u in toFilter
        return false if an inconsistency is detected wrt global all diff */
@@ -358,7 +358,7 @@ int igraph_i_lad_removeValue(int u, int v, Tdomain* D, Tgraph* Gp,
 }
 
 
-int igraph_i_lad_matchVertices(int nb, igraph_vector_int_t* toBeMatched,
+static int igraph_i_lad_matchVertices(int nb, igraph_vector_int_t* toBeMatched,
                                bool induced, Tdomain* D, Tgraph* Gp,
                                Tgraph* Gt, int *invalid) {
     /* for each u in toBeMatched[0..nb-1], match u to
@@ -439,7 +439,7 @@ int igraph_i_lad_matchVertices(int nb, igraph_vector_int_t* toBeMatched,
 }
 
 
-bool igraph_i_lad_matchVertex(int u, bool induced, Tdomain* D, Tgraph* Gp,
+static bool igraph_i_lad_matchVertex(int u, bool induced, Tdomain* D, Tgraph* Gp,
                               Tgraph *Gt) {
     int invalid;
     /* match u to D->val[D->firstVal[u]] and filter domains of other non
@@ -461,13 +461,13 @@ bool igraph_i_lad_matchVertex(int u, bool induced, Tdomain* D, Tgraph* Gp,
 }
 
 
-int igraph_i_lad_qcompare (void const *a, void const *b) {
+static int igraph_i_lad_qcompare (void const *a, void const *b) {
     /* function used by the qsort function */
     int pa = *((int*)a) - *((int*)b);
     return pa;
 }
 
-bool igraph_i_lad_compare(int size_mu, int* mu, int size_mv, int* mv) {
+static bool igraph_i_lad_compare(int size_mu, int* mu, int size_mv, int* mv) {
     /* return true if for every element u of mu there exists
        a different element v of mv such that u <= v;
        return false otherwise */
@@ -484,7 +484,7 @@ bool igraph_i_lad_compare(int size_mu, int* mu, int size_mv, int* mv) {
     return true;
 }
 
-int igraph_i_lad_initDomains(bool initialDomains,
+static int igraph_i_lad_initDomains(bool initialDomains,
                              igraph_vector_ptr_t *domains, Tdomain* D,
                              Tgraph* Gp, Tgraph* Gt, int *empty) {
     /* for every pattern node u, initialize D(u) with every vertex v
@@ -637,14 +637,14 @@ int igraph_i_lad_initDomains(bool initialDomains,
 #define toBeDeleted 3
 #define deleted 4
 
-void igraph_i_lad_addToDelete(int u, int* list, int* nb, int* marked) {
+static void igraph_i_lad_addToDelete(int u, int* list, int* nb, int* marked) {
     if (marked[u] < toBeDeleted) {
         list[(*nb)++] = u;
         marked[u] = toBeDeleted;
     }
 }
 
-int igraph_i_lad_updateMatching(int sizeOfU, int sizeOfV,
+static int igraph_i_lad_updateMatching(int sizeOfU, int sizeOfV,
                                 igraph_vector_int_t *degree,
                                 igraph_vector_int_t *firstAdj,
                                 igraph_vector_int_t *adj,
@@ -897,7 +897,7 @@ cleanup:
     return 0;
 }
 
-void igraph_i_lad_DFS(int nbU, int nbV, int u, bool* marked, int* nbSucc,
+static void igraph_i_lad_DFS(int nbU, int nbV, int u, bool* marked, int* nbSucc,
                       int* succ, igraph_vector_int_t * matchedWithU,
                       int* order, int* nb) {
     /* perform a depth first search, starting from u, in the bipartite
@@ -925,7 +925,7 @@ void igraph_i_lad_DFS(int nbU, int nbV, int u, bool* marked, int* nbSucc,
     order[*nb] = u; (*nb)--;
 }
 
-int igraph_i_lad_SCC(int nbU, int nbV, int* numV, int* numU,
+static int igraph_i_lad_SCC(int nbU, int nbV, int* numV, int* numU,
                      int* nbSucc, int* succ,
                      int* nbPred, int* pred,
                      igraph_vector_int_t * matchedWithU,
@@ -1000,7 +1000,7 @@ int igraph_i_lad_SCC(int nbU, int nbV, int* numV, int* numU,
 }
 
 
-int igraph_i_lad_ensureGACallDiff(bool induced, Tgraph* Gp, Tgraph* Gt,
+static int igraph_i_lad_ensureGACallDiff(bool induced, Tgraph* Gp, Tgraph* Gt,
                                   Tdomain* D, int *invalid) {
     /* precondition: D->globalMatchingP is an all different matching of
        the pattern vertices
@@ -1127,7 +1127,7 @@ cleanup:
 /* Coming from lad.c                                        */
 /* ---------------------------------------------------------*/
 
-int igraph_i_lad_checkLAD(int u, int v, Tdomain* D, Tgraph* Gp, Tgraph* Gt,
+static int igraph_i_lad_checkLAD(int u, int v, Tdomain* D, Tgraph* Gp, Tgraph* Gt,
                           bool *result) {
     /* return true if G_(u, v) has a adj(u)-covering matching; false
        otherwise */
@@ -1278,7 +1278,7 @@ cleanup:
 /* Coming from main.c                                      */
 /* ---------------------------------------------------------*/
 
-int igraph_i_lad_filter(bool induced, Tdomain* D, Tgraph* Gp, Tgraph* Gt,
+static int igraph_i_lad_filter(bool induced, Tdomain* D, Tgraph* Gp, Tgraph* Gt,
                         bool *result) {
     /* filter domains of all vertices in D->toFilter wrt LAD and ensure
        GAC(allDiff)
@@ -1327,7 +1327,7 @@ int igraph_i_lad_filter(bool induced, Tdomain* D, Tgraph* Gp, Tgraph* Gt,
 
 
 
-int igraph_i_lad_solve(int timeLimit, bool firstSol, bool induced,
+static int igraph_i_lad_solve(int timeLimit, bool firstSol, bool induced,
                        Tdomain* D, Tgraph* Gp, Tgraph* Gt,
                        int *invalid, igraph_bool_t *iso,
                        igraph_vector_t *map, igraph_vector_ptr_t *maps,

--- a/src/layout.c
+++ b/src/layout.c
@@ -380,9 +380,7 @@ int igraph_layout_springs(const igraph_t *graph, igraph_matrix_t *res,
     return 0;
 }
 
-void igraph_i_norm2d(igraph_real_t *x, igraph_real_t *y);
-
-void igraph_i_norm2d(igraph_real_t *x, igraph_real_t *y) {
+static void igraph_i_norm2d(igraph_real_t *x, igraph_real_t *y) {
     igraph_real_t len = sqrt((*x) * (*x) + (*y) * (*y));
     if (len != 0) {
         *x /= len;
@@ -696,13 +694,7 @@ int igraph_layout_lgl(const igraph_t *graph, igraph_matrix_t *res,
 
 }
 
-int igraph_i_layout_reingold_tilford_unreachable(
-    const igraph_t *graph,
-    igraph_neimode_t mode,
-    long int real_root,
-    long int no_of_nodes,
-    igraph_vector_t *pnewedges);
-int igraph_i_layout_reingold_tilford_unreachable(
+static int igraph_i_layout_reingold_tilford_unreachable(
     const igraph_t *graph,
     igraph_neimode_t mode,
     long int real_root,
@@ -786,20 +778,16 @@ struct igraph_i_reingold_tilford_vertex {
     igraph_real_t offset_follow_rc;  /* X offset when following the right contour */
 };
 
-int igraph_i_layout_reingold_tilford_postorder(struct igraph_i_reingold_tilford_vertex *vdata,
-        long int node, long int vcount);
-int igraph_i_layout_reingold_tilford_calc_coords(struct igraph_i_reingold_tilford_vertex *vdata,
-        igraph_matrix_t *res, long int node,
-        long int vcount, igraph_real_t xpos);
+static int igraph_i_layout_reingold_tilford_postorder(struct igraph_i_reingold_tilford_vertex *vdata,
+                                                      long int node, long int vcount);
+static int igraph_i_layout_reingold_tilford_calc_coords(struct igraph_i_reingold_tilford_vertex *vdata,
+                                                        igraph_matrix_t *res, long int node,
+                                                        long int vcount, igraph_real_t xpos);
 
-int igraph_i_layout_reingold_tilford(const igraph_t *graph,
-                                     igraph_matrix_t *res,
-                                     igraph_neimode_t mode,
-                                     long int root);
-int igraph_i_layout_reingold_tilford(const igraph_t *graph,
-                                     igraph_matrix_t *res,
-                                     igraph_neimode_t mode,
-                                     long int root) {
+static int igraph_i_layout_reingold_tilford(const igraph_t *graph,
+                                            igraph_matrix_t *res,
+                                            igraph_neimode_t mode,
+                                            long int root) {
     long int no_of_nodes = igraph_vcount(graph);
     long int i, n, j;
     igraph_dqueue_t q = IGRAPH_DQUEUE_NULL;
@@ -871,7 +859,8 @@ int igraph_i_layout_reingold_tilford(const igraph_t *graph,
     return 0;
 }
 
-int igraph_i_layout_reingold_tilford_calc_coords(struct igraph_i_reingold_tilford_vertex *vdata,
+static int igraph_i_layout_reingold_tilford_calc_coords(
+        struct igraph_i_reingold_tilford_vertex *vdata,
         igraph_matrix_t *res, long int node,
         long int vcount, igraph_real_t xpos) {
     long int i;
@@ -888,7 +877,8 @@ int igraph_i_layout_reingold_tilford_calc_coords(struct igraph_i_reingold_tilfor
     return 0;
 }
 
-int igraph_i_layout_reingold_tilford_postorder(struct igraph_i_reingold_tilford_vertex *vdata,
+static int igraph_i_layout_reingold_tilford_postorder(
+        struct igraph_i_reingold_tilford_vertex *vdata,
         long int node, long int vcount) {
     long int i, j, childcount, leftroot, leftrootidx;
     igraph_real_t avg;
@@ -1419,10 +1409,12 @@ int igraph_layout_reingold_tilford_circular(const igraph_t *graph,
 #define COULOMBS_CONSTANT 8987500000.0
 
 
-igraph_real_t igraph_i_distance_between(const igraph_matrix_t *c, long int a,
-                                        long int b);
+static igraph_real_t igraph_i_distance_between(
+        const igraph_matrix_t *c,
+        long int a, long int b);
 
-int igraph_i_determine_electric_axal_forces(const igraph_matrix_t *pos,
+static int igraph_i_determine_electric_axal_forces(
+        const igraph_matrix_t *pos,
         igraph_real_t *x,
         igraph_real_t *y,
         igraph_real_t directed_force,
@@ -1430,14 +1422,16 @@ int igraph_i_determine_electric_axal_forces(const igraph_matrix_t *pos,
         long int other_node,
         long int this_node);
 
-int igraph_i_apply_electrical_force(const igraph_matrix_t *pos,
-                                    igraph_vector_t *pending_forces_x,
-                                    igraph_vector_t *pending_forces_y,
-                                    long int other_node, long int this_node,
-                                    igraph_real_t node_charge,
-                                    igraph_real_t distance);
+static int igraph_i_apply_electrical_force(
+        const igraph_matrix_t *pos,
+        igraph_vector_t *pending_forces_x,
+        igraph_vector_t *pending_forces_y,
+        long int other_node, long int this_node,
+        igraph_real_t node_charge,
+        igraph_real_t distance);
 
-int igraph_i_determine_spring_axal_forces(const igraph_matrix_t *pos,
+static int igraph_i_determine_spring_axal_forces(
+        const igraph_matrix_t *pos,
         igraph_real_t *x, igraph_real_t *y,
         igraph_real_t directed_force,
         igraph_real_t distance,
@@ -1445,27 +1439,30 @@ int igraph_i_determine_spring_axal_forces(const igraph_matrix_t *pos,
         long int other_node,
         long int this_node);
 
-int igraph_i_apply_spring_force(const igraph_matrix_t *pos,
-                                igraph_vector_t *pending_forces_x,
-                                igraph_vector_t *pending_forces_y,
-                                long int other_node,
-                                long int this_node, int spring_length,
-                                igraph_real_t spring_constant);
+static int igraph_i_apply_spring_force(
+        const igraph_matrix_t *pos,
+        igraph_vector_t *pending_forces_x,
+        igraph_vector_t *pending_forces_y,
+        long int other_node,
+        long int this_node, int spring_length,
+        igraph_real_t spring_constant);
 
-int igraph_i_move_nodes(igraph_matrix_t *pos,
-                        const igraph_vector_t *pending_forces_x,
-                        const igraph_vector_t *pending_forces_y,
-                        igraph_real_t node_mass,
-                        igraph_real_t max_sa_movement);
+static int igraph_i_move_nodes(
+        igraph_matrix_t *pos,
+        const igraph_vector_t *pending_forces_x,
+        const igraph_vector_t *pending_forces_y,
+        igraph_real_t node_mass,
+        igraph_real_t max_sa_movement);
 
-igraph_real_t igraph_i_distance_between(const igraph_matrix_t *c, long int a,
-                                        long int b) {
+static igraph_real_t igraph_i_distance_between(
+        const igraph_matrix_t *c,
+        long int a, long int b) {
     igraph_real_t diffx = MATRIX(*c, a, 0) - MATRIX(*c, b, 0);
     igraph_real_t diffy = MATRIX(*c, a, 1) - MATRIX(*c, b, 1);
     return sqrt( diffx * diffx + diffy * diffy );
 }
 
-int igraph_i_determine_electric_axal_forces(const igraph_matrix_t *pos,
+static int igraph_i_determine_electric_axal_forces(const igraph_matrix_t *pos,
         igraph_real_t *x,
         igraph_real_t *y,
         igraph_real_t directed_force,
@@ -1518,12 +1515,13 @@ int igraph_i_determine_electric_axal_forces(const igraph_matrix_t *pos,
     return 0;
 }
 
-int igraph_i_apply_electrical_force(const igraph_matrix_t *pos,
-                                    igraph_vector_t *pending_forces_x,
-                                    igraph_vector_t *pending_forces_y,
-                                    long int other_node, long int this_node,
-                                    igraph_real_t node_charge,
-                                    igraph_real_t distance) {
+static int igraph_i_apply_electrical_force(
+        const igraph_matrix_t *pos,
+        igraph_vector_t *pending_forces_x,
+        igraph_vector_t *pending_forces_y,
+        long int other_node, long int this_node,
+        igraph_real_t node_charge,
+        igraph_real_t distance) {
 
     igraph_real_t directed_force = COULOMBS_CONSTANT *
                                    ((node_charge * node_charge) / (distance * distance));
@@ -1541,7 +1539,8 @@ int igraph_i_apply_electrical_force(const igraph_matrix_t *pos,
     return 0;
 }
 
-int igraph_i_determine_spring_axal_forces(const igraph_matrix_t *pos,
+static int igraph_i_determine_spring_axal_forces(
+        const igraph_matrix_t *pos,
         igraph_real_t *x, igraph_real_t *y,
         igraph_real_t directed_force,
         igraph_real_t distance,
@@ -1579,12 +1578,13 @@ int igraph_i_determine_spring_axal_forces(const igraph_matrix_t *pos,
     return 0;
 }
 
-int igraph_i_apply_spring_force(const igraph_matrix_t *pos,
-                                igraph_vector_t *pending_forces_x,
-                                igraph_vector_t *pending_forces_y,
-                                long int other_node,
-                                long int this_node, int spring_length,
-                                igraph_real_t spring_constant) {
+static int igraph_i_apply_spring_force(
+        const igraph_matrix_t *pos,
+        igraph_vector_t *pending_forces_x,
+        igraph_vector_t *pending_forces_y,
+        long int other_node,
+        long int this_node, int spring_length,
+        igraph_real_t spring_constant) {
 
     // determined using Hooke's Law:
     //   force = -kx
@@ -1625,11 +1625,12 @@ int igraph_i_apply_spring_force(const igraph_matrix_t *pos,
     return 0;
 }
 
-int igraph_i_move_nodes(igraph_matrix_t *pos,
-                        const igraph_vector_t *pending_forces_x,
-                        const igraph_vector_t *pending_forces_y,
-                        igraph_real_t node_mass,
-                        igraph_real_t max_sa_movement) {
+static int igraph_i_move_nodes(
+        igraph_matrix_t *pos,
+        const igraph_vector_t *pending_forces_x,
+        const igraph_vector_t *pending_forces_y,
+        igraph_real_t node_mass,
+        igraph_real_t max_sa_movement) {
 
     // Since each iteration is isolated, time is constant at 1.
     // Therefore:
@@ -1822,11 +1823,13 @@ int igraph_layout_graphopt(const igraph_t *graph, igraph_matrix_t *res,
     return 0;
 }
 
+/* not 'static', used in tests */
 int igraph_i_layout_merge_dla(igraph_i_layout_mergegrid_t *grid,
                               long int actg, igraph_real_t *x, igraph_real_t *y, igraph_real_t r,
                               igraph_real_t cx, igraph_real_t cy, igraph_real_t startr,
                               igraph_real_t killr);
 
+/* TODO: not 'static' because used in tests */
 int igraph_i_layout_sphere_2d(igraph_matrix_t *coords, igraph_real_t *x,
                               igraph_real_t *y, igraph_real_t *r);
 int igraph_i_layout_sphere_3d(igraph_matrix_t *coords, igraph_real_t *x,
@@ -1981,7 +1984,8 @@ int igraph_layout_merge_dla(igraph_vector_ptr_t *thegraphs,
     return 0;
 }
 
-int igraph_i_layout_sphere_2d(igraph_matrix_t *coords, igraph_real_t *x, igraph_real_t *y,
+int igraph_i_layout_sphere_2d(igraph_matrix_t *coords,
+                              igraph_real_t *x, igraph_real_t *y,
                               igraph_real_t *r) {
     long int nodes = igraph_matrix_nrow(coords);
     long int i;
@@ -2012,7 +2016,8 @@ int igraph_i_layout_sphere_2d(igraph_matrix_t *coords, igraph_real_t *x, igraph_
     return 0;
 }
 
-int igraph_i_layout_sphere_3d(igraph_matrix_t *coords, igraph_real_t *x, igraph_real_t *y,
+int igraph_i_layout_sphere_3d(igraph_matrix_t *coords,
+                              igraph_real_t *x, igraph_real_t *y,
                               igraph_real_t *z, igraph_real_t *r) {
     long int nodes = igraph_matrix_nrow(coords);
     long int i;
@@ -2094,14 +2099,14 @@ int igraph_i_layout_merge_dla(igraph_i_layout_mergegrid_t *grid,
     return 0;
 }
 
-int igraph_i_layout_mds_step(igraph_real_t *to, const igraph_real_t *from,
-                             int n, void *extra);
+static int igraph_i_layout_mds_step(igraph_real_t *to, const igraph_real_t *from,
+                                    int n, void *extra);
 
-int igraph_i_layout_mds_single(const igraph_t* graph, igraph_matrix_t *res,
-                               igraph_matrix_t *dist, long int dim);
+static int igraph_i_layout_mds_single(const igraph_t* graph, igraph_matrix_t *res,
+                                      igraph_matrix_t *dist, long int dim);
 
-int igraph_i_layout_mds_step(igraph_real_t *to, const igraph_real_t *from,
-                             int n, void *extra) {
+static int igraph_i_layout_mds_step(igraph_real_t *to, const igraph_real_t *from,
+                                    int n, void *extra) {
     igraph_matrix_t* matrix = (igraph_matrix_t*)extra;
     IGRAPH_UNUSED(n);
     igraph_blas_dgemv_array(0, 1, matrix, from, 0, to);

--- a/src/layout_dh.c
+++ b/src/layout_dh.c
@@ -29,6 +29,7 @@
 
 #include <math.h>
 
+/* not 'static', used in tests */
 igraph_bool_t igraph_i_segments_intersect(float p0_x, float p0_y,
         float p1_x, float p1_y,
         float p2_x, float p2_y,
@@ -52,6 +53,7 @@ igraph_bool_t igraph_i_segments_intersect(float p0_x, float p0_y,
     return s >= 0 && s <= 1 && t >= 0 && t <= 1 ? 1 : 0;
 }
 
+/* not 'static', used in tests */
 float igraph_i_point_segment_dist2(float v_x, float v_y,
                                    float u1_x, float u1_y,
                                    float u2_x, float u2_y) {

--- a/src/layout_fr.c
+++ b/src/layout_fr.c
@@ -28,16 +28,16 @@
 #include "igraph_components.h"
 #include "igraph_types_internal.h"
 
-int igraph_layout_i_fr(const igraph_t *graph,
-                       igraph_matrix_t *res,
-                       igraph_bool_t use_seed,
-                       igraph_integer_t niter,
-                       igraph_real_t start_temp,
-                       const igraph_vector_t *weight,
-                       const igraph_vector_t *minx,
-                       const igraph_vector_t *maxx,
-                       const igraph_vector_t *miny,
-                       const igraph_vector_t *maxy) {
+static int igraph_layout_i_fr(const igraph_t *graph,
+                              igraph_matrix_t *res,
+                              igraph_bool_t use_seed,
+                              igraph_integer_t niter,
+                              igraph_real_t start_temp,
+                              const igraph_vector_t *weight,
+                              const igraph_vector_t *minx,
+                              const igraph_vector_t *maxx,
+                              const igraph_vector_t *miny,
+                              const igraph_vector_t *maxy) {
 
     igraph_integer_t no_nodes = igraph_vcount(graph);
     igraph_integer_t no_edges = igraph_ecount(graph);
@@ -188,12 +188,13 @@ int igraph_layout_i_fr(const igraph_t *graph,
     return 0;
 }
 
-int igraph_layout_i_grid_fr(const igraph_t *graph,
-                            igraph_matrix_t *res, igraph_bool_t use_seed,
-                            igraph_integer_t niter, igraph_real_t start_temp,
-                            const igraph_vector_t *weight, const igraph_vector_t *minx,
-                            const igraph_vector_t *maxx, const igraph_vector_t *miny,
-                            const igraph_vector_t *maxy) {
+static int igraph_layout_i_grid_fr(
+        const igraph_t *graph,
+        igraph_matrix_t *res, igraph_bool_t use_seed,
+        igraph_integer_t niter, igraph_real_t start_temp,
+        const igraph_vector_t *weight, const igraph_vector_t *minx,
+        const igraph_vector_t *maxx, const igraph_vector_t *miny,
+        const igraph_vector_t *maxy) {
 
     igraph_integer_t no_nodes = igraph_vcount(graph);
     igraph_integer_t no_edges = igraph_ecount(graph);

--- a/src/lsap.c
+++ b/src/lsap.c
@@ -40,30 +40,30 @@ typedef struct {
 /* public interface */
 
 /* constructors and destructor */
-AP     *ap_create_problem(double *t, int n);
-AP     *ap_create_problem_from_matrix(double **t, int n);
-AP     *ap_read_problem(char *file);
-void    ap_free(AP *p);
+static AP     *ap_create_problem(double *t, int n);
+static AP     *ap_create_problem_from_matrix(double **t, int n);
+static AP     *ap_read_problem(char *file);
+static void    ap_free(AP *p);
 
-int     ap_assignment(AP *p, int *res);
-int     ap_costmatrix(AP *p, double **m);
-int     ap_datamatrix(AP *p, double **m);
-int     ap_iterations(AP *p);
-int     ap_hungarian(AP *p);
-double  ap_mincost(AP *p);
-void    ap_print_solution(AP *p);
-void    ap_show_data(AP *p);
-int     ap_size(AP *p);
-int     ap_time(AP *p);
+static int     ap_assignment(AP *p, int *res);
+static int     ap_costmatrix(AP *p, double **m);
+static int     ap_datamatrix(AP *p, double **m);
+static int     ap_iterations(AP *p);
+static int     ap_hungarian(AP *p);
+static double  ap_mincost(AP *p);
+static void    ap_print_solution(AP *p);
+static void    ap_show_data(AP *p);
+static int     ap_size(AP *p);
+static int     ap_time(AP *p);
 
 /* error reporting */
-void ap_error(char *message);
+static void ap_error(char *message);
 
 /* private functions */
-void    preprocess(AP *p);
-void    preassign(AP *p);
-int     cover(AP *p, int *ri, int *ci);
-void    reduce(AP *p, int *ri, int *ci);
+static void    preprocess(AP *p);
+static void    preassign(AP *p);
+static int     cover(AP *p, int *ri, int *ci);
+static void    reduce(AP *p, int *ri, int *ci);
 
 int ap_hungarian(AP *p) {
     int      n;            /* size of problem */

--- a/src/matching.c
+++ b/src/matching.c
@@ -207,10 +207,12 @@ int igraph_is_maximal_matching(const igraph_t* graph,
     return IGRAPH_SUCCESS;
 }
 
-int igraph_i_maximum_bipartite_matching_unweighted(const igraph_t* graph,
+static int igraph_i_maximum_bipartite_matching_unweighted(
+        const igraph_t* graph,
         const igraph_vector_bool_t* types, igraph_integer_t* matching_size,
         igraph_vector_long_t* matching);
-int igraph_i_maximum_bipartite_matching_weighted(const igraph_t* graph,
+static int igraph_i_maximum_bipartite_matching_weighted(
+        const igraph_t* graph,
         const igraph_vector_bool_t* types, igraph_integer_t* matching_size,
         igraph_real_t* matching_weight, igraph_vector_long_t* matching,
         const igraph_vector_t* weights, igraph_real_t eps);
@@ -306,7 +308,8 @@ int igraph_maximum_bipartite_matching(const igraph_t* graph,
     }
 }
 
-int igraph_i_maximum_bipartite_matching_unweighted_relabel(const igraph_t* graph,
+static int igraph_i_maximum_bipartite_matching_unweighted_relabel(
+        const igraph_t* graph,
         const igraph_vector_bool_t* types, igraph_vector_t* labels,
         igraph_vector_long_t* matching, igraph_bool_t smaller_set);
 
@@ -323,7 +326,8 @@ int igraph_i_maximum_bipartite_matching_unweighted_relabel(const igraph_t* graph
  * Avancée en Calcul Scientifique).
  * http://www.cerfacs.fr/algor/reports/2011/TR_PA_11_33.pdf
  */
-int igraph_i_maximum_bipartite_matching_unweighted(const igraph_t* graph,
+static int igraph_i_maximum_bipartite_matching_unweighted(
+        const igraph_t* graph,
         const igraph_vector_bool_t* types, igraph_integer_t* matching_size,
         igraph_vector_long_t* matching) {
     long int i, j, k, n, no_of_nodes = igraph_vcount(graph);
@@ -460,7 +464,8 @@ int igraph_i_maximum_bipartite_matching_unweighted(const igraph_t* graph,
     return IGRAPH_SUCCESS;
 }
 
-int igraph_i_maximum_bipartite_matching_unweighted_relabel(const igraph_t* graph,
+static int igraph_i_maximum_bipartite_matching_unweighted_relabel(
+        const igraph_t* graph,
         const igraph_vector_bool_t* types, igraph_vector_t* labels,
         igraph_vector_long_t* match, igraph_bool_t smaller_set) {
     long int i, j, n, no_of_nodes = igraph_vcount(graph), matched_to;
@@ -529,7 +534,8 @@ int igraph_i_maximum_bipartite_matching_unweighted_relabel(const igraph_t* graph
  * an edge falls below \c eps, it will be considered tight. If all your
  * weights are integers, you can safely set \c eps to zero.
  */
-int igraph_i_maximum_bipartite_matching_weighted(const igraph_t* graph,
+static int igraph_i_maximum_bipartite_matching_weighted(
+        const igraph_t* graph,
         const igraph_vector_bool_t* types, igraph_integer_t* matching_size,
         igraph_real_t* matching_weight, igraph_vector_long_t* matching,
         const igraph_vector_t* weights, igraph_real_t eps) {

--- a/src/math.c
+++ b/src/math.c
@@ -33,9 +33,7 @@
 #endif
 
 int igraph_finite(double x) {
-#ifdef isfinite
-    return isfinite(x);
-#elif HAVE_ISFINITE == 1
+#if HAVE_DECL_ISFINITE
     return isfinite(x);
 #elif HAVE_FINITE == 1
     return finite(x);

--- a/src/maximal_cliques.c
+++ b/src/maximal_cliques.c
@@ -35,13 +35,14 @@
 #define CONCAT2(a,b) CONCAT2x(a,b)
 #define FUNCTION(name,sfx) CONCAT2(name,sfx)
 
-int igraph_i_maximal_cliques_reorder_adjlists(
-    const igraph_vector_int_t *PX,
-    int PS, int PE, int XS, int XE,
-    const igraph_vector_int_t *pos,
-    igraph_adjlist_t *adjlist);
+static int igraph_i_maximal_cliques_reorder_adjlists(
+        const igraph_vector_int_t *PX,
+        int PS, int PE, int XS, int XE,
+        const igraph_vector_int_t *pos,
+        igraph_adjlist_t *adjlist);
 
-int igraph_i_maximal_cliques_select_pivot(const igraph_vector_int_t *PX,
+static int igraph_i_maximal_cliques_select_pivot(
+        const igraph_vector_int_t *PX,
         int PS, int PE, int XS, int XE,
         const igraph_vector_int_t *pos,
         const igraph_adjlist_t *adjlist,
@@ -49,23 +50,26 @@ int igraph_i_maximal_cliques_select_pivot(const igraph_vector_int_t *PX,
         igraph_vector_int_t *nextv,
         int oldPS, int oldXE);
 
-int igraph_i_maximal_cliques_down(igraph_vector_int_t *PX,
-                                  int PS, int PE, int XS, int XE,
-                                  igraph_vector_int_t *pos,
-                                  igraph_adjlist_t *adjlist, int mynextv,
-                                  igraph_vector_int_t *R,
-                                  int *newPS, int *newXE);
+static int igraph_i_maximal_cliques_down(
+        igraph_vector_int_t *PX,
+        int PS, int PE, int XS, int XE,
+        igraph_vector_int_t *pos,
+        igraph_adjlist_t *adjlist, int mynextv,
+        igraph_vector_int_t *R,
+        int *newPS, int *newXE);
 
-int igraph_i_maximal_cliques_PX(igraph_vector_int_t *PX, int PS, int *PE,
-                                int *XS, int XE, igraph_vector_int_t *pos,
-                                igraph_adjlist_t *adjlist, int v,
-                                igraph_vector_int_t *H);
+static int igraph_i_maximal_cliques_PX(
+        igraph_vector_int_t *PX, int PS, int *PE,
+        int *XS, int XE, igraph_vector_int_t *pos,
+        igraph_adjlist_t *adjlist, int v,
+        igraph_vector_int_t *H);
 
-int igraph_i_maximal_cliques_up(igraph_vector_int_t *PX, int PS, int PE,
-                                int XS, int XE, igraph_vector_int_t *pos,
-                                igraph_adjlist_t *adjlist,
-                                igraph_vector_int_t *R,
-                                igraph_vector_int_t *H);
+static int igraph_i_maximal_cliques_up(
+        igraph_vector_int_t *PX, int PS, int PE,
+        int XS, int XE, igraph_vector_int_t *pos,
+        igraph_adjlist_t *adjlist,
+        igraph_vector_int_t *R,
+        igraph_vector_int_t *H);
 
 #define PRINT_PX do {                              \
         int j;                                 \
@@ -109,11 +113,11 @@ int igraph_i_maximal_cliques_up(igraph_vector_int_t *PX, int PS, int PE,
         printf("\n");                              \
     } while (0)
 
-int igraph_i_maximal_cliques_reorder_adjlists(
-    const igraph_vector_int_t *PX,
-    int PS, int PE, int XS, int XE,
-    const igraph_vector_int_t *pos,
-    igraph_adjlist_t *adjlist) {
+static int igraph_i_maximal_cliques_reorder_adjlists(
+        const igraph_vector_int_t *PX,
+        int PS, int PE, int XS, int XE,
+        const igraph_vector_int_t *pos,
+        igraph_adjlist_t *adjlist) {
     int j;
     int sPS = PS + 1, sPE = PE + 1;
 
@@ -140,7 +144,8 @@ int igraph_i_maximal_cliques_reorder_adjlists(
     return 0;
 }
 
-int igraph_i_maximal_cliques_select_pivot(const igraph_vector_int_t *PX,
+static int igraph_i_maximal_cliques_select_pivot(
+        const igraph_vector_int_t *PX,
         int PS, int PE, int XS, int XE,
         const igraph_vector_int_t *pos,
         const igraph_adjlist_t *adjlist,
@@ -216,12 +221,12 @@ int igraph_i_maximal_cliques_select_pivot(const igraph_vector_int_t *PX,
         VECTOR(*pos)[v2] = (p1)+1;          \
     } while (0)
 
-int igraph_i_maximal_cliques_down(igraph_vector_int_t *PX,
-                                  int PS, int PE, int XS, int XE,
-                                  igraph_vector_int_t *pos,
-                                  igraph_adjlist_t *adjlist, int mynextv,
-                                  igraph_vector_int_t *R,
-                                  int *newPS, int *newXE) {
+static int igraph_i_maximal_cliques_down(igraph_vector_int_t *PX,
+                                         int PS, int PE, int XS, int XE,
+                                         igraph_vector_int_t *pos,
+                                         igraph_adjlist_t *adjlist, int mynextv,
+                                         igraph_vector_int_t *R,
+                                         int *newPS, int *newXE) {
 
     igraph_vector_int_t *vneis = igraph_adjlist_get(adjlist, mynextv);
     int j, vneislen = igraph_vector_int_size(vneis);
@@ -247,10 +252,10 @@ int igraph_i_maximal_cliques_down(igraph_vector_int_t *PX,
 
 #undef SWAP
 
-int igraph_i_maximal_cliques_PX(igraph_vector_int_t *PX, int PS, int *PE,
-                                int *XS, int XE, igraph_vector_int_t *pos,
-                                igraph_adjlist_t *adjlist, int v,
-                                igraph_vector_int_t *H) {
+static int igraph_i_maximal_cliques_PX(igraph_vector_int_t *PX, int PS, int *PE,
+                                       int *XS, int XE, igraph_vector_int_t *pos,
+                                       igraph_adjlist_t *adjlist, int v,
+                                       igraph_vector_int_t *H) {
 
     int vpos = VECTOR(*pos)[v] - 1;
     int tmp = VECTOR(*PX)[*PE];
@@ -264,11 +269,11 @@ int igraph_i_maximal_cliques_PX(igraph_vector_int_t *PX, int PS, int *PE,
     return 0;
 }
 
-int igraph_i_maximal_cliques_up(igraph_vector_int_t *PX, int PS, int PE,
-                                int XS, int XE, igraph_vector_int_t *pos,
-                                igraph_adjlist_t *adjlist,
-                                igraph_vector_int_t *R,
-                                igraph_vector_int_t *H) {
+static int igraph_i_maximal_cliques_up(igraph_vector_int_t *PX, int PS, int PE,
+                                       int XS, int XE, igraph_vector_int_t *pos,
+                                       igraph_adjlist_t *adjlist,
+                                       igraph_vector_int_t *R,
+                                       igraph_vector_int_t *H) {
     int vv;
     igraph_vector_int_pop_back(R);
 

--- a/src/motifs.c
+++ b/src/motifs.c
@@ -51,7 +51,8 @@ extern unsigned int igraph_i_isoclass_4u_idx[];
  * Callback function for igraph_motifs_randesu that counts the motifs by
  * isomorphism class in a histogram.
  */
-igraph_bool_t igraph_i_motifs_randesu_update_hist(const igraph_t *graph,
+static igraph_bool_t igraph_i_motifs_randesu_update_hist(
+        const igraph_t *graph,
         igraph_vector_t *vids, int isoclass, void* extra) {
     igraph_vector_t *hist = (igraph_vector_t*)extra;
     IGRAPH_UNUSED(graph); IGRAPH_UNUSED(vids);

--- a/src/operators.c
+++ b/src/operators.c
@@ -183,8 +183,7 @@ int igraph_disjoint_union_many(igraph_t *res,
     return 0;
 }
 
-int igraph_i_order_edgelist_cmp(void *edges, const void *e1,
-                                const void *e2) {
+static int igraph_i_order_edgelist_cmp(void *edges, const void *e1, const void *e2) {
     igraph_vector_t *edgelist = edges;
     long int edge1 = (*(const long int*) e1) * 2;
     long int edge2 = (*(const long int*) e2) * 2;
@@ -210,9 +209,9 @@ int igraph_i_order_edgelist_cmp(void *edges, const void *e1,
 #define IGRAPH_MODE_UNION        1
 #define IGRAPH_MODE_INTERSECTION 2
 
-int igraph_i_merge(igraph_t *res, int mode,
-                   const igraph_t *left, const igraph_t *right,
-                   igraph_vector_t *edge_map1, igraph_vector_t *edge_map2) {
+static int igraph_i_merge(igraph_t *res, int mode,
+                          const igraph_t *left, const igraph_t *right,
+                          igraph_vector_t *edge_map1, igraph_vector_t *edge_map2) {
 
     long int no_of_nodes_left = igraph_vcount(left);
     long int no_of_nodes_right = igraph_vcount(right);
@@ -431,7 +430,7 @@ int igraph_intersection(igraph_t *res,
                           edge_map1, edge_map2);
 }
 
-void igraph_i_union_many_free(igraph_vector_ptr_t *v) {
+static void igraph_i_union_many_free(igraph_vector_ptr_t *v) {
     long int i, n = igraph_vector_ptr_size(v);
     for (i = 0; i < n; i++) {
         if (VECTOR(*v)[i] != 0) {
@@ -442,7 +441,7 @@ void igraph_i_union_many_free(igraph_vector_ptr_t *v) {
     igraph_vector_ptr_destroy(v);
 }
 
-void igraph_i_union_many_free2(igraph_vector_ptr_t *v) {
+static void igraph_i_union_many_free2(igraph_vector_ptr_t *v) {
     long int i, n = igraph_vector_ptr_size(v);
     for (i = 0; i < n; i++) {
         if (VECTOR(*v)[i] != 0) {
@@ -453,7 +452,7 @@ void igraph_i_union_many_free2(igraph_vector_ptr_t *v) {
     igraph_vector_ptr_destroy(v);
 }
 
-void igraph_i_union_many_free3(igraph_vector_ptr_t *v) {
+static void igraph_i_union_many_free3(igraph_vector_ptr_t *v) {
     long int i, n = igraph_vector_ptr_size(v);
     for (i = 0; i < n; i++) {
         if (VECTOR(*v)[i] != 0) {

--- a/src/random.c
+++ b/src/random.c
@@ -1538,7 +1538,7 @@ int imin2(int x, int y) {
     return (x < y) ? x : y;
 }
 
-#if HAVE_WORKING_ISFINITE || HAVE_ISFINITE
+#if HAVE_WORKING_ISFINITE || HAVE_DECL_ISFINITE
     /* isfinite is defined in <math.h> according to C99 */
     #define R_FINITE(x)    isfinite(x)
 #elif HAVE_WORKING_FINITE || HAVE_FINITE
@@ -1556,7 +1556,7 @@ int imin2(int x, int y) {
 #endif
 
 int R_finite(double x) {
-#if HAVE_WORKING_ISFINITE || HAVE_ISFINITE
+#if HAVE_WORKING_ISFINITE || HAVE_DECL_ISFINITE
     return isfinite(x);
 #elif HAVE_WORKING_FINITE || HAVE_FINITE
     return finite(x);

--- a/src/random.c
+++ b/src/random.c
@@ -126,8 +126,7 @@ typedef struct {
     long int x[31];
 } igraph_i_rng_glibc2_state_t;
 
-unsigned long int igraph_i_rng_glibc2_get(int *i, int *j, int n,
-        long int *x) {
+static unsigned long int igraph_i_rng_glibc2_get(int *i, int *j, int n, long int *x) {
     unsigned long int k;
 
     x[*i] += x[*j];
@@ -158,8 +157,8 @@ igraph_real_t igraph_rng_glibc2_get_real(void *state) {
 
 /* this function is independent of the bit size */
 
-void igraph_i_rng_glibc2_init(long int *x, int n,
-                              unsigned long int s) {
+static void igraph_i_rng_glibc2_init(long int *x, int n,
+                                     unsigned long int s) {
     int i;
 
     if (s == 0) {
@@ -977,8 +976,9 @@ float rintf (float x) {
  * result vector.
  */
 
-int igraph_i_random_sample_alga(igraph_vector_t *res, igraph_integer_t l, igraph_integer_t h,
-                                igraph_integer_t length) {
+static int igraph_i_random_sample_alga(igraph_vector_t *res,
+                                       igraph_integer_t l, igraph_integer_t h,
+                                       igraph_integer_t length) {
     igraph_real_t N = h - l + 1;
     igraph_real_t n = length;
 

--- a/src/scan.c
+++ b/src/scan.c
@@ -75,7 +75,7 @@ int igraph_local_scan_0(const igraph_t *graph, igraph_vector_t *res,
 }
 
 /* From triangles.c */
-
+/* TODO add to private header */
 int igraph_i_trans4_al_simplify(igraph_adjlist_t *al,
                                 const igraph_vector_int_t *rank);
 
@@ -83,8 +83,8 @@ int igraph_i_trans4_al_simplify(igraph_adjlist_t *al,
    "backwards" according to the rank vector. It works on
    edge lists */
 
-int igraph_i_trans4_il_simplify(const igraph_t *graph, igraph_inclist_t *il,
-                                const igraph_vector_int_t *rank) {
+static int igraph_i_trans4_il_simplify(const igraph_t *graph, igraph_inclist_t *il,
+                                       const igraph_vector_int_t *rank) {
 
     long int i;
     long int n = il->length;
@@ -119,10 +119,10 @@ int igraph_i_trans4_il_simplify(const igraph_t *graph, igraph_inclist_t *il,
 
 /* This one handles both weighted and unweighted cases */
 
-int igraph_i_local_scan_1_directed(const igraph_t *graph,
-                                   igraph_vector_t *res,
-                                   const igraph_vector_t *weights,
-                                   igraph_neimode_t mode) {
+static int igraph_i_local_scan_1_directed(const igraph_t *graph,
+                                          igraph_vector_t *res,
+                                          const igraph_vector_t *weights,
+                                          igraph_neimode_t mode) {
 
     int no_of_nodes = igraph_vcount(graph);
     igraph_inclist_t incs;
@@ -180,9 +180,9 @@ int igraph_i_local_scan_1_directed(const igraph_t *graph,
     return 0;
 }
 
-int igraph_i_local_scan_1_directed_all(const igraph_t *graph,
-                                       igraph_vector_t *res,
-                                       const igraph_vector_t *weights) {
+static int igraph_i_local_scan_1_directed_all(const igraph_t *graph,
+                                              igraph_vector_t *res,
+                                              const igraph_vector_t *weights) {
 
     int no_of_nodes = igraph_vcount(graph);
     igraph_inclist_t incs;
@@ -250,9 +250,9 @@ int igraph_i_local_scan_1_directed_all(const igraph_t *graph,
     return 0;
 }
 
-int igraph_i_local_scan_1_sumweights(const igraph_t *graph,
-                                     igraph_vector_t *res,
-                                     const igraph_vector_t *weights) {
+static int igraph_i_local_scan_1_sumweights(const igraph_t *graph,
+                                            igraph_vector_t *res,
+                                            const igraph_vector_t *weights) {
 
     long int no_of_nodes = igraph_vcount(graph);
     long int node, i, j, nn;
@@ -384,10 +384,10 @@ int igraph_local_scan_1_ecount(const igraph_t *graph, igraph_vector_t *res,
     return 0;
 }
 
-int igraph_i_local_scan_0_them_w(const igraph_t *us, const igraph_t *them,
-                                 igraph_vector_t *res,
-                                 const igraph_vector_t *weights_them,
-                                 igraph_neimode_t mode) {
+static int igraph_i_local_scan_0_them_w(const igraph_t *us, const igraph_t *them,
+                                        igraph_vector_t *res,
+                                        const igraph_vector_t *weights_them,
+                                        igraph_neimode_t mode) {
 
     igraph_t is;
     igraph_vector_t map2;

--- a/src/scg.c
+++ b/src/scg.c
@@ -471,13 +471,13 @@ int igraph_scg_grouping(const igraph_matrix_t *V,
     return 0;
 }
 
-int igraph_i_scg_semiprojectors_sym(const igraph_vector_t *groups,
-                                    igraph_matrix_t *L,
-                                    igraph_matrix_t *R,
-                                    igraph_sparsemat_t *Lsparse,
-                                    igraph_sparsemat_t *Rsparse,
-                                    int no_of_groups,
-                                    int no_of_nodes) {
+static int igraph_i_scg_semiprojectors_sym(const igraph_vector_t *groups,
+                                           igraph_matrix_t *L,
+                                           igraph_matrix_t *R,
+                                           igraph_sparsemat_t *Lsparse,
+                                           igraph_sparsemat_t *Rsparse,
+                                           int no_of_groups,
+                                           int no_of_nodes) {
 
     igraph_vector_t tab;
     int i;
@@ -536,14 +536,14 @@ int igraph_i_scg_semiprojectors_sym(const igraph_vector_t *groups,
     return 0;
 }
 
-int igraph_i_scg_semiprojectors_lap(const igraph_vector_t *groups,
-                                    igraph_matrix_t *L,
-                                    igraph_matrix_t *R,
-                                    igraph_sparsemat_t *Lsparse,
-                                    igraph_sparsemat_t *Rsparse,
-                                    int no_of_groups,
-                                    int no_of_nodes,
-                                    igraph_scg_norm_t norm) {
+static int igraph_i_scg_semiprojectors_lap(const igraph_vector_t *groups,
+                                           igraph_matrix_t *L,
+                                           igraph_matrix_t *R,
+                                           igraph_sparsemat_t *Lsparse,
+                                           igraph_sparsemat_t *Rsparse,
+                                           int no_of_groups,
+                                           int no_of_nodes,
+                                           igraph_scg_norm_t norm) {
 
     igraph_vector_t tab;
     int i;
@@ -633,15 +633,15 @@ int igraph_i_scg_semiprojectors_lap(const igraph_vector_t *groups,
     return 0;
 }
 
-int igraph_i_scg_semiprojectors_sto(const igraph_vector_t *groups,
-                                    igraph_matrix_t *L,
-                                    igraph_matrix_t *R,
-                                    igraph_sparsemat_t *Lsparse,
-                                    igraph_sparsemat_t *Rsparse,
-                                    int no_of_groups,
-                                    int no_of_nodes,
-                                    const igraph_vector_t *p,
-                                    igraph_scg_norm_t norm) {
+static int igraph_i_scg_semiprojectors_sto(const igraph_vector_t *groups,
+                                           igraph_matrix_t *L,
+                                           igraph_matrix_t *R,
+                                           igraph_sparsemat_t *Lsparse,
+                                           igraph_sparsemat_t *Rsparse,
+                                           int no_of_groups,
+                                           int no_of_nodes,
+                                           const igraph_vector_t *p,
+                                           igraph_scg_norm_t norm) {
 
     igraph_vector_t pgr, pnormed;
     int i;
@@ -974,9 +974,9 @@ int igraph_scg_norm_eps(const igraph_matrix_t *V,
     return 0;
 }
 
-int igraph_i_matrix_laplacian(const igraph_matrix_t *matrix,
-                              igraph_matrix_t *mymatrix,
-                              igraph_scg_norm_t norm) {
+static int igraph_i_matrix_laplacian(const igraph_matrix_t *matrix,
+                                     igraph_matrix_t *mymatrix,
+                                     igraph_scg_norm_t norm) {
 
     igraph_vector_t degree;
     int i, j, n = (int) igraph_matrix_nrow(matrix);
@@ -1006,9 +1006,9 @@ int igraph_i_matrix_laplacian(const igraph_matrix_t *matrix,
     return 0;
 }
 
-int igraph_i_sparsemat_laplacian(const igraph_sparsemat_t *sparse,
-                                 igraph_sparsemat_t *mysparse,
-                                 igraph_scg_norm_t norm) {
+static int igraph_i_sparsemat_laplacian(const igraph_sparsemat_t *sparse,
+                                        igraph_sparsemat_t *mysparse,
+                                        igraph_scg_norm_t norm) {
 
     igraph_vector_t degree;
     int i, n = (int) igraph_sparsemat_nrow(sparse);
@@ -1058,9 +1058,9 @@ int igraph_i_sparsemat_laplacian(const igraph_sparsemat_t *sparse,
     return 0;
 }
 
-int igraph_i_matrix_stochastic(const igraph_matrix_t *matrix,
-                               igraph_matrix_t *mymatrix,
-                               igraph_scg_norm_t norm) {
+static int igraph_i_matrix_stochastic(const igraph_matrix_t *matrix,
+                                      igraph_matrix_t *mymatrix,
+                                      igraph_scg_norm_t norm) {
 
     int i, j, n = (int) igraph_matrix_nrow(matrix);
     IGRAPH_CHECK(igraph_matrix_copy(mymatrix, matrix));
@@ -1096,12 +1096,13 @@ int igraph_i_matrix_stochastic(const igraph_matrix_t *matrix,
     return 0;
 }
 
+/* TODO prototype; function is defined in conversion.c */
 int igraph_i_normalize_sparsemat(igraph_sparsemat_t *sparsemat,
                                  igraph_bool_t column_wise);
 
-int igraph_i_sparsemat_stochastic(const igraph_sparsemat_t *sparse,
-                                  igraph_sparsemat_t *mysparse,
-                                  igraph_scg_norm_t norm) {
+static int igraph_i_sparsemat_stochastic(const igraph_sparsemat_t *sparse,
+                                         igraph_sparsemat_t *mysparse,
+                                         igraph_scg_norm_t norm) {
 
     IGRAPH_CHECK(igraph_sparsemat_copy(mysparse, sparse));
     IGRAPH_FINALLY(igraph_sparsemat_destroy, mysparse);
@@ -1112,15 +1113,15 @@ int igraph_i_sparsemat_stochastic(const igraph_sparsemat_t *sparse,
     return 0;
 }
 
-int igraph_i_scg_get_result(igraph_scg_matrix_t type,
-                            const igraph_matrix_t *matrix,
-                            const igraph_sparsemat_t *sparsemat,
-                            const igraph_sparsemat_t *Lsparse,
-                            const igraph_sparsemat_t *Rsparse_t,
-                            igraph_t *scg_graph,
-                            igraph_matrix_t *scg_matrix,
-                            igraph_sparsemat_t *scg_sparsemat,
-                            igraph_bool_t directed) {
+static int igraph_i_scg_get_result(igraph_scg_matrix_t type,
+                                   const igraph_matrix_t *matrix,
+                                   const igraph_sparsemat_t *sparsemat,
+                                   const igraph_sparsemat_t *Lsparse,
+                                   const igraph_sparsemat_t *Rsparse_t,
+                                   igraph_t *scg_graph,
+                                   igraph_matrix_t *scg_matrix,
+                                   igraph_sparsemat_t *scg_sparsemat,
+                                   igraph_bool_t directed) {
 
     /* We need to calculate either scg_matrix (if input is dense), or
        scg_sparsemat (if input is sparse). For the latter we might need
@@ -1269,20 +1270,20 @@ int igraph_i_scg_get_result(igraph_scg_matrix_t type,
     return 0;
 }
 
-int igraph_i_scg_common_checks(const igraph_t *graph,
-                               const igraph_matrix_t *matrix,
-                               const igraph_sparsemat_t *sparsemat,
-                               const igraph_vector_t *ev,
-                               igraph_integer_t nt,
-                               const igraph_vector_t *nt_vec,
-                               const igraph_matrix_t *vectors,
-                               const igraph_matrix_complex_t *vectors_cmplx,
-                               const igraph_vector_t *groups,
-                               const igraph_t *scg_graph,
-                               const igraph_matrix_t *scg_matrix,
-                               const igraph_sparsemat_t *scg_sparsemat,
-                               const igraph_vector_t *p,
-                               igraph_real_t *evmin, igraph_real_t *evmax) {
+static int igraph_i_scg_common_checks(const igraph_t *graph,
+                                      const igraph_matrix_t *matrix,
+                                      const igraph_sparsemat_t *sparsemat,
+                                      const igraph_vector_t *ev,
+                                      igraph_integer_t nt,
+                                      const igraph_vector_t *nt_vec,
+                                      const igraph_matrix_t *vectors,
+                                      const igraph_matrix_complex_t *vectors_cmplx,
+                                      const igraph_vector_t *groups,
+                                      const igraph_t *scg_graph,
+                                      const igraph_matrix_t *scg_matrix,
+                                      const igraph_sparsemat_t *scg_sparsemat,
+                                      const igraph_vector_t *p,
+                                      igraph_real_t *evmin, igraph_real_t *evmax) {
 
     int no_of_nodes = -1;
     igraph_real_t min, max;

--- a/src/separators.c
+++ b/src/separators.c
@@ -35,14 +35,14 @@
 #include "igraph_stack.h"
 #include "igraph_interrupt_internal.h"
 
-int igraph_i_is_separator(const igraph_t *graph,
-                          igraph_vit_t *vit,
-                          long int except,
-                          igraph_bool_t *res,
-                          igraph_vector_bool_t *removed,
-                          igraph_dqueue_t *Q,
-                          igraph_vector_t *neis,
-                          long int no_of_nodes) {
+static int igraph_i_is_separator(const igraph_t *graph,
+                                 igraph_vit_t *vit,
+                                 long int except,
+                                 igraph_bool_t *res,
+                                 igraph_vector_bool_t *removed,
+                                 igraph_dqueue_t *Q,
+                                 igraph_vector_t *neis,
+                                 long int no_of_nodes) {
 
     long int start = 0;
 
@@ -266,11 +266,11 @@ int igraph_is_minimal_separator(const igraph_t *graph,
         }                                                  \
     } while (0)
 
-int igraph_i_clusters_leaveout(const igraph_adjlist_t *adjlist,
-                               igraph_vector_t *components,
-                               igraph_vector_t *leaveout,
-                               unsigned long int *mark,
-                               igraph_dqueue_t *Q) {
+static int igraph_i_clusters_leaveout(const igraph_adjlist_t *adjlist,
+                                      igraph_vector_t *components,
+                                      igraph_vector_t *leaveout,
+                                      unsigned long int *mark,
+                                      igraph_dqueue_t *Q) {
 
     /* Another trick: we use the same 'leaveout' vector to mark the
      * vertices that were already found in the BFS
@@ -314,8 +314,8 @@ int igraph_i_clusters_leaveout(const igraph_adjlist_t *adjlist,
     return 0;
 }
 
-igraph_bool_t igraph_i_separators_newsep(const igraph_vector_ptr_t *comps,
-        const igraph_vector_t *newc) {
+static igraph_bool_t igraph_i_separators_newsep(const igraph_vector_ptr_t *comps,
+                                                const igraph_vector_t *newc) {
 
     long int co, nocomps = igraph_vector_ptr_size(comps);
 
@@ -330,12 +330,12 @@ igraph_bool_t igraph_i_separators_newsep(const igraph_vector_ptr_t *comps,
     return 1;
 }
 
-int igraph_i_separators_store(igraph_vector_ptr_t *separators,
-                              const igraph_adjlist_t *adjlist,
-                              igraph_vector_t *components,
-                              igraph_vector_t *leaveout,
-                              unsigned long int *mark,
-                              igraph_vector_t *sorter) {
+static int igraph_i_separators_store(igraph_vector_ptr_t *separators,
+                                     const igraph_adjlist_t *adjlist,
+                                     igraph_vector_t *components,
+                                     igraph_vector_t *leaveout,
+                                     unsigned long int *mark,
+                                     igraph_vector_t *sorter) {
 
     /* We need to stote N(C), the neighborhood of C, but only if it is
      * not already stored among the separators.
@@ -387,7 +387,7 @@ int igraph_i_separators_store(igraph_vector_ptr_t *separators,
     return 0;
 }
 
-void igraph_i_separators_free(igraph_vector_ptr_t *separators) {
+static void igraph_i_separators_free(igraph_vector_ptr_t *separators) {
     long int i, n = igraph_vector_ptr_size(separators);
     for (i = 0; i < n; i++) {
         igraph_vector_t *vec = VECTOR(*separators)[i];
@@ -557,8 +557,8 @@ int igraph_all_minimal_st_separators(const igraph_t *graph,
 
 #undef UPDATEMARK
 
-int igraph_i_minimum_size_separators_append(igraph_vector_ptr_t *old,
-        igraph_vector_ptr_t *new) {
+static int igraph_i_minimum_size_separators_append(igraph_vector_ptr_t *old,
+                                                   igraph_vector_ptr_t *new) {
 
     long int olen = igraph_vector_ptr_size(old);
     long int nlen = igraph_vector_ptr_size(new);
@@ -587,9 +587,9 @@ int igraph_i_minimum_size_separators_append(igraph_vector_ptr_t *old,
     return 0;
 }
 
-int igraph_i_minimum_size_separators_topkdeg(const igraph_t *graph,
-        igraph_vector_t *res,
-        long int k) {
+static int igraph_i_minimum_size_separators_topkdeg(const igraph_t *graph,
+                                                    igraph_vector_t *res,
+                                                    long int k) {
     long int no_of_nodes = igraph_vcount(graph);
     igraph_vector_t deg, order;
     long int i;
@@ -612,7 +612,7 @@ int igraph_i_minimum_size_separators_topkdeg(const igraph_t *graph,
     return 0;
 }
 
-void igraph_i_separators_stcuts_free(igraph_vector_ptr_t *p) {
+static void igraph_i_separators_stcuts_free(igraph_vector_ptr_t *p) {
     long int i, n = igraph_vector_ptr_size(p);
     for (i = 0; i < n; i++) {
         igraph_vector_t *v = VECTOR(*p)[i];

--- a/src/sir.c
+++ b/src/sir.c
@@ -55,7 +55,7 @@ void igraph_sir_destroy(igraph_sir_t *sir) {
     igraph_vector_int_destroy(&sir->no_r);
 }
 
-void igraph_i_sir_destroy(igraph_vector_ptr_t *v) {
+static void igraph_i_sir_destroy(igraph_vector_ptr_t *v) {
     int i, n = igraph_vector_ptr_size(v);
     for (i = 0; i < n; i++) {
         igraph_sir_t *s = VECTOR(*v)[i];

--- a/src/spanning_trees.c
+++ b/src/spanning_trees.c
@@ -33,10 +33,10 @@
 #include "igraph_progress.h"
 #include "igraph_types_internal.h"
 
-int igraph_i_minimum_spanning_tree_unweighted(const igraph_t *graph,
-        igraph_vector_t *result);
-int igraph_i_minimum_spanning_tree_prim(const igraph_t *graph,
-                                        igraph_vector_t *result, const igraph_vector_t *weights);
+static int igraph_i_minimum_spanning_tree_unweighted(const igraph_t *graph,
+                                                     igraph_vector_t *result);
+static int igraph_i_minimum_spanning_tree_prim(const igraph_t *graph,
+                                               igraph_vector_t *result, const igraph_vector_t *weights);
 
 /**
  * \ingroup structural
@@ -203,8 +203,7 @@ int igraph_minimum_spanning_tree_prim(const igraph_t *graph, igraph_t *mst,
 }
 
 
-int igraph_i_minimum_spanning_tree_unweighted(const igraph_t* graph,
-        igraph_vector_t* res) {
+static int igraph_i_minimum_spanning_tree_unweighted(const igraph_t* graph, igraph_vector_t* res) {
 
     long int no_of_nodes = igraph_vcount(graph);
     long int no_of_edges = igraph_ecount(graph);
@@ -271,8 +270,8 @@ int igraph_i_minimum_spanning_tree_unweighted(const igraph_t* graph,
     return IGRAPH_SUCCESS;
 }
 
-int igraph_i_minimum_spanning_tree_prim(const igraph_t* graph,
-                                        igraph_vector_t* res, const igraph_vector_t *weights) {
+static int igraph_i_minimum_spanning_tree_prim(
+        const igraph_t* graph, igraph_vector_t* res, const igraph_vector_t *weights) {
 
     long int no_of_nodes = igraph_vcount(graph);
     long int no_of_edges = igraph_ecount(graph);

--- a/src/sparsemat.c
+++ b/src/sparsemat.c
@@ -320,10 +320,10 @@ int igraph_sparsemat_permute(const igraph_sparsemat_t *A,
     return 0;
 }
 
-int igraph_i_sparsemat_index_rows(const igraph_sparsemat_t *A,
-                                  const igraph_vector_int_t *p,
-                                  igraph_sparsemat_t *res,
-                                  igraph_real_t *constres) {
+static int igraph_i_sparsemat_index_rows(const igraph_sparsemat_t *A,
+                                         const igraph_vector_int_t *p,
+                                         igraph_sparsemat_t *res,
+                                         igraph_real_t *constres) {
 
     igraph_sparsemat_t II, II2;
     long int nrow = A->cs->m;
@@ -358,10 +358,10 @@ int igraph_i_sparsemat_index_rows(const igraph_sparsemat_t *A,
     return 0;
 }
 
-int igraph_i_sparsemat_index_cols(const igraph_sparsemat_t *A,
-                                  const igraph_vector_int_t *q,
-                                  igraph_sparsemat_t *res,
-                                  igraph_real_t *constres) {
+static int igraph_i_sparsemat_index_cols(const igraph_sparsemat_t *A,
+                                         const igraph_vector_int_t *q,
+                                         igraph_sparsemat_t *res,
+                                         igraph_real_t *constres) {
 
     igraph_sparsemat_t JJ, JJ2;
     long int ncol = A->cs->n;
@@ -590,6 +590,7 @@ int igraph_sparsemat_transpose(const igraph_sparsemat_t *A,
     return 0;
 }
 
+static
 igraph_bool_t
 igraph_i_sparsemat_is_symmetric_cc(const igraph_sparsemat_t *A) {
     igraph_sparsemat_t t, tt;
@@ -619,6 +620,7 @@ igraph_i_sparsemat_is_symmetric_cc(const igraph_sparsemat_t *A) {
     return res;
 }
 
+static
 igraph_bool_t
 igraph_i_sparsemat_is_symmetric_triplet(const igraph_sparsemat_t *A) {
     igraph_sparsemat_t tmp;
@@ -1048,8 +1050,8 @@ int igraph_sparsemat_lusol(const igraph_sparsemat_t *A,
     return 0;
 }
 
-int igraph_i_sparsemat_cc(igraph_t *graph, const igraph_sparsemat_t *A,
-                          igraph_bool_t directed) {
+static int igraph_i_sparsemat_cc(igraph_t *graph, const igraph_sparsemat_t *A,
+                                 igraph_bool_t directed) {
 
     igraph_vector_t edges;
     long int no_of_nodes = A->cs->m;
@@ -1088,8 +1090,8 @@ int igraph_i_sparsemat_cc(igraph_t *graph, const igraph_sparsemat_t *A,
     return 0;
 }
 
-int igraph_i_sparsemat_triplet(igraph_t *graph, const igraph_sparsemat_t *A,
-                               igraph_bool_t directed) {
+static int igraph_i_sparsemat_triplet(igraph_t *graph, const igraph_sparsemat_t *A,
+                                      igraph_bool_t directed) {
 
     igraph_vector_t edges;
     long int no_of_nodes = A->cs->m;
@@ -1149,11 +1151,11 @@ int igraph_sparsemat(igraph_t *graph, const igraph_sparsemat_t *A,
     }
 }
 
-int igraph_i_weighted_sparsemat_cc(const igraph_sparsemat_t *A,
-                                   igraph_bool_t directed, const char *attr,
-                                   igraph_bool_t loops,
-                                   igraph_vector_t *edges,
-                                   igraph_vector_t *weights) {
+static int igraph_i_weighted_sparsemat_cc(const igraph_sparsemat_t *A,
+                                          igraph_bool_t directed, const char *attr,
+                                          igraph_bool_t loops,
+                                          igraph_vector_t *edges,
+                                          igraph_vector_t *weights) {
 
     long int no_of_edges = A->cs->p[A->cs->n];
     int *p = A->cs->p;
@@ -1189,12 +1191,12 @@ int igraph_i_weighted_sparsemat_cc(const igraph_sparsemat_t *A,
     return 0;
 }
 
-int igraph_i_weighted_sparsemat_triplet(const igraph_sparsemat_t *A,
-                                        igraph_bool_t directed,
-                                        const char *attr,
-                                        igraph_bool_t loops,
-                                        igraph_vector_t *edges,
-                                        igraph_vector_t *weights) {
+static int igraph_i_weighted_sparsemat_triplet(const igraph_sparsemat_t *A,
+                                               igraph_bool_t directed,
+                                               const char *attr,
+                                               igraph_bool_t loops,
+                                               igraph_vector_t *edges,
+                                               igraph_vector_t *weights) {
 
     IGRAPH_UNUSED(A); IGRAPH_UNUSED(directed); IGRAPH_UNUSED(attr);
     IGRAPH_UNUSED(loops); IGRAPH_UNUSED(edges); IGRAPH_UNUSED(weights);
@@ -1338,8 +1340,8 @@ int igraph_sparsemat_print(const igraph_sparsemat_t *A,
 
 #undef CHECK
 
-int igraph_i_sparsemat_eye_triplet(igraph_sparsemat_t *A, int n, int nzmax,
-                                   igraph_real_t value) {
+static int igraph_i_sparsemat_eye_triplet(igraph_sparsemat_t *A, int n, int nzmax,
+                                          igraph_real_t value) {
     long int i;
 
     IGRAPH_CHECK(igraph_sparsemat_init(A, n, n, nzmax));
@@ -1351,8 +1353,8 @@ int igraph_i_sparsemat_eye_triplet(igraph_sparsemat_t *A, int n, int nzmax,
     return 0;
 }
 
-int igraph_i_sparsemat_eye_cc(igraph_sparsemat_t *A, int n,
-                              igraph_real_t value) {
+static int igraph_i_sparsemat_eye_cc(igraph_sparsemat_t *A, int n,
+                                     igraph_real_t value) {
     long int i;
 
     if (! (A->cs = cs_spalloc(n, n, n, /*values=*/ 1, /*triplet=*/ 0)) ) {
@@ -1397,8 +1399,8 @@ int igraph_sparsemat_eye(igraph_sparsemat_t *A, int n, int nzmax,
     }
 }
 
-int igraph_i_sparsemat_diag_triplet(igraph_sparsemat_t *A, int nzmax,
-                                    const igraph_vector_t *values) {
+static int igraph_i_sparsemat_diag_triplet(igraph_sparsemat_t *A, int nzmax,
+                                           const igraph_vector_t *values) {
 
     int i, n = (int) igraph_vector_size(values);
 
@@ -1412,8 +1414,8 @@ int igraph_i_sparsemat_diag_triplet(igraph_sparsemat_t *A, int nzmax,
 
 }
 
-int igraph_i_sparsemat_diag_cc(igraph_sparsemat_t *A,
-                               const igraph_vector_t *values) {
+static int igraph_i_sparsemat_diag_cc(igraph_sparsemat_t *A,
+                                      const igraph_vector_t *values) {
 
     int i, n = (int) igraph_vector_size(values);
 
@@ -1461,10 +1463,10 @@ int igraph_sparsemat_diag(igraph_sparsemat_t *A, int nzmax,
     }
 }
 
-int igraph_i_sparsemat_arpack_multiply(igraph_real_t *to,
-                                       const igraph_real_t *from,
-                                       int n,
-                                       void *extra) {
+static int igraph_i_sparsemat_arpack_multiply(igraph_real_t *to,
+                                              const igraph_real_t *from,
+                                              int n,
+                                              void *extra) {
     igraph_sparsemat_t *A = extra;
     igraph_vector_t vto, vfrom;
     igraph_vector_view(&vto, to, n);
@@ -1481,10 +1483,10 @@ typedef struct igraph_i_sparsemat_arpack_rssolve_data_t {
     igraph_sparsemat_solve_t method;
 } igraph_i_sparsemat_arpack_rssolve_data_t;
 
-int igraph_i_sparsemat_arpack_solve(igraph_real_t *to,
-                                    const igraph_real_t *from,
-                                    int n,
-                                    void *extra) {
+static int igraph_i_sparsemat_arpack_solve(igraph_real_t *to,
+                                           const igraph_real_t *from,
+                                           int n,
+                                           void *extra) {
 
     igraph_i_sparsemat_arpack_rssolve_data_t *data = extra;
     igraph_vector_t vfrom, vto;
@@ -1958,8 +1960,8 @@ int igraph_matrix_as_sparsemat(igraph_sparsemat_t *res,
     return 0;
 }
 
-int igraph_i_sparsemat_as_matrix_cc(igraph_matrix_t *res,
-                                    const igraph_sparsemat_t *spmat) {
+static int igraph_i_sparsemat_as_matrix_cc(igraph_matrix_t *res,
+                                           const igraph_sparsemat_t *spmat) {
 
     int nrow = (int) igraph_sparsemat_nrow(spmat);
     int ncol = (int) igraph_sparsemat_ncol(spmat);
@@ -1986,8 +1988,8 @@ int igraph_i_sparsemat_as_matrix_cc(igraph_matrix_t *res,
     return 0;
 }
 
-int igraph_i_sparsemat_as_matrix_triplet(igraph_matrix_t *res,
-        const igraph_sparsemat_t *spmat) {
+static int igraph_i_sparsemat_as_matrix_triplet(igraph_matrix_t *res,
+                                                const igraph_sparsemat_t *spmat) {
     int nrow = (int) igraph_sparsemat_nrow(spmat);
     int ncol = (int) igraph_sparsemat_ncol(spmat);
     int *i = spmat->cs->p;
@@ -2201,8 +2203,8 @@ long int igraph_sparsemat_count_nonzerotol(igraph_sparsemat_t *A,
     return res;
 }
 
-int igraph_i_sparsemat_rowsums_triplet(const igraph_sparsemat_t *A,
-                                       igraph_vector_t *res) {
+static int igraph_i_sparsemat_rowsums_triplet(const igraph_sparsemat_t *A,
+                                              igraph_vector_t *res) {
     int i;
     int *pi = A->cs->i;
     double *px = A->cs->x;
@@ -2217,8 +2219,8 @@ int igraph_i_sparsemat_rowsums_triplet(const igraph_sparsemat_t *A,
     return 0;
 }
 
-int igraph_i_sparsemat_rowsums_cc(const igraph_sparsemat_t *A,
-                                  igraph_vector_t *res) {
+static int igraph_i_sparsemat_rowsums_cc(const igraph_sparsemat_t *A,
+                                         igraph_vector_t *res) {
     int ne = A->cs->p[A->cs->n];
     double *px = A->cs->x;
     int *pi = A->cs->i;
@@ -2254,8 +2256,8 @@ int igraph_sparsemat_rowsums(const igraph_sparsemat_t *A,
     }
 }
 
-int igraph_i_sparsemat_rowmins_triplet(const igraph_sparsemat_t *A,
-                                       igraph_vector_t *res) {
+static int igraph_i_sparsemat_rowmins_triplet(const igraph_sparsemat_t *A,
+                                              igraph_vector_t *res) {
     int i;
     int *pi = A->cs->i;
     double *px = A->cs->x;
@@ -2273,8 +2275,8 @@ int igraph_i_sparsemat_rowmins_triplet(const igraph_sparsemat_t *A,
     return 0;
 }
 
-int igraph_i_sparsemat_rowmins_cc(igraph_sparsemat_t *A,
-                                  igraph_vector_t *res) {
+static int igraph_i_sparsemat_rowmins_cc(igraph_sparsemat_t *A,
+                                         igraph_vector_t *res) {
     int ne;
     double *px;
     int *pi;
@@ -2308,8 +2310,8 @@ int igraph_sparsemat_rowmins(igraph_sparsemat_t *A,
 }
 
 
-int igraph_i_sparsemat_rowmaxs_triplet(const igraph_sparsemat_t *A,
-                                       igraph_vector_t *res) {
+static int igraph_i_sparsemat_rowmaxs_triplet(const igraph_sparsemat_t *A,
+                                              igraph_vector_t *res) {
     int i;
     int *pi = A->cs->i;
     double *px = A->cs->x;
@@ -2327,8 +2329,8 @@ int igraph_i_sparsemat_rowmaxs_triplet(const igraph_sparsemat_t *A,
     return 0;
 }
 
-int igraph_i_sparsemat_rowmaxs_cc(igraph_sparsemat_t *A,
-                                  igraph_vector_t *res) {
+static int igraph_i_sparsemat_rowmaxs_cc(igraph_sparsemat_t *A,
+                                         igraph_vector_t *res) {
     int ne;
     double *px;
     int *pi;
@@ -2361,8 +2363,8 @@ int igraph_sparsemat_rowmaxs(igraph_sparsemat_t *A,
     }
 }
 
-int igraph_i_sparsemat_colmins_triplet(const igraph_sparsemat_t *A,
-                                       igraph_vector_t *res) {
+static int igraph_i_sparsemat_colmins_triplet(const igraph_sparsemat_t *A,
+                                              igraph_vector_t *res) {
     int i;
     int *pp = A->cs->p;
     double *px = A->cs->x;
@@ -2380,8 +2382,8 @@ int igraph_i_sparsemat_colmins_triplet(const igraph_sparsemat_t *A,
     return 0;
 }
 
-int igraph_i_sparsemat_colmins_cc(igraph_sparsemat_t *A,
-                                  igraph_vector_t *res) {
+static int igraph_i_sparsemat_colmins_cc(igraph_sparsemat_t *A,
+                                         igraph_vector_t *res) {
     int n;
     double *px;
     int *pp;
@@ -2419,8 +2421,8 @@ int igraph_sparsemat_colmins(igraph_sparsemat_t *A,
     }
 }
 
-int igraph_i_sparsemat_colmaxs_triplet(const igraph_sparsemat_t *A,
-                                       igraph_vector_t *res) {
+static int igraph_i_sparsemat_colmaxs_triplet(const igraph_sparsemat_t *A,
+                                              igraph_vector_t *res) {
     int i;
     int *pp = A->cs->p;
     double *px = A->cs->x;
@@ -2438,8 +2440,8 @@ int igraph_i_sparsemat_colmaxs_triplet(const igraph_sparsemat_t *A,
     return 0;
 }
 
-int igraph_i_sparsemat_colmaxs_cc(igraph_sparsemat_t *A,
-                                  igraph_vector_t *res) {
+static int igraph_i_sparsemat_colmaxs_cc(igraph_sparsemat_t *A,
+                                         igraph_vector_t *res) {
     int n;
     double *px;
     int *pp;
@@ -2477,9 +2479,9 @@ int igraph_sparsemat_colmaxs(igraph_sparsemat_t *A,
     }
 }
 
-int igraph_i_sparsemat_which_min_rows_triplet(igraph_sparsemat_t *A,
-        igraph_vector_t *res,
-        igraph_vector_int_t *pos) {
+static int igraph_i_sparsemat_which_min_rows_triplet(igraph_sparsemat_t *A,
+                                                     igraph_vector_t *res,
+                                                     igraph_vector_int_t *pos) {
     int i;
     int *pi = A->cs->i;
     int *pp = A->cs->p;
@@ -2501,9 +2503,9 @@ int igraph_i_sparsemat_which_min_rows_triplet(igraph_sparsemat_t *A,
     return 0;
 }
 
-int igraph_i_sparsemat_which_min_rows_cc(igraph_sparsemat_t *A,
-        igraph_vector_t *res,
-        igraph_vector_int_t *pos) {
+static int igraph_i_sparsemat_which_min_rows_cc(igraph_sparsemat_t *A,
+                                                igraph_vector_t *res,
+                                                igraph_vector_int_t *pos) {
     int n;
     double *px;
     int *pp;
@@ -2545,9 +2547,9 @@ int igraph_sparsemat_which_min_rows(igraph_sparsemat_t *A,
     }
 }
 
-int igraph_i_sparsemat_which_min_cols_triplet(igraph_sparsemat_t *A,
-        igraph_vector_t *res,
-        igraph_vector_int_t *pos) {
+static int igraph_i_sparsemat_which_min_cols_triplet(igraph_sparsemat_t *A,
+                                                     igraph_vector_t *res,
+                                                     igraph_vector_int_t *pos) {
 
     int i;
     int *pi = A->cs->i;
@@ -2570,9 +2572,9 @@ int igraph_i_sparsemat_which_min_cols_triplet(igraph_sparsemat_t *A,
     return 0;
 }
 
-int igraph_i_sparsemat_which_min_cols_cc(igraph_sparsemat_t *A,
-        igraph_vector_t *res,
-        igraph_vector_int_t *pos) {
+static int igraph_i_sparsemat_which_min_cols_cc(igraph_sparsemat_t *A,
+                                                igraph_vector_t *res,
+                                                igraph_vector_int_t *pos) {
     int n, j, p;
     double *px;
     double *pr;
@@ -2612,8 +2614,8 @@ int igraph_sparsemat_which_min_cols(igraph_sparsemat_t *A,
     }
 }
 
-int igraph_i_sparsemat_colsums_triplet(const igraph_sparsemat_t *A,
-                                       igraph_vector_t *res) {
+static int igraph_i_sparsemat_colsums_triplet(const igraph_sparsemat_t *A,
+                                              igraph_vector_t *res) {
     int i;
     int *pp = A->cs->p;
     double *px = A->cs->x;
@@ -2628,8 +2630,8 @@ int igraph_i_sparsemat_colsums_triplet(const igraph_sparsemat_t *A,
     return 0;
 }
 
-int igraph_i_sparsemat_colsums_cc(const igraph_sparsemat_t *A,
-                                  igraph_vector_t *res) {
+static int igraph_i_sparsemat_colsums_cc(const igraph_sparsemat_t *A,
+                                         igraph_vector_t *res) {
     int n = A->cs->n;
     double *px = A->cs->x;
     int *pp = A->cs->p;
@@ -2828,8 +2830,8 @@ int igraph_sparsemat_scale_rows(igraph_sparsemat_t *A,
     return 0;
 }
 
-int igraph_i_sparsemat_scale_cols_cc(igraph_sparsemat_t *A,
-                                     const igraph_vector_t *fact) {
+static int igraph_i_sparsemat_scale_cols_cc(igraph_sparsemat_t *A,
+                                            const igraph_vector_t *fact) {
     int *i = A->cs->i;
     igraph_real_t *x = A->cs->x;
     int no_of_edges = A->cs->p[A->cs->n];
@@ -2848,8 +2850,8 @@ int igraph_i_sparsemat_scale_cols_cc(igraph_sparsemat_t *A,
     return 0;
 }
 
-int igraph_i_sparsemat_scale_cols_triplet(igraph_sparsemat_t *A,
-        const igraph_vector_t *fact) {
+static int igraph_i_sparsemat_scale_cols_triplet(igraph_sparsemat_t *A,
+                                                 const igraph_vector_t *fact) {
     int *j = A->cs->p;
     igraph_real_t *x = A->cs->x;
     int no_of_edges = A->cs->nz;

--- a/src/spectral_properties.c
+++ b/src/spectral_properties.c
@@ -27,10 +27,10 @@
 #include "config.h"
 #include <math.h>
 
-int igraph_i_weighted_laplacian(const igraph_t *graph, igraph_matrix_t *res,
-                                igraph_sparsemat_t *sparseres,
-                                igraph_bool_t normalized,
-                                const igraph_vector_t *weights) {
+static int igraph_i_weighted_laplacian(const igraph_t *graph, igraph_matrix_t *res,
+                                       igraph_sparsemat_t *sparseres,
+                                       igraph_bool_t normalized,
+                                       const igraph_vector_t *weights) {
 
     igraph_eit_t edgeit;
     int no_of_nodes = (int) igraph_vcount(graph);

--- a/src/st-cuts.c
+++ b/src/st-cuts.c
@@ -244,7 +244,7 @@ typedef struct igraph_i_dbucket_t {
     igraph_vector_long_t next;
 } igraph_i_dbucket_t;
 
-int igraph_i_dbucket_init(igraph_i_dbucket_t *buck, long int size) {
+static int igraph_i_dbucket_init(igraph_i_dbucket_t *buck, long int size) {
     IGRAPH_CHECK(igraph_vector_long_init(&buck->head, size));
     IGRAPH_FINALLY(igraph_vector_long_destroy, &buck->head);
     IGRAPH_CHECK(igraph_vector_long_init(&buck->next, size));
@@ -252,42 +252,42 @@ int igraph_i_dbucket_init(igraph_i_dbucket_t *buck, long int size) {
     return 0;
 }
 
-void igraph_i_dbucket_destroy(igraph_i_dbucket_t *buck) {
+static void igraph_i_dbucket_destroy(igraph_i_dbucket_t *buck) {
     igraph_vector_long_destroy(&buck->head);
     igraph_vector_long_destroy(&buck->next);
 }
 
-int igraph_i_dbucket_insert(igraph_i_dbucket_t *buck, long int bid,
-                            long int elem) {
+static int igraph_i_dbucket_insert(igraph_i_dbucket_t *buck, long int bid,
+                                   long int elem) {
     /* Note: we can do this, since elem is not in any buckets */
     VECTOR(buck->next)[elem] = VECTOR(buck->head)[bid];
     VECTOR(buck->head)[bid] = elem + 1;
     return 0;
 }
 
-long int igraph_i_dbucket_empty(const igraph_i_dbucket_t *buck,
-                                long int bid) {
+static long int igraph_i_dbucket_empty(const igraph_i_dbucket_t *buck,
+                                       long int bid) {
     return VECTOR(buck->head)[bid] == 0;
 }
 
-long int igraph_i_dbucket_delete(igraph_i_dbucket_t *buck, long int bid) {
+static long int igraph_i_dbucket_delete(igraph_i_dbucket_t *buck, long int bid) {
     long int elem = VECTOR(buck->head)[bid] - 1;
     VECTOR(buck->head)[bid] = VECTOR(buck->next)[elem];
     return elem;
 }
 
-int igraph_i_dominator_LINK(long int v, long int w,
-                            igraph_vector_long_t *ancestor) {
+static int igraph_i_dominator_LINK(long int v, long int w,
+                                   igraph_vector_long_t *ancestor) {
     VECTOR(*ancestor)[w] = v + 1;
     return 0;
 }
 
 /* TODO: don't always reallocate path */
 
-int igraph_i_dominator_COMPRESS(long int v,
-                                igraph_vector_long_t *ancestor,
-                                igraph_vector_long_t *label,
-                                igraph_vector_long_t *semi) {
+static int igraph_i_dominator_COMPRESS(long int v,
+                                       igraph_vector_long_t *ancestor,
+                                       igraph_vector_long_t *label,
+                                       igraph_vector_long_t *semi) {
     igraph_stack_long_t path;
     long int w = v;
     long int top, pretop;
@@ -319,10 +319,10 @@ int igraph_i_dominator_COMPRESS(long int v,
     return 0;
 }
 
-long int igraph_i_dominator_EVAL(long int v,
-                                 igraph_vector_long_t *ancestor,
-                                 igraph_vector_long_t *label,
-                                 igraph_vector_long_t *semi) {
+static long int igraph_i_dominator_EVAL(long int v,
+                                        igraph_vector_long_t *ancestor,
+                                        igraph_vector_long_t *label,
+                                        igraph_vector_long_t *semi) {
     if (VECTOR(*ancestor)[v] == 0) {
         return v;
     } else {
@@ -579,7 +579,8 @@ typedef struct igraph_i_all_st_cuts_minimal_dfs_data_t {
     const igraph_vector_t *map;
 } igraph_i_all_st_cuts_minimal_dfs_data_t;
 
-igraph_bool_t igraph_i_all_st_cuts_minimal_dfs_incb(const igraph_t *graph,
+static igraph_bool_t igraph_i_all_st_cuts_minimal_dfs_incb(
+        const igraph_t *graph,
         igraph_integer_t vid,
         igraph_integer_t dist,
         void *extra) {
@@ -604,7 +605,8 @@ igraph_bool_t igraph_i_all_st_cuts_minimal_dfs_incb(const igraph_t *graph,
     return 0;
 }
 
-igraph_bool_t igraph_i_all_st_cuts_minimal_dfs_otcb(const igraph_t *graph,
+static igraph_bool_t igraph_i_all_st_cuts_minimal_dfs_otcb(
+        const igraph_t *graph,
         igraph_integer_t vid,
         igraph_integer_t dist,
         void *extra) {
@@ -623,13 +625,13 @@ igraph_bool_t igraph_i_all_st_cuts_minimal_dfs_otcb(const igraph_t *graph,
     return 0;
 }
 
-int igraph_i_all_st_cuts_minimal(const igraph_t *graph,
-                                 const igraph_t *domtree,
-                                 long int root,
-                                 const igraph_marked_queue_t *X,
-                                 const igraph_vector_bool_t *GammaX,
-                                 const igraph_vector_t *invmap,
-                                 igraph_vector_t *minimal) {
+static int igraph_i_all_st_cuts_minimal(const igraph_t *graph,
+                                        const igraph_t *domtree,
+                                        long int root,
+                                        const igraph_marked_queue_t *X,
+                                        const igraph_vector_bool_t *GammaX,
+                                        const igraph_vector_t *invmap,
+                                        igraph_vector_t *minimal) {
 
     long int no_of_nodes = igraph_vcount(graph);
     igraph_stack_t stack;
@@ -684,6 +686,7 @@ int igraph_i_all_st_cuts_minimal(const igraph_t *graph,
     return 0;
 }
 
+/* not 'static' because used in igraph_all_st_cuts.c test program */
 int igraph_i_all_st_cuts_pivot(const igraph_t *graph,
                                const igraph_marked_queue_t *S,
                                const igraph_estack_t *T,
@@ -1118,10 +1121,10 @@ int igraph_all_st_cuts(const igraph_t *graph,
    zero-indegree vertices.
 */
 
-int igraph_i_all_st_mincuts_minimal(const igraph_t *Sbar,
-                                    const igraph_vector_bool_t *active,
-                                    const igraph_vector_t *invmap,
-                                    igraph_vector_t *minimal) {
+static int igraph_i_all_st_mincuts_minimal(const igraph_t *Sbar,
+                                           const igraph_vector_bool_t *active,
+                                           const igraph_vector_t *invmap,
+                                           igraph_vector_t *minimal) {
 
     long int no_of_nodes = igraph_vcount(Sbar);
     igraph_vector_t indeg;
@@ -1178,14 +1181,14 @@ typedef struct igraph_i_all_st_mincuts_data_t {
     const igraph_vector_bool_t *active;
 } igraph_i_all_st_mincuts_data_t;
 
-int igraph_i_all_st_mincuts_pivot(const igraph_t *graph,
-                                  const igraph_marked_queue_t *S,
-                                  const igraph_estack_t *T,
-                                  long int source,
-                                  long int target,
-                                  long int *v,
-                                  igraph_vector_t *Isv,
-                                  void *arg) {
+static int igraph_i_all_st_mincuts_pivot(const igraph_t *graph,
+                                         const igraph_marked_queue_t *S,
+                                         const igraph_estack_t *T,
+                                         long int source,
+                                         long int target,
+                                         long int *v,
+                                         igraph_vector_t *Isv,
+                                         void *arg) {
 
     igraph_i_all_st_mincuts_data_t *data = arg;
     const igraph_vector_bool_t *active = data->active;

--- a/src/structure_generators.c
+++ b/src/structure_generators.c
@@ -796,12 +796,12 @@ int igraph_lattice(igraph_t *graph, const igraph_vector_t *dimvector,
     if (coords == 0) {
         IGRAPH_ERROR("lattice failed", IGRAPH_ENOMEM);
     }
-    IGRAPH_FINALLY(free, coords); /* TODO: hack */
+    IGRAPH_FINALLY(igraph_free, coords);
     weights = igraph_Calloc(dims, long int);
     if (weights == 0) {
         IGRAPH_ERROR("lattice failed", IGRAPH_ENOMEM);
     }
-    IGRAPH_FINALLY(free, weights);
+    IGRAPH_FINALLY(igraph_free, weights);
     if (dims > 0) {
         weights[0] = 1;
         for (i = 1; i < dims; i++) {

--- a/src/structure_generators.c
+++ b/src/structure_generators.c
@@ -100,18 +100,18 @@ int igraph_create(igraph_t *graph, const igraph_vector_t *edges,
     return 0;
 }
 
-int igraph_i_adjacency_directed(igraph_matrix_t *adjmatrix,
-                                igraph_vector_t *edges);
-int igraph_i_adjacency_max(igraph_matrix_t *adjmatrix,
-                           igraph_vector_t *edges);
-int igraph_i_adjacency_upper(igraph_matrix_t *adjmatrix,
-                             igraph_vector_t *edges);
-int igraph_i_adjacency_lower(igraph_matrix_t *adjmatrix,
-                             igraph_vector_t *edges);
-int igraph_i_adjacency_min(igraph_matrix_t *adjmatrix,
-                           igraph_vector_t *edges);
+static int igraph_i_adjacency_directed(igraph_matrix_t *adjmatrix,
+                                       igraph_vector_t *edges);
+static int igraph_i_adjacency_max(igraph_matrix_t *adjmatrix,
+                                  igraph_vector_t *edges);
+static int igraph_i_adjacency_upper(igraph_matrix_t *adjmatrix,
+                                    igraph_vector_t *edges);
+static int igraph_i_adjacency_lower(igraph_matrix_t *adjmatrix,
+                                    igraph_vector_t *edges);
+static int igraph_i_adjacency_min(igraph_matrix_t *adjmatrix,
+                                  igraph_vector_t *edges);
 
-int igraph_i_adjacency_directed(igraph_matrix_t *adjmatrix, igraph_vector_t *edges) {
+static int igraph_i_adjacency_directed(igraph_matrix_t *adjmatrix, igraph_vector_t *edges) {
 
     long int no_of_nodes = igraph_matrix_nrow(adjmatrix);
     long int i, j, k;
@@ -129,7 +129,7 @@ int igraph_i_adjacency_directed(igraph_matrix_t *adjmatrix, igraph_vector_t *edg
     return 0;
 }
 
-int igraph_i_adjacency_max(igraph_matrix_t *adjmatrix, igraph_vector_t *edges) {
+static int igraph_i_adjacency_max(igraph_matrix_t *adjmatrix, igraph_vector_t *edges) {
 
     long int no_of_nodes = igraph_matrix_nrow(adjmatrix);
     long int i, j, k;
@@ -151,7 +151,7 @@ int igraph_i_adjacency_max(igraph_matrix_t *adjmatrix, igraph_vector_t *edges) {
     return 0;
 }
 
-int igraph_i_adjacency_upper(igraph_matrix_t *adjmatrix, igraph_vector_t *edges) {
+static int igraph_i_adjacency_upper(igraph_matrix_t *adjmatrix, igraph_vector_t *edges) {
 
     long int no_of_nodes = igraph_matrix_nrow(adjmatrix);
     long int i, j, k;
@@ -168,7 +168,7 @@ int igraph_i_adjacency_upper(igraph_matrix_t *adjmatrix, igraph_vector_t *edges)
     return 0;
 }
 
-int igraph_i_adjacency_lower(igraph_matrix_t *adjmatrix, igraph_vector_t *edges) {
+static int igraph_i_adjacency_lower(igraph_matrix_t *adjmatrix, igraph_vector_t *edges) {
 
     long int no_of_nodes = igraph_matrix_nrow(adjmatrix);
     long int i, j, k;
@@ -185,7 +185,7 @@ int igraph_i_adjacency_lower(igraph_matrix_t *adjmatrix, igraph_vector_t *edges)
     return 0;
 }
 
-int igraph_i_adjacency_min(igraph_matrix_t *adjmatrix, igraph_vector_t *edges) {
+static int igraph_i_adjacency_min(igraph_matrix_t *adjmatrix, igraph_vector_t *edges) {
 
     long int no_of_nodes = igraph_matrix_nrow(adjmatrix);
     long int i, j, k;
@@ -311,32 +311,39 @@ int igraph_adjacency(igraph_t *graph, igraph_matrix_t *adjmatrix,
     return 0;
 }
 
-int igraph_i_weighted_adjacency_directed(const igraph_matrix_t *adjmatrix,
+static int igraph_i_weighted_adjacency_directed(
+        const igraph_matrix_t *adjmatrix,
         igraph_vector_t *edges,
         igraph_vector_t *weights,
         igraph_bool_t loops);
-int igraph_i_weighted_adjacency_plus(const igraph_matrix_t *adjmatrix,
-                                     igraph_vector_t *edges,
-                                     igraph_vector_t *weights,
-                                     igraph_bool_t loops);
-int igraph_i_weighted_adjacency_max(const igraph_matrix_t *adjmatrix,
-                                    igraph_vector_t *edges,
-                                    igraph_vector_t *weights,
-                                    igraph_bool_t loops);
-int igraph_i_weighted_adjacency_upper(const igraph_matrix_t *adjmatrix,
-                                      igraph_vector_t *edges,
-                                      igraph_vector_t *weights,
-                                      igraph_bool_t loops);
-int igraph_i_weighted_adjacency_lower(const igraph_matrix_t *adjmatrix,
-                                      igraph_vector_t *edges,
-                                      igraph_vector_t *weights,
-                                      igraph_bool_t loops);
-int igraph_i_weighted_adjacency_min(const igraph_matrix_t *adjmatrix,
-                                    igraph_vector_t *edges,
-                                    igraph_vector_t *weights,
-                                    igraph_bool_t loops);
+static int igraph_i_weighted_adjacency_plus(
+        const igraph_matrix_t *adjmatrix,
+        igraph_vector_t *edges,
+        igraph_vector_t *weights,
+        igraph_bool_t loops);
+static int igraph_i_weighted_adjacency_max(
+        const igraph_matrix_t *adjmatrix,
+        igraph_vector_t *edges,
+        igraph_vector_t *weights,
+        igraph_bool_t loops);
+static int igraph_i_weighted_adjacency_upper(
+        const igraph_matrix_t *adjmatrix,
+        igraph_vector_t *edges,
+        igraph_vector_t *weights,
+        igraph_bool_t loops);
+static int igraph_i_weighted_adjacency_lower(
+        const igraph_matrix_t *adjmatrix,
+        igraph_vector_t *edges,
+        igraph_vector_t *weights,
+        igraph_bool_t loops);
+static int igraph_i_weighted_adjacency_min(
+        const igraph_matrix_t *adjmatrix,
+        igraph_vector_t *edges,
+        igraph_vector_t *weights,
+        igraph_bool_t loops);
 
-int igraph_i_weighted_adjacency_directed(const igraph_matrix_t *adjmatrix,
+static int igraph_i_weighted_adjacency_directed(
+        const igraph_matrix_t *adjmatrix,
         igraph_vector_t *edges,
         igraph_vector_t *weights,
         igraph_bool_t loops) {
@@ -362,10 +369,11 @@ int igraph_i_weighted_adjacency_directed(const igraph_matrix_t *adjmatrix,
     return 0;
 }
 
-int igraph_i_weighted_adjacency_plus(const igraph_matrix_t *adjmatrix,
-                                     igraph_vector_t *edges,
-                                     igraph_vector_t *weights,
-                                     igraph_bool_t loops) {
+static int igraph_i_weighted_adjacency_plus(
+        const igraph_matrix_t *adjmatrix,
+        igraph_vector_t *edges,
+        igraph_vector_t *weights,
+        igraph_bool_t loops) {
 
     long int no_of_nodes = igraph_matrix_nrow(adjmatrix);
     long int i, j;
@@ -391,10 +399,11 @@ int igraph_i_weighted_adjacency_plus(const igraph_matrix_t *adjmatrix,
     return 0;
 }
 
-int igraph_i_weighted_adjacency_max(const igraph_matrix_t *adjmatrix,
-                                    igraph_vector_t *edges,
-                                    igraph_vector_t *weights,
-                                    igraph_bool_t loops) {
+static int igraph_i_weighted_adjacency_max(
+        const igraph_matrix_t *adjmatrix,
+        igraph_vector_t *edges,
+        igraph_vector_t *weights,
+        igraph_bool_t loops) {
 
     long int no_of_nodes = igraph_matrix_nrow(adjmatrix);
     long int i, j;
@@ -420,10 +429,11 @@ int igraph_i_weighted_adjacency_max(const igraph_matrix_t *adjmatrix,
     return 0;
 }
 
-int igraph_i_weighted_adjacency_upper(const igraph_matrix_t *adjmatrix,
-                                      igraph_vector_t *edges,
-                                      igraph_vector_t *weights,
-                                      igraph_bool_t loops) {
+static int igraph_i_weighted_adjacency_upper(
+        const igraph_matrix_t *adjmatrix,
+        igraph_vector_t *edges,
+        igraph_vector_t *weights,
+        igraph_bool_t loops) {
 
     long int no_of_nodes = igraph_matrix_nrow(adjmatrix);
     long int i, j;
@@ -445,10 +455,11 @@ int igraph_i_weighted_adjacency_upper(const igraph_matrix_t *adjmatrix,
     return 0;
 }
 
-int igraph_i_weighted_adjacency_lower(const igraph_matrix_t *adjmatrix,
-                                      igraph_vector_t *edges,
-                                      igraph_vector_t *weights,
-                                      igraph_bool_t loops) {
+static int igraph_i_weighted_adjacency_lower(
+        const igraph_matrix_t *adjmatrix,
+        igraph_vector_t *edges,
+        igraph_vector_t *weights,
+        igraph_bool_t loops) {
 
     long int no_of_nodes = igraph_matrix_nrow(adjmatrix);
     long int i, j;
@@ -470,10 +481,11 @@ int igraph_i_weighted_adjacency_lower(const igraph_matrix_t *adjmatrix,
     return 0;
 }
 
-int igraph_i_weighted_adjacency_min(const igraph_matrix_t *adjmatrix,
-                                    igraph_vector_t *edges,
-                                    igraph_vector_t *weights,
-                                    igraph_bool_t loops) {
+static int igraph_i_weighted_adjacency_min(
+        const igraph_matrix_t *adjmatrix,
+        igraph_vector_t *edges,
+        igraph_vector_t *weights,
+        igraph_bool_t loops) {
 
     long int no_of_nodes = igraph_matrix_nrow(adjmatrix);
     long int i, j;
@@ -1991,9 +2003,7 @@ const igraph_real_t igraph_i_famous_zachary[] = {
     32, 33
 };
 
-int igraph_i_famous(igraph_t *graph, const igraph_real_t *data);
-
-int igraph_i_famous(igraph_t *graph, const igraph_real_t *data) {
+static int igraph_i_famous(igraph_t *graph, const igraph_real_t *data) {
     long int no_of_nodes = (long int) data[0];
     long int no_of_edges = (long int) data[1];
     igraph_bool_t directed = (igraph_bool_t) data[2];

--- a/src/sugiyama.c
+++ b/src/sugiyama.c
@@ -157,8 +157,8 @@ typedef struct {
 /**
  * Initializes a layering.
  */
-int igraph_i_layering_init(igraph_i_layering_t* layering,
-                           const igraph_vector_t* membership) {
+static int igraph_i_layering_init(igraph_i_layering_t* layering,
+                                  const igraph_vector_t* membership) {
     long int i, n, num_layers;
 
     if (igraph_vector_size(membership) == 0) {
@@ -193,21 +193,21 @@ int igraph_i_layering_init(igraph_i_layering_t* layering,
 /**
  * Destroys a layering.
  */
-void igraph_i_layering_destroy(igraph_i_layering_t* layering) {
+static void igraph_i_layering_destroy(igraph_i_layering_t* layering) {
     igraph_vector_ptr_destroy_all(&layering->layers);
 }
 
 /**
  * Returns the number of layers in a layering.
  */
-int igraph_i_layering_num_layers(const igraph_i_layering_t* layering) {
+static int igraph_i_layering_num_layers(const igraph_i_layering_t* layering) {
     return (int) igraph_vector_ptr_size(&layering->layers);
 }
 
 /**
  * Returns the list of vertices in a given layer
  */
-igraph_vector_t* igraph_i_layering_get(const igraph_i_layering_t* layering,
+static igraph_vector_t* igraph_i_layering_get(const igraph_i_layering_t* layering,
                                        long int index) {
     return (igraph_vector_t*)VECTOR(layering->layers)[index];
 }

--- a/src/topology.c
+++ b/src/topology.c
@@ -1640,7 +1640,8 @@ typedef struct {
     void *arg, *carg;
 } igraph_i_iso_cb_data_t;
 
-igraph_bool_t igraph_i_isocompat_node_cb(const igraph_t *graph1,
+static igraph_bool_t igraph_i_isocompat_node_cb(
+        const igraph_t *graph1,
         const igraph_t *graph2,
         const igraph_integer_t g1_num,
         const igraph_integer_t g2_num,
@@ -1649,7 +1650,8 @@ igraph_bool_t igraph_i_isocompat_node_cb(const igraph_t *graph1,
     return data->node_compat_fn(graph1, graph2, g1_num, g2_num, data->carg);
 }
 
-igraph_bool_t igraph_i_isocompat_edge_cb(const igraph_t *graph1,
+static igraph_bool_t igraph_i_isocompat_edge_cb(
+        const igraph_t *graph1,
         const igraph_t *graph2,
         const igraph_integer_t g1_num,
         const igraph_integer_t g2_num,
@@ -1658,9 +1660,9 @@ igraph_bool_t igraph_i_isocompat_edge_cb(const igraph_t *graph1,
     return data->edge_compat_fn(graph1, graph2, g1_num, g2_num, data->carg);
 }
 
-igraph_bool_t igraph_i_isomorphic_vf2(igraph_vector_t *map12,
-                                      igraph_vector_t *map21,
-                                      void *arg) {
+static igraph_bool_t igraph_i_isomorphic_vf2(igraph_vector_t *map12,
+                                             igraph_vector_t *map21,
+                                             void *arg) {
     igraph_i_iso_cb_data_t *data = arg;
     igraph_bool_t *iso = data->arg;
     IGRAPH_UNUSED(map12); IGRAPH_UNUSED(map21);
@@ -1756,7 +1758,8 @@ int igraph_isomorphic_vf2(const igraph_t *graph1, const igraph_t *graph2,
     return 0;
 }
 
-igraph_bool_t igraph_i_count_isomorphisms_vf2(const igraph_vector_t *map12,
+static igraph_bool_t igraph_i_count_isomorphisms_vf2(
+        const igraph_vector_t *map12,
         const igraph_vector_t *map21,
         void *arg) {
     igraph_i_iso_cb_data_t *data = arg;
@@ -1828,7 +1831,7 @@ int igraph_count_isomorphisms_vf2(const igraph_t *graph1, const igraph_t *graph2
     return 0;
 }
 
-void igraph_i_get_isomorphisms_free(igraph_vector_ptr_t *data) {
+static void igraph_i_get_isomorphisms_free(igraph_vector_ptr_t *data) {
     long int i, n = igraph_vector_ptr_size(data);
     for (i = 0; i < n; i++) {
         igraph_vector_t *vec = VECTOR(*data)[i];
@@ -1837,7 +1840,8 @@ void igraph_i_get_isomorphisms_free(igraph_vector_ptr_t *data) {
     }
 }
 
-igraph_bool_t igraph_i_get_isomorphisms_vf2(const igraph_vector_t *map12,
+static igraph_bool_t igraph_i_get_isomorphisms_vf2(
+        const igraph_vector_t *map12,
         const igraph_vector_t *map21,
         void *arg) {
 
@@ -2473,7 +2477,8 @@ int igraph_subisomorphic_function_vf2(const igraph_t *graph1,
     return 0;
 }
 
-igraph_bool_t igraph_i_subisomorphic_vf2(const igraph_vector_t *map12,
+static igraph_bool_t igraph_i_subisomorphic_vf2(
+        const igraph_vector_t *map12,
         const igraph_vector_t *map21,
         void *arg) {
     igraph_i_iso_cb_data_t *data = arg;
@@ -2560,7 +2565,8 @@ int igraph_subisomorphic_vf2(const igraph_t *graph1, const igraph_t *graph2,
     return 0;
 }
 
-igraph_bool_t igraph_i_count_subisomorphisms_vf2(const igraph_vector_t *map12,
+static igraph_bool_t igraph_i_count_subisomorphisms_vf2(
+        const igraph_vector_t *map12,
         const igraph_vector_t *map21,
         void *arg) {
     igraph_i_iso_cb_data_t *data = arg;
@@ -2635,7 +2641,7 @@ int igraph_count_subisomorphisms_vf2(const igraph_t *graph1, const igraph_t *gra
     return 0;
 }
 
-void igraph_i_get_subisomorphisms_free(igraph_vector_ptr_t *data) {
+static void igraph_i_get_subisomorphisms_free(igraph_vector_ptr_t *data) {
     long int i, n = igraph_vector_ptr_size(data);
     for (i = 0; i < n; i++) {
         igraph_vector_t *vec = VECTOR(*data)[i];
@@ -2644,7 +2650,8 @@ void igraph_i_get_subisomorphisms_free(igraph_vector_ptr_t *data) {
     }
 }
 
-igraph_bool_t igraph_i_get_subisomorphisms_vf2(const igraph_vector_t *map12,
+static igraph_bool_t igraph_i_get_subisomorphisms_vf2(
+        const igraph_vector_t *map12,
         const igraph_vector_t *map21,
         void *arg) {
 

--- a/src/triangles.c
+++ b/src/triangles.c
@@ -394,7 +394,7 @@ int igraph_transitivity_local_undirected2(const igraph_t *graph,
 
 /* This removes loop, multiple edges and edges that point
      "backwards" according to the rank vector. */
-
+/* TODO used in scan.c, add prototype to private header */
 int igraph_i_trans4_al_simplify(igraph_adjlist_t *al,
                                 const igraph_vector_int_t *rank) {
     long int i;

--- a/src/type_indexededgelist.c
+++ b/src/type_indexededgelist.c
@@ -30,8 +30,9 @@
 
 /* Internal functions */
 
-int igraph_i_create_start(igraph_vector_t *res, igraph_vector_t *el, igraph_vector_t *index,
-                          igraph_integer_t nodes);
+static int igraph_i_create_start(
+        igraph_vector_t *res, igraph_vector_t *el,
+        igraph_vector_t *index, igraph_integer_t nodes);
 
 /**
  * \section about_basic_interface
@@ -829,8 +830,9 @@ int igraph_neighbors(const igraph_t *graph, igraph_vector_t *neis, igraph_intege
  *
  */
 
-int igraph_i_create_start(igraph_vector_t *res, igraph_vector_t *el, igraph_vector_t *iindex,
-                          igraph_integer_t nodes) {
+static int igraph_i_create_start(
+        igraph_vector_t *res, igraph_vector_t *el,
+        igraph_vector_t *iindex, igraph_integer_t nodes) {
 
 # define EDGE(i) (VECTOR(*el)[ (long int) VECTOR(*iindex)[(i)] ])
 


### PR DESCRIPTION
This PR attempts to make functions 'static' (i.e. local to the translation unit) when appropriate.

This is a step towards cleaning up the code, finding unused functions (the compiler can provide better warnings), sorting internal functions from ones that should be public, and making sure that everything used across multiple translation units has a prototype in a header.

This is not completed yet (still some files to go through) but I'm putting it out here in case anyone has comments.