### PR TITLE
Verify FINAL stack size when debugging.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,14 +43,14 @@ jobs:
       os: linux
       install:
         - ./bootstrap.sh
-        - ./configure --with-external-glpk
+        - ./configure --enable-verify-finally --with-external-glpk
         - make
     - name: "Linux external deps"
       os: linux
       dist: bionic
       install:
         - ./bootstrap.sh
-        - ./configure --with-external-glpk --with-external-blas --with-external-lapack --with-external-arpack
+        - ./configure --enable-verify-finally --with-external-glpk --with-external-blas --with-external-lapack --with-external-arpack
         - make        
     - name: "Linux x87"
       os: linux
@@ -58,13 +58,13 @@ jobs:
         - CFLAGS="-mfpmath=387" CXXFLAGS="-mfpmath=387"
       install:
         - ./bootstrap.sh
-        - ./configure --with-external-glpk
+        - ./configure --enable-verify-finally --with-external-glpk
         - make
     - name: "macOS"
       os: osx
       install:
         - ./bootstrap.sh
-        - ./configure --with-external-glpk --enable-asan
+        - ./configure --enable-verify-finally --enable-asan --with-external-glpk 
         - make
     - name: "Documentation"
       language: shell

--- a/configure.ac
+++ b/configure.ac
@@ -131,6 +131,11 @@ AC_ARG_ENABLE(asan,
               AC_HELP_STRING([--enable-asan], [Enable Clang address sanitizer]),
               [use_asan=$enableval], [use_asan=no])
 
+verify_finally=no
+AC_ARG_ENABLE(verify-finally,
+              AC_HELP_STRING([--enable-verify-finally], [Enable verifying the ``finally'' stack size]),
+              [verify_finally=$enableval], [verify_finally=no])
+
 debug=no
 AC_ARG_ENABLE(debug,
               AC_HELP_STRING([--enable-debug], [Enable debug build]),
@@ -384,6 +389,14 @@ if test "$use_asan" != "yes" -a "$use_gprof" != "yes" -a "$debug" != "yes"; then
   CXXFLAGS="${CXXFLAGS} -O3"
 fi
 
+if test "$verify_finally" = "yes"; then
+  CPPFLAGS="${CPPFLAGS} -DIGRAPH_VERIFY_FINALLY_STACK=1"
+fi
+
+if test "$verify_finally" = "no"; then
+  CPPFLAGS="${CPPFLAGS} -DIGRAPH_VERIFY_FINALLY_STACK=0"
+fi
+
 AC_CONFIG_FILES([Makefile src/Makefile igraph.pc igraph_Info.plist doc/Makefile include/igraph_version.h include/igraph_threading.h])
 AC_OUTPUT
 
@@ -405,6 +418,7 @@ if test "$glpk_support" != "no"; then
 fi
 AC_MSG_RESULT([  Debug build            -- $debug])
 AC_MSG_RESULT([  Clang AddressSanitizer -- $use_asan])
+AC_MSG_RESULT([  Verify finally stack   -- $verify_finally])
 AC_MSG_RESULT([  Profiling              -- $use_gprof])
 AC_MSG_RESULT([  Link time optimization -- $use_lto])
 

--- a/include/igraph_error.h
+++ b/include/igraph_error.h
@@ -616,7 +616,7 @@ DECLDIR int IGRAPH_FINALLY_STACK_SIZE(void);
                 IGRAPH_ERROR("", igraph_i_ret); \
             } \
             if (enter_stack_size != IGRAPH_FINALLY_STACK_SIZE()) { \
-                IGRAPH_ERROR("Non-matching number of IGRAPH_FINAL and IGRAPH_FINALLY_CLEAN", IGRAPH_FAILURE); \
+                IGRAPH_ERROR("Non-matching number of IGRAPH_FINALLY and IGRAPH_FINALLY_CLEAN", IGRAPH_FAILURE); \
             } \
         } while (0)
 #else

