### PR TITLE
Improvements to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,13 @@ language: c
 dist: xenial
 os: linux
 
+env:
+  global:
+    - MAKEFLAGS="-j 2"
+
 addons:
   apt:
     packages:
-    - gfortran
     - flex
     - bison
     - docbook2x
@@ -16,10 +19,14 @@ addons:
     - libxml2-utils
     - xsltproc
     - fop
+    - libgmp-dev
+    - libglpk-dev
   homebrew:
     packages:
     - flex
     - bison
+    - gmp
+    - glpk
 
 script:
   - make check
@@ -29,19 +36,27 @@ after_failure:
 
 jobs:
   include:
-    - stage: test
+    - name: "Linux"
       os: linux
       install:
         - ./bootstrap.sh
-        - ./configure
+        - ./configure --with-external-glpk
         - make
-    - stage: test
+    - name: "Linux x87"
+      os: linux
+      env:
+        - CFLAGS="-mfpmath=387" CXXFLAGS="-mfpmath=387"
+      install:
+        - ./bootstrap.sh
+        - ./configure --with-external-glpk
+        - make
+    - name: "macOS"
       os: osx
       install:
         - ./bootstrap.sh
-        - ./configure --enable-asan
+        - ./configure --with-external-glpk --enable-asan
         - make
-    - stage: documentation
+    - name: "Documentation"
       language: shell
       os: linux
       install:


### PR DESCRIPTION
Fixes #1387 

Changes:

 - Build with external GLPK for a small speedup
 - Remove stages and use only jobs for full parallelization (i.e. test doc build in parallel)
 - Test with 80-bit x87 floating-point arithmetic (currently reveals failures)
 - Identify each job by name