### PR TITLE
First stub with igraph_set_t

### DIFF
--- a/include/igraph_set.h
+++ b/include/igraph_set.h
@@ -1,0 +1,73 @@
+/* -*- mode: C -*-  */
+/*
+   IGraph library.
+   Copyright (C) 2009-2012  Gabor Csardi <csardi.gabor@gmail.com>
+   334 Harvard street, Cambridge, MA 02139 USA
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc.,  51 Franklin Street, Fifth Floor, Boston, MA
+   02110-1301 USA
+
+*/
+
+#ifndef IGRAPH_SET_H
+#define IGRAPH_SET_H
+
+#include "igraph_types.h"
+#include "igraph_decls.h"
+
+__BEGIN_DECLS
+
+/* -------------------------------------------------- */
+/* set containing items regardless of order           */
+/* -------------------------------------------------- */
+
+#define BASE_IGRAPH_REAL
+#include "igraph_pmt.h"
+#include "igraph_set_pmt.h"
+#include "igraph_pmt_off.h"
+#undef BASE_IGRAPH_REAL
+
+#define BASE_LONG
+#include "igraph_pmt.h"
+#include "igraph_set_pmt.h"
+#include "igraph_pmt_off.h"
+#undef BASE_LONG
+
+#define BASE_CHAR
+#include "igraph_pmt.h"
+#include "igraph_set_pmt.h"
+#include "igraph_pmt_off.h"
+#undef BASE_CHAR
+
+#define BASE_BOOL
+#include "igraph_pmt.h"
+#include "igraph_set_pmt.h"
+#include "igraph_pmt_off.h"
+#undef BASE_BOOL
+
+#define BASE_INT
+#include "igraph_pmt.h"
+#include "igraph_set_pmt.h"
+#include "igraph_pmt_off.h"
+#undef BASE_INT
+
+#define IGRAPH_SET_NULL { 0,0,0 }
+#define IGRAPH_SET_INIT_FINALLY(v, size) \
+    do { IGRAPH_CHECK(igraph_set_init(v, size)); \
+        IGRAPH_FINALLY(igraph_set_destroy, v); } while (0)
+
+__END_DECLS
+
+#endif

--- a/include/igraph_set_pmt.h
+++ b/include/igraph_set_pmt.h
@@ -1,0 +1,46 @@
+/* -*- mode: C -*-  */
+/*
+   IGraph library.
+   Copyright (C) 2007-2012  Gabor Csardi <csardi.gabor@gmail.com>
+   334 Harvard street, Cambridge, MA 02139 USA
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc.,  51 Franklin Street, Fifth Floor, Boston, MA
+   02110-1301 USA
+
+*/
+
+/**
+ * Set containing items regardless of the order
+ * \ingroup types
+ */
+
+typedef struct TYPE(igraph_set) {
+    BASE *stor_begin;
+    BASE *stor_end;
+    BASE *end;
+} TYPE(igraph_set);
+
+DECLDIR int FUNCTION(igraph_set, init)      (TYPE(igraph_set)* set, long int size);
+DECLDIR void FUNCTION(igraph_set, destroy)   (TYPE(igraph_set)* set);
+DECLDIR igraph_bool_t FUNCTION(igraph_set, inited)   (TYPE(igraph_set)* set);
+DECLDIR int FUNCTION(igraph_set, reserve)   (TYPE(igraph_set)* set, long int size);
+DECLDIR igraph_bool_t FUNCTION(igraph_set, empty)     (const TYPE(igraph_set)* set);
+DECLDIR void FUNCTION(igraph_set, clear)      (TYPE(igraph_set)* set);
+DECLDIR long int FUNCTION(igraph_set, size)      (const TYPE(igraph_set)* set);
+DECLDIR int FUNCTION(igraph_set, add) (TYPE(igraph_set)* v, igraph_integer_t e);
+DECLDIR igraph_bool_t FUNCTION(igraph_set, contains) (TYPE(igraph_set)* set, igraph_integer_t e);
+DECLDIR igraph_bool_t FUNCTION(igraph_set, iterate) (TYPE(igraph_set)* set, long int* state,
+                                  igraph_integer_t* element);
+

--- a/src/igraph_set.c
+++ b/src/igraph_set.c
@@ -22,6 +22,7 @@
 */
 
 #include "igraph_types.h"
+#include "igraph_set.h"
 #include "igraph_memory.h"
 #include "igraph_error.h"
 #include "igraph_types_internal.h"

--- a/src/igraph_types_internal.h
+++ b/src/igraph_types_internal.h
@@ -343,37 +343,6 @@ int igraph_i_cutheap_update(igraph_i_cutheap_t *ch, igraph_integer_t index,
                             igraph_real_t add);
 int igraph_i_cutheap_reset_undefine(igraph_i_cutheap_t *ch, long int vertex);
 
-/* -------------------------------------------------- */
-/* Flexible set                                       */
-/* -------------------------------------------------- */
-
-/**
- * Set containing integer numbers regardless of the order
- * \ingroup types
- */
-
-typedef struct s_set {
-    igraph_integer_t* stor_begin;
-    igraph_integer_t* stor_end;
-    igraph_integer_t* end;
-} igraph_set_t;
-
-#define IGRAPH_SET_NULL { 0,0,0 }
-#define IGRAPH_SET_INIT_FINALLY(v, size) \
-    do { IGRAPH_CHECK(igraph_set_init(v, size)); \
-        IGRAPH_FINALLY(igraph_set_destroy, v); } while (0)
-
-int igraph_set_init      (igraph_set_t* set, long int size);
-void igraph_set_destroy   (igraph_set_t* set);
-igraph_bool_t igraph_set_inited   (igraph_set_t* set);
-int igraph_set_reserve   (igraph_set_t* set, long int size);
-igraph_bool_t igraph_set_empty     (const igraph_set_t* set);
-void igraph_set_clear      (igraph_set_t* set);
-long int igraph_set_size      (const igraph_set_t* set);
-int igraph_set_add (igraph_set_t* v, igraph_integer_t e);
-igraph_bool_t igraph_set_contains (igraph_set_t* set, igraph_integer_t e);
-igraph_bool_t igraph_set_iterate (igraph_set_t* set, long int* state,
-                                  igraph_integer_t* element);
 
 /* -------------------------------------------------- */
 /* Vectorlist, fixed length                           */


### PR DESCRIPTION
We [recently](https://igraph.discourse.group/t/data-structure-type-usage-and-visibility/316/3) discussed the possibility of exposing and documenting a bunch of internal types.

This PR is bringing that discussion forth, currently with a single example of `igraph_set_t`.

Seems like for each type one has to:
- make a `igraph_<type>.h` file by copying from another type
- make a `igraph_<type>_pmt.h` file by moving and adapting what's currently in `igraph_types_internal.h`
- change the header include in the implementation file
- add documentation if needed.

What do you guys think? Shall we make a list or abandon this PR until 1.0?