### PR TITLE
Correct cutoff for betweenness.

### DIFF
--- a/examples/simple/igraph_betweenness.c
+++ b/examples/simple/igraph_betweenness.c
@@ -36,6 +36,8 @@ int main() {
     igraph_t g;
     igraph_vector_t bet, bet2, weights, edges;
 
+    igraph_real_t cutoff = 0.0;
+
     igraph_real_t nontriv[] = { 0, 19, 0, 16, 0, 20, 1, 19, 2, 5, 3, 7, 3, 8,
                                 4, 15, 4, 11, 5, 8, 5, 19, 6, 7, 6, 10, 6, 8,
                                 6, 9, 7, 20, 9, 10, 9, 20, 10, 19,
@@ -57,6 +59,8 @@ int main() {
 
     /*******************************************************/
 
+    printf("BA graph\n");
+    printf("==========================================================\n");
     igraph_barabasi_game(/* graph= */    &g,
                                          /* n= */        1000,
                                          /* power= */    1,
@@ -83,8 +87,8 @@ int main() {
     igraph_vector_destroy(&bet);
     igraph_destroy(&g);
 
-    /*******************************************************/
-
+    printf("Tree\n");
+    printf("==========================================================\n");
     igraph_tree(&g, 20000, 10, IGRAPH_TREE_UNDIRECTED);
 
     igraph_vector_init(&bet, 0);
@@ -118,7 +122,8 @@ int main() {
     igraph_vector_destroy(&weights);
     igraph_destroy(&g);
 
-    /* Non-trivial weighted graph */
+    printf("Non-trivial weighted graph\n");
+    printf("==========================================================\n");
     igraph_vector_view(&edges, nontriv, sizeof(nontriv) / sizeof(igraph_real_t));
     igraph_create(&g, &edges, 0, /* directed= */ 0);
     igraph_vector_view(&weights, nontriv_weights,
@@ -139,7 +144,8 @@ int main() {
     igraph_destroy(&g);
 
 
-    /* test corner case of cutoff = 0 */
+    printf("Corner case cutoff 0.0\n");
+    printf("==========================================================\n");
     igraph_tree(&g, 20, 3, IGRAPH_TREE_UNDIRECTED);
 
     /* unweighted */
@@ -161,9 +167,8 @@ int main() {
             /* weights=   */ 0,
             /* nobigint=  */ 1);
 
-    if (!igraph_vector_all_e(&bet, &bet2)) {
-        return 1;
-    }
+    igraph_vector_print(&bet);
+    igraph_vector_print(&bet2);
 
     igraph_vector_destroy(&bet);
     igraph_vector_destroy(&bet2);
@@ -190,8 +195,90 @@ int main() {
             /* weights=   */ &weights,
             /* nobigint=  */ 1);
 
-    if (!igraph_vector_all_e(&bet, &bet2)) {
-        return 1;
+    igraph_vector_print(&bet);
+    igraph_vector_print(&bet2);
+
+    igraph_vector_destroy(&bet);
+    igraph_vector_destroy(&bet2);
+    igraph_vector_destroy(&weights);
+    igraph_destroy(&g);
+
+    printf("Single path graph\n");
+    printf("==========================================================\n");
+    igraph_small(&g, 5, IGRAPH_UNDIRECTED,
+                            0, 1,
+                            1, 2,
+                            2, 3,
+                            3, 4, -1);
+    igraph_vector_init(&bet, igraph_vcount(&g));
+    igraph_vector_init(&bet2, igraph_vcount(&g));
+    igraph_vector_init(&weights, igraph_ecount(&g));
+    igraph_vector_fill(&weights, 1);
+
+    for (cutoff = -1.0; cutoff < 5.0; cutoff++)
+    {
+        printf("Cutoff %.0f\n", cutoff);
+        printf("Unweighted\n");
+        igraph_betweenness_estimate(&g, &bet,
+                                    igraph_vss_all(), IGRAPH_UNDIRECTED,
+                                    /* cutoff */ cutoff,
+                                    /* weights */ NULL,
+                                    /* nobigint */ 1);
+        igraph_vector_print(&bet);
+
+        printf("Weighted\n");
+        igraph_betweenness_estimate(&g, &bet2,
+                                    igraph_vss_all(), IGRAPH_UNDIRECTED,
+                                    /* cutoff */ cutoff,
+                                    /* weights */ &weights,
+                                    /* nobigint */ 1);
+        igraph_vector_print(&bet2);
+        printf("\n");
+
+        if (!igraph_vector_all_e(&bet, &bet2)) {
+            return 3;
+        }        
+    }
+
+    igraph_vector_destroy(&bet);
+    igraph_vector_destroy(&bet2);
+    igraph_vector_destroy(&weights);
+    igraph_destroy(&g);
+
+    printf("Cycle graph\n");
+    printf("==========================================================\n");
+    igraph_small(&g, 4, IGRAPH_UNDIRECTED,
+                            0, 1,
+                            0, 2,
+                            1, 3,
+                            2, 3, -1);
+    igraph_vector_init(&bet, igraph_vcount(&g));
+    igraph_vector_init(&bet2, igraph_vcount(&g));
+    igraph_vector_init(&weights, igraph_ecount(&g));
+    VECTOR(weights)[0] = 1.01;
+    VECTOR(weights)[1] = 2;
+    VECTOR(weights)[2] = 0.99;
+    VECTOR(weights)[3] = 2;
+
+    for (cutoff = -1.0; cutoff < 5.0; cutoff++)
+    {
+        printf("Cutoff %.0f\n", cutoff);
+        printf("Unweighted\n");
+        igraph_betweenness_estimate(&g, &bet,
+                                    igraph_vss_all(), IGRAPH_UNDIRECTED,
+                                    /* cutoff */ cutoff,
+                                    /* weights */ NULL,
+                                    /* nobigint */ 1);
+        igraph_vector_print(&bet);
+
+        printf("Weighted\n");
+        igraph_betweenness_estimate(&g, &bet2,
+                                    igraph_vss_all(), IGRAPH_UNDIRECTED,
+                                    /* cutoff */ cutoff,
+                                    /* weights */ &weights,
+                                    /* nobigint */ 1);
+        igraph_vector_print(&bet2);
+        printf("\n");
     }
 
     igraph_vector_destroy(&bet);

--- a/examples/simple/igraph_betweenness.out
+++ b/examples/simple/igraph_betweenness.out
@@ -1,0 +1,88 @@
+BA graph
+==========================================================
+Tree
+==========================================================
+Non-trivial weighted graph
+==========================================================
+Corner case cutoff 0.0
+==========================================================
+0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+104 122 51 51 51 51 18 0 0 0 0 0 0 0 0 0 0 0 0 0
+0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+104 122 51 51 51 51 18 0 0 0 0 0 0 0 0 0 0 0 0 0
+Single path graph
+==========================================================
+Cutoff -1
+Unweighted
+0 3 4 3 0
+Weighted
+0 3 4 3 0
+
+Cutoff 0
+Unweighted
+0 0 0 0 0
+Weighted
+0 0 0 0 0
+
+Cutoff 1
+Unweighted
+0 0 0 0 0
+Weighted
+0 0 0 0 0
+
+Cutoff 2
+Unweighted
+0 1 1 1 0
+Weighted
+0 1 1 1 0
+
+Cutoff 3
+Unweighted
+0 2 3 2 0
+Weighted
+0 2 3 2 0
+
+Cutoff 4
+Unweighted
+0 3 4 3 0
+Weighted
+0 3 4 3 0
+
+Cycle graph
+==========================================================
+Cutoff -1
+Unweighted
+0.5 0.5 0.5 0.5
+Weighted
+0 1 0 1
+
+Cutoff 0
+Unweighted
+0 0 0 0
+Weighted
+0 0 0 0
+
+Cutoff 1
+Unweighted
+0 0 0 0
+Weighted
+0 0 0 0
+
+Cutoff 2
+Unweighted
+0.5 0.5 0.5 0.5
+Weighted
+0 1 0 0
+
+Cutoff 3
+Unweighted
+0.5 0.5 0.5 0.5
+Weighted
+0 1 0 1
+
+Cutoff 4
+Unweighted
+0.5 0.5 0.5 0.5
+Weighted
+0 1 0 1
+

--- a/src/centrality.c
+++ b/src/centrality.c
@@ -1726,7 +1726,7 @@ static int igraph_i_betweenness_estimate_weighted(
                     VECTOR(dist)[to] = altdist;
                     IGRAPH_CHECK(igraph_2wheap_modify(&Q, to, -altdist));
                 } else if (cmp_result == 0 &&
-                    (altdist <= cutoff + 1.0 || cutoff <= 0)) {
+                    (altdist <= cutoff + 1.0 || cutoff < 0)) {
                     /* Only add if the node is not more distant than the cutoff */
                     igraph_vector_int_t *v = igraph_adjlist_get(&fathers, to);
                     igraph_vector_int_push_back(v, minnei);
@@ -1826,8 +1826,8 @@ static void igraph_i_destroy_biguints(igraph_biguint_t *p) {
  * \param directed Logical, if true directed paths will be considered
  *        for directed graphs. It is ignored for undirected graphs.
  * \param cutoff The maximal length of paths that will be considered.
- *        If zero or negative, the exact betweenness will be calculated
- *        (no upper limit on path lengths).
+ *        If negative, the exact betweenness will be calculated, and
+ *        there will be no upper limit on path lengths.
  * \param weights An optional vector containing edge weights for
  *        calculating weighted betweenness. Supply a null pointer here
  *        for unweighted betweenness.
@@ -1969,7 +1969,7 @@ int igraph_betweenness_estimate(const igraph_t *graph, igraph_vector_t *res,
             long int actnode = (long int) igraph_dqueue_pop(&q);
 
             /* Ignore vertices that are more distant than the cutoff */
-            if (cutoff > 0 && distance[actnode] > cutoff + 1) {
+            if (cutoff >= 0 && distance[actnode] > cutoff + 1) {
                 /* Reset variables if node is too distant */
                 distance[actnode] = 0;
                 if (nobigint) {

--- a/src/centrality.c
+++ b/src/centrality.c
@@ -1679,10 +1679,17 @@ static int igraph_i_betweenness_estimate_weighted(
             igraph_vector_int_t *neis;
             long int nlen;
 
-            igraph_stack_push(&S, minnei);
-            if (cutoff > 0 && VECTOR(dist)[minnei] >= cutoff + 1.0) {
+            /* Ignore vertices that are more distant than the cutoff */
+            if (cutoff >= 0 && mindist > cutoff + 1.0) {
+                /* Reset variables if node is too distant */
+                VECTOR(tmpscore)[minnei] = 0;
+                VECTOR(dist)[minnei] = 0;
+                VECTOR(nrgeo)[minnei] = 0;
+                igraph_vector_int_clear(igraph_adjlist_get(&fathers, minnei));
                 continue;
             }
+
+            igraph_stack_push(&S, minnei);
 
             /* Now check all neighbors of 'minnei' for a shorter path */
             neis = igraph_inclist_get(&inclist, minnei);
@@ -1718,7 +1725,9 @@ static int igraph_i_betweenness_estimate_weighted(
 
                     VECTOR(dist)[to] = altdist;
                     IGRAPH_CHECK(igraph_2wheap_modify(&Q, to, -altdist));
-                } else if (cmp_result == 0) {
+                } else if (cmp_result == 0 &&
+                    (altdist <= cutoff + 1.0 || cutoff <= 0)) {
+                    /* Only add if the node is not more distant than the cutoff */
                     igraph_vector_int_t *v = igraph_adjlist_get(&fathers, to);
                     igraph_vector_int_push_back(v, minnei);
                     VECTOR(nrgeo)[to] += VECTOR(nrgeo)[minnei];
@@ -1739,6 +1748,7 @@ static int igraph_i_betweenness_estimate_weighted(
                 VECTOR(*tmpres)[w] += VECTOR(tmpscore)[w];
             }
 
+            /* Reset variables */
             VECTOR(tmpscore)[w] = 0;
             VECTOR(dist)[w] = 0;
             VECTOR(nrgeo)[w] = 0;
@@ -1957,12 +1967,22 @@ int igraph_betweenness_estimate(const igraph_t *graph, igraph_vector_t *res,
 
         while (!igraph_dqueue_empty(&q)) {
             long int actnode = (long int) igraph_dqueue_pop(&q);
-            IGRAPH_CHECK(igraph_stack_push(&stack, actnode));
 
-            if (cutoff > 0 && distance[actnode] >= cutoff + 1) {
+            /* Ignore vertices that are more distant than the cutoff */
+            if (cutoff > 0 && distance[actnode] > cutoff + 1) {
+                /* Reset variables if node is too distant */
+                distance[actnode] = 0;
+                if (nobigint) {
+                    nrgeo[actnode] = 0;
+                } else {
+                    igraph_biguint_set_limb(&big_nrgeo[actnode], 0);
+                }
+                tmpscore[actnode] = 0;
+                igraph_vector_int_clear(igraph_adjlist_get(adjlist_in_p, actnode));
                 continue;
             }
 
+            IGRAPH_CHECK(igraph_stack_push(&stack, actnode));
             neis = igraph_adjlist_get(adjlist_out_p, actnode);
             nneis = igraph_vector_int_size(neis);
             for (j = 0; j < nneis; j++) {
@@ -1971,7 +1991,9 @@ int igraph_betweenness_estimate(const igraph_t *graph, igraph_vector_t *res,
                     distance[neighbor] = distance[actnode] + 1;
                     IGRAPH_CHECK(igraph_dqueue_push(&q, neighbor));
                 }
-                if (distance[neighbor] == distance[actnode] + 1) {
+                if (distance[neighbor] == distance[actnode] + 1 &&
+                    (distance[neighbor] <= cutoff + 1 || cutoff < 0)) {
+                    /* Only add if the node is not more distant than the cutoff */
                     igraph_vector_int_t *v = igraph_adjlist_get(adjlist_in_p,
                                              neighbor);
                     igraph_vector_int_push_back(v, actnode);
@@ -2017,6 +2039,7 @@ int igraph_betweenness_estimate(const igraph_t *graph, igraph_vector_t *res,
                 VECTOR(*tmpres)[actnode] += tmpscore[actnode];
             }
 
+            /* Reset variables */
             distance[actnode] = 0;
             if (nobigint) {
                 nrgeo[actnode] = 0;

--- a/tests/structural_properties.at
+++ b/tests/structural_properties.at
@@ -99,7 +99,8 @@ AT_CLEANUP
 
 AT_SETUP([Betweenness (igraph_betweenness): ])
 AT_KEYWORDS([igraph_betweenness betweenness])
-AT_COMPILE_CHECK([simple/igraph_betweenness.c])
+AT_COMPILE_CHECK([simple/igraph_betweenness.c],
+                 [simple/igraph_betweenness.out])
 AT_CLEANUP
 
 AT_SETUP([Betweenness, big integers (igraph_betweenness): ])


### PR DESCRIPTION
This should fix #1316, where incorrect results for betweenness were reported when a cutoff was being used.

The problem was twofold:
1. Some nodes were incorrectly being seen as too distant for some source node because the distance was not reset if that node was too distant for another source node.
2. Nodes were still being added to the predecessor list, even when they were too distant.

The same problem may also play in other parts:
- `igraph_i_edge_betweenness_estimate_weighted`
- `igraph_i_closeness_estimate_weighted`
- `igraph_closeness_estimate`

These should still be corrected.

I would like to suggest to rewrite significant parts of the code. First of all, it would be a lot clearer if we indeed would use actual distances, instead of using distances + 1. Secondly, some variable names are not as clear as they could be. Finally, some parts seem to use a sort of legacy code, where simply direct arrays are used instead of `igraph_vector_t`. I think it would be good to simply use the types that are supplied by `igraph` as much as possible, instead of arrays. If you agree, I will do so in this PR.

@szhorvat, could you first double check if things are working correctly now? I have a test case, we could also add it to the tests, let me know what you prefer.
