### PR TITLE
Various small code cleanups

### DIFF
--- a/doc/introduction.xml
+++ b/doc/introduction.xml
@@ -20,7 +20,7 @@ or the index of this book to get an impression of what is available.</para>
 Second, igraph provides a platform for developing and/or
 implementing graph algorithms. It has an efficient data structure
 for representing graphs, and a number of other data structures like
-flexible vectors, stacks, heaps, queues, adjacency lists that are useful for implementing graph algorthms. In fact these data structures evolved along with the
+flexible vectors, stacks, heaps, queues, adjacency lists that are useful for implementing graph algorithms. In fact these data structures evolved along with the
 implementation of the classic and non-classic graph algorithms which
 make up the major part of the igraph library. This way, they were fine-tuned
 and checked for correctness several times.

--- a/doc/pmt.xml
+++ b/doc/pmt.xml
@@ -9,7 +9,7 @@
 <para>
 Some of the container types listed in this section are defined for
 many base types. This is similar to templates in C++ and generics in
-Ada, but it is implemented via precompiler macros since the C language
+Ada, but it is implemented via preprocessor macros since the C language
 cannot handle it. Here is the list of template types and the all base
 types they currently support:
 <glosslist>
@@ -59,8 +59,8 @@ types they currently support:
 </para>
 
 <para>
-The name of the base element (in parens) is added to the function
-names, except for te default type.
+The name of the base element (in parentheses) is added to the function
+names, except for the default type.
 </para>
 
 <para>

--- a/doc/tutorial.xml
+++ b/doc/tutorial.xml
@@ -44,7 +44,7 @@ type. Fourth, the <link
 linkend="igraph_erdos_renyi_game"><function>igraph_erdos_renyi_game()</function></link>
 creates a graph and <link
 linkend="igraph_destroy"><function>igraph_destroy()</function></link>
-destroys it, ie. deallocates the memory associated to it.
+destroys it, i.e. deallocates the memory associated to it.
 </para>
 
 <para>
@@ -112,7 +112,7 @@ generators. Stochastic (i.e. randomized) graph generators are called
 <command>igraph</command> can handle directed and undirected graphs. Most graph
 generators are able to create both types of graphs and most other
 functions are usually also capable of handling
-both. Eg. <link linkend="igraph_shortest_paths"><function>igraph_shortest_paths()</function></link>
+both. E.g. <link linkend="igraph_shortest_paths"><function>igraph_shortest_paths()</function></link>
 which (surprisingly) calculates
 shortest paths from a vertex to other vertices can calculate
 directed or undirected paths.
@@ -182,7 +182,7 @@ needed any more by calling
 on them. A vector can be indexed by the 
 <link linkend="VECTOR"><function>VECTOR()</function></link> function
 (right now it is a macro). Vectors 
-can be resized, eg. most <command>igraph</command> functions returning the result in a
+can be resized, e.g. most <command>igraph</command> functions returning the result in a
 vector resize it to the size of the result.
 </para>
 
@@ -219,7 +219,7 @@ between the same pair of vertices.
 <type>igraph_t</type> can of course
 represent loops and
 multiple edges, although some routines expect simple graphs,
-ie. graphs without loop and multiple edges, because for example some
+i.e. graphs without loop and multiple edges, because for example some
 structural properties are ill-defined for non-simple graphs. Loop
 edges can be removed by calling 
 <link linkend="igraph_simplify"><function>igraph_simplify()</function></link>.

--- a/include/igraph_arpack.h
+++ b/include/igraph_arpack.h
@@ -25,8 +25,8 @@
 #include "igraph_vector.h"
 #include "igraph_matrix.h"
 
-#ifndef ARPACK_H
-#define ARPACK_H
+#ifndef IGRAPH_ARPACK_H
+#define IGRAPH_ARPACK_H
 
 #include "igraph_decls.h"
 

--- a/include/igraph_attributes.h
+++ b/include/igraph_attributes.h
@@ -21,8 +21,8 @@
 
 */
 
-#ifndef REST_ATTRIBUTES_H
-#define REST_ATTRIBUTES_H
+#ifndef IGRAPH_ATTRIBUTES_H
+#define IGRAPH_ATTRIBUTES_H
 
 #include "igraph_decls.h"
 #include "igraph_datatype.h"

--- a/include/igraph_blas.h
+++ b/include/igraph_blas.h
@@ -21,8 +21,8 @@
 
 */
 
-#ifndef BLAS_H
-#define BLAS_H
+#ifndef IGRAPH_BLAS_H
+#define IGRAPH_BLAS_H
 
 #include "igraph_types.h"
 #include "igraph_vector.h"

--- a/include/igraph_coloring.h
+++ b/include/igraph_coloring.h
@@ -1,3 +1,23 @@
+/*
+  Heuristic graph coloring algorithms.
+  Copyright (C) 2017 Szabolcs Horvat <szhorvat@gmail.com>
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+  02110-1301 USA
+*/
+
 #ifndef IGRAPH_COLORING_H
 #define IGRAPH_COLORING_H
 

