### PR TITLE
change some instances of free() to igraph_free() or igraph_Free()

### DIFF
--- a/src/cocitation.c
+++ b/src/cocitation.c
@@ -460,7 +460,7 @@ int igraph_similarity_jaccard_pairs(const igraph_t *graph, igraph_vector_t *res,
         if (seen == 0) {
             IGRAPH_ERROR("cannot calculate Jaccard similarity", IGRAPH_ENOMEM);
         }
-        IGRAPH_FINALLY(free, seen);
+        IGRAPH_FINALLY(igraph_free, seen);
 
         for (i = 0; i < k; i++) {
             j = (long int) VECTOR(*pairs)[i];
@@ -474,7 +474,7 @@ int igraph_similarity_jaccard_pairs(const igraph_t *graph, igraph_vector_t *res,
             }
         }
 
-        free(seen);
+        igraph_Free(seen);
         IGRAPH_FINALLY_CLEAN(1);
     }
 

--- a/src/community.c
+++ b/src/community.c
@@ -721,7 +721,7 @@ int igraph_community_edge_betweenness(const igraph_t *graph,
 
     if (result_owned) {
         igraph_vector_destroy(result);
-        free(result);
+        igraph_Free(result);
         IGRAPH_FINALLY_CLEAN(2);
     }
 
@@ -1516,7 +1516,7 @@ void igraph_i_error_handler_none(const char *reason, const char *file,
  *    \ref igraph_vector_t object. The user is responsible of
  *    deallocating the memory that belongs to the individual vectors,
  *    by calling first \ref igraph_vector_destroy(), and then
- *    <code>free()</code> on them.
+ *    \ref igraph_free() on them.
  * \param history Pointer to an initialized vector or a null pointer.
  *    If not a null pointer, then a trace of the algorithm is stored
  *    here, encoded numerically. The various operations:
@@ -2732,7 +2732,7 @@ int igraph_i_multilevel_simplify_multiple(igraph_t *graph, igraph_vector_t *eids
     if (links == 0) {
         IGRAPH_ERROR("multi-level community structure detection failed", IGRAPH_ENOMEM);
     }
-    IGRAPH_FINALLY(free, links);
+    IGRAPH_FINALLY(igraph_free, links);
 
     for (i = 0; i < ecount; i++) {
         igraph_edge(graph, (igraph_integer_t) i, &from, &to);
@@ -2762,7 +2762,7 @@ int igraph_i_multilevel_simplify_multiple(igraph_t *graph, igraph_vector_t *eids
         VECTOR(*eids)[links[i].id] = l;
     }
 
-    free(links);
+    igraph_Free(links);
     IGRAPH_FINALLY_CLEAN(1);
 
     igraph_destroy(graph);
@@ -3533,12 +3533,12 @@ int igraph_i_entropy_and_mutual_information(const igraph_vector_t* v1,
     if (p1 == 0) {
         IGRAPH_ERROR("igraph_i_entropy_and_mutual_information failed", IGRAPH_ENOMEM);
     }
-    IGRAPH_FINALLY(free, p1);
+    IGRAPH_FINALLY(igraph_free, p1);
     p2 = igraph_Calloc(k2, double);
     if (p2 == 0) {
         IGRAPH_ERROR("igraph_i_entropy_and_mutual_information failed", IGRAPH_ENOMEM);
     }
-    IGRAPH_FINALLY(free, p2);
+    IGRAPH_FINALLY(igraph_free, p2);
 
     /* Calculate the entropy of v1 */
     *h1 = 0.0;
@@ -3586,7 +3586,7 @@ int igraph_i_entropy_and_mutual_information(const igraph_vector_t* v1,
 
     igraph_spmatrix_iter_destroy(&mit);
     igraph_spmatrix_destroy(&m);
-    free(p1); free(p2);
+    igraph_Free(p1); igraph_Free(p2);
 
     IGRAPH_FINALLY_CLEAN(4);
 

--- a/src/community_leiden.c
+++ b/src/community_leiden.c
@@ -815,7 +815,7 @@ int igraph_i_community_leiden(const igraph_t *graph,
             if (tmp_graph == 0) {
                 IGRAPH_ERROR("Leiden algorithm failed, could not allocate memory for aggregate graph", IGRAPH_ENOMEM);
             }
-            IGRAPH_FINALLY(free, tmp_graph);
+            IGRAPH_FINALLY(igraph_free, tmp_graph);
 
             IGRAPH_CHECK(igraph_i_community_leiden_aggregate(
                              aggregated_graph, &edges_per_node, aggregated_edge_weights, aggregated_node_weights,
@@ -845,7 +845,7 @@ int igraph_i_community_leiden(const igraph_t *graph,
                 if (aggregated_edge_weights == 0) {
                     IGRAPH_ERROR("Leiden algorithm failed, could not allocate memory for aggregate edge weights", IGRAPH_ENOMEM);
                 }
-                IGRAPH_FINALLY(free, aggregated_edge_weights);
+                IGRAPH_FINALLY(igraph_free, aggregated_edge_weights);
                 IGRAPH_CHECK(igraph_vector_init(aggregated_edge_weights, 0));
                 IGRAPH_FINALLY(igraph_vector_destroy, aggregated_edge_weights);
 
@@ -853,7 +853,7 @@ int igraph_i_community_leiden(const igraph_t *graph,
                 if (aggregated_node_weights == 0) {
                     IGRAPH_ERROR("Leiden algorithm failed, could not allocate memory for aggregate node weights", IGRAPH_ENOMEM);
                 }
-                IGRAPH_FINALLY(free, aggregated_node_weights);
+                IGRAPH_FINALLY(igraph_free, aggregated_node_weights);
                 IGRAPH_CHECK(igraph_vector_init(aggregated_node_weights, 0));
                 IGRAPH_FINALLY(igraph_vector_destroy, aggregated_node_weights);
 
@@ -861,7 +861,7 @@ int igraph_i_community_leiden(const igraph_t *graph,
                 if (aggregated_membership == 0) {
                     IGRAPH_ERROR("Leiden algorithm failed, could not allocate memory for aggregate membership", IGRAPH_ENOMEM);
                 }
-                IGRAPH_FINALLY(free, aggregated_membership);
+                IGRAPH_FINALLY(igraph_free, aggregated_membership);
                 IGRAPH_CHECK(igraph_vector_init(aggregated_membership, 0));
                 IGRAPH_FINALLY(igraph_vector_destroy, aggregated_membership);
             }
@@ -1037,7 +1037,7 @@ int igraph_community_leiden(const igraph_t *graph,
             IGRAPH_ERROR("Leiden algorithm failed, could not allocate memory for edge weights", IGRAPH_ENOMEM);
         }
         IGRAPH_CHECK(igraph_vector_init(i_edge_weights, igraph_ecount(graph)));
-        IGRAPH_FINALLY(free, i_edge_weights);
+        IGRAPH_FINALLY(igraph_free, i_edge_weights);
         IGRAPH_FINALLY(igraph_vector_destroy, i_edge_weights);
         igraph_vector_fill(i_edge_weights, 1);
     } else {
@@ -1051,7 +1051,7 @@ int igraph_community_leiden(const igraph_t *graph,
             IGRAPH_ERROR("Leiden algorithm failed, could not allocate memory for node weights", IGRAPH_ENOMEM);
         }
         IGRAPH_CHECK(igraph_vector_init(i_node_weights, n));
-        IGRAPH_FINALLY(free, i_node_weights);
+        IGRAPH_FINALLY(igraph_free, i_node_weights);
         IGRAPH_FINALLY(igraph_vector_destroy, i_node_weights);
         igraph_vector_fill(i_node_weights, 1);
     } else {

--- a/src/components.c
+++ b/src/components.c
@@ -410,7 +410,7 @@ int igraph_is_connected_weak(const igraph_t *graph, igraph_bool_t *res) {
     if (already_added == 0) {
         IGRAPH_ERROR("is connected (weak) failed", IGRAPH_ENOMEM);
     }
-    IGRAPH_FINALLY(free, already_added); /* TODO: hack */
+    IGRAPH_FINALLY(igraph_free, already_added);
 
     IGRAPH_DQUEUE_INIT_FINALLY(&q, 10);
     IGRAPH_VECTOR_INIT_FINALLY(&neis, 0);
@@ -616,7 +616,7 @@ static int igraph_i_decompose_weak(const igraph_t *graph,
     igraph_vector_destroy(&neis);
     igraph_vector_destroy(&verts);
     igraph_dqueue_destroy(&q);
-    igraph_free(already_added);
+    igraph_Free(already_added);
     IGRAPH_FINALLY_CLEAN(5);  /* + components */
 
     return 0;
@@ -889,7 +889,7 @@ void igraph_i_free_vectorlist(igraph_vector_ptr_t *list) {
  *     a spanning tree of the biconnected component is returned.
  *     Note you'll have to
  *     destroy each vector first by calling \ref igraph_vector_destroy()
- *     and then <code>free()</code> on it, plus you need to call
+ *     and then \ref igraph_free() on it, plus you need to call
  *     \ref igraph_vector_ptr_destroy() on the list to regain all
  *     allocated memory.
  * \param component_edges If not a NULL pointer, then the edges of the

--- a/src/fast_community.c
+++ b/src/fast_community.c
@@ -147,12 +147,12 @@ void igraph_i_fastgreedy_community_list_destroy(
     for (i = 0; i < list->n; i++) {
         igraph_vector_ptr_destroy(&list->e[i].neis);
     }
-    free(list->e);
+    igraph_Free(list->e);
     if (list->heapindex != 0) {
-        free(list->heapindex);
+        igraph_Free(list->heapindex);
     }
     if (list->heap != 0) {
-        free(list->heap);
+        igraph_Free(list->heap);
     }
 }
 
@@ -698,12 +698,12 @@ int igraph_community_fastgreedy(const igraph_t *graph,
     if (communities.e == 0) {
         IGRAPH_ERROR("can't run fast greedy community detection", IGRAPH_ENOMEM);
     }
-    IGRAPH_FINALLY(free, communities.e);
+    IGRAPH_FINALLY(igraph_free, communities.e);
     communities.heap = (igraph_i_fastgreedy_community**)calloc((size_t) no_of_nodes, sizeof(igraph_i_fastgreedy_community*));
     if (communities.heap == 0) {
         IGRAPH_ERROR("can't run fast greedy community detection", IGRAPH_ENOMEM);
     }
-    IGRAPH_FINALLY(free, communities.heap);
+    IGRAPH_FINALLY(igraph_free, communities.heap);
     communities.heapindex = (igraph_integer_t*)calloc((size_t)no_of_nodes, sizeof(igraph_integer_t));
     if (communities.heapindex == 0) {
         IGRAPH_ERROR("can't run fast greedy community detection", IGRAPH_ENOMEM);
@@ -722,7 +722,7 @@ int igraph_community_fastgreedy(const igraph_t *graph,
     if (dq == 0) {
         IGRAPH_ERROR("can't run fast greedy community detection", IGRAPH_ENOMEM);
     }
-    IGRAPH_FINALLY(free, dq);
+    IGRAPH_FINALLY(igraph_free, dq);
     debug("Creating community pair list\n");
     IGRAPH_CHECK(igraph_eit_create(graph, igraph_ess_all(0), &edgeit));
     IGRAPH_FINALLY(igraph_eit_destroy, &edgeit);
@@ -730,7 +730,7 @@ int igraph_community_fastgreedy(const igraph_t *graph,
     if (pairs == 0) {
         IGRAPH_ERROR("can't run fast greedy community detection", IGRAPH_ENOMEM);
     }
-    IGRAPH_FINALLY(free, pairs);
+    IGRAPH_FINALLY(igraph_free, pairs);
     loop_weight_sum = 0;
     for (i = 0, j = 0; !IGRAPH_EIT_END(edgeit); i += 2, j++, IGRAPH_EIT_NEXT(edgeit)) {
         long int eidx = IGRAPH_EIT_GET(edgeit);
@@ -1022,12 +1022,12 @@ int igraph_community_fastgreedy(const igraph_t *graph,
         if (ivec == 0) {
             IGRAPH_ERROR("can't run fast greedy community detection", IGRAPH_ENOMEM);
         }
-        IGRAPH_FINALLY(free, ivec);
+        IGRAPH_FINALLY(igraph_free, ivec);
         for (i = 0; i < no_of_joins; i++) {
             ivec[i] = i + 1;
         }
         igraph_matrix_permdelete_rows(merges, ivec, total_joins - no_of_joins);
-        free(ivec);
+        igraph_Free(ivec);
         IGRAPH_FINALLY_CLEAN(1);
     }
     IGRAPH_PROGRESS("fast greedy community detection", 100.0, 0);
@@ -1038,8 +1038,8 @@ int igraph_community_fastgreedy(const igraph_t *graph,
     }
 
     debug("Freeing memory\n");
-    free(pairs);
-    free(dq);
+    igraph_Free(pairs);
+    igraph_Free(dq);
     igraph_i_fastgreedy_community_list_destroy(&communities);
     igraph_vector_destroy(&a);
     IGRAPH_FINALLY_CLEAN(4);

--- a/src/feedback_arc_set.c
+++ b/src/feedback_arc_set.c
@@ -475,7 +475,7 @@ int igraph_i_feedback_arc_set_ip(const igraph_t *graph, igraph_vector_t *result,
         if (vptr == 0) {
             IGRAPH_ERROR("cannot calculate feedback arc set using IP", IGRAPH_ENOMEM);
         }
-        IGRAPH_FINALLY(free, vptr);
+        IGRAPH_FINALLY(igraph_free, vptr);
         IGRAPH_CHECK(igraph_vector_init(vptr, 0));
         IGRAPH_FINALLY_CLEAN(1);
         VECTOR(vertices_by_components)[i] = vptr;
@@ -487,7 +487,7 @@ int igraph_i_feedback_arc_set_ip(const igraph_t *graph, igraph_vector_t *result,
         if (vptr == 0) {
             IGRAPH_ERROR("cannot calculate feedback arc set using IP", IGRAPH_ENOMEM);
         }
-        IGRAPH_FINALLY(free, vptr);
+        IGRAPH_FINALLY(igraph_free, vptr);
         IGRAPH_CHECK(igraph_vector_init(vptr, 0));
         IGRAPH_FINALLY_CLEAN(1);
         VECTOR(edges_by_components)[i] = vptr;

--- a/src/foreign-pajek-parser.y
+++ b/src/foreign-pajek-parser.y
@@ -631,7 +631,7 @@ int igraph_i_pajek_add_string_vertex_attribute(const char *name,
   if (tmp==0) {
     IGRAPH_ERROR("cannot add element to hash table", IGRAPH_ENOMEM);
   }
-  IGRAPH_FINALLY(free, tmp);
+  IGRAPH_FINALLY(igraph_free, tmp);
   strncpy(tmp, value, len);
   tmp[len]='\0';
 
@@ -658,7 +658,7 @@ int igraph_i_pajek_add_string_edge_attribute(const char *name,
   if (tmp==0) {
     IGRAPH_ERROR("cannot add element to hash table", IGRAPH_ENOMEM);
   }
-  IGRAPH_FINALLY(free, tmp);
+  IGRAPH_FINALLY(igraph_free, tmp);
   strncpy(tmp, value, len);
   tmp[len]='\0';
   

--- a/src/games.c
+++ b/src/games.c
@@ -124,7 +124,7 @@ int igraph_i_barabasi_game_bag(igraph_t *graph, igraph_integer_t n,
     if (bag == 0) {
         IGRAPH_ERROR("barabasi_game failed", IGRAPH_ENOMEM);
     }
-    IGRAPH_FINALLY(free, bag);    /* TODO: hack */
+    IGRAPH_FINALLY(igraph_free, bag);    /* TODO: hack */
 
     /* The first node(s) in the bag */
     if (start_from) {
@@ -860,7 +860,7 @@ int igraph_degree_sequence_game_simple(igraph_t *graph,
     if (bag1 == 0) {
         IGRAPH_ERROR("degree sequence game (simple)", IGRAPH_ENOMEM);
     }
-    IGRAPH_FINALLY(free, bag1);   /* TODO: hack */
+    IGRAPH_FINALLY(igraph_free, bag1);   /* TODO: hack */
 
     for (i = 0; i < no_of_nodes; i++) {
         for (j = 0; j < VECTOR(*out_seq)[i]; j++) {
@@ -872,7 +872,7 @@ int igraph_degree_sequence_game_simple(igraph_t *graph,
         if (bag2 == 0) {
             IGRAPH_ERROR("degree sequence game (simple)", IGRAPH_ENOMEM);
         }
-        IGRAPH_FINALLY(free, bag2);
+        IGRAPH_FINALLY(igraph_free, bag2);
         for (i = 0; i < no_of_nodes; i++) {
             for (j = 0; j < VECTOR(*in_seq)[i]; j++) {
                 bag2[bagp2++] = i;

--- a/src/heap.c
+++ b/src/heap.c
@@ -289,12 +289,12 @@ int igraph_indheap_reserve        (igraph_indheap_t* h, long int size) {
     if (tmp1 == 0) {
         IGRAPH_ERROR("indheap reserve failed", IGRAPH_ENOMEM);
     }
-    IGRAPH_FINALLY(free, tmp1);   /* TODO: hack */
+    IGRAPH_FINALLY(igraph_free, tmp1);
     tmp2 = igraph_Calloc(size, long int);
     if (tmp2 == 0) {
         IGRAPH_ERROR("indheap reserve failed", IGRAPH_ENOMEM);
     }
-    IGRAPH_FINALLY(free, tmp2);
+    IGRAPH_FINALLY(igraph_free, tmp2);
     memcpy(tmp1, h->stor_begin, (size_t) actual_size * sizeof(igraph_real_t));
     memcpy(tmp2, h->index_begin, (size_t) actual_size * sizeof(long int));
     igraph_Free(h->stor_begin);
@@ -575,17 +575,17 @@ int igraph_d_indheap_reserve        (igraph_d_indheap_t* h, long int size) {
     if (tmp1 == 0) {
         IGRAPH_ERROR("d_indheap reserve failed", IGRAPH_ENOMEM);
     }
-    IGRAPH_FINALLY(free, tmp1);   /* TODO: hack */
+    IGRAPH_FINALLY(igraph_free, tmp1);
     tmp2 = igraph_Calloc(size, long int);
     if (tmp2 == 0) {
         IGRAPH_ERROR("d_indheap reserve failed", IGRAPH_ENOMEM);
     }
-    IGRAPH_FINALLY(free, tmp2);   /* TODO: hack */
+    IGRAPH_FINALLY(igraph_free, tmp2);
     tmp3 = igraph_Calloc(size, long int);
     if (tmp3 == 0) {
         IGRAPH_ERROR("d_indheap reserve failed", IGRAPH_ENOMEM);
     }
-    IGRAPH_FINALLY(free, tmp3);   /* TODO: hack */
+    IGRAPH_FINALLY(igraph_free, tmp3);
 
     memcpy(tmp1, h->stor_begin, (size_t) actual_size * sizeof(igraph_real_t));
     memcpy(tmp2, h->index_begin, (size_t) actual_size * sizeof(long int));

--- a/src/igraph_hashtable.c
+++ b/src/igraph_hashtable.c
@@ -87,7 +87,7 @@ int igraph_hashtable_addset2(igraph_hashtable_t *ht,
     if (tmp == 0) {
         IGRAPH_ERROR("cannot add element to hash table", IGRAPH_ENOMEM);
     }
-    IGRAPH_FINALLY(free, tmp);
+    IGRAPH_FINALLY(igraph_free, tmp);
     strncpy(tmp, elem, elemlen);
     tmp[elemlen] = '\0';
 

--- a/src/igraph_trie.c
+++ b/src/igraph_trie.c
@@ -210,9 +210,9 @@ int igraph_trie_get_node(igraph_trie_node_t *t, const char *key,
                 IGRAPH_ERROR("cannot add to trie", IGRAPH_ENOMEM);
             }
             str2[diff] = '\0';
-            IGRAPH_FINALLY(free, str2);
+            IGRAPH_FINALLY(igraph_free, str2);
             IGRAPH_CHECK(igraph_strvector_set(&t->strs, i, str2));
-            free(str2);
+            igraph_Free(str2);
             IGRAPH_FINALLY_CLEAN(4);
 
             VECTOR(t->values)[i] = newvalue;
@@ -246,9 +246,9 @@ int igraph_trie_get_node(igraph_trie_node_t *t, const char *key,
                 IGRAPH_ERROR("cannot add to trie", IGRAPH_ENOMEM);
             }
             str2[diff] = '\0';
-            IGRAPH_FINALLY(free, str2);
+            IGRAPH_FINALLY(igraph_free, str2);
             IGRAPH_CHECK(igraph_strvector_set(&t->strs, i, str2));
-            free(str2);
+            igraph_Free(str2);
             IGRAPH_FINALLY_CLEAN(4);
 
             VECTOR(t->values)[i] = -1;
@@ -345,7 +345,7 @@ int igraph_trie_get2(igraph_trie_t *t, const char *key, long int length,
 
     strncpy(tmp, key, length);
     tmp[length] = '\0';
-    IGRAPH_FINALLY(free, tmp);
+    IGRAPH_FINALLY(igraph_free, tmp);
     IGRAPH_CHECK(igraph_trie_get(t, tmp, id));
     igraph_Free(tmp);
     IGRAPH_FINALLY_CLEAN(1);

--- a/src/structure_generators.c
+++ b/src/structure_generators.c
@@ -796,12 +796,12 @@ int igraph_lattice(igraph_t *graph, const igraph_vector_t *dimvector,
     if (coords == 0) {
         IGRAPH_ERROR("lattice failed", IGRAPH_ENOMEM);
     }
-    IGRAPH_FINALLY(free, coords); /* TODO: hack */
+    IGRAPH_FINALLY(igraph_free, coords);
     weights = igraph_Calloc(dims, long int);
     if (weights == 0) {
         IGRAPH_ERROR("lattice failed", IGRAPH_ENOMEM);
     }
-    IGRAPH_FINALLY(free, weights);
+    IGRAPH_FINALLY(igraph_free, weights);
     if (dims > 0) {
         weights[0] = 1;
         for (i = 1; i < dims; i++) {


### PR DESCRIPTION
This changes many instances of `IGRAPH_FINALLY(free, ...)` to `IGRAPH_FINALLY(igraph_free, ...)` and also `free()` to `igraph_Free()`.

`structural_properties.c` is not included as I'm working on that and it will cause inconvenient conflicts.

Reference: https://igraph.discourse.group/t/todo-in-unweighted-shortest-path-implementations-bfs/125/3