--- a/include/igraph_error.h
+++ b/include/igraph_error.h
@@ -330,7 +330,7 @@ DECLDIR igraph_error_handler_t* igraph_set_error_handler(igraph_error_handler_t*
  * \enumval IGRAPH_ERWSTUCK Random walk got stuck.
  */
 
-typedef enum {    
+typedef enum {
     IGRAPH_SUCCESS           = 0,
     IGRAPH_FAILURE           = 1,
     IGRAPH_ENOMEM            = 2,
@@ -607,11 +607,26 @@ DECLDIR int IGRAPH_FINALLY_STACK_SIZE(void);
  * call which can return an error code.
  */
 
+#ifndef NDEBUG
+#define IGRAPH_CHECK(a) \
+        do { \
+            int enter_stack_size = IGRAPH_FINALLY_STACK_SIZE(); \
+            int igraph_i_ret=(a); \
+            if (IGRAPH_UNLIKELY(igraph_i_ret != 0)) {\
+                IGRAPH_ERROR("", igraph_i_ret); \
+            } \
+            if (enter_stack_size != IGRAPH_FINALLY_STACK_SIZE()) { \
+                IGRAPH_ERROR("Non-matching number of IGRAPH_FINAL and IGRAPH_FINALLY_CLEAN", IGRAPH_FAILURE); \
+            } \
+        } while (0)
+#else
 #define IGRAPH_CHECK(a) do { \
         int igraph_i_ret=(a); \
         if (IGRAPH_UNLIKELY(igraph_i_ret != 0)) {\
             IGRAPH_ERROR("", igraph_i_ret); \
         } } while (0)
+#endif
+
 
 
 /**

--- a/include/igraph_error.h
+++ b/include/igraph_error.h
@@ -607,7 +607,7 @@ DECLDIR int IGRAPH_FINALLY_STACK_SIZE(void);
  * call which can return an error code.
  */
 
-#ifndef NDEBUG
+#if IGRAPH_VERIFY_FINALLY_STACK == 1
 #define IGRAPH_CHECK(a) \
         do { \
             int enter_stack_size = IGRAPH_FINALLY_STACK_SIZE(); \

--- a/include/igraph_error.h
+++ b/include/igraph_error.h
@@ -584,6 +584,19 @@ DECLDIR int IGRAPH_FINALLY_STACK_SIZE(void);
     #define IGRAPH_LIKELY(a)   a
 #endif
 
+#if IGRAPH_VERIFY_FINALLY_STACK == 1
+#define IGRAPH_CHECK(a) \
+        do { \
+            int enter_stack_size = IGRAPH_FINALLY_STACK_SIZE(); \
+            int igraph_i_ret=(a); \
+            if (IGRAPH_UNLIKELY(igraph_i_ret != 0)) {\
+                IGRAPH_ERROR("", igraph_i_ret); \
+            } \
+            if (enter_stack_size != IGRAPH_FINALLY_STACK_SIZE()) { \
+                IGRAPH_ERROR("Non-matching number of IGRAPH_FINALLY and IGRAPH_FINALLY_CLEAN", IGRAPH_FAILURE); \
+            } \
+        } while (0)
+#else
 /**
  * \define IGRAPH_CHECK
  * \brief Check the return value of a function call.
@@ -606,20 +619,6 @@ DECLDIR int IGRAPH_FINALLY_STACK_SIZE(void);
  * by using <function>IGRAPH_CHECK</function> on every \a igraph
  * call which can return an error code.
  */
-
-#if IGRAPH_VERIFY_FINALLY_STACK == 1
-#define IGRAPH_CHECK(a) \
-        do { \
-            int enter_stack_size = IGRAPH_FINALLY_STACK_SIZE(); \
-            int igraph_i_ret=(a); \
-            if (IGRAPH_UNLIKELY(igraph_i_ret != 0)) {\
-                IGRAPH_ERROR("", igraph_i_ret); \
-            } \
-            if (enter_stack_size != IGRAPH_FINALLY_STACK_SIZE()) { \
-                IGRAPH_ERROR("Non-matching number of IGRAPH_FINALLY and IGRAPH_FINALLY_CLEAN", IGRAPH_FAILURE); \
-            } \
-        } while (0)
-#else
 #define IGRAPH_CHECK(a) do { \
         int igraph_i_ret=(a); \
         if (IGRAPH_UNLIKELY(igraph_i_ret != 0)) {\

--- a/src/lad.c
+++ b/src/lad.c
@@ -98,7 +98,7 @@ typedef struct {
     igraph_matrix_char_t isEdge;
 } Tgraph;
 
-int igraph_i_lad_createGraph(const igraph_t *igraph, Tgraph* graph) {
+static int igraph_i_lad_createGraph(const igraph_t *igraph, Tgraph* graph) {
     long int i, j, n;
     long int no_of_nodes = igraph_vcount(igraph);
     igraph_vector_int_t *neis;
@@ -111,8 +111,7 @@ int igraph_i_lad_createGraph(const igraph_t *igraph, Tgraph* graph) {
 
     IGRAPH_CHECK(igraph_adjlist_init(igraph, &graph->succ, IGRAPH_OUT));
     IGRAPH_FINALLY(igraph_adjlist_destroy, &graph->succ);
-    IGRAPH_CHECK(igraph_matrix_char_init(&graph->isEdge,
-                                         no_of_nodes, no_of_nodes));
+    IGRAPH_CHECK(igraph_matrix_char_init(&graph->isEdge, no_of_nodes, no_of_nodes));
     IGRAPH_FINALLY(igraph_matrix_char_destroy, &graph->isEdge);
 
     for (i = 0; i < no_of_nodes; i++) {
@@ -128,8 +127,17 @@ int igraph_i_lad_createGraph(const igraph_t *igraph, Tgraph* graph) {
         }
     }
 
-    return 0;
+    IGRAPH_FINALLY_CLEAN(3);
+
+    return IGRAPH_SUCCESS;
 }
+
+static void igraph_i_lad_destroyGraph(Tgraph *graph) {
+    igraph_matrix_char_destroy(&graph->isEdge);
+    igraph_adjlist_destroy(&graph->succ);
+    igraph_vector_destroy(&graph->nbSucc);
+}
+
 
 /* ---------------------------------------------------------*/
 /* Coming from domains.c                                    */
@@ -484,8 +492,8 @@ static bool igraph_i_lad_compare(int size_mu, int* mu, int size_mv, int* mv) {
 }
 
 static int igraph_i_lad_initDomains(bool initialDomains,
-                             igraph_vector_ptr_t *domains, Tdomain* D,
-                             Tgraph* Gp, Tgraph* Gt, int *empty) {
+                                    const igraph_vector_ptr_t *domains, Tdomain *D,
+                                    const Tgraph *Gp, const Tgraph *Gt, int *empty) {
     /* for every pattern node u, initialize D(u) with every vertex v
        such that for every neighbor u' of u there exists a different
        neighbor v' of v such that degree(u) <= degree(v)
@@ -511,16 +519,13 @@ static int igraph_i_lad_initDomains(bool initialDomains,
         IGRAPH_ERROR("cannot allocated 'dom' array in igraph_i_lad_initDomains", IGRAPH_ENOMEM);
     }
 
-    IGRAPH_CHECK(igraph_vector_int_init(&D->globalMatchingP, Gp->nbVertices));
-    IGRAPH_FINALLY(igraph_vector_int_destroy, &D->globalMatchingP);
+    IGRAPH_VECTOR_INT_INIT_FINALLY(&D->globalMatchingP, Gp->nbVertices);
     igraph_vector_int_fill(&D->globalMatchingP, -1L);
 
-    IGRAPH_CHECK(igraph_vector_int_init(&D->globalMatchingT, Gt->nbVertices));
-    IGRAPH_FINALLY(igraph_vector_int_destroy, &D->globalMatchingT);
+    IGRAPH_VECTOR_INT_INIT_FINALLY(&D->globalMatchingT, Gt->nbVertices);
     igraph_vector_int_fill(&D->globalMatchingT, -1L);
 
-    IGRAPH_CHECK(igraph_vector_int_init(&D->nbVal, Gp->nbVertices));
-    IGRAPH_FINALLY(igraph_vector_int_destroy, &D->nbVal);
+    IGRAPH_VECTOR_INT_INIT_FINALLY(&D->nbVal, Gp->nbVertices);
 
     IGRAPH_CHECK(igraph_vector_int_init(&D->firstVal, Gp->nbVertices));
     IGRAPH_FINALLY(igraph_vector_int_destroy, &D->firstVal);
@@ -536,8 +541,7 @@ static int igraph_i_lad_initDomains(bool initialDomains,
     IGRAPH_CHECK(igraph_vector_char_init(&D->markedToFilter, Gp->nbVertices));
     IGRAPH_FINALLY(igraph_vector_char_destroy, &D->markedToFilter);
 
-    IGRAPH_CHECK(igraph_vector_int_init(&D->toFilter, Gp->nbVertices));
-    IGRAPH_FINALLY(igraph_vector_int_destroy, &D->toFilter);
+    IGRAPH_VECTOR_INT_INIT_FINALLY(&D->toFilter, Gp->nbVertices);
 
     D->valSize = 0;
     matchingSize = 0;
@@ -602,29 +606,54 @@ static int igraph_i_lad_initDomains(bool initialDomains,
         }
         if (VECTOR(D->nbVal)[u] == 0) {
             *empty = 1;  /* empty domain */
+
             igraph_free(val);
             igraph_free(dom);
-            return 0;
+
+            /* On this branch, 'val' and 'matching' are unused.
+             * We init them anyway so that we can have a consistent destructor. */
+            IGRAPH_VECTOR_INT_INIT_FINALLY(&D->val, 0);
+            IGRAPH_VECTOR_INT_INIT_FINALLY(&D->matching, 0);
+            IGRAPH_FINALLY_CLEAN(10);
+
+            return IGRAPH_SUCCESS;
         }
     }
-    IGRAPH_CHECK(igraph_vector_int_init(&D->val, D->valSize));
-    IGRAPH_FINALLY(igraph_vector_int_destroy, &D->val);
+    IGRAPH_VECTOR_INT_INIT_FINALLY(&D->val, D->valSize);
     for (i = 0; i < D->valSize; i++) {
         VECTOR(D->val)[i] = val[i];
     }
 
-    IGRAPH_CHECK(igraph_vector_int_init(&D->matching, matchingSize));
-    IGRAPH_FINALLY(igraph_vector_int_destroy, &D->matching);
+    IGRAPH_VECTOR_INT_INIT_FINALLY(&D->matching, matchingSize);
     igraph_vector_int_fill(&D->matching, -1);
 
     D->nextOutToFilter = 0;
     D->lastInToFilter = (int) (Gp->nbVertices - 1);
+
     *empty = 0;
 
     igraph_free(val);
     igraph_free(dom);
-    return 0;
+
+    IGRAPH_FINALLY_CLEAN(10);
+
+    return IGRAPH_SUCCESS;
 }
+
+static void igraph_i_lad_destroyDomains(Tdomain *D) {
+    igraph_vector_int_destroy(&D->globalMatchingP);
+    igraph_vector_int_destroy(&D->globalMatchingT);
+    igraph_vector_int_destroy(&D->nbVal);
+    igraph_vector_int_destroy(&D->firstVal);
+    igraph_matrix_int_destroy(&D->posInVal);
+    igraph_matrix_int_destroy(&D->firstMatch);
+    igraph_vector_char_destroy(&D->markedToFilter);
+    igraph_vector_int_destroy(&D->toFilter);
+
+    igraph_vector_int_destroy(&D->val);
+    igraph_vector_int_destroy(&D->matching);
+}
+
 
 /* ---------------------------------------------------------*/
 /* Coming from allDiff.c                                    */
@@ -1574,14 +1603,18 @@ int igraph_subisomorphic_lad(const igraph_t *pattern, const igraph_t *target,
     }
 
     IGRAPH_CHECK(igraph_i_lad_createGraph(pattern, &Gp));
+    IGRAPH_FINALLY(igraph_i_lad_destroyGraph, &Gp);
+
     IGRAPH_CHECK(igraph_i_lad_createGraph(target, &Gt));
+    IGRAPH_FINALLY(igraph_i_lad_destroyGraph, &Gt);
 
     if (Gp.nbVertices > Gt.nbVertices) {
         goto exit3;
     }
 
-    IGRAPH_CHECK(igraph_i_lad_initDomains(initialDomains, domains, &D, &Gp,
-                                          &Gt, &invalidDomain));
+    IGRAPH_CHECK(igraph_i_lad_initDomains(initialDomains, domains, &D, &Gp, &Gt, &invalidDomain));
+    IGRAPH_FINALLY(igraph_i_lad_destroyDomains, &D);
+
     if (invalidDomain) {
         goto exit2;
     }
@@ -1633,32 +1666,16 @@ int igraph_subisomorphic_lad(const igraph_t *pattern, const igraph_t *target,
     IGRAPH_FINALLY_CLEAN(1);
 
 exit:
-
-    igraph_vector_int_destroy(&D.val);
-    igraph_vector_int_destroy(&D.matching);
-    IGRAPH_FINALLY_CLEAN(2);
-
 exit2:
 
-    igraph_vector_int_destroy(&D.globalMatchingP);
-    igraph_vector_int_destroy(&D.globalMatchingT);
-    igraph_vector_int_destroy(&D.nbVal);
-    igraph_vector_int_destroy(&D.firstVal);
-    igraph_matrix_int_destroy(&D.posInVal);
-    igraph_matrix_int_destroy(&D.firstMatch);
-    igraph_vector_char_destroy(&D.markedToFilter);
-    igraph_vector_int_destroy(&D.toFilter);
-    IGRAPH_FINALLY_CLEAN(8);
+    igraph_i_lad_destroyDomains(&D);
+    IGRAPH_FINALLY_CLEAN(1);
 
 exit3:
 
-    igraph_matrix_char_destroy(&Gt.isEdge);
-    igraph_adjlist_destroy(&Gt.succ);
-    igraph_vector_destroy(&Gt.nbSucc);
-    igraph_matrix_char_destroy(&Gp.isEdge);
-    igraph_adjlist_destroy(&Gp.succ);
-    igraph_vector_destroy(&Gp.nbSucc);
-    IGRAPH_FINALLY_CLEAN(6);
+    igraph_i_lad_destroyGraph(&Gt);
+    igraph_i_lad_destroyGraph(&Gp);
+    IGRAPH_FINALLY_CLEAN(2);
 
     return 0;
 }

--- a/src/st-cuts.c
+++ b/src/st-cuts.c
@@ -1170,7 +1170,7 @@ static int igraph_i_all_st_mincuts_minimal(const igraph_t *Sbar,
 
     igraph_vector_destroy(&indeg);
     igraph_vector_destroy(&neis);
-    IGRAPH_FINALLY_CLEAN(3);
+    IGRAPH_FINALLY_CLEAN(2);
 
     return 0;
 }


### PR DESCRIPTION
Following up on the excellent idea in PR #1400, I thought it would be good to test whether stack sizes are the same when entering and exiting functions. This is most readily done in the `IGRAPH_CHECK` macro, because these are already defined in many places. Obviously, missing `IGRAPH_CHECK` will continue to be a problem.

Note that this degrades performance significantly, so this should *never* be used in actual compilation, and only when compiled in debug mode (i.e. `NDEBUG` should be defined to prevent using this), but it does make it a lot easier to track down bugs in the error handling. This PR reveals a number of problems across `igraph`, which we should check out in more detail. I think it would be best to solve those problems in separate PRs to keep everything neat.

Curious to hear what you all think of this suggestion!