--- a/include/igraph_error.h
+++ b/include/igraph_error.h
@@ -330,9 +330,7 @@ DECLDIR igraph_error_handler_t* igraph_set_error_handler(igraph_error_handler_t*
  * \enumval IGRAPH_ERWSTUCK Random walk got stuck.
  */
 
-/* Each enum value below must have a corresponding error string in
- * igraph_i_error_strings[] in igraph_error.c */
-typedef enum {
+typedef enum {    
     IGRAPH_SUCCESS           = 0,
     IGRAPH_FAILURE           = 1,
     IGRAPH_ENOMEM            = 2,
@@ -394,6 +392,8 @@ typedef enum {
     IGRAPH_ERWSTUCK          = 59,
     IGRAPH_STOP              = 60, /* undocumented, used internally; signals a request to stop in functions like igraph_i_maximal_cliques_bk */
 } igraph_error_type_t;
+/* Each enum value above must have a corresponding error string in
+ * igraph_i_error_strings[] in igraph_error.c */
 
 /**
  * \define IGRAPH_ERROR

--- a/include/igraph_error.h
+++ b/include/igraph_error.h
@@ -112,7 +112,7 @@ __BEGIN_DECLS
  * function of type \ref igraph_error_handler_t and calling
  * \ref igraph_set_error_handler(). This feature is useful for interface
  * writers, as \a igraph will have the chance to
- * signal errors the appropriate way, eg. the R interface defines an
+ * signal errors the appropriate way, e.g. the R interface defines an
  * error handler which calls the <function>error()</function>
  * function, as required by R, while the Python interface has an error
  * handler which raises an exception according to the Python way.
@@ -268,7 +268,7 @@ DECLDIR igraph_error_handler_t* igraph_set_error_handler(igraph_error_handler_t*
  * \enumval IGRAPH_ENOMEM There wasn't enough memory to allocate
  *    on the heap.
  * \enumval IGRAPH_PARSEERROR A parse error was found in a file.
- * \enumval IGRAPH_EINVAL A parameter's value is invalid. Eg. negative
+ * \enumval IGRAPH_EINVAL A parameter's value is invalid. E.g. negative
  *    number was specified as the number of vertices.
  * \enumval IGRAPH_EXISTS A graph/vertex/edge attribute is already
  *    installed with the given name.
@@ -278,7 +278,7 @@ DECLDIR igraph_error_handler_t* igraph_set_error_handler(igraph_error_handler_t*
  * \enumval IGRAPH_NONSQUARE A non-square matrix was received while a
  *    square matrix was expected.
  * \enumval IGRAPH_EINVMODE Invalid mode parameter.
- * \enumval IGRAPH_EFILE A file operation failed. Eg. a file doesn't exist,
+ * \enumval IGRAPH_EFILE A file operation failed. E.g. a file doesn't exist,
  *   or the user has no rights to open it.
  * \enumval IGRAPH_UNIMPLEMENTED Attempted to call an unimplemented or
  *   disabled (at compile-time) function.
@@ -408,7 +408,7 @@ typedef enum {
  * \ref igraph_error() directly.
  * \param reason Textual description of the error. This should be
  *   something more descriptive than the text associated with the error
- *   code. Eg. if the error code is \c IGRAPH_EINVAL,
+ *   code. E.g. if the error code is \c IGRAPH_EINVAL,
  *   its associated text (see  \ref igraph_strerror()) is "Invalid
  *   value" and this string should explain which parameter was invalid
  *   and maybe why.
@@ -448,7 +448,7 @@ DECLDIR int igraph_error(const char *reason, const char *file, int line,
  * \brief Trigger an error, printf-like version.
  *
  * \param reason Textual description of the error, interpreted as
- *               a printf format string.
+ *               a \c printf format string.
  * \param file The source file in which the error was noticed.
  * \param line The line in the source file which triggered the error.
  * \param igraph_errno The \a igraph error code.
@@ -596,7 +596,7 @@ DECLDIR int IGRAPH_FINALLY_STACK_SIZE(void);
  * igraph_error_handler_printignore), and the \a igraph function
  * signalling the error is called from another \a igraph function
  * then we need to make sure that the error is propagated back to
- * the auxiliary (ie. non-igraph) calling function. This is achieved
+ * the auxiliary (i.e. non-igraph) calling function. This is achieved
  * by using <function>IGRAPH_CHECK</function> on every \a igraph
  * call which can return an error code.
  */

--- a/include/igraph_lsap.h
+++ b/include/igraph_lsap.h
@@ -1,6 +1,6 @@
 
-#ifndef IGRAPH_LSAP
-#define IGRAPH_LSAP
+#ifndef IGRAPH_LSAP_H
+#define IGRAPH_LSAP_H
 
 #include "igraph_types.h"
 #include "igraph_vector.h"

--- a/include/igraph_memory.h
+++ b/include/igraph_memory.h
@@ -21,8 +21,8 @@
 
 */
 
-#ifndef REST_MEMORY_H
-#define REST_MEMORY_H
+#ifndef IGRAPH_MEMORY_H
+#define IGRAPH_MEMORY_H
 
 #include <stdlib.h>
 #include "igraph_decls.h"

--- a/include/igraph_statusbar.h
+++ b/include/igraph_statusbar.h
@@ -21,8 +21,8 @@
 
 */
 
-#ifndef IGRAPH_STATUSBAR
-#define IGRAPH_STATUSBAR
+#ifndef IGRAPH_STATUSBAR_H
+#define IGRAPH_STATUSBAR_H
 
 #include "igraph_decls.h"
 

--- a/include/igraph_types.h
+++ b/include/igraph_types.h
@@ -21,8 +21,8 @@
 
 */
 
-#ifndef REST_TYPES_H
-#define REST_TYPES_H
+#ifndef IGRAPH_TYPES_H
+#define IGRAPH_TYPES_H
 
 #include "igraph_decls.h"
 

--- a/include/igraph_vector.h
+++ b/include/igraph_vector.h
@@ -28,14 +28,6 @@
 #include "igraph_types.h"
 #include "igraph_complex.h"
 
-#ifdef HAVE_STDINT_H
-    #include <stdint.h>
-#else
-    #if defined(HAVE_SYS_INT_TYPES_H) && HAVE_SYS_INT_TYPES_H
-        #include <sys/int_types.h>    /* for Solaris */
-    #endif
-#endif
-
 __BEGIN_DECLS
 
 /* -------------------------------------------------- */

--- a/src/DensityGrid.cpp
+++ b/src/DensityGrid.cpp
@@ -33,17 +33,14 @@
 // This file contains the member definitions of the DensityGrid.h class
 // This code is modified from the original code by B.N. Wylie
 
-#include <string>
-#include <deque>
-#include <iostream>
-#include <cmath>
-#include <cstdlib>
-
-using namespace std;
-
 #include "drl_Node.h"
 #include "DensityGrid.h"
 #include "igraph_error.h"
+
+#include <deque>
+#include <cmath>
+
+using namespace std;
 
 #define GET_BIN(y, x) (Bins[y*GRID_SIZE+x])
 

--- a/src/DensityGrid.h
+++ b/src/DensityGrid.h
@@ -36,16 +36,13 @@
 
 // Compile time adjustable parameters
 
-
-#include <deque>
-
-using namespace std;
-
 #include "drl_layout.h"
 #include "drl_Node.h"
 #ifdef MUSE_MPI
     #include <mpi.h>
 #endif
+
+#include <deque>
 
 namespace drl {
 
@@ -74,7 +71,7 @@ private:
     // new dynamic variables -- SBM
     float (*fall_off)[RADIUS * 2 + 1];
     float (*Density)[GRID_SIZE];
-    deque<Node>* Bins;
+    std::deque<Node>* Bins;
 
     // old static variables
     //float fall_off[RADIUS*2+1][RADIUS*2+1];

--- a/src/DensityGrid_3d.cpp
+++ b/src/DensityGrid_3d.cpp
@@ -33,17 +33,14 @@
 // This file contains the member definitions of the DensityGrid.h class
 // This code is modified from the original code by B.N. Wylie
 
-#include <string>
-#include <deque>
-#include <iostream>
-#include <cmath>
-#include <cstdlib>
-
-using namespace std;
-
 #include "drl_Node_3d.h"
 #include "DensityGrid_3d.h"
 #include "igraph_error.h"
+
+#include <deque>
+#include <cmath>
+
+using namespace std;
 
 #define GET_BIN(z, y, x) (Bins[(z*GRID_SIZE+y)*GRID_SIZE+x])
 

--- a/src/DensityGrid_3d.h
+++ b/src/DensityGrid_3d.h
@@ -36,16 +36,13 @@
 
 // Compile time adjustable parameters
 
-
-#include <deque>
-
-using namespace std;
-
 #include "drl_layout_3d.h"
 #include "drl_Node_3d.h"
 #ifdef MUSE_MPI
     #include <mpi.h>
 #endif
+
+#include <deque>
 
 namespace drl3d {
 
@@ -74,7 +71,7 @@ private:
     // new dynamic variables -- SBM
     float (*fall_off)[RADIUS * 2 + 1][RADIUS * 2 + 1];
     float (*Density)[GRID_SIZE][GRID_SIZE];
-    deque<Node>* Bins;
+    std::deque<Node>* Bins;
 
     // old static variables
     //float fall_off[RADIUS*2+1][RADIUS*2+1];

--- a/src/NetDataTypes.cpp
+++ b/src/NetDataTypes.cpp
@@ -43,10 +43,9 @@
 #ifdef HAVE_CONFIG_H
     #include <config.h>
 #endif
-#include <cstdlib>
-#include <cstdio>
-#include <cstring>
+
 #include "NetDataTypes.h"
+#include <cstring>
 
 //#################################################################################
 //###############################################################################

--- a/src/NetDataTypes.h
+++ b/src/NetDataTypes.h
@@ -43,7 +43,7 @@
 #ifndef NETDATATYPES_H
 #define NETDATATYPES_H
 
-#include <string.h>
+#include <cstring>
 
 //###########################################################################################
 

--- a/src/NetRoutines.cpp
+++ b/src/NetRoutines.cpp
@@ -40,15 +40,15 @@
  *   (at your option) any later version.                                   *
  *                                                                         *
  ***************************************************************************/
-#include <cstdlib>
-#include <cstdio>
-#include <cstring>
+
 #include "NetRoutines.h"
 #include "NetDataTypes.h"
 
 #include "igraph_types.h"
 #include "igraph_interface.h"
 #include "igraph_conversion.h"
+
+#include <cstring>
 
 int igraph_i_read_network(const igraph_t *graph,
                           const igraph_vector_t *weights,

--- a/src/bfgs.c
+++ b/src/bfgs.c
@@ -24,7 +24,6 @@
 #include "igraph_nongraph.h"
 #include "igraph_interrupt_internal.h"
 #include "igraph_statusbar.h"
-#include "memory.h"
 #include "config.h"
 
 #include <math.h>

--- a/src/bignum.c
+++ b/src/bignum.c
@@ -19,11 +19,10 @@
  *
  *  $Id: bignum.c,v 1.17 2005/07/23 02:55:53 pullmoll Exp $
  ******************************************************************************/
-#include <math.h>
+
 #include "bignum.h"
-#include "config.h"
-#include "math.h"
 #include "igraph_error.h"
+#include "config.h"
 
 #ifndef ASM_X86
     #ifdef  X86

--- a/src/cattributes.c
+++ b/src/cattributes.c
@@ -23,10 +23,10 @@
 
 #include "igraph_attributes.h"
 #include "igraph_memory.h"
-#include "config.h"
 #include "igraph_math.h"
 #include "igraph_interface.h"
 #include "igraph_random.h"
+#include "config.h"
 
 #include <string.h>
 

--- a/src/centrality.c
+++ b/src/centrality.c
@@ -22,9 +22,6 @@
 
 */
 
-#include <math.h>
-#include <string.h>    /* memset */
-#include <assert.h>
 #include "igraph_centrality.h"
 #include "igraph_math.h"
 #include "igraph_memory.h"
@@ -41,6 +38,9 @@
 
 #include "bigint.h"
 #include "prpack.h"
+
+#include <math.h>
+#include <string.h>    /* memset */
 
 int igraph_personalized_pagerank_arpack(const igraph_t *graph,
                                         igraph_vector_t *vector,

--- a/src/cliquer/cliquer.c
+++ b/src/cliquer/cliquer.c
@@ -2,7 +2,7 @@
 /*
  * This file contains the clique searching routines.
  *
- * Copyright (C) 2002 Sampo Niskanen, Patric Östergård.
+ * Copyright (C) 2002 Sampo Niskanen, Patric Ã–stergÃ¥rd.
  * Licensed under the GNU GPL, read the file LICENSE for details.
  */
 

--- a/src/cliquer/cliquer_graph.c
+++ b/src/cliquer/cliquer_graph.c
@@ -2,7 +2,7 @@
 /*
  * This file contains the graph handling routines.
  *
- * Copyright (C) 2002 Sampo Niskanen, Patric Östergård.
+ * Copyright (C) 2002 Sampo Niskanen, Patric Ã–stergÃ¥rd.
  * Licensed under the GNU GPL, read the file LICENSE for details.
  */
 

--- a/src/cliquer/reorder.c
+++ b/src/cliquer/reorder.c
@@ -2,7 +2,7 @@
 /*
  * This file contains the vertex reordering routines.
  *
- * Copyright (C) 2002 Sampo Niskanen, Patric Östergård.
+ * Copyright (C) 2002 Sampo Niskanen, Patric Ã–stergÃ¥rd.
  * Licensed under the GNU GPL, read the file LICENSE for details.
  */
 

--- a/src/cliquer/set.h
+++ b/src/cliquer/set.h
@@ -2,7 +2,7 @@
 /*
  * This file contains the set handling routines.
  *
- * Copyright (C) 2002 Sampo Niskanen, Patric Östergård.
+ * Copyright (C) 2002 Sampo Niskanen, Patric Ã–stergÃ¥rd.
  * Licensed under the GNU GPL, read the file LICENSE for details.
  */
 

--- a/src/cliques.c
+++ b/src/cliques.c
@@ -23,7 +23,6 @@
 
 #include "igraph_cliques.h"
 #include "igraph_memory.h"
-#include "igraph_random.h"
 #include "igraph_constants.h"
 #include "igraph_adjlist.h"
 #include "igraph_interrupt_internal.h"

--- a/src/clustertool.cpp
+++ b/src/clustertool.cpp
@@ -45,11 +45,6 @@
     #include <config.h>
 #endif
 
-#include <iostream>
-#include <cstdlib>
-#include <cstdio>
-#include <ctime>
-
 #include "NetDataTypes.h"
 #include "NetRoutines.h"
 #include "pottsmodel_2.h"

--- a/src/cohesive_blocks.c
+++ b/src/cohesive_blocks.c
@@ -27,7 +27,6 @@
 #include "igraph_flow.h"
 #include "igraph_separators.h"
 #include "igraph_structural.h"
-#include "igraph_components.h"
 #include "igraph_dqueue.h"
 #include "igraph_constructors.h"
 #include "igraph_interrupt_internal.h"

--- a/src/coloring.c
+++ b/src/coloring.c
@@ -1,3 +1,22 @@
+/*
+  Heuristic graph coloring algorithms.
+  Copyright (C) 2017 Szabolcs Horvat <szhorvat@gmail.com>
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+  02110-1301 USA
+*/
 
 #include "igraph_coloring.h"
 #include "igraph_interface.h"

--- a/src/community.c
+++ b/src/community.c
@@ -27,7 +27,6 @@
 #include "igraph_memory.h"
 #include "igraph_random.h"
 #include "igraph_arpack.h"
-#include "igraph_arpack_internal.h"
 #include "igraph_adjlist.h"
 #include "igraph_interface.h"
 #include "igraph_interrupt_internal.h"

--- a/src/components.c
+++ b/src/components.c
@@ -32,7 +32,6 @@
 #include "igraph_stack.h"
 #include "igraph_vector.h"
 #include "config.h"
-#include <string.h>
 #include <limits.h>
 
 static int igraph_i_clusters_weak(const igraph_t *graph, igraph_vector_t *membership,

--- a/src/drl_graph.cpp
+++ b/src/drl_graph.cpp
@@ -32,13 +32,10 @@
  */
 // This file contains the member definitions of the master class
 
-#include <iostream>
-#include <fstream>
+
 #include <map>
 #include <vector>
-#include <cstdlib>
 #include <cmath>
-#include <cstring>
 
 using namespace std;
 

--- a/src/drl_graph.h
+++ b/src/drl_graph.h
@@ -37,7 +37,13 @@
 #include "DensityGrid.h"
 #include "igraph_layout.h"
 
+#include <map>
+#include <vector>
+#include <ctime>
+
 namespace drl {
+
+using namespace std;
 
 // layout schedule information
 struct layout_schedule {

--- a/src/drl_graph.h
+++ b/src/drl_graph.h
@@ -43,8 +43,6 @@
 
 namespace drl {
 
-using namespace std;
-
 // layout schedule information
 struct layout_schedule {
     int iterations;
@@ -87,8 +85,8 @@ private:
     void update_nodes ( );
     float Compute_Node_Energy ( int node_ind );
     void Solve_Analytic ( int node_ind, float &pos_x, float &pos_y );
-    void get_positions ( vector<int> &node_indices, float return_positions[2 * MAX_PROCS] );
-    void update_density ( vector<int> &node_indices,
+    void get_positions ( std::vector<int> &node_indices, float return_positions[2 * MAX_PROCS] );
+    void update_density ( std::vector<int> &node_indices,
                           float old_positions[2 * MAX_PROCS],
                           float new_positions[2 * MAX_PROCS] );
     void update_node_pos ( int node_ind,
@@ -101,11 +99,11 @@ private:
     // graph decomposition information
     int num_nodes;                  // number of nodes in graph
     float highest_sim;              // highest sim for normalization
-    map <int, int> id_catalog;      // id_catalog[file id] = internal id
-    map <int, map <int, float> > neighbors;     // neighbors of nodes on this proc.
+    std::map <int, int> id_catalog;      // id_catalog[file id] = internal id
+    std::map <int, std::map <int, float> > neighbors;     // neighbors of nodes on this proc.
 
     // graph layout information
-    vector<Node> positions;
+    std::vector<Node> positions;
     DensityGrid density_server;
 
     // original VxOrd information

--- a/src/drl_graph_3d.cpp
+++ b/src/drl_graph_3d.cpp
@@ -32,13 +32,9 @@
  */
 // This file contains the member definitions of the master class
 
-#include <iostream>
-#include <fstream>
 #include <map>
 #include <vector>
-#include <cstdlib>
 #include <cmath>
-#include <cstring>
 
 using namespace std;
 

--- a/src/drl_graph_3d.h
+++ b/src/drl_graph_3d.h
@@ -43,8 +43,6 @@
 
 namespace drl3d {
 
-using namespace std;
-
 // layout schedule information
 struct layout_schedule {
     int iterations;
@@ -79,8 +77,8 @@ private:
     void update_nodes ( );
     float Compute_Node_Energy ( int node_ind );
     void Solve_Analytic ( int node_ind, float &pos_x, float &pos_y, float &pos_z );
-    void get_positions ( vector<int> &node_indices, float return_positions[3 * MAX_PROCS] );
-    void update_density ( vector<int> &node_indices,
+    void get_positions ( std::vector<int> &node_indices, float return_positions[3 * MAX_PROCS] );
+    void update_density ( std::vector<int> &node_indices,
                           float old_positions[3 * MAX_PROCS],
                           float new_positions[3 * MAX_PROCS] );
     void update_node_pos ( int node_ind,
@@ -93,11 +91,11 @@ private:
     // graph decomposition information
     int num_nodes;                  // number of nodes in graph
     float highest_sim;              // highest sim for normalization
-    map <int, int> id_catalog;      // id_catalog[file id] = internal id
-    map <int, map <int, float> > neighbors;     // neighbors of nodes on this proc.
+    std::map <int, int> id_catalog;      // id_catalog[file id] = internal id
+    std::map <int, std::map <int, float> > neighbors;     // neighbors of nodes on this proc.
 
     // graph layout information
-    vector<Node> positions;
+    std::vector<Node> positions;
     DensityGrid density_server;
 
     // original VxOrd information

--- a/src/drl_graph_3d.h
+++ b/src/drl_graph_3d.h
@@ -37,7 +37,13 @@
 #include "DensityGrid_3d.h"
 #include "igraph_layout.h"
 
+#include <map>
+#include <vector>
+#include <ctime>
+
 namespace drl3d {
+
+using namespace std;
 
 // layout schedule information
 struct layout_schedule {

--- a/src/drl_layout.cpp
+++ b/src/drl_layout.cpp
@@ -45,12 +45,7 @@
 // 5/6/2005
 
 // C++ library routines
-#include <iostream>
-#include <fstream>
 #include <map>
-#include <set>
-#include <string>
-#include <deque>
 #include <vector>
 
 using namespace std;

--- a/src/drl_layout_3d.cpp
+++ b/src/drl_layout_3d.cpp
@@ -45,12 +45,7 @@
 // 5/6/2005
 
 // C++ library routines
-#include <iostream>
-#include <fstream>
 #include <map>
-#include <set>
-#include <string>
-#include <deque>
 #include <vector>
 
 using namespace std;

--- a/src/drl_parse.cpp
+++ b/src/drl_parse.cpp
@@ -32,14 +32,6 @@
  */
 // This file contains the methods for the parse.h class
 
-#include <string>
-#include <iostream>
-#include <map>
-#include <cstdlib>
-#include <cstdio>
-
-using namespace std;
-
 #include "drl_layout.h"
 #include "drl_parse.h"
 

--- a/src/drl_parse.h
+++ b/src/drl_parse.h
@@ -41,8 +41,6 @@
 
 namespace drl {
 
-using namespace std;
-
 class parse {
 
 public:
@@ -53,10 +51,10 @@ public:
     ~parse () {}
 
     // user parameters
-    string sim_file;        // .sim file
-    string coord_file;      // .coord file
-    string parms_file;      // .parms file
-    string real_file;       // .real file
+    std::string sim_file;        // .sim file
+    std::string coord_file;      // .coord file
+    std::string parms_file;      // .parms file
+    std::string real_file;       // .real file
 
     int rand_seed;      // random seed int >= 0
     float edge_cut;         // edge cutting real [0,1]

--- a/src/drl_parse.h
+++ b/src/drl_parse.h
@@ -37,7 +37,11 @@
     #include <mpi.h>
 #endif
 
+#include <string>
+
 namespace drl {
+
+using namespace std;
 
 class parse {
 

--- a/src/embedding.c
+++ b/src/embedding.c
@@ -24,7 +24,6 @@
 #include "igraph_embedding.h"
 #include "igraph_interface.h"
 #include "igraph_adjlist.h"
-#include "igraph_random.h"
 #include "igraph_centrality.h"
 #include "igraph_blas.h"
 

--- a/src/flow.c
+++ b/src/flow.c
@@ -33,15 +33,12 @@
 #include "igraph_structural.h"
 #include "igraph_components.h"
 #include "igraph_types_internal.h"
-#include "config.h"
 #include "igraph_math.h"
 #include "igraph_dqueue.h"
-#include "igraph_visitor.h"
 #include "igraph_interrupt_internal.h"
 #include "igraph_topology.h"
+#include "config.h"
 
-#include <limits.h>
-#include <stdio.h>
 
 /*
  * Some general remarks about the functions in this file.

--- a/src/foreign.c
+++ b/src/foreign.c
@@ -22,7 +22,6 @@
 */
 
 #include "igraph_foreign.h"
-#include "config.h"
 #include "igraph_math.h"
 #include "igraph_gml_tree.h"
 #include "igraph_memory.h"
@@ -31,6 +30,7 @@
 #include "igraph_interrupt_internal.h"
 #include "igraph_constructors.h"
 #include "igraph_types_internal.h"
+#include "config.h"
 
 #include <ctype.h>      /* isspace */
 #include <string.h>

--- a/src/games.c
+++ b/src/games.c
@@ -124,7 +124,7 @@ static int igraph_i_barabasi_game_bag(igraph_t *graph, igraph_integer_t n,
     if (bag == 0) {
         IGRAPH_ERROR("barabasi_game failed", IGRAPH_ENOMEM);
     }
-    IGRAPH_FINALLY(igraph_free, bag);    /* TODO: hack */
+    IGRAPH_FINALLY(igraph_free, bag);
 
     /* The first node(s) in the bag */
     if (start_from) {
@@ -860,7 +860,7 @@ int igraph_degree_sequence_game_simple(igraph_t *graph,
     if (bag1 == 0) {
         IGRAPH_ERROR("degree sequence game (simple)", IGRAPH_ENOMEM);
     }
-    IGRAPH_FINALLY(igraph_free, bag1);   /* TODO: hack */
+    IGRAPH_FINALLY(igraph_free, bag1);
 
     for (i = 0; i < no_of_nodes; i++) {
         for (j = 0; j < VECTOR(*out_seq)[i]; j++) {

--- a/src/gengraph_random.cpp
+++ b/src/gengraph_random.cpp
@@ -28,8 +28,8 @@
 // See the header file random.h for a description of the contents of this
 // file as well as references and credits.
 
-#include <cmath>
 #include "gengraph_random.h"
+#include <cmath>
 
 using namespace std;
 using namespace KW_RNG;

--- a/src/gengraph_random.h
+++ b/src/gengraph_random.h
@@ -22,8 +22,6 @@
 #define RNG_H
 
 #include "igraph_random.h"
-#include <iostream>
-using namespace std;
 
 namespace KW_RNG {
 

--- a/src/glpk_support.c
+++ b/src/glpk_support.c
@@ -30,7 +30,6 @@
 #include "igraph_error.h"
 #include "igraph_interrupt_internal.h"
 #include <glpk.h>
-#include <memory.h>
 #include <stdio.h>
 
 void igraph_i_glpk_interruption_hook(glp_tree *tree, void *info) {

--- a/src/heap.c
+++ b/src/heap.c
@@ -24,10 +24,9 @@
 #include "igraph_types.h"
 #include "igraph_types_internal.h"
 #include "igraph_memory.h"
-#include "igraph_random.h"
 #include "igraph_error.h"
-#include "config.h"
 #include "igraph_math.h"
+#include "config.h"
 
 #include <assert.h>
 #include <string.h>         /* memcpy & co. */

--- a/src/hrg_dendro.h
+++ b/src/hrg_dendro.h
@@ -65,16 +65,14 @@
 #ifndef IGRAPH_HRG_DENDRO
 #define IGRAPH_HRG_DENDRO
 
-#include <iostream>
-#include <fstream>
-#include <cstdio>
-#include <cmath>
-
 #include "hrg_graph.h"
 #include "hrg_rbtree.h"
 #include "hrg_splittree_eq.h"
 
 #include "igraph_hrg.h"
+
+#include <string>
+#include <cmath>
 
 using namespace std;
 using namespace fitHRG;

--- a/src/hrg_dendro.h
+++ b/src/hrg_dendro.h
@@ -74,7 +74,6 @@
 #include <string>
 #include <cmath>
 
-using namespace std;
 using namespace fitHRG;
 
 namespace fitHRG {
@@ -103,7 +102,7 @@ struct ipair {
     int    x;
     int y;
     short int t;
-    string sp;
+    std::string sp;
 };
 struct child {
     int index;
@@ -145,7 +144,7 @@ public:
 
 class split {
 public:
-    string s;           // partition assignment of leaf vertices
+    std::string s;           // partition assignment of leaf vertices
     split(): s("") { }
     ~split() { }
     void initializeSplit(const int n) {
@@ -155,7 +154,7 @@ public:
         }
     }
     bool checkSplit() {
-        if (s.empty() || s.find("-", 0) != string::npos) {
+        if (s.empty() || s.find("-", 0) != std::string::npos) {
             return false;
         } else {
             return true;
@@ -179,7 +178,7 @@ public:
 class interns {
 private:
     ipair* edgelist;   // list of internal edges represented
-    string* splitlist; // split representation of the internal edges
+    std::string* splitlist; // split representation of the internal edges
     int** indexLUT;    // table of indices of internal edges in edgelist
     int q;         // number of internal edges
     int count;         // (for adding edges) edgelist index of new edge to add
@@ -194,9 +193,9 @@ public:
     // returns a uniformly random internal edge, O(1)
     ipair* getRandomEdge();
     // returns the ith split of the splitlist, O(1)
-    string getSplit(const int);
+    std::string getSplit(const int);
     // replace an existing split, O(1)
-    bool replaceSplit(const int, const string);
+    bool replaceSplit(const int, const std::string);
     // swaps two edges, O(1)
     bool swapEdges(const int, const int, const short int, const int,
                    const int, const short int);
@@ -248,12 +247,12 @@ private:
     // return path to root from leaf
     list* binarySearchFind(const double);
     // build split for this internal edge
-    string buildSplit(elementd*);
+    std::string buildSplit(elementd*);
     // compute number of edges between two internal subtrees
     int computeEdgeCount(const int, const short int, const int,
                          const short int);
     // (consensus tree) counts children
-    int countChildren(const string);
+    int countChildren(const std::string);
     // find internal node of D that is common ancestor of i,j
     elementd* findCommonAncestor(list**, const int, const int);
     // return reverse of path to leaf from root

--- a/src/hrg_graph.h
+++ b/src/hrg_graph.h
@@ -61,11 +61,11 @@
 #ifndef IGRAPH_HRG_GRAPH
 #define IGRAPH_HRG_GRAPH
 
-#include <cstdio>
+#include "hrg_rbtree.h"
+
+#include <string>
 #include <cstring>
 #include <cstdlib>
-
-#include "hrg_rbtree.h"
 
 using namespace std;
 

--- a/src/hrg_graph.h
+++ b/src/hrg_graph.h
@@ -67,8 +67,6 @@
 #include <cstring>
 #include <cstdlib>
 
-using namespace std;
-
 namespace fitHRG {
 
 // ******** Basic Structures *********************************************
@@ -96,7 +94,7 @@ public:
 #define IGRAPH_HRG_VERT
 class vert {
 public:
-    string name;           // (external) name of vertex
+    std::string name;           // (external) name of vertex
     int degree;            // degree of this vertex
 
     vert(): name(""), degree(0) { }
@@ -122,7 +120,7 @@ public:
     // returns degree of vertex i
     int getDegree(const int);
     // returns name of vertex i
-    string getName(const int);
+    std::string getName(const int);
     // returns edge list of vertex i
     edge* getNeighborList(const int);
     // return ptr to histogram of edge (i,j)
@@ -148,7 +146,7 @@ public:
     // allocate edge histograms
     void setAdjacencyHistograms(const int);
     // set name of vertex i
-    bool setName(const int, const string);
+    bool setName(const int, const std::string);
 
 private:
     bool predict;      // do we need prediction?

--- a/src/hrg_graph_simp.h
+++ b/src/hrg_graph_simp.h
@@ -60,12 +60,11 @@
 #ifndef IGRAPH_HRG_SIMPLEGRAPH
 #define IGRAPH_HRG_SIMPLEGRAPH
 
-#include <cstdio>
-#include <cstring>
-#include <cstdlib>
-
 #include "hrg_rbtree.h"
 #include "hrg_dendro.h"
+
+#include <cstring>
+#include <cstdlib>
 
 using namespace std;
 

--- a/src/hrg_graph_simp.h
+++ b/src/hrg_graph_simp.h
@@ -66,8 +66,6 @@
 #include <cstring>
 #include <cstdlib>
 
-using namespace std;
-
 namespace fitHRG {
 
 // ******** Basic Structures *********************************************
@@ -88,7 +86,7 @@ public:
 #define IGRAPH_HRG_SIMPLEVERT
 class simpleVert {
 public:
-    string name;          // (external) name of vertex
+    std::string name;          // (external) name of vertex
     int degree;           // degree of this vertex
     int group_true;       // index of vertex's true group
 
@@ -128,7 +126,7 @@ public:
     // returns group label of vertex i
     int getGroupLabel(const int);
     // returns name of vertex i
-    string getName(const int);
+    std::string getName(const int);
     // returns edge list of vertex i
     simpleEdge* getNeighborList(const int);
     // return pointer to a node
@@ -140,7 +138,7 @@ public:
     // returns n
     int getNumNodes();
     // set name of vertex i
-    bool setName(const int, const string);
+    bool setName(const int, const std::string);
 
 private:
     simpleVert* nodes;        // list of nodes

--- a/src/hrg_rbtree.h
+++ b/src/hrg_rbtree.h
@@ -55,10 +55,6 @@
 #ifndef IGRAPH_HRG_RBTREE
 #define IGRAPH_HRG_RBTREE
 
-#include <iostream>
-
-using namespace std;
-
 namespace fitHRG {
 
 // ******** Basic Structures *********************************************

--- a/src/hrg_splittree_eq.h
+++ b/src/hrg_splittree_eq.h
@@ -64,8 +64,6 @@
 
 #include <string>
 
-using namespace std;
-
 namespace fitHRG {
 
 // ******** Basic Structures *********************************************
@@ -74,7 +72,7 @@ namespace fitHRG {
 #define IGRAPH_HRG_SLIST
 class slist {
 public:
-    string x;         // stored elementd in linked-list
+    std::string x;         // stored elementd in linked-list
     slist* next;          // pointer to next elementd
     slist(): x(""), next(0) { }
     ~slist() { }
@@ -83,7 +81,7 @@ public:
 
 class keyValuePairSplit {
 public:
-    string x;         // elementsp split (string)
+    std::string x;         // elementsp split (string)
     double y;         // stored weight   (double)
     int c;            // stored count    (int)
     keyValuePairSplit* next;  // linked-list pointer
@@ -95,7 +93,7 @@ public:
 
 class elementsp {
 public:
-    string split;             // split represented as a string
+    std::string split;             // split represented as a string
     double weight;            // total weight of this split
     int count;                // number of observations of this split
 
@@ -149,21 +147,21 @@ public:
     // default constructor/destructor
     splittree(); ~splittree();
     // returns value associated with searchKey
-    double returnValue(const string);
+    double returnValue(const std::string);
     // returns T if searchKey found, and points foundNode at the
     // corresponding node
-    elementsp* findItem(const string);
+    elementsp* findItem(const std::string);
     // update total_count and total_weight
     void finishedThisRound();
     // insert a new key with stored value
-    bool insertItem(string, double);
+    bool insertItem(std::string, double);
     void clearTree();
     // delete a node with given key
-    void deleteItem(string);
+    void deleteItem(std::string);
     // delete the entire tree
     void deleteTree();
     // return array of keys in tree
-    string* returnArrayOfKeys();
+    std::string* returnArrayOfKeys();
     // return list of keys in tree
     slist* returnListOfKeys();
     // return the tree as a list of keyValuePairSplits

--- a/src/hrg_splittree_eq.h
+++ b/src/hrg_splittree_eq.h
@@ -62,7 +62,7 @@
 #ifndef IGRAPH_HRG_SPLITTREE
 #define IGRAPH_HRG_SPLITTREE
 
-#include <iostream>
+#include <string>
 
 using namespace std;
 

--- a/src/igraph_hrg_types.cc
+++ b/src/igraph_hrg_types.cc
@@ -41,6 +41,7 @@
 #include "igraph_constructors.h"
 #include "igraph_random.h"
 
+using namespace std;
 using namespace fitHRG;
 
 // ******** Red-Black Tree Methods ***************************************

--- a/src/igraph_strvector.c
+++ b/src/igraph_strvector.c
@@ -24,7 +24,6 @@
 #include "igraph_types.h"
 #include "igraph_strvector.h"
 #include "igraph_memory.h"
-#include "igraph_random.h"
 #include "igraph_error.h"
 #include "config.h"
 

--- a/src/infomap_FlowGraph.cc
+++ b/src/infomap_FlowGraph.cc
@@ -26,6 +26,8 @@
 
 #define plogp( x ) ( (x) > 0.0 ? (x)*log(x) : 0.0 )
 
+using namespace std;
+
 void FlowGraph::init(int n, const igraph_vector_t *v_weights) {
     alpha = 0.15;
     beta  = 1.0 - alpha;

--- a/src/infomap_FlowGraph.h
+++ b/src/infomap_FlowGraph.h
@@ -62,7 +62,7 @@ public:
     double alpha, beta;
 
     int Ndanglings;
-    vector<int> danglings; // id of dangling nodes
+    std::vector<int> danglings; // id of dangling nodes
 
     double exit;                  //
     double exitFlow;              //

--- a/src/infomap_Greedy.cc
+++ b/src/infomap_Greedy.cc
@@ -26,6 +26,8 @@
 #include <iterator>
 #define plogp( x ) ( (x) > 0.0 ? (x)*log(x) : 0.0 )
 
+using namespace std;
+
 Greedy::Greedy(FlowGraph * fgraph) {
     graph = fgraph;
     Nnode = graph->Nnode;

--- a/src/infomap_Greedy.h
+++ b/src/infomap_Greedy.h
@@ -69,16 +69,16 @@ public:
     double alpha, beta;
     // local copy of fgraph alpha, beta (=alpha -  Nnode = graph->Nnode;1)
 
-    vector<int> node_index;  // module number of each node
+    std::vector<int> node_index;  // module number of each node
 
     int Nempty;
-    vector<int> mod_empty;
+    std::vector<int> mod_empty;
 
-    vector<double> mod_exit;  // version tmp de node
-    vector<double> mod_size;
-    vector<double> mod_danglingSize;
-    vector<double> mod_teleportWeight;
-    vector<int> mod_members;
+    std::vector<double> mod_exit;  // version tmp de node
+    std::vector<double> mod_size;
+    std::vector<double> mod_danglingSize;
+    std::vector<double> mod_teleportWeight;
+    std::vector<int> mod_members;
 };
 
 void delete_Greedy(Greedy *greedy);

--- a/src/infomap_Node.cc
+++ b/src/infomap_Node.cc
@@ -24,6 +24,8 @@
 
 #include "infomap_Node.h"
 
+using namespace std;
+
 Node::Node() {
     exit = 0.0;
     size = 0.0;

--- a/src/infomap_Node.h
+++ b/src/infomap_Node.h
@@ -30,18 +30,15 @@
 
 #include "igraph_interface.h"
 
-class Node;
-using namespace std;
-
 class Node {
 public:
 
     Node();
     Node(int modulenr, double tpweight);
 
-    vector<int> members;
-    vector< pair<int, double> > inLinks;
-    vector< pair<int, double> > outLinks;
+    std::vector<int> members;
+    std::vector< std::pair<int, double> > inLinks;
+    std::vector< std::pair<int, double> > outLinks;
     double selfLink;
 
     double teleportWeight;

--- a/src/iterators.c
+++ b/src/iterators.c
@@ -23,7 +23,6 @@
 
 #include "igraph_iterators.h"
 #include "igraph_memory.h"
-#include "igraph_random.h"
 #include "igraph_interface.h"
 #include "config.h"
 

--- a/src/lad.c
+++ b/src/lad.c
@@ -46,13 +46,6 @@
    -- Tamas Nepusz, 11 July 2013
 */
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <unistd.h>
-#include <time.h>
-#include <limits.h>
-
 #include "igraph_interface.h"
 #include "igraph_adjlist.h"
 #include "igraph_vector.h"
@@ -60,6 +53,12 @@
 #include "igraph_memory.h"
 #include "igraph_matrix.h"
 #include "igraph_interrupt_internal.h"
+
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <limits.h>
+
 
 /* define boolean type as char */
 #define true 1

--- a/src/layout.c
+++ b/src/layout.c
@@ -44,7 +44,6 @@
 #include "config.h"
 #include <math.h>
 #include "igraph_math.h"
-#include <stdio.h> /* FIXME */
 
 
 /**

--- a/src/lsap.c
+++ b/src/lsap.c
@@ -2,7 +2,7 @@
 #include "igraph_lsap.h"
 #include "igraph_error.h"
 
-#include <stdio.h>
+/* #include <stdio.h> */
 #include <stdlib.h>
 #include <math.h>
 #include <limits.h>     /* INT_MAX */
@@ -50,13 +50,13 @@ static int     ap_datamatrix(AP *p, double **m);
 static int     ap_iterations(AP *p);
 static int     ap_hungarian(AP *p);
 static double  ap_mincost(AP *p);
-static void    ap_print_solution(AP *p);
-static void    ap_show_data(AP *p);
+/* static void    ap_print_solution(AP *p); */
+/* static void    ap_show_data(AP *p); */
 static int     ap_size(AP *p);
 static int     ap_time(AP *p);
 
 /* error reporting */
-static void ap_error(char *message);
+/* static void ap_error(char *message); */
 
 /* private functions */
 static void    preprocess(AP *p);

--- a/src/lsap.c
+++ b/src/lsap.c
@@ -7,7 +7,6 @@
 #include <math.h>
 #include <limits.h>     /* INT_MAX */
 #include <float.h>      /* DBL_MAX */
-#include <assert.h>
 #include <time.h>
 
 /* constants used for improving readability of code */

--- a/src/matching.c
+++ b/src/matching.c
@@ -21,17 +21,15 @@
 
 */
 
-#include <assert.h>
-#include <math.h>
-#include "config.h"
 #include "igraph_adjlist.h"
 #include "igraph_constructors.h"
 #include "igraph_conversion.h"
 #include "igraph_dqueue.h"
-#include "igraph_flow.h"
 #include "igraph_interface.h"
 #include "igraph_matching.h"
 #include "igraph_structural.h"
+#include "config.h"
+#include <math.h>
 
 /* #define MATCHING_DEBUG */
 

--- a/src/motifs.c
+++ b/src/motifs.c
@@ -31,6 +31,7 @@
 #include "igraph_stack.h"
 #include "config.h"
 
+/* TODO create header for these functions: */
 extern unsigned int igraph_i_isoclass_3[];
 extern unsigned int igraph_i_isoclass_4[];
 extern unsigned int igraph_i_isoclass_3u[];

--- a/src/motifs.c
+++ b/src/motifs.c
@@ -28,11 +28,8 @@
 #include "igraph_interrupt_internal.h"
 #include "igraph_interface.h"
 #include "igraph_nongraph.h"
-#include "igraph_structural.h"
 #include "igraph_stack.h"
 #include "config.h"
-
-#include <string.h>
 
 extern unsigned int igraph_i_isoclass_3[];
 extern unsigned int igraph_i_isoclass_4[];

--- a/src/operators.c
+++ b/src/operators.c
@@ -31,8 +31,8 @@
 #include "igraph_attributes.h"
 #include "igraph_conversion.h"
 #include "igraph_qsort.h"
-#include <limits.h>
 #include "config.h"
+#include <limits.h>
 
 /**
  * \function igraph_disjoint_union

--- a/src/optimal_modularity.c
+++ b/src/optimal_modularity.c
@@ -23,7 +23,6 @@
 */
 
 #include "igraph_interface.h"
-#include "igraph_structural.h"
 #include "igraph_community.h"
 #include "igraph_error.h"
 #include "igraph_glpk_support.h"

--- a/src/other.c
+++ b/src/other.c
@@ -23,15 +23,11 @@
 
 #include "igraph_nongraph.h"
 #include "igraph_types.h"
-#include "igraph_memory.h"
 #include "igraph_interrupt_internal.h"
-#include "igraph_types_internal.h"
 #include "config.h"
 #include "plfit/error.h"
 #include "plfit/plfit.h"
 #include <math.h>
-#include <stdarg.h>
-#include <string.h>
 
 /**
  * \ingroup nongraph

--- a/src/pottsmodel_2.cpp
+++ b/src/pottsmodel_2.cpp
@@ -21,7 +21,7 @@
 
 */
 
-/* The original version of this file was written by Jörg Reichardt
+/* The original version of this file was written by JÃ¶rg Reichardt
    This file was modified by Vincent Traag
    The original copyright notice follows here */
 

--- a/src/pottsmodel_2.cpp
+++ b/src/pottsmodel_2.cpp
@@ -42,18 +42,17 @@
  *                                                                         *
  ***************************************************************************/
 
-#include <cstdlib>
-#include <cstdio>
-#include <cstring>
-#include <cmath>
 #include "pottsmodel_2.h"
 #include "NetRoutines.h"
-
-using namespace std;
 
 #include "igraph_random.h"
 #include "igraph_interrupt_internal.h"
 #include "config.h"
+
+#include <cstring>
+#include <cmath>
+
+using namespace std;
 
 //#################################################################################################
 PottsModel::PottsModel(network *n, unsigned int qvalue, int m) : acceptance(0) {

--- a/src/pottsmodel_2.h
+++ b/src/pottsmodel_2.h
@@ -21,7 +21,7 @@
 
 */
 
-/* The original version of this file was written by Jörg Reichardt
+/* The original version of this file was written by JÃ¶rg Reichardt
    This file was modified by Vincent Traag
    The original copyright notice follows here */
 

--- a/src/random.c
+++ b/src/random.c
@@ -23,16 +23,13 @@
 
 #include "igraph_random.h"
 #include "igraph_error.h"
-#include "config.h"
-
-#include <math.h>
-#include <limits.h>
-#include <string.h>
 #include "igraph_math.h"
 #include "igraph_types.h"
 #include "igraph_vector.h"
 #include "igraph_memory.h"
-#include "igraph_matrix.h"
+#include "config.h"
+#include <math.h>
+#include <string.h>
 
 /**
  * \section about_rngs

--- a/src/random.c
+++ b/src/random.c
@@ -510,7 +510,7 @@ IGRAPH_THREAD_LOCAL igraph_rng_t igraph_i_rng_default = {
  *
  * \param rng The random number generator to use as default from now
  *    on. Calling \ref igraph_rng_destroy() on it, while it is still
- *    being used as the default will result craches and/or
+ *    being used as the default will result crashes and/or
  *    unpredictable results.
  *
  * Time complexity: O(1).

--- a/src/random_walk.c
+++ b/src/random_walk.c
@@ -43,7 +43,7 @@
  * \param start The start vertex for the walk.
  * \param steps The number of steps to take. If the random walk gets
  *   stuck, then the \p stuck argument specifies what happens.
- * \param mode How to walk along the edges in direted graphs.
+ * \param mode How to walk along the edges in directed graphs.
  *   \c IGRAPH_OUT means following edge directions, \c IGRAPH_IN means
  *   going opposite the edge directions, \c IGRAPH_ALL means ignoring
  *   edge directions. This argument is ignored for undirected graphs.
@@ -142,7 +142,7 @@ static void vec_destr(igraph_vector_t *vec) {
  * \param start The start vertex for the walk.
  * \param steps The number of steps to take. If the random walk gets
  *   stuck, then the \p stuck argument specifies what happens.
- * \param mode How to walk along the edges in direted graphs.
+ * \param mode How to walk along the edges in directed graphs.
  *   \c IGRAPH_OUT means following edge directions, \c IGRAPH_IN means
  *   going opposite the edge directions, \c IGRAPH_ALL means ignoring
  *   edge directions. This argument is ignored for undirected graphs.

--- a/src/scg_approximate_methods.c
+++ b/src/scg_approximate_methods.c
@@ -64,10 +64,9 @@
  *    centers as used in intervals_plus_kmeans.
  */
 
+#include "scg_headers.h"
 #include "igraph_error.h"
 #include "igraph_types.h"
-#include "scg_headers.h"
-#include "igraph_memory.h"
 #include "igraph_vector.h"
 
 int igraph_i_intervals_plus_kmeans(const igraph_vector_t *v, int *gr,

--- a/src/scg_exact_scg.c
+++ b/src/scg_exact_scg.c
@@ -29,8 +29,8 @@
  *    See also Section 5.4.1 (last paragraph) of the above reference.
  */
 
-#include "igraph_memory.h"
 #include "scg_headers.h"
+#include "igraph_memory.h"
 #include <math.h>
 
 int igraph_i_exact_coarse_graining(const igraph_real_t *v,

--- a/src/scg_headers.h
+++ b/src/scg_headers.h
@@ -55,11 +55,11 @@
 #ifndef SCG_HEADERS_H
 #define SCG_HEADERS_H
 
-#include <stdio.h>
-#include <stdlib.h>
-
 #include "igraph_types.h"
 #include "igraph_vector.h"
+
+#include <stdio.h>
+#include <stdlib.h>
 
 typedef struct ind_val {
     int ind;

--- a/src/scg_kmeans.c
+++ b/src/scg_kmeans.c
@@ -31,8 +31,6 @@
  *    See also Section 5.3.3 of the above reference.
  */
 
-#include "igraph_memory.h"
-
 #include "scg_headers.h"
 
 int igraph_i_kmeans_Lloyd(const igraph_vector_t *x, int n, int p,

--- a/src/scg_optimal_method.c
+++ b/src/scg_optimal_method.c
@@ -35,12 +35,11 @@
  *    starting from 0.
  */
 
+#include "scg_headers.h"
 #include "igraph_error.h"
 #include "igraph_memory.h"
 #include "igraph_matrix.h"
 #include "igraph_vector.h"
-
-#include "scg_headers.h"
 
 int igraph_i_optimal_partition(const igraph_real_t *v, int *gr, int n,
                                int nt, int matrix, const igraph_real_t *p,

--- a/src/scg_utils.c
+++ b/src/scg_utils.c
@@ -27,10 +27,9 @@
  *    functions used throughout the SCGlib.
  */
 
+#include "scg_headers.h"
 #include "igraph_error.h"
 #include "igraph_memory.h"
-
-#include "scg_headers.h"
 
 /*to be used with qsort and struct ind_val arrays */
 int igraph_i_compare_ind_val(const void *a, const void *b) {

--- a/src/separators.c
+++ b/src/separators.c
@@ -28,11 +28,8 @@
 #include "igraph_vector.h"
 #include "igraph_interface.h"
 #include "igraph_flow.h"
-#include "igraph_flow_internal.h"
 #include "igraph_components.h"
 #include "igraph_structural.h"
-#include "igraph_constructors.h"
-#include "igraph_stack.h"
 #include "igraph_interrupt_internal.h"
 
 static int igraph_i_is_separator(const igraph_t *graph,

--- a/src/sir.c
+++ b/src/sir.c
@@ -235,18 +235,10 @@ int igraph_sir(const igraph_t *graph, igraph_real_t beta,
                 }
             }
 
-            if (times_v) {
-                igraph_vector_push_back(times_v, tt + igraph_vector_tail(times_v));
-            }
-            if (no_s_v)  {
-                igraph_vector_int_push_back(no_s_v, ns);
-            }
-            if (no_i_v)  {
-                igraph_vector_int_push_back(no_i_v, ni);
-            }
-            if (no_r_v)  {
-                igraph_vector_int_push_back(no_r_v, nr);
-            }
+            igraph_vector_push_back(times_v, tt + igraph_vector_tail(times_v));
+            igraph_vector_int_push_back(no_s_v, ns);
+            igraph_vector_int_push_back(no_i_v, ni);
+            igraph_vector_int_push_back(no_r_v, nr);
 
         } /* psum > 0 */
 

--- a/src/spmatrix.c
+++ b/src/spmatrix.c
@@ -24,14 +24,11 @@
 
 #include "igraph_types.h"
 #include "igraph_spmatrix.h"
-#include "igraph_memory.h"
-#include "igraph_random.h"
 #include "igraph_error.h"
 #include "config.h"
 
 #include <assert.h>
 #include <string.h>     /* memcpy & co. */
-#include <stdlib.h>
 
 /**
  * \section igraph_spmatrix_constructor_and_destructor Sparse matrix constructors

--- a/src/st-cuts.c
+++ b/src/st-cuts.c
@@ -28,18 +28,16 @@
 #include "igraph_constants.h"
 #include "igraph_interface.h"
 #include "igraph_adjlist.h"
-#include "igraph_conversion.h"
 #include "igraph_constructors.h"
 #include "igraph_structural.h"
 #include "igraph_components.h"
-#include "igraph_types_internal.h"
-#include "config.h"
 #include "igraph_math.h"
 #include "igraph_dqueue.h"
 #include "igraph_visitor.h"
 #include "igraph_marked_queue.h"
 #include "igraph_stack.h"
 #include "igraph_estack.h"
+#include "config.h"
 
 /*
  * \function igraph_even_tarjan_reduction

--- a/src/statusbar.c
+++ b/src/statusbar.c
@@ -21,10 +21,10 @@
 
 */
 
-#include "config.h"
 #include "igraph_types.h"
 #include "igraph_statusbar.h"
 #include "igraph_error.h"
+#include "config.h"
 #include <stdio.h>
 #include <stdarg.h>
 

--- a/src/sugiyama.c
+++ b/src/sugiyama.c
@@ -22,7 +22,6 @@
 
 */
 
-#include "config.h"
 #include "igraph_centrality.h"
 #include "igraph_components.h"
 #include "igraph_constants.h"
@@ -34,6 +33,7 @@
 #include "igraph_memory.h"
 #include "igraph_structural.h"
 #include "igraph_types.h"
+#include "config.h"
 
 #include <limits.h>
 

--- a/src/type_indexededgelist.c
+++ b/src/type_indexededgelist.c
@@ -25,7 +25,6 @@
 #include "igraph_interface.h"
 #include "igraph_attributes.h"
 #include "igraph_memory.h"
-#include <string.h>     /* memset & co. */
 #include "config.h"
 
 /* Internal functions */

--- a/src/vector.pmt
+++ b/src/vector.pmt
@@ -2064,7 +2064,7 @@ int FUNCTION(igraph_vector, swap)(TYPE(igraph_vector) *v1, TYPE(igraph_vector) *
  * \param v The input vector.
  * \param i Index of the first element.
  * \param j Index of the second element (may be the same as the
- * first one.)
+ * first one).
  * \return Error code, currently always \c IGRAPH_SUCCESS.
  *
  * Time complexity: O(1).

--- a/src/walktrap.cpp
+++ b/src/walktrap.cpp
@@ -55,18 +55,12 @@
 
 #include "walktrap_graph.h"
 #include "walktrap_communities.h"
-#include <ctime>
-#include <set>
-#include <cstdlib>
-#include <iostream>
-#include <fstream>
 
 #include "igraph_community.h"
 #include "igraph_components.h"
 #include "igraph_interface.h"
 #include "igraph_interrupt_internal.h"
 
-using namespace std;
 using namespace igraph::walktrap;
 
 /**

--- a/src/walktrap_communities.cpp
+++ b/src/walktrap_communities.cpp
@@ -54,12 +54,11 @@
 // see readme.txt for more details
 
 #include "walktrap_communities.h"
-#include <cstdlib>
-#include <iostream>
-#include <cmath>
-#include <algorithm>
-
 #include "config.h"
+#include <algorithm>
+#include <cmath>
+
+using namespace std;
 
 namespace igraph {
 

--- a/src/walktrap_communities.h
+++ b/src/walktrap_communities.h
@@ -54,8 +54,8 @@
 // see readme.txt for more details
 
 
-#ifndef COMMUNITIES_H
-#define COMMUNITIES_H
+#ifndef WALKTRAP_COMMUNITIES_H
+#define WALKTRAP_COMMUNITIES_H
 
 #include "walktrap_graph.h"
 #include "walktrap_heap.h"
@@ -172,4 +172,4 @@ public:
 }
 }       /* end of namespaces */
 
-#endif
+#endif // WALKTRAP_COMMUNITIES_H

--- a/src/walktrap_communities.h
+++ b/src/walktrap_communities.h
@@ -59,7 +59,6 @@
 
 #include "walktrap_graph.h"
 #include "walktrap_heap.h"
-
 #include "igraph_community.h"
 #include "config.h"
 

--- a/src/walktrap_graph.cpp
+++ b/src/walktrap_graph.cpp
@@ -53,14 +53,10 @@
 //-----------------------------------------------------------------------------
 // see readme.txt for more details
 
-#include <iostream>
-#include <fstream>
-#include <sstream>
+#include "walktrap_graph.h"
+#include "igraph_interface.h"
 #include <algorithm>
 #include <cstring>      // strlen
-#include "walktrap_graph.h"
-
-#include "igraph_interface.h"
 
 using namespace std;
 

--- a/src/walktrap_graph.h
+++ b/src/walktrap_graph.h
@@ -57,15 +57,12 @@
 
 #ifndef GRAPH_H
 #define GRAPH_H
-#include <iostream>
 
 #include "igraph_community.h"
 
 namespace igraph {
 
 namespace walktrap {
-
-using namespace std;
 
 class Edge {            // code an edge of a given vertex
 public:

--- a/src/walktrap_graph.h
+++ b/src/walktrap_graph.h
@@ -55,8 +55,8 @@
 /* FSF address above was fixed by Tamas Nepusz */
 
 
-#ifndef GRAPH_H
-#define GRAPH_H
+#ifndef WALKTRAP_GRAPH_H
+#define WALKTRAP_GRAPH_H
 
 #include "igraph_community.h"
 
@@ -101,5 +101,5 @@ public:
 }
 }        /* end of namespaces */
 
-#endif
+#endif // WALKTRAP_GRAPH_H
 

--- a/src/walktrap_heap.cpp
+++ b/src/walktrap_heap.cpp
@@ -54,11 +54,7 @@
 // see readme.txt for more details
 
 #include "walktrap_heap.h"
-#include <cstdlib>
-#include <iostream>
 
-
-using namespace std;
 using namespace igraph::walktrap;
 
 void Neighbor_heap::move_up(int index) {

--- a/src/walktrap_heap.h
+++ b/src/walktrap_heap.h
@@ -53,8 +53,8 @@
 //-----------------------------------------------------------------------------
 // see readme.txt for more details
 
-#ifndef HEAP_H
-#define HEAP_H
+#ifndef WALKTRAP_HEAP_H
+#define WALKTRAP_HEAP_H
 
 namespace igraph {
 
@@ -130,5 +130,5 @@ public:
 }
 }        /* end of namespaces */
 
-#endif
+#endif // WALKTRAP_HEAP_H
 


### PR DESCRIPTION
This PR contains various small cleanups (with the `#include` cleanup touching lots of files). Please see the commits for details.

----

Any unneeded header includes are removed and headers are included in a consistent order, from most specific to least specific, i.e.:

 - igraph headers
 - `config.h` (unless there's a reason to put it in a different location in the header order)
 - system headers

----

Some always-true conditionals are removed from `sir.c` (if those pointers were NULL, the preceding code would fail too in that function).

----

Consistent header guard naming (I was uncomfortable with names like `ARPACK_H` that lacked the `IGRAPH_` prefix)

----

Re-encode some files are UTF8

----

Comments and minor fixes

