### PR TITLE
Corrected cutoff for edge_betweenness

### DIFF
--- a/examples/simple/igraph_edge_betweenness.c
+++ b/examples/simple/igraph_edge_betweenness.c
@@ -75,7 +75,7 @@ int test_bug1050() {
     igraph_edge_betweenness_estimate(&g, &eb, IGRAPH_UNDIRECTED, /* cutoff */ -1, /* weights */ 0);
     igraph_edge_betweenness_estimate(&g, &eb2, IGRAPH_UNDIRECTED, /* cutoff */ 0, /* weights */ 0);
 
-    if (!igraph_vector_all_e(&eb, &eb2)) {
+    if (igraph_vector_all_e(&eb, &eb2)) {
         return 1;
     }
 
@@ -94,7 +94,7 @@ int test_bug1050() {
     igraph_edge_betweenness_estimate(&g, &eb, IGRAPH_UNDIRECTED, /* cutoff */ -1, &weights);
     igraph_edge_betweenness_estimate(&g, &eb2, IGRAPH_UNDIRECTED, /* cutoff */ 0, &weights);
 
-    if (!igraph_vector_all_e(&eb, &eb2)) {
+    if (igraph_vector_all_e(&eb, &eb2)) {
         return 1;
     }
 

--- a/src/centrality.c
+++ b/src/centrality.c
@@ -2158,10 +2158,6 @@ static int igraph_i_edge_betweenness_estimate_weighted(
 
         /*     printf("source: %li\n", source); */
 
-        igraph_vector_null(&distance);
-        igraph_vector_null(&tmpscore);
-        igraph_vector_long_null(&nrgeo);
-
         igraph_2wheap_push_with_index(&Q, source, -1.0);
         VECTOR(distance)[source] = 1.0;
         VECTOR(nrgeo)[source] = 1;
@@ -2175,11 +2171,17 @@ static int igraph_i_edge_betweenness_estimate_weighted(
             /* printf("SP to %li is final, dist: %g, nrgeo: %li\n", minnei, */
             /* VECTOR(distance)[minnei]-1.0, VECTOR(nrgeo)[minnei]); */
 
-            igraph_stack_push(&S, minnei);
-
-            if (cutoff > 0 && VECTOR(distance)[minnei] >= cutoff + 1.0) {
+            /* Ignore vertices that are more distant than the cutoff */
+            if (cutoff >= 0 && VECTOR(distance)[minnei] > cutoff + 1.0) {
+                /* Reset variables if node is too distant */
+                VECTOR(tmpscore)[minnei] = 0;
+                VECTOR(distance)[minnei] = 0;
+                VECTOR(nrgeo)[minnei] = 0;
+                igraph_vector_int_clear(igraph_inclist_get(&fathers, minnei));
                 continue;
             }
+
+            igraph_stack_push(&S, minnei);
 
             neis = igraph_inclist_get(&inclist, minnei);
             nlen = igraph_vector_int_size(neis);
@@ -2216,10 +2218,12 @@ static int igraph_i_edge_betweenness_estimate_weighted(
                     VECTOR(nrgeo)[to] = VECTOR(nrgeo)[minnei];
                     VECTOR(distance)[to] = altdist;
                     IGRAPH_CHECK(igraph_2wheap_modify(&Q, to, -altdist));
-                } else if (cmp_result == 0) {
+                } else if (cmp_result == 0 &&
+                    (altdist <= cutoff + 1.0 || cutoff < 0)) {
+                    /* Only add if the edge is not more distant than the cutoff */
                     igraph_vector_int_t *v = igraph_inclist_get(&fathers, to);
                     /* printf("Found a second SP to %li (from %li)\n", to, minnei); */
-                    igraph_vector_int_push_back(v, edge);
+                    IGRAPH_CHECK(igraph_vector_int_push_back(v, edge));
                     VECTOR(nrgeo)[to] += VECTOR(nrgeo)[minnei];
                 }
             }
@@ -2242,6 +2246,7 @@ static int igraph_i_edge_betweenness_estimate_weighted(
                     VECTOR(nrgeo)[w];
             }
 
+            /* Reset variables */
             VECTOR(tmpscore)[w] = 0;
             VECTOR(distance)[w] = 0;
             VECTOR(nrgeo)[w] = 0;
@@ -2332,8 +2337,8 @@ int igraph_edge_betweenness(const igraph_t *graph, igraph_vector_t *result,
  * \param directed Logical, if true directed paths will be considered
  *        for directed graphs. It is ignored for undirected graphs.
  * \param cutoff The maximal length of paths that will be considered.
- *        If zero or negative, the exact betweenness will be calculated
- *        (no upper limit on path lengths).
+ *        If negative, the exact betweenness will be calculated (no
+ *        upper limit on path lengths).
  * \param weights An optional weight vector for weighted
  *        betweenness. Supply a null pointer here for unweighted
  *        betweenness.
@@ -2418,11 +2423,6 @@ int igraph_edge_betweenness_estimate(const igraph_t *graph, igraph_vector_t *res
         IGRAPH_PROGRESS("Edge betweenness centrality: ", 100.0 * source / no_of_nodes, 0);
         IGRAPH_ALLOW_INTERRUPTION();
 
-        memset(distance, 0, (size_t) no_of_nodes * sizeof(long int));
-        memset(nrgeo, 0, (size_t) no_of_nodes * sizeof(unsigned long long int));
-        memset(tmpscore, 0, (size_t) no_of_nodes * sizeof(double));
-        igraph_stack_clear(&stack); /* it should be empty anyway... */
-
         IGRAPH_CHECK(igraph_dqueue_push(&q, source));
 
         nrgeo[source] = 1;
@@ -2431,9 +2431,15 @@ int igraph_edge_betweenness_estimate(const igraph_t *graph, igraph_vector_t *res
         while (!igraph_dqueue_empty(&q)) {
             long int actnode = (long int) igraph_dqueue_pop(&q);
 
-            if (cutoff > 0 && distance[actnode] >= cutoff ) {
+            if (cutoff >= 0 && distance[actnode] > cutoff ) {
+                /* Reset variables if node is too distant */
+                distance[actnode] = 0;
+                tmpscore[actnode] = 0;
+                nrgeo[actnode] = 0;
                 continue;
             }
+
+            IGRAPH_CHECK(igraph_stack_push(&stack, actnode));
 
             /* check the neighbors and add to them to the queue if unseen before */
             neip = igraph_inclist_get(elist_out_p, actnode);
@@ -2448,12 +2454,12 @@ int igraph_edge_betweenness_estimate(const igraph_t *graph, igraph_vector_t *res
                     if (distance[neighbor] == distance[actnode] + 1) {
                         nrgeo[neighbor] += nrgeo[actnode];
                     }
-                } else {
-                    /* we haven't seen this node yet */
+                } else if (distance[actnode] + 1 <= cutoff || cutoff < 0) {
+                    /* we haven't seen this node yet, but we only consider
+                     * it if it is not more distant than the cutoff. */
                     nrgeo[neighbor] += nrgeo[actnode];
                     distance[neighbor] = distance[actnode] + 1;
                     IGRAPH_CHECK(igraph_dqueue_push(&q, neighbor));
-                    IGRAPH_CHECK(igraph_stack_push(&stack, neighbor));
                 }
             }
         } /* while !igraph_dqueue_empty */
@@ -2464,9 +2470,11 @@ int igraph_edge_betweenness_estimate(const igraph_t *graph, igraph_vector_t *res
         while (!igraph_stack_empty(&stack)) {
             long int actnode = (long int) igraph_stack_pop(&stack);
             if (distance[actnode] < 1) {
+                distance[actnode] = 0;
+                tmpscore[actnode] = 0;
+                nrgeo[actnode] = 0;
                 continue;    /* skip source node */
             }
-
             /* set the temporary score of the friends */
             neip = igraph_inclist_get(elist_in_p, actnode);
             neino = igraph_vector_int_size(neip);
@@ -2484,6 +2492,10 @@ int igraph_edge_betweenness_estimate(const igraph_t *graph, igraph_vector_t *res
                         (tmpscore[actnode] + 1) * nrgeo[neighbor] / nrgeo[actnode];
                 }
             }
+            /* Reset variables */
+            distance[actnode] = 0;
+            tmpscore[actnode] = 0;
+            nrgeo[actnode] = 0;
         }
         /* Ok, we've the scores for this source */
     } /* for source <= no_of_nodes */


### PR DESCRIPTION
Similar to #1316 and as implemented in #1392, this changes the cutoff as used for `igraph_edge_beweenness`.

There are two changes in this PR. For `igraph_edge_betweenness` all vectors were always being cleared (unlike for `igraph_betweenness`), making the cutoff not problematic. This is changed, so that only the actually used nodes are being reset, similar to the implementation in `igraph_betweenness`. The resetting of these nodes is now correctly implemented, so that the cutoff works properly.

Secondly, the cutoff that is now used is consistent with the implementation in #1392, and considers all paths for which `distance <= cutoff`, as opposed to `distance < cutoff`, which it was before. Because of this, `cutoff = 0` is also used, and will return all zero results (this reverts #1050). When `cutff < 0`, no cutoff is used at all, and paths of all lengths are considered.