### PR TITLE
igraph_i_dfs

### DIFF
--- a/include/igraph_visitor.h
+++ b/include/igraph_visitor.h
@@ -85,7 +85,8 @@ DECLDIR int igraph_bfs(const igraph_t *graph,
                igraph_vector_t *dist, igraph_bfshandler_t *callback,
                void *extra);
 
-int igraph_i_bfs(igraph_t *graph, igraph_integer_t vid, igraph_neimode_t mode,
+int igraph_i_bfs(igraph_t *graph, igraph_integer_t vid,
+                 igraph_neimode_t mode,
                  igraph_vector_t *vids, igraph_vector_t *layers,
                  igraph_vector_t *parents);
 
@@ -126,6 +127,11 @@ DECLDIR int igraph_dfs(const igraph_t *graph, igraph_integer_t root,
                igraph_vector_t *dist, igraph_dfshandler_t *in_callback,
                igraph_dfshandler_t *out_callback,
                void *extra);
+
+int igraph_i_dfs(igraph_t *graph, igraph_integer_t vid,
+                 igraph_neimode_t mode,
+                 igraph_vector_t *vids,
+                 igraph_vector_t *parents);
 
 __END_DECLS
 


### PR DESCRIPTION
I'm trying to implement depth first search in the Python interface copying from breath first.

Python-level BFS uses the C core `igraph_i_bfs` function, which is a quicker and less flexible version of `igraph_bfs`.

We don't have an equivalent `igraph_i_dfs` function.

This PR aims initially at providing the latter function for internal use and for use in the Python interface. Depending on the feedback received, that scope might expand into a slightly deeper redesign of both visitor functions.

Either way, efficient traversal functions are essential to both `igraph` and its high-level interfaces, so this is quite useful I think.