### PR TITLE
Community_leiden: fixed refinement bug and corrected warnings.

### DIFF
--- a/src/community_leiden.c
+++ b/src/community_leiden.c
@@ -702,11 +702,10 @@ static int igraph_i_community_leiden_quality(
  * refined partition, using the non-refined partition to create an initial
  * partition for the aggregate network.
  */
-static int igraph_i_community_leiden(
-        const igraph_t *graph,
-        const igraph_vector_t *edge_weights, const igraph_vector_t *node_weights,
-        const igraph_real_t resolution_parameter, const igraph_real_t beta,
-        igraph_vector_t *membership, igraph_integer_t *nb_clusters, igraph_real_t *quality) {
+int igraph_i_community_leiden(const igraph_t *graph,
+                              igraph_vector_t *edge_weights, igraph_vector_t *node_weights,
+                              const igraph_real_t resolution_parameter, const igraph_real_t beta,
+                              igraph_vector_t *membership, igraph_integer_t *nb_clusters, igraph_real_t *quality) {
     igraph_integer_t nb_refined_clusters;
     long int i, c, n = igraph_vcount(graph);
     igraph_t *aggregated_graph, *tmp_graph;
@@ -743,7 +742,7 @@ static int igraph_i_community_leiden(
     IGRAPH_FINALLY(igraph_vector_destroy, &refined_membership);
 
     /* Initialize aggregated graph, weights and membership. */
-    aggregated_graph = graph;
+    aggregated_graph = (igraph_t*)graph;
     aggregated_edge_weights = edge_weights;
     aggregated_node_weights = node_weights;
     aggregated_membership = membership;
@@ -807,6 +806,7 @@ static int igraph_i_community_leiden(
              * the actual clustering */
             if (nb_refined_clusters >= igraph_vcount(aggregated_graph)) {
                 igraph_vector_update(&refined_membership, aggregated_membership);
+                nb_refined_clusters = *nb_clusters;
             }
 
             /* Keep track of aggregate node. */
@@ -1048,7 +1048,7 @@ int igraph_community_leiden(const igraph_t *graph,
         IGRAPH_FINALLY(igraph_vector_destroy, i_edge_weights);
         igraph_vector_fill(i_edge_weights, 1);
     } else {
-        i_edge_weights = edge_weights;
+        i_edge_weights = (igraph_vector_t*)edge_weights;
     }
 
     /* Check edge weights to possibly use default */
@@ -1062,7 +1062,7 @@ int igraph_community_leiden(const igraph_t *graph,
         IGRAPH_FINALLY(igraph_vector_destroy, i_node_weights);
         igraph_vector_fill(i_node_weights, 1);
     } else {
-        i_node_weights = node_weights;
+        i_node_weights = (igraph_vector_t*)node_weights;
     }
 
     /* Perform actual Leiden algorithm */


### PR DESCRIPTION
This fixes #1356. The bug arised whenever the refinement didn't result in an aggregation, in which case the aggregation is based on the current clustering (instead of the refinement). However, the number of clusters was incorrectly not updated to the current clustering instead of the refinement.

This also fixes #1353. I've chosen to not have a `const` qualifier anymore on the internal function `igraph_i_community_leiden`. When using actual `const` consistently becomes more problematic in places elsewhere, and this is the cleanest approach I believe. The problem is that the graph (and corresponding edge weights and node weights) are initially supplied (and not modified), hence the `const` qualifier makes sense. However, the graph is continuously being aggregated, at which point the `const` makes less sense. I think the current solution is a reasonable compromise. The warning about `igraph_i_vector_binsearch_slice` is separately addressed in PR #1341, but that can only be merged for version 0.9.0.