### PR TITLE
Gcc warnings

### DIFF
--- a/src/centrality.c
+++ b/src/centrality.c
@@ -2622,7 +2622,8 @@ static int igraph_i_closeness_estimate_weighted(const igraph_t *graph,
 
     int cmp_result;
     const double eps = IGRAPH_SHORTEST_PATH_EPSILON;
-    igraph_real_t mindist;
+
+    igraph_real_t mindist = 0;
 
     igraph_bool_t warning_shown = 0;
 
@@ -2807,8 +2808,9 @@ int igraph_closeness_estimate(const igraph_t *graph, igraph_vector_t *res,
     igraph_vector_int_t *neis;
     long int i, j;
     long int nodes_reached;
-    long int actdist;
     igraph_adjlist_t allneis;
+
+    long int actdist = 0;
 
     igraph_dqueue_t q;
 

--- a/src/lad.c
+++ b/src/lad.c
@@ -701,7 +701,7 @@ static int igraph_i_lad_updateMatching(int sizeOfU, int sizeOfV,
                  vertex of U in the DAG */
     int *listV, *listU, *listDV, *listDU;
     int nbV, nbU, nbDV, nbDU;
-    int i, j, k, stop, u, v, w;
+    int i, j, k, stop, u, v;
     int *markedV, *markedU;
     /* markedX[i]=white if X[i] is not in the DAG
        markedX[i]=grey if X[i] has been added to the DAG, but not its successors
@@ -894,7 +894,6 @@ static int igraph_i_lad_updateMatching(int sizeOfU, int sizeOfV,
                 while (igraph_vector_int_size(&path) > 1) {
                     u = igraph_vector_int_pop_back(&path);
                     v = igraph_vector_int_pop_back(&path);
-                    w = matchedWithV[v]; /* match v with u instead of v with w */
                     VECTOR(*matchedWithU)[u] = v;
                     matchedWithV[v] = u;
                 }

--- a/src/layout_fr.c
+++ b/src/layout_fr.c
@@ -47,7 +47,7 @@ static int igraph_layout_i_fr(const igraph_t *graph,
     igraph_real_t difftemp = start_temp / niter;
     float width = sqrtf(no_nodes), height = width;
     igraph_bool_t conn = 1;
-    float C;
+    float C = 0;
 
     igraph_is_connected(graph, &conn, IGRAPH_WEAK);
     if (!conn) {
@@ -501,7 +501,7 @@ int igraph_layout_fruchterman_reingold_3d(const igraph_t *graph,
     igraph_real_t difftemp = start_temp / niter;
     float width = sqrtf(no_nodes), height = width, depth = width;
     igraph_bool_t conn = 1;
-    float C;
+    float C = 0;
 
     if (niter < 0) {
         IGRAPH_ERROR("Number of iterations must be non-negative in "

--- a/src/paths.c
+++ b/src/paths.c
@@ -74,7 +74,7 @@ int igraph_get_all_simple_paths(const igraph_t *graph,
     igraph_vector_int_t stack, dist;
     igraph_vector_char_t added;
     igraph_vector_int_t nptr;
-    int iteration;
+    int iteration = 0;
 
     if (from < 0 || from >= no_nodes) {
         IGRAPH_ERROR("Invalid starting vertex", IGRAPH_EINVAL);

--- a/src/scg.c
+++ b/src/scg.c
@@ -903,7 +903,6 @@ int igraph_scg_norm_eps(const igraph_matrix_t *V,
                         igraph_scg_norm_t norm) {
 
     int no_of_nodes = (int) igraph_vector_size(groups);
-    int no_of_groups;
     int no_of_vectors = (int) igraph_matrix_ncol(V);
     igraph_real_t min, max;
     igraph_sparsemat_t Lsparse, Rsparse, Lsparse2, Rsparse2, Rsparse3, proj;
@@ -916,7 +915,6 @@ int igraph_scg_norm_eps(const igraph_matrix_t *V,
     }
 
     igraph_vector_minmax(groups, &min, &max);
-    no_of_groups = (int) max + 1;
 
     if (min < 0 || max >= no_of_nodes) {
         IGRAPH_ERROR("Invalid membership vector", IGRAPH_EINVAL);

--- a/src/triangles_template.h
+++ b/src/triangles_template.h
@@ -22,13 +22,24 @@
 
 */
 
+#ifdef TRANSIT
+#define TRANSIT_TRIEDGES
+#endif
+#ifdef TRIEDGES
+#define TRANSIT_TRIEDGES
+#endif
+
 long int no_of_nodes = igraph_vcount(graph);
 long int node, i, j, nn;
 igraph_adjlist_t allneis;
 igraph_vector_int_t *neis1, *neis2;
-long int neilen1, neilen2, deg1;
+long int neilen1, neilen2;
 long int *neis;
 long int maxdegree;
+
+#ifdef TRANSIT_TRIEDGES
+long int deg1;
+#endif
 
 igraph_vector_int_t order;
 igraph_vector_int_t rank;
@@ -72,7 +83,11 @@ for (nn = no_of_nodes - 1; nn >= 0; nn--) {
 
     neis1 = igraph_adjlist_get(&allneis, node);
     neilen1 = igraph_vector_int_size(neis1);
+
+#ifdef TRANSIT_TRIEDGES
     deg1 = (long int) VECTOR(degree)[node];
+#endif
+
     /* Mark the neighbors of the node */
     for (i = 0; i < neilen1; i++) {
         neis[ (long int) VECTOR(*neis1)[i] ] = node + 1;
@@ -116,3 +131,7 @@ igraph_vector_int_destroy(&rank);
 igraph_vector_destroy(&degree);
 igraph_vector_int_destroy(&order);
 IGRAPH_FINALLY_CLEAN(5);
+
+#ifdef TRANSIT_TRIEDGES
+#undef TRANSIT_TRIEDGES
+#endif


### PR DESCRIPTION
Addressing issue #297.

There are quite a few more warnings, but they are related to dependencies (f2c or lapack in particular). Probably not going to fix those.

Also, the fix for `triangles_template.h` is a little questionable - a sometimes unused variable is now defined under an `#ifdef`. Suggestions to improve that one are welcome.