### PR TITLE
Fix arpack callback for sparse matrixes

### DIFF
--- a/src/eigen.c
+++ b/src/eigen.c
@@ -457,7 +457,7 @@ static int igraph_i_eigen_matrix_sym_arpack_cb(igraph_real_t *to,
     } else { /* data->sA */
         igraph_vector_t vto, vfrom;
         igraph_vector_view(&vto, to, n);
-        igraph_vector_view(&vfrom, to, n);
+        igraph_vector_view(&vfrom, from, n);
         igraph_vector_null(&vto);
         igraph_sparsemat_gaxpy(data->sA, &vfrom, &vto);
     }


### PR DESCRIPTION
Fix wrong vector usage in igraph_i_eigen_matrix_sym_arpack_cb: source vector was completely ignored leading to incorrect multiplications in igraph_eigen_matrix_symmetric for sparse matrix.

Also, there is the duplicate code in sparsemat.c (function igraph_i_sparsemat_arpack_multiply), but I propose to add small patch to next bugfix release without major refactoring.