### PR TITLE
Support for directed graphs when calculating modularity

### DIFF
--- a/examples/tests/igraph_modularity.c
+++ b/examples/tests/igraph_modularity.c
@@ -1,0 +1,113 @@
+/* -*- mode: C -*-  */
+/*
+   IGraph library.
+   Copyright (C) 2006-2012  Gabor Csardi <csardi.gabor@gmail.com>
+   334 Harvard street, Cambridge, MA 02139 USA
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc.,  51 Franklin Street, Fifth Floor, Boston, MA
+   02110-1301 USA
+
+*/
+
+#include <igraph.h>
+
+#include "test_utilities.inc"
+
+int main() {
+    igraph_t graph;
+    igraph_vector_t weights;
+    igraph_vector_t membership;
+    igraph_real_t modularity, resolution;
+    igraph_attribute_combination_t comb;
+
+    /* turn on attribute handling */
+    igraph_i_set_attribute_table(&igraph_cattribute_table);
+
+    igraph_attribute_combination(&comb,
+                                 "weight", IGRAPH_ATTRIBUTE_COMBINE_SUM,
+                                 IGRAPH_NO_MORE_ATTRIBUTES);
+
+    /* Set default seed to get reproducible results */
+    igraph_rng_seed(igraph_rng_default(), 0);
+
+    /* Simple unweighted graph */
+    igraph_small(&graph, 10, IGRAPH_UNDIRECTED,
+                 0, 1, 0, 2, 0, 3, 0, 4, 1, 2, 1, 3, 1, 4, 2, 3, 2, 4, 3, 4,
+                 5, 6, 5, 7, 5, 8, 5, 9, 6, 7, 6, 8, 6, 9, 7, 8, 7, 9, 8, 9,
+                 0, 5, -1);
+
+    /* Set weights */
+    igraph_vector_init(&weights, igraph_ecount(&graph));
+    igraph_vector_fill(&weights, 1.0);
+    SETEANV(&graph, "weight", &weights);
+
+    /* Set membership */
+    igraph_vector_init(&membership, igraph_vcount(&graph));
+    VECTOR(membership)[0] = 0;
+    VECTOR(membership)[1] = 0;
+    VECTOR(membership)[2] = 0;
+    VECTOR(membership)[3] = 0;
+    VECTOR(membership)[4] = 0;
+    VECTOR(membership)[5] = 1;
+    VECTOR(membership)[6] = 1;
+    VECTOR(membership)[7] = 1;
+    VECTOR(membership)[8] = 1;
+    VECTOR(membership)[9] = 1;
+
+    /* Calculate modularity */
+    for (resolution = 0.5; resolution <= 1.5; resolution += 0.5)
+    {
+        igraph_modularity(&graph, &membership, &weights,
+                        /* resolution */ resolution,
+                        /* directed */ 1, &modularity);
+        printf("Modularity (resolution %.2f) is %f.\n", resolution, modularity);
+    }
+
+    igraph_to_directed(&graph, IGRAPH_TO_DIRECTED_MUTUAL);
+    igraph_vector_resize(&weights, igraph_ecount(&graph));
+    igraph_vector_fill(&weights, 1.0);
+    for (resolution = 0.5; resolution <= 1.5; resolution += 0.5)
+    {
+        igraph_modularity(&graph, &membership, &weights,
+                        /* resolution */ resolution,
+                        /* directed */ 1, &modularity);
+        printf("Modularity (resolution %.2f) is %f on directed graph.\n", resolution, modularity);
+    }
+
+    /* Recalculate modularity on contracted graph */
+    igraph_contract_vertices(&graph, &membership, NULL);
+    igraph_vector_destroy(&membership);
+
+    igraph_simplify(&graph, /* multiple */ 1, /* loops */ 0, &comb);
+
+    igraph_vector_init_seq(&membership, 0, igraph_vcount(&graph) - 1);
+    EANV(&graph, "weight", &weights);
+    for (resolution = 0.5; resolution <= 1.5; resolution += 0.5)
+    {
+        igraph_modularity(&graph, &membership, &weights,
+                        /* resolution */ resolution,
+                        /* directed */ 1, &modularity);
+        printf("Modularity (resolution %.2f) is %f after aggregation.\n", resolution, modularity);
+    }
+
+    igraph_vector_destroy(&membership);
+    igraph_vector_destroy(&weights);
+    igraph_destroy(&graph);
+    igraph_attribute_combination_destroy(&comb);
+
+    VERIFY_FINALLY_STACK();
+
+    return 0;
+}

