### PR TITLE
Corrected non-matching FINALLY and FINALLY_CLEAN when combining edges

### DIFF
--- a/src/cattributes.c
+++ b/src/cattributes.c
@@ -2187,7 +2187,7 @@ int igraph_i_cattribute_combine_edges(const igraph_t *graph,
 
     igraph_free(funcs);
     igraph_free(TODO);
-    IGRAPH_FINALLY_CLEAN(2);
+    IGRAPH_FINALLY_CLEAN(3);
 
     return 0;
 }


### PR DESCRIPTION
Using PR #1404, it became clear that the non-matching FINAL stack size in PR #1403 was due to a non-matching number of `IGRAPH_FINALLY` and `IGRAPH_FINALLY_CLEAN` calls. This PR corrects that problem, and hence, also corrects the problem report in #1403.