### PR TITLE
Corrected edge attribute description in the documentation

### DIFF
--- a/include/igraph_attributes.h
+++ b/include/igraph_attributes.h
@@ -778,7 +778,7 @@ DECLDIR void igraph_cattribute_remove_all(igraph_t *graph, igraph_bool_t g,
 #define SETVASV(graph,n,v) (igraph_cattribute_VAS_setv((graph),(n),(v)))
 /**
  * \define SETEANV
- *  Set a numeric edge attribute for all vertices
+ *  Set a numeric edge attribute for all edges
  *
  * This is a shorthand for \ref igraph_cattribute_EAN_setv().
  * \param graph The graph.
@@ -788,7 +788,7 @@ DECLDIR void igraph_cattribute_remove_all(igraph_t *graph, igraph_bool_t g,
 #define SETEANV(graph,n,v) (igraph_cattribute_EAN_setv((graph),(n),(v)))
 /**
  * \define SETEABV
- *  Set a boolean edge attribute for all vertices
+ *  Set a boolean edge attribute for all edges
  *
  * This is a shorthand for \ref igraph_cattribute_EAB_setv().
  * \param graph The graph.
@@ -798,7 +798,7 @@ DECLDIR void igraph_cattribute_remove_all(igraph_t *graph, igraph_bool_t g,
 #define SETEABV(graph,n,v) (igraph_cattribute_EAB_setv((graph),(n),(v)))
 /**
  * \define SETEASV
- *  Set a string edge attribute for all vertices
+ *  Set a string edge attribute for all edges
  *
  * This is a shorthand for \ref igraph_cattribute_EAS_setv().
  * \param graph The graph.

--- a/src/cattributes.c
+++ b/src/cattributes.c
@@ -3878,7 +3878,7 @@ int igraph_cattribute_VAS_setv(igraph_t *graph, const char *name,
 
 /**
  * \function igraph_cattribute_EAN_setv
- * Set a numeric edge attribute for all vertices.
+ * Set a numeric edge attribute for all edges.
  *
  * The attribute will be added if not present yet.
  * \param graph The graph.
@@ -3944,7 +3944,7 @@ int igraph_cattribute_EAN_setv(igraph_t *graph, const char *name,
 
 /**
  * \function igraph_cattribute_EAB_setv
- * Set a boolean edge attribute for all vertices.
+ * Set a boolean edge attribute for all edges.
  *
  * The attribute will be added if not present yet.
  * \param graph The graph.
@@ -4010,7 +4010,7 @@ int igraph_cattribute_EAB_setv(igraph_t *graph, const char *name,
 
 /**
  * \function igraph_cattribute_EAS_setv
- * Set a string edge attribute for all vertices.
+ * Set a string edge attribute for all edges.
  *
  * The attribute will be added if not present yet.
  * \param graph The graph.


### PR DESCRIPTION
Accidentally, some edge attribute were described as being set for all *vertices*, instead of all *edges*.