--- a/examples/tests/igraph_modularity.out
+++ b/examples/tests/igraph_modularity.out
@@ -1,0 +1,9 @@
+Modularity (resolution 0.50) is 0.702381.
+Modularity (resolution 1.00) is 0.452381.
+Modularity (resolution 1.50) is 0.202381.
+Modularity (resolution 0.50) is 0.702381 on directed graph.
+Modularity (resolution 1.00) is 0.452381 on directed graph.
+Modularity (resolution 1.50) is 0.202381 on directed graph.
+Modularity (resolution 0.50) is 0.702381 after aggregation.
+Modularity (resolution 1.00) is 0.452381 after aggregation.
+Modularity (resolution 1.50) is 0.202381 after aggregation.

--- a/include/igraph_community.h
+++ b/include/igraph_community.h
@@ -109,6 +109,7 @@ DECLDIR int igraph_community_edge_betweenness(const igraph_t *graph,
         igraph_bool_t directed,
         const igraph_vector_t *weights);
 DECLDIR int igraph_community_eb_get_merges(const igraph_t *graph,
+        const igraph_bool_t directed,
         const igraph_vector_t *edges,
         const igraph_vector_t *weights,
         igraph_matrix_t *merges,
@@ -136,6 +137,7 @@ DECLDIR int igraph_modularity(const igraph_t *graph,
                               const igraph_vector_t *membership,
                               const igraph_vector_t *weights,
                               const igraph_real_t resolution,
+                              const igraph_bool_t directed,
                               igraph_real_t *modularity);
 
 DECLDIR int igraph_modularity_matrix(const igraph_t *graph,

--- a/interfaces/functions.def
+++ b/interfaces/functions.def
@@ -1312,6 +1312,7 @@ igraph_modularity:
         PARAMS: GRAPH graph, VECTOR membership, \
                 IN VECTOR_OR_0 weights=NULL, \
                 REAL resolution=1.0, \
+                BOOLEAN directed=True,
                 OUT REALPTR modularity
         NAME-R: modularity.igraph
         IGNORE: RNamespace, RR

--- a/tests/community.at
+++ b/tests/community.at
@@ -21,6 +21,11 @@
 
 AT_BANNER([[Community structure]])
 
+AT_SETUP([Modularity (igraph_modularity): ])
+AT_KEYWORDS([modularity community clustering])
+AT_COMPILE_CHECK([tests/igraph_modularity.c], [tests/igraph_modularity.out])
+AT_CLEANUP
+
 AT_SETUP([Spinglass clustering (igraph_spinglass_community): ])
 AT_KEYWORDS([spin glass spinglass community clustering])
 AT_COMPILE_CHECK([simple/spinglass.c])


### PR DESCRIPTION
I implemented the calculation of modularity for directed graphs, as requested in #1358. Note that many functions currently do not support directed graphs, and hence, for those functions `igraph_modularity` now returns the undirected version of modularity. One function does support directed graphs (`igraph_community_edge_betweenness`) and for that it does return the directed version of modularity (if so indicated).

I've also provided some tests to check whether the directed definition provides the same modularity as the undirected definition when simply expanding an undirected graph to a directed graph with both directions present. Additionally, I check whether the aggregation also works correctly and provides the same modularity.

Note that for this test it seems that the stack is not empty. I am still checking where the problem is (not in `igraph_modularity`). But great improvement to catch these things early on @szhorvat and @ntamas ! Until that is sorted out, I mark this as a draft PR, but feel free to already comment if you want.