### PR TITLE
Add search box to html C manual

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -223,8 +223,10 @@ graphlets.xml: graphlets.xxml $(SRCDIR)/glet.c
 
 html/stamp: igraph-docs0.xml $(DOCFIX2) gtk-doc.xsl
 	if [ "x$(top_srcdir)" != "x$(top_builddir)" ]; then cp $(DOCFIX2) . ; fi && \
-	xmlto -x $(top_srcdir)/doc/gtk-doc.xsl -o html xhtml igraph-docs0.xml \
-	&& touch html/stamp
+	xmlto -x $(top_srcdir)/doc/gtk-doc.xsl -o html xhtml igraph-docs0.xml && \
+	sed -i "/class=\"toc\"/i `cat $(top_srcdir)/doc/search_box.html`" $(top_srcdir)/doc/html/index.html
+
+	touch html/stamp
 
 jekyll/stamp: html/stamp
 	rm -rf jekyll && mkdir jekyll && cp html/* jekyll/ && rm jekyll/stamp

--- a/doc/doxrox.py
+++ b/doc/doxrox.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2.7
 
 #   IGraph R package
 #   Copyright (C) 2005-2012  Gabor Csardi <csardi.gabor@gmail.com>

--- a/doc/igraph-docs.xml
+++ b/doc/igraph-docs.xml
@@ -30,7 +30,7 @@
       </affiliation>
       </author>
 
-      </author><firstname>Vincent</firstname><surname>Traag</surname>
+      <author><firstname>Vincent</firstname><surname>Traag</surname>
       <affiliation>
       <orgname>Centre for Science and Technology Studies, Leiden University</orgname>
       <address>Room B5.31, Kolffpad 1, 2333 BN Leiden, Netherlands</address>

--- a/doc/igraph-docs.xml
+++ b/doc/igraph-docs.xml
@@ -17,15 +17,37 @@
     <releaseinfo>&version;</releaseinfo>
     <authorgroup>
       <author><firstname>Gábor</firstname><surname>Csárdi</surname>
-      <affiliation><orgname>Department of Statistics, Harvard University
-    </orgname>
+      <affiliation>
+      <orgname>Department of Statistics, Harvard University</orgname>
       <address>1 Oxford street, Cambridge, MA, 02138 USA</address>
       </affiliation>
       </author>
+
       <author><firstname>Tamás</firstname><surname>Nepusz</surname>
-      <affiliation><orgname>Department of Biological Physics,
-      Eötvös University</orgname>
+      <affiliation>
+      <orgname>Department of Biological Physics, Eötvös University</orgname>
       <address>1/a Pázmány Péter sétány, 1117 Budapest, Hungary</address>
+      </affiliation>
+      </author>
+
+      </author><firstname>Vincent</firstname><surname>Traag</surname>
+      <affiliation>
+      <orgname>Centre for Science and Technology Studies, Leiden University</orgname>
+      <address>Room B5.31, Kolffpad 1, 2333 BN Leiden, Netherlands</address>
+      </affiliation>
+      </author>
+
+      <author><firstname>Szabolcs</firstname><surname>Horvát</surname>
+      <affiliation>
+      <orgname>Center for Systems Biology Dresden</orgname>
+      <address>Room 115, Pfotenhauerstr. 108, 01307 Dresden, Germany</address>
+      </affiliation>
+      </author>
+
+      <author><firstname>Fabio</firstname><surname>Zanini</surname>
+      <affiliation>
+      <orgname>Lowy Cancer Research Centre, University of New South Wales</orgname>
+      <address>Room 211, Botany and High St, Kensington, NSW, 2033, Australia</address>
       </affiliation>
       </author>
     </authorgroup>
@@ -34,7 +56,8 @@
       <para>This manual is for &igraph;, version &version;.</para>
 
       <para>
-      Copyright (C) 2005-2020 Gábor Csárdi and Tamás Nepusz.
+      Copyright (C) 2005-2019 Gábor Csárdi and Tamás Nepusz.
+      Copyright (C) 2020 igraph development team.
       Permission is granted to copy, distribute and/or modify this document
       under the terms of the GNU Free Documentation License, Version 1.2
       or any later version published by the Free Software Foundation;

--- a/doc/search_box.html
+++ b/doc/search_box.html
@@ -1,0 +1,1 @@
+<script async src="https://cse.google.com/cse.js?cx=002857573326368977024:vrx_-4dpms0"></script><div class="gcse-search"></div>


### PR DESCRIPTION
I added an additional filter with sed to the docs `Makefile.am` such that only in the html version, a customized google search box for the C manual is inserted before the table of contents.

That should partially address (for now) the lack of searchability of the docs.

I also renamed the shebang in the custom python filter to use python2.7. Notice that is past end of life, so we should do something about that within a year or so.

I also added Vincent, Szabolcs and myself to the list of authors. @gaborcsardi and @ntamas , you might want to update your affiliations. If so please push to this PR or just write in the comments and I'll update them.