### PR TITLE
Removed internal functions from public header for heap

### DIFF
--- a/include/igraph_heap_pmt.h
+++ b/include/igraph_heap_pmt.h
@@ -37,9 +37,3 @@ DECLDIR BASE FUNCTION(igraph_heap, top)(TYPE(igraph_heap)* h);
 DECLDIR BASE FUNCTION(igraph_heap, delete_top)(TYPE(igraph_heap)* h);
 DECLDIR long int FUNCTION(igraph_heap, size)(TYPE(igraph_heap)* h);
 DECLDIR int FUNCTION(igraph_heap, reserve)(TYPE(igraph_heap)* h, long int size);
-
-void FUNCTION(igraph_heap, i_build)(BASE* arr, long int size, long int head);
-void FUNCTION(igraph_heap, i_shift_up)(BASE* arr, long int size, long int elem);
-void FUNCTION(igraph_heap, i_sink)(BASE* arr, long int size, long int head);
-void FUNCTION(igraph_heap, i_switch)(BASE* arr, long int e1, long int e2);
-

--- a/src/heap.pmt
+++ b/src/heap.pmt
@@ -33,6 +33,12 @@
 #define LEFTCHILD(x)  (((x)+1)*2-1)
 #define RIGHTCHILD(x) (((x)+1)*2)
 
+/* Define internal functions */
+void FUNCTION(igraph_heap, i_build)(BASE* arr, long int size, long int head);
+void FUNCTION(igraph_heap, i_shift_up)(BASE* arr, long int size, long int elem);
+void FUNCTION(igraph_heap, i_sink)(BASE* arr, long int size, long int head);
+void FUNCTION(igraph_heap, i_switch)(BASE* arr, long int e1, long int e2);
+
 /**
  * \ingroup heap
  * \function igraph_heap_init


### PR DESCRIPTION
This PR moves the declaration of some internal functions (that are clearly marked for internal use) of the `heap` type to the source file. This is line with the earlier [comment](https://github.com/igraph/igraph/pull/1425#issuecomment-652496090) by @szhorvat:

> If it's in the public headers, it should be exported, regardless of whether it's documented or not. If it really not appropriate to export it, it should probably removed from the public headers and added to the private one instead.

I think this is a good suggestion, and that we should generally follow this.