### PR TITLE
Changed Leiden algorithm test code to avoid rounding errors.

### DIFF
--- a/examples/tests/igraph_community_leiden.c
+++ b/examples/tests/igraph_community_leiden.c
@@ -159,7 +159,8 @@ int main() {
 
     /* Ring graph with loop edges */
     igraph_small(&graph, 6, IGRAPH_UNDIRECTED,
-                 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 0, 0, 0, 2, 2, -1);
+                 0,1, 1,2, 2,3, 3,4, 4,5, 5,0,
+                 0,0, 1,1, 2,2, 3,3, 4,4, 5,5, -1);
     run_leiden_modularity(&graph, NULL);
     igraph_destroy(&graph);
 

--- a/examples/tests/igraph_community_leiden.out
+++ b/examples/tests/igraph_community_leiden.out
@@ -28,8 +28,8 @@ Membership: 0 0 0 0 0 0 0 0 0 0 1 1 1 1 1 1 1 1 1 1
 Leiden found 10 clusters using modularity, quality is nan.
 Membership: 0 1 2 3 4 5 6 7 8 9
 
-Leiden found 3 clusters using modularity, quality is 0.2812.
-Membership: 0 0 1 1 2 2
+Leiden found 6 clusters using modularity, quality is 0.3333.
+Membership: 0 1 2 3 4 5
 
 Leiden found 2 clusters using modularity, quality is 0.5000.
 Membership: 0 1


### PR DESCRIPTION
In issue #1337, it appeared that on Windows the test code for the Leiden algorithm failed due to a rounding problem. It seems that rounding is working differently on Windows than on other platforms (see https://www.exploringbinary.com/inconsistent-rounding-of-printed-floating-point-numbers/). In particular, the rounding of halves work differently, where on Windows the rounding is always done away from 0 (i.e. halves are rounded up for positive numbers), whereas on other platforms it is rounded to the nearest even number (e.g. 3.5 is rounded to 4, while 2.5 is rounded to 2), following the IEEE 754 standard.

This PR changes the test so that no such rounding error appears, which fixes #1337.

Note that this "problem" might appear more often also in other contexts. A more fundamental correction would be to somehow set the correct rounding mode somewhere using [`fesetround`](https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/fegetround-fesetround2?view=vs-2019).