### PR TITLE
Added Leiden algorithm to functions.def

### DIFF
--- a/interfaces/functions.def
+++ b/interfaces/functions.def
@@ -1370,6 +1370,15 @@ igraph_community_optimal_modularity:
         NAME-R: cluster_optimal
         IGNORE: RR
 
+igraph_community_leiden:
+        PARAMS: GRAPH graph, EDGEWEIGHTS weights=NULL, \
+                VERTEXWEIGHTS vertex_weights=NULL, \
+                REAL resolution_parameter, REAL beta, \
+                BOOLEAN start, INOUT VECTOR_OR_0 membership, \
+                OUT INTEGERPTR nb_clusters, OUT REALPTR quality
+        NAME-R: cluster_leiden
+        IGNORE: RR
+
 igraph_split_join_distance:
         PARAMS: VECTOR comm1, VECTOR comm2, OUT INTEGERPTR distance12, \
 		        OUT INTEGERPTR distance21


### PR DESCRIPTION
In order to make the Leiden algorithm available in R the function still needed to be added to `functions.def`. This is done in this PR. I used a branch on the main repository, so that the PR in the `rigraph` repository can immediately use this commit, see https://github.com/igraph/rigraph/pull/399 for the PR for the R interface. 

That PR now currently points to this commit. I think that after we merge the commit reference will remain the same, or not? I'm not 100% sure. If it remains the same, we can simply merge this without any problems.