### PR TITLE
Check that the arguments of IGRAPH_FINALLY have the correct type

### DIFF
--- a/examples/simple/tls1.c
+++ b/examples/simple/tls1.c
@@ -26,7 +26,7 @@
 #include <unistd.h>
 
 void *thread_function(void *arg) {
-    IGRAPH_FINALLY(0, 0);
+    IGRAPH_FINALLY(igraph_free, NULL);
     return 0;
 }
 

--- a/include/igraph_error.h
+++ b/include/igraph_error.h
@@ -564,7 +564,10 @@ DECLDIR int IGRAPH_FINALLY_STACK_SIZE(void);
  */
 
 #define IGRAPH_FINALLY(func,ptr) \
-    IGRAPH_FINALLY_REAL((igraph_finally_func_t*)(func), (ptr))
+    { \
+        if (0) { func(ptr); } \
+        IGRAPH_FINALLY_REAL((igraph_finally_func_t*)(func), (ptr)); \
+    }
 
 #if !defined(GCC_VERSION_MAJOR) && defined(__GNUC__)
     #define GCC_VERSION_MAJOR  __GNUC__

--- a/include/igraph_error.h
+++ b/include/igraph_error.h
@@ -565,6 +565,9 @@ DECLDIR int IGRAPH_FINALLY_STACK_SIZE(void);
 
 #define IGRAPH_FINALLY(func,ptr) \
     { \
+        /* the following branch makes the compiler check the compatibility of \
+         * func and ptr to detect cases when we are accidentally invoking an \
+         * incorrect destructor function with the pointer */ \
         if (0) { func(ptr); } \
         IGRAPH_FINALLY_REAL((igraph_finally_func_t*)(func), (ptr)); \
     }

--- a/include/igraph_strvector.h
+++ b/include/igraph_strvector.h
@@ -57,7 +57,7 @@ typedef struct s_igraph_strvector {
 #define IGRAPH_STRVECTOR_NULL { 0,0 }
 #define IGRAPH_STRVECTOR_INIT_FINALLY(v, size) \
     do { IGRAPH_CHECK(igraph_strvector_init(v, size)); \
-        IGRAPH_FINALLY( (igraph_finally_func_t*) igraph_strvector_destroy, v); } while (0)
+        IGRAPH_FINALLY( igraph_strvector_destroy, v); } while (0)
 
 DECLDIR int igraph_strvector_init(igraph_strvector_t *sv, long int len);
 DECLDIR void igraph_strvector_destroy(igraph_strvector_t *sv);

--- a/src/cattributes.c
+++ b/src/cattributes.c
@@ -3801,7 +3801,7 @@ int igraph_cattribute_VAB_setv(igraph_t *graph, const char *name,
         IGRAPH_FINALLY(igraph_free, log);
         rec->value = log;
         IGRAPH_CHECK(igraph_vector_bool_copy(log, v));
-        IGRAPH_FINALLY(igraph_vector_destroy, log);
+        IGRAPH_FINALLY(igraph_vector_bool_destroy, log);
         IGRAPH_CHECK(igraph_vector_ptr_push_back(val, rec));
         IGRAPH_FINALLY_CLEAN(4);
     }

--- a/src/flow.c
+++ b/src/flow.c
@@ -742,7 +742,7 @@ int igraph_maxflow(const igraph_t *graph, igraph_real_t *value,
         IGRAPH_CHECK(igraph_vector_int_init(&added, no_of_nodes));
         IGRAPH_FINALLY(igraph_vector_int_destroy, &added);
         IGRAPH_CHECK(igraph_dqueue_init(&Q, 100));
-        IGRAPH_FINALLY(igraph_dqueue_destroy, &added);
+        IGRAPH_FINALLY(igraph_dqueue_destroy, &Q);
 
         igraph_dqueue_push(&Q, source);
         igraph_dqueue_push(&Q, 0);
@@ -2526,4 +2526,3 @@ int igraph_gomory_hu_tree(const igraph_t *graph, igraph_t *tree,
 
     return IGRAPH_SUCCESS;
 }
-

--- a/src/foreign.c
+++ b/src/foreign.c
@@ -1155,7 +1155,7 @@ int igraph_read_graph_gml(igraph_t *graph, FILE *instream) {
     }
     gtree = igraph_gml_tree_get_tree(context.tree, gidx);
 
-    IGRAPH_FINALLY(igraph_i_gml_destroy_attrs, &attrs);
+    IGRAPH_FINALLY(igraph_i_gml_destroy_attrs, attrs);
     igraph_vector_ptr_init(&gattrs, 0);
     igraph_vector_ptr_init(&vattrs, 0);
     igraph_vector_ptr_init(&eattrs, 0);
@@ -3386,5 +3386,3 @@ int igraph_write_graph_leda(const igraph_t *graph, FILE *outstream,
 }
 
 #undef CHECK
-
-

--- a/src/glet.c
+++ b/src/glet.c
@@ -173,9 +173,9 @@ static int igraph_i_subclique_next(const igraph_t *graph,
     igraph_vector_init(&newedges, 100);
     IGRAPH_FINALLY(igraph_vector_destroy, &newedges);
     igraph_vector_int_init(&mark, no_of_nodes);
-    IGRAPH_FINALLY(igraph_vector_destroy, &mark);
+    IGRAPH_FINALLY(igraph_vector_int_destroy, &mark);
     igraph_vector_int_init(&map, no_of_nodes);
-    IGRAPH_FINALLY(igraph_vector_destroy, &map);
+    IGRAPH_FINALLY(igraph_vector_int_destroy, &map);
     igraph_vector_int_init(&edges, 100);
     IGRAPH_FINALLY(igraph_vector_int_destroy, &edges);
     igraph_vector_init(&neis, 10);

--- a/src/igraph_fixed_vectorlist.c
+++ b/src/igraph_fixed_vectorlist.c
@@ -50,7 +50,7 @@ int igraph_fixed_vectorlist_convert(igraph_fixed_vectorlist_t *l,
     }
     IGRAPH_FINALLY(igraph_free, l->vecs);
     IGRAPH_CHECK(igraph_vector_ptr_init(&l->v, size));
-    IGRAPH_FINALLY(igraph_fixed_vectorlist_destroy, &l->v);
+    IGRAPH_FINALLY(igraph_vector_ptr_destroy, &l->v);
     IGRAPH_VECTOR_INIT_FINALLY(&sizes, size);
 
     for (i = 0; i < no; i++) {

--- a/src/igraph_hashtable.c
+++ b/src/igraph_hashtable.c
@@ -32,7 +32,7 @@ int igraph_hashtable_init(igraph_hashtable_t *ht) {
     IGRAPH_CHECK(igraph_trie_init(&ht->keys, 1));
     IGRAPH_FINALLY(igraph_trie_destroy, &ht->keys);
     IGRAPH_CHECK(igraph_strvector_init(&ht->elements, 0));
-    IGRAPH_FINALLY(igraph_trie_destroy, &ht->elements);
+    IGRAPH_FINALLY(igraph_strvector_destroy, &ht->elements);
     IGRAPH_CHECK(igraph_strvector_init(&ht->defaults, 0));
 
     IGRAPH_FINALLY_CLEAN(2);

--- a/src/igraph_trie.c
+++ b/src/igraph_trie.c
@@ -47,7 +47,7 @@ static int igraph_i_trie_init_node(igraph_trie_node_t *t) {
     return 0;
 }
 
-static void igraph_i_trie_destroy_node(igraph_trie_node_t *t, igraph_bool_t sfree);
+static void igraph_i_trie_destroy_node(igraph_trie_node_t *t);
 
 /**
  * \ingroup igraphtrie
@@ -59,8 +59,8 @@ static void igraph_i_trie_destroy_node(igraph_trie_node_t *t, igraph_bool_t sfre
 int igraph_trie_init(igraph_trie_t *t, igraph_bool_t storekeys) {
     t->maxvalue = -1;
     t->storekeys = storekeys;
-    IGRAPH_CHECK(igraph_i_trie_init_node( (igraph_trie_node_t *)t ));
-    IGRAPH_FINALLY(igraph_i_trie_destroy_node, t);
+    IGRAPH_CHECK(igraph_i_trie_init_node( (igraph_trie_node_t *) t ));
+    IGRAPH_FINALLY(igraph_i_trie_destroy_node, (igraph_trie_node_t *) t );
     if (storekeys) {
         IGRAPH_CHECK(igraph_strvector_init(&t->keys, 0));
     }
@@ -74,13 +74,13 @@ int igraph_trie_init(igraph_trie_t *t, igraph_bool_t storekeys) {
  * \brief Destroys a node of a trie (not to be called directly).
  */
 
-static void igraph_i_trie_destroy_node(igraph_trie_node_t *t, igraph_bool_t sfree) {
+static void igraph_i_trie_destroy_node_helper(igraph_trie_node_t *t, igraph_bool_t sfree) {
     long int i;
     igraph_strvector_destroy(&t->strs);
     for (i = 0; i < igraph_vector_ptr_size(&t->children); i++) {
         igraph_trie_node_t *child = VECTOR(t->children)[i];
         if (child != 0) {
-            igraph_i_trie_destroy_node(child, 1);
+            igraph_i_trie_destroy_node_helper(child, 1);
         }
     }
     igraph_vector_ptr_destroy(&t->children);
@@ -88,6 +88,10 @@ static void igraph_i_trie_destroy_node(igraph_trie_node_t *t, igraph_bool_t sfre
     if (sfree) {
         igraph_Free(t);
     }
+}
+
+static void igraph_i_trie_destroy_node(igraph_trie_node_t *t) {
+    igraph_i_trie_destroy_node_helper(t, 0);
 }
 
 /**
@@ -99,7 +103,7 @@ void igraph_trie_destroy(igraph_trie_t *t) {
     if (t->storekeys) {
         igraph_strvector_destroy(&t->keys);
     }
-    igraph_i_trie_destroy_node( (igraph_trie_node_t*) t, 0);
+    igraph_i_trie_destroy_node( (igraph_trie_node_t*) t);
 }
 
 

--- a/src/scg_optimal_method.c
+++ b/src/scg_optimal_method.c
@@ -113,7 +113,7 @@ int igraph_i_optimal_partition(const igraph_real_t *v, int *gr, int n,
 
     IGRAPH_MATRIX_INIT_FINALLY(&F, nt, n);
     IGRAPH_CHECK(igraph_matrix_int_init(&Q, nt, n));
-    IGRAPH_FINALLY(igraph_matrix_destroy, &Q);
+    IGRAPH_FINALLY(igraph_matrix_int_destroy, &Q);
 
     for (i = 0; i < n; i++) {
         MATRIX(Q, 0, i)++;
@@ -237,4 +237,3 @@ int igraph_i_cost_matrix(igraph_real_t*Cv, const igraph_i_scg_indval_t *vs,
 
     return 0;
 }
-


### PR DESCRIPTION
I tend to make the mistake that I swap the arguments of `IGRAPH_FINALLY` and I write `IGRAPH_FINALLY(ptr, fun)` instead of the correct `IGRAPH_FINALLY(fun, ptr)`.

Normally, my IDE (or the compiler) would warn when something like this is wrong. But `IGRAPH_FINALLY` is casting its arguments, which masks any errors.

This PR attempts to allow `IGRAPH_FINALLY` to check its args, like this:

```c
#define IGRAPH_FINALLY(func,ptr) \
    { \
        if (0) { func(ptr); } \
        IGRAPH_FINALLY_REAL((igraph_finally_func_t*)(func), (ptr)); \
    }
```

The `if (0)` should be optimized away by the compiler, so performance is not a concern (unless I am missing something). But this line will cause the compiler to complain if the types don't match.

As expected, this keeps revealing errors. I did not fix them yet. Even if we do not decide to keep this modification to `IGRAPH_FINALLY`, we should fix these errors. I invite everyone to push to this PR and contribute. Note that we must pay attention to compiler warnings as well as to errors. Some problems show up as warnings only.

If you plan to work on a particular issue, post a note so we don't end up working on the same thing in parallel.