### PR TITLE
Memory and error handling in Leiden algorithm

### DIFF
--- a/src/community_leiden.c
+++ b/src/community_leiden.c
@@ -1046,8 +1046,8 @@ int igraph_community_leiden(const igraph_t *graph,
         if (i_edge_weights == 0) {
             IGRAPH_ERROR("Leiden algorithm failed, could not allocate memory for edge weights", IGRAPH_ENOMEM);
         }
-        IGRAPH_CHECK(igraph_vector_init(i_edge_weights, igraph_ecount(graph)));
         IGRAPH_FINALLY(igraph_free, i_edge_weights);
+        IGRAPH_CHECK(igraph_vector_init(i_edge_weights, igraph_ecount(graph)));
         IGRAPH_FINALLY(igraph_vector_destroy, i_edge_weights);
         igraph_vector_fill(i_edge_weights, 1);
     } else {
@@ -1060,8 +1060,8 @@ int igraph_community_leiden(const igraph_t *graph,
         if (i_node_weights == 0) {
             IGRAPH_ERROR("Leiden algorithm failed, could not allocate memory for node weights", IGRAPH_ENOMEM);
         }
-        IGRAPH_CHECK(igraph_vector_init(i_node_weights, n));
         IGRAPH_FINALLY(igraph_free, i_node_weights);
+        IGRAPH_CHECK(igraph_vector_init(i_node_weights, n));
         IGRAPH_FINALLY(igraph_vector_destroy, i_node_weights);
         igraph_vector_fill(i_node_weights, 1);
     } else {

--- a/src/community_leiden.c
+++ b/src/community_leiden.c
@@ -610,16 +610,19 @@ static int igraph_i_community_leiden_aggregate(
 
     }
 
-    IGRAPH_CHECK(igraph_create(aggregated_graph, &aggregated_edges, nb_refined_clusters,
-                               IGRAPH_UNDIRECTED));
-
     igraph_vector_destroy(&neighbor_clusters);
     igraph_vector_bool_destroy(&neighbor_cluster_added);
     igraph_vector_destroy(&edge_weight_to_cluster);
-    igraph_vector_destroy(&aggregated_edges);
     igraph_vector_ptr_destroy_all(&refined_clusters);
 
-    IGRAPH_FINALLY_CLEAN(5);
+    IGRAPH_FINALLY_CLEAN(4);
+
+    IGRAPH_CHECK(igraph_create(aggregated_graph, &aggregated_edges, nb_refined_clusters,
+                               IGRAPH_UNDIRECTED));
+
+    igraph_vector_destroy(&aggregated_edges);
+
+    IGRAPH_FINALLY_CLEAN(1);
 
     return IGRAPH_SUCCESS;
 }


### PR DESCRIPTION
This PR may addresses some issues around memory allocation and error handling that might be causing some problem that were identified in #1435. 

The first commit already releases some chunk of memory before allocating an additional chunk of memory, thereby decreasing the overall memory footprint.

The second commit changes the order of an `IGRAPH_FINALLY(igraph_Free, ...)` and the initialization of a vector. In the current code, it might be that the memory to create the vector itself was not allocated, in which case the vector might have been incorrectly attempted to be initalised. This is now corrected.

However, I believe there is an issue with the way that FINALLY error handling currently works. As it stands, it is implemented as a stack, meaning that the last one to be pushed on should be the first one to be popped off. However, this is not the case in the Leiden algorithm I notice (and it might also not be the case elsewhere). In particular, the Leiden algorithm uses something as follows:

```c
do {

    /* Get incidence list for fast iteration */
    IGRAPH_CHECK(igraph_inclist_init(aggregated_graph, &edges_per_node, IGRAPH_ALL));
    IGRAPH_FINALLY(igraph_inclist_destroy, &edges_per_node);

    ...

    /* Allocate temporary graph */
    tmp_graph = igraph_Calloc(1, igraph_t);
    if (tmp_graph == 0) {
        IGRAPH_ERROR("Leiden algorithm failed, could not allocate memory for aggregate graph", IGRAPH_ENOMEM);
    }
    IGRAPH_FINALLY(igraph_free, tmp_graph);

    IGRAPH_CHECK(igraph_i_community_leiden_aggregate(
                        aggregated_graph, &edges_per_node, aggregated_edge_weights, aggregated_node_weights,
                        aggregated_membership, &refined_membership, nb_refined_clusters,
                        tmp_graph, &tmp_edge_weights, &tmp_node_weights, &tmp_membership));

    /* Graph has been created by aggregation, ensure it is properly destroyed if
        * an error occurs. */
    IGRAPH_FINALLY(igraph_destroy, tmp_graph);

    if (level >= 1) {
        /* Destroy previously allocated graph (note that aggregated_graph points to
            * the previously allocated tmp_graph). */
        igraph_destroy(aggregated_graph);
        igraph_Free(aggregated_graph);
        IGRAPH_FINALLY_CLEAN(2);
    }

    /* Set the aggregated graph correctly */
    aggregated_graph = tmp_graph;    

    ...

    /* We are done iterating, so we destroy the incidence list */
    igraph_inclist_destroy(&edges_per_node);
    IGRAPH_FINALLY_CLEAN(1);
} while (continue_clustering);
```
(Here, the `...` indicate some code that is nonessential for this discussion).

The problem now is the following. What gets pushed on the stack is (in this order):
1. `igraph_inclist_destroy(&edges_per_node)` 
2. `igraph_free(tmp_graph)`
3. `igraph_destroy(tmp_graph)`

The last line that cleans one `FINALLY`, meaning the last one is popped off the stack, meaning the stack will read
1. `igraph_inclist_destroy(&edges_per_node)` 
2. `igraph_free(tmp_graph)`

When the `do .. while` loop continues in its next iteration, it will become
1. `igraph_inclist_destroy(&edges_per_node)` 
2. `igraph_free(tmp_graph)`
3. `igraph_inclist_destroy(&edges_per_node)` 
4. `igraph_free(tmp_graph2)`
5. `igraph_destroy(tmp_graph2)`

(here `tmp_graph2` refers to a newly allocated `igraph_t` object), and the last two will be popped off (when destroying `tmp_graph`), so that the FINALLY stack becomes
1. `igraph_inclist_destroy(&edges_per_node)` 
2. `igraph_free(tmp_graph)`
3. `igraph_inclist_destroy(&edges_per_node)` 

after which the last one is correctly popped off.

This explains the error with the `inclist` being destroyed when an out-of-memory error occurs (which I noted [here](https://github.com/igraph/igraph/issues/1435#issuecomment-656919699)). While executing everything from the FINALLY` stack, the `igraph_inclist_destroy(&edges_per_node)` is on the stack one time too many (and some graph objects are actually not properly destroyed).

I have been thinking of finding a way to rewrite this part without causing a problem, but I'm afraid I don't see an easy solution. Do you have any idea whether this problem might occur more often? Does anybody have any suggestion for how to solve this problem?