### PR TITLE
Corrected cutoff for closenes

### DIFF
--- a/examples/tests/igraph_closeness.c
+++ b/examples/tests/igraph_closeness.c
@@ -18,7 +18,7 @@ void simple_test_case_no_weights_undirected() {
 
     igraph_closeness_estimate(&g, &vector_actual_results /*store results here*/, 
                              /*calculating for all vectors in the graph*/ igraph_vss_all(), 
-                             IGRAPH_ALL  /*graph is "undirected"*/, /*cutoff*/ 0 /*calculating exact centrality*/, 
+                             IGRAPH_ALL  /*graph is "undirected"*/, /*cutoff*/ -1 /*calculating exact centrality*/,
                              NULL /*unweighted*/, /*not normalised*/ 0);
 
     printf("Non normalised results below\n");
@@ -28,7 +28,7 @@ void simple_test_case_no_weights_undirected() {
 
     igraph_closeness_estimate(&g, &vector_actual_results /*store results here*/, 
                              /*calculating for all vectors in the graph*/ igraph_vss_all(), 
-                             IGRAPH_ALL  /*graph is "undirected"*/, /*cutoff*/ 0 /*calculating exact centrality*/, 
+                             IGRAPH_ALL  /*graph is "undirected"*/, /*cutoff*/ -1 /*calculating exact centrality*/,
                              NULL, /*normalised*/ 1);
 
     printf("\nNormalised results below\n");
@@ -59,7 +59,7 @@ void simple_test_case_with_weights_undirected() {
 
     igraph_closeness_estimate(&g, &vector_actual_results /*store results here*/, 
                              /*calculating for all vectors in the graph*/ igraph_vss_all(), 
-                             IGRAPH_ALL  /*graph is "undirected"*/, /*cutoff*/ 0 /*calculating exact centrality*/, 
+                             IGRAPH_ALL  /*graph is "undirected"*/, /*cutoff*/ -1 /*calculating exact centrality*/,
                              &vector_weights, /*not normalised*/ 0);
  
     printf("Non normalised test below\n"); 
@@ -72,7 +72,7 @@ void simple_test_case_with_weights_undirected() {
 
     igraph_closeness_estimate(&g, &vector_actual_results /*store results here*/, 
                              /*calculating for all vectors in the graph*/ igraph_vss_all(), 
-                             IGRAPH_ALL  /*graph is "undirected"*/, /*cutoff*/ 0 /*calculating exact centrality*/, 
+                             IGRAPH_ALL  /*graph is "undirected"*/, /*cutoff*/ -1 /*calculating exact centrality*/,
                              &vector_weights, /*normalised*/ 1);
 
     print_vector(&vector_actual_results, stdout);
@@ -102,7 +102,7 @@ void advanced_test_case_no_weights_undirected() {
 
     igraph_closeness_estimate(&g, &vector_actual_results /*store results here*/, 
                              /*calculating for all vectors in the graph*/ igraph_vss_all(), 
-                             IGRAPH_ALL  /*graph is "undirected"*/, /*cutoff*/ 0 /*calculating exact centrality*/, 
+                             IGRAPH_ALL  /*graph is "undirected"*/, /*cutoff*/ -1 /*calculating exact centrality*/,
                              NULL, /*not normalised*/ 0);
 
     print_vector(&vector_actual_results, stdout);
@@ -113,7 +113,7 @@ void advanced_test_case_no_weights_undirected() {
 
     igraph_closeness_estimate(&g, &vector_actual_results /*store results here*/, 
                              /*calculating for all vectors in the graph*/ igraph_vss_all(), 
-                             IGRAPH_ALL  /*graph is "undirected"*/, /*cutoff*/ 0 /*calculating exact centrality*/, 
+                             IGRAPH_ALL  /*graph is "undirected"*/, /*cutoff*/ -1 /*calculating exact centrality*/,
                              NULL, /*normalised*/ 1);
 
     print_vector(&vector_actual_results, stdout);
@@ -147,7 +147,7 @@ void advanced_test_case_with_weights() {
 
     igraph_closeness_estimate(&g, &vector_actual_results /*store results here*/, 
                              /*calculating for all vectors in the graph*/ igraph_vss_all(), 
-                             IGRAPH_ALL  /*graph is "undirected"*/, /*cutoff*/ 0 /*calculating exact centrality*/, 
+                             IGRAPH_ALL  /*graph is "undirected"*/, /*cutoff*/ -1 /*calculating exact centrality*/,
                              &vector_weights, /*not normalised*/ 0);
 
     print_vector(&vector_actual_results, stdout);
@@ -159,7 +159,7 @@ void advanced_test_case_with_weights() {
 
     igraph_closeness_estimate(&g, &vector_actual_results /*store results here*/, 
                              /*calculating for all vectors in the graph*/ igraph_vss_all(), 
-                             IGRAPH_OUT  /*graph is "out directed"*/, /*cutoff*/ 0 /*calculating exact centrality*/, 
+                             IGRAPH_OUT  /*graph is "out directed"*/, /*cutoff*/ -1 /*calculating exact centrality*/,
                              &vector_weights, /*not normalised*/ 0);
 
     print_vector(&vector_actual_results, stdout);
@@ -170,7 +170,7 @@ void advanced_test_case_with_weights() {
 
     igraph_closeness_estimate(&g, &vector_actual_results /*store results here*/, 
                              /*calculating for all vectors in the graph*/ igraph_vss_all(), 
-                             IGRAPH_IN  /*graph is "in directed"*/, /*cutoff*/ 0 /*calculating exact centrality*/, 
+                             IGRAPH_IN  /*graph is "in directed"*/, /*cutoff*/ -1 /*calculating exact centrality*/,
                              &vector_weights, /*not normalised*/ 0);
 
     print_vector(&vector_actual_results, stdout); 

--- a/src/centrality.c
+++ b/src/centrality.c
@@ -2667,7 +2667,7 @@ static int igraph_i_closeness_estimate_weighted(const igraph_t *graph,
             VECTOR(*res)[i] += (mindist - 1.0);
             nodes_reached++;
 
-            if (cutoff > 0 && mindist >= cutoff + 1.0) {
+            if (cutoff >= 0 && mindist > cutoff + 1.0) {
                 continue;    /* NOT break!!! */
             }
 
@@ -2701,7 +2701,7 @@ static int igraph_i_closeness_estimate_weighted(const igraph_t *graph,
         VECTOR(*res)[i] += ((igraph_real_t)no_of_nodes * (no_of_nodes - nodes_reached));
         VECTOR(*res)[i] = (no_of_nodes - 1) / VECTOR(*res)[i];
 
-        if (((cutoff > 0 && mindist < cutoff + 1.0) || (cutoff <= 0)) &&
+        if (((cutoff >= 0 && mindist <= cutoff + 1.0) || (cutoff < 0)) &&
             nodes_reached < no_of_nodes && !warning_shown) {
             IGRAPH_WARNING("closeness centrality is not well-defined for disconnected graphs");
             warning_shown = 1;
@@ -2764,8 +2764,8 @@ static int igraph_i_closeness_estimate_weighted(const igraph_t *graph,
  *          undirected one for the computation.
  *        \endclist
  * \param cutoff The maximal length of paths that will be considered.
- *        If zero or negative, the exact closeness will be calculated
- *        (no upper limit on path lengths).
+ *        If negative, the exact closeness will be calculated (no upper
+ *        limit on path lengths).
  * \param weights An optional vector containing edge weights for
  *        weighted closeness. Supply a null pointer here for
  *        traditional, unweighted closeness.
@@ -2852,7 +2852,7 @@ int igraph_closeness_estimate(const igraph_t *graph, igraph_vector_t *res,
 
             VECTOR(*res)[i] += actdist;
 
-            if (cutoff > 0 && actdist >= cutoff) {
+            if (cutoff >= 0 && actdist > cutoff) {
                 continue;    /* NOT break!!! */
             }
 
@@ -2874,7 +2874,7 @@ int igraph_closeness_estimate(const igraph_t *graph, igraph_vector_t *res,
         VECTOR(*res)[i] += ((igraph_real_t)no_of_nodes * (no_of_nodes - nodes_reached));
         VECTOR(*res)[i] = (no_of_nodes - 1) / VECTOR(*res)[i];
 
-        if (((cutoff > 0 && actdist < cutoff) || cutoff <= 0) &&
+        if (((cutoff >= 0 && actdist <= cutoff) || cutoff < 0) &&
             no_of_nodes > nodes_reached && !warning_shown) {
             IGRAPH_WARNING("closeness centrality is not well-defined for disconnected graphs");
             warning_shown = 1;


### PR DESCRIPTION
Similar to #1316 and as implemented in #1392, this changes the cutoff as used for `igraph_closeness`.

Unlike for `igraph_betweenness`, the cutoff was not problematic for closeness.

The cutoff that is now used is consistent with the implementation in #1392, and considers all paths for which `distance <= cutoff`, as opposed to `distance < cutoff`, which it was before. Because of this, `cutoff = 0` is also used, and will return all zero results (this reverts #1050). When `cutff < 0`, no cutoff is used at all, and paths of all lengths are considered.