### PR TITLE
Check for int overflow in edge_betweenness

### DIFF
--- a/include/igraph_error.h
+++ b/include/igraph_error.h
@@ -328,6 +328,7 @@ DECLDIR igraph_error_handler_t* igraph_set_error_handler(igraph_error_handler_t*
  * \enumval IGRAPH_CPUTIME CPU time exceeded.
  * \enumval IGRAPH_EUNDERFLOW Integer or double underflow.
  * \enumval IGRAPH_ERWSTUCK Random walk got stuck.
+ * \enumval IGRAPH_EINTOVERFLOW Integer overflow
  */
 
 typedef enum {
@@ -390,7 +391,8 @@ typedef enum {
     IGRAPH_CPUTIME           = 57,
     IGRAPH_EUNDERFLOW        = 58,
     IGRAPH_ERWSTUCK          = 59,
-    IGRAPH_STOP              = 60  /* undocumented, used internally; signals a request to stop in functions like igraph_i_maximal_cliques_bk */
+    IGRAPH_STOP              = 60,  /* undocumented, used internally; signals a request to stop in functions like igraph_i_maximal_cliques_bk */
+    IGRAPH_EINTOVERFLOW      = 61
 } igraph_error_type_t;
 /* Each enum value above must have a corresponding error string in
  * igraph_i_error_strings[] in igraph_error.c */

--- a/src/centrality.c
+++ b/src/centrality.c
@@ -2450,12 +2450,21 @@ int igraph_edge_betweenness_estimate(const igraph_t *graph, igraph_vector_t *res
                 if (nrgeo[neighbor] != 0) {
                     /* we've already seen this node, another shortest path? */
                     if (distance[neighbor] == distance[actnode] + 1) {
-                        nrgeo[neighbor] += nrgeo[actnode];
+                        /* check for overflow */
+                        unsigned long long int tot = nrgeo[neighbor] + nrgeo[actnode];
+                        if (tot < nrgeo[neighbor]) {
+                            IGRAPH_ERROR("unsigned long long int overflow in geodesics", IGRAPH_EINTOVERFLOW);
+                        }
+                        nrgeo[neighbor] = tot;
                     }
                 } else if (distance[actnode] + 1 <= cutoff || cutoff < 0) {
                     /* we haven't seen this node yet, but we only consider
                      * it if it is not more distant than the cutoff. */
-                    nrgeo[neighbor] += nrgeo[actnode];
+                    unsigned long long int tot = nrgeo[neighbor] + nrgeo[actnode];
+                    if (tot < nrgeo[neighbor]) {
+                        IGRAPH_ERROR("unsigned long long int overflow in geodesics", IGRAPH_EINTOVERFLOW);
+                    }
+                    nrgeo[neighbor] = tot;
                     distance[neighbor] = distance[actnode] + 1;
                     IGRAPH_CHECK(igraph_dqueue_push(&q, neighbor));
                 }

--- a/src/community.c
+++ b/src/community.c
@@ -549,11 +549,19 @@ int igraph_community_edge_betweenness(const igraph_t *graph,
                         if (nrgeo[neighbor] != 0) {
                             /* we've already seen this node, another shortest path? */
                             if (distance[neighbor] == distance[actnode] + 1) {
-                                nrgeo[neighbor] += nrgeo[actnode];
+                                unsigned long long int tot = nrgeo[neighbor] + nrgeo[actnode];
+                                if (tot < nrgeo[neighbor]) {
+                                    IGRAPH_ERROR("unsigned long long int overflow in geodesics", IGRAPH_EINTOVERFLOW);
+                                }
+                                nrgeo[neighbor] = tot;
                             }
                         } else {
                             /* we haven't seen this node yet */
-                            nrgeo[neighbor] += nrgeo[actnode];
+                            unsigned long long int tot = nrgeo[neighbor] + nrgeo[actnode];
+                            if (tot < nrgeo[neighbor]) {
+                                IGRAPH_ERROR("unsigned long long int overflow in geodesics", IGRAPH_EINTOVERFLOW);
+                            }
+                            nrgeo[neighbor] = tot;
                             distance[neighbor] = distance[actnode] + 1;
                             IGRAPH_CHECK(igraph_dqueue_push(&q, neighbor));
                             IGRAPH_CHECK(igraph_stack_push(&stack, neighbor));
@@ -638,9 +646,13 @@ int igraph_community_edge_betweenness(const igraph_t *graph,
                             IGRAPH_CHECK(igraph_2wheap_modify(&heap, to, -altdist));
                         } else if (altdist == curdist - 1) {
                             /* Another path with the same length */
+                            unsigned long long int tot = nrgeo[to] + nrgeo[minnei];
+                            if (tot < nrgeo[to]) {
+                                IGRAPH_ERROR("unsigned long long int overflow in geodesics", IGRAPH_EINTOVERFLOW);
+                            }
+                            nrgeo[to] = tot;
                             v = igraph_inclist_get(&fathers, to);
                             igraph_vector_int_push_back(v, edge);
-                            nrgeo[to] += nrgeo[minnei];
                         }
                     }
                 } /* igraph_2wheap_empty(&Q) */


### PR DESCRIPTION
Addressing #51 

Problems found:
 - [x] `edge_betweenness`
 - [ ] `betweenness` is already using doubles... is that alright??
 - [x] `community_edge_betweenness`

There are no other instances of `unsigned long long int` or `unsigned long int` or `long long int` in the `src` folder, so I take it that these should be the only two obvious cases.

Is that fine that the `betweenness` is using doubles?