### PR TITLE
Bliss: catch exceptions and convert to igraph error codes

### DIFF
--- a/src/bliss.cc
+++ b/src/bliss.cc
@@ -25,6 +25,7 @@
 #include "igraph_datatype.h"
 #include "igraph_interface.h"
 
+#include "igraph_handle_exceptions.h"
 
 using namespace bliss;
 using namespace std;
@@ -153,24 +154,27 @@ void collect_generators(void *generators, unsigned int n, const unsigned int *au
  */
 int igraph_canonical_permutation(const igraph_t *graph, const igraph_vector_int_t *colors,
                                  igraph_vector_t *labeling, igraph_bliss_sh_t sh, igraph_bliss_info_t *info) {
-    AbstractGraph *g = bliss_from_igraph(graph);
-    IGRAPH_FINALLY(bliss_free_graph, g);
-    const unsigned int N = g->get_nof_vertices();
+    IGRAPH_HANDLE_EXCEPTIONS(
+        AbstractGraph *g = bliss_from_igraph(graph);
+        IGRAPH_FINALLY(bliss_free_graph, g);
+        const unsigned int N = g->get_nof_vertices();
 
-    IGRAPH_CHECK(bliss_set_sh(g, sh, igraph_is_directed(graph)));
-    IGRAPH_CHECK(bliss_set_colors(g, colors));
+        IGRAPH_CHECK(bliss_set_sh(g, sh, igraph_is_directed(graph)));
+        IGRAPH_CHECK(bliss_set_colors(g, colors));
 
-    Stats stats;
-    const unsigned int *cl = g->canonical_form(stats, NULL, NULL);
-    IGRAPH_CHECK(igraph_vector_resize(labeling, N));
-    for (unsigned int i = 0; i < N; i++) {
-        VECTOR(*labeling)[i] = cl[i];
-    }
+        Stats stats;
+        const unsigned int *cl = g->canonical_form(stats, NULL, NULL);
+        IGRAPH_CHECK(igraph_vector_resize(labeling, N));
+        for (unsigned int i = 0; i < N; i++) {
+            VECTOR(*labeling)[i] = cl[i];
+        }
 
-    bliss_info_to_igraph(info, stats);
+        bliss_info_to_igraph(info, stats);
 
-    delete g;
-    IGRAPH_FINALLY_CLEAN(1);
+        delete g;
+        IGRAPH_FINALLY_CLEAN(1);
+    );
+
     return IGRAPH_SUCCESS;
 }
 
@@ -199,19 +203,21 @@ int igraph_canonical_permutation(const igraph_t *graph, const igraph_vector_int_
  */
 int igraph_automorphisms(const igraph_t *graph, const igraph_vector_int_t *colors,
                          igraph_bliss_sh_t sh, igraph_bliss_info_t *info) {
-    AbstractGraph *g = bliss_from_igraph(graph);
-    IGRAPH_FINALLY(bliss_free_graph, g);
+    IGRAPH_HANDLE_EXCEPTIONS(
+        AbstractGraph *g = bliss_from_igraph(graph);
+        IGRAPH_FINALLY(bliss_free_graph, g);
 
-    IGRAPH_CHECK(bliss_set_sh(g, sh, igraph_is_directed(graph)));
-    IGRAPH_CHECK(bliss_set_colors(g, colors));
+        IGRAPH_CHECK(bliss_set_sh(g, sh, igraph_is_directed(graph)));
+        IGRAPH_CHECK(bliss_set_colors(g, colors));
 
-    Stats stats;
-    g->find_automorphisms(stats, NULL, NULL);
+        Stats stats;
+        g->find_automorphisms(stats, NULL, NULL);
 
-    bliss_info_to_igraph(info, stats);
+        bliss_info_to_igraph(info, stats);
 
-    delete g;
-    IGRAPH_FINALLY_CLEAN(1);
+        delete g;
+        IGRAPH_FINALLY_CLEAN(1);
+    );
     return IGRAPH_SUCCESS;
 }
 
@@ -241,20 +247,23 @@ int igraph_automorphisms(const igraph_t *graph, const igraph_vector_int_t *color
 int igraph_automorphism_group(
     const igraph_t *graph, const igraph_vector_int_t *colors, igraph_vector_ptr_t *generators,
     igraph_bliss_sh_t sh, igraph_bliss_info_t *info) {
-    AbstractGraph *g = bliss_from_igraph(graph);
-    IGRAPH_FINALLY(bliss_free_graph, g);
+    IGRAPH_HANDLE_EXCEPTIONS(
+        AbstractGraph *g = bliss_from_igraph(graph);
+        IGRAPH_FINALLY(bliss_free_graph, g);
 
-    IGRAPH_CHECK(bliss_set_sh(g, sh, igraph_is_directed(graph)));
-    IGRAPH_CHECK(bliss_set_colors(g, colors));
+        IGRAPH_CHECK(bliss_set_sh(g, sh, igraph_is_directed(graph)));
+        IGRAPH_CHECK(bliss_set_colors(g, colors));
 
-    Stats stats;
-    igraph_vector_ptr_resize(generators, 0);
-    g->find_automorphisms(stats, collect_generators, generators);
+        Stats stats;
+        igraph_vector_ptr_resize(generators, 0);
+        g->find_automorphisms(stats, collect_generators, generators);
 
-    bliss_info_to_igraph(info, stats);
+        bliss_info_to_igraph(info, stats);
 
-    delete g;
-    IGRAPH_FINALLY_CLEAN(1);
+        delete g;
+        IGRAPH_FINALLY_CLEAN(1);
+    );
+
     return IGRAPH_SUCCESS;
 }
 

--- a/src/bliss.cc
+++ b/src/bliss.cc
@@ -54,7 +54,7 @@ inline AbstractGraph *bliss_from_igraph(const igraph_t *graph) {
 }
 
 
-void bliss_free_graph(AbstractGraph *g) {
+static void bliss_free_graph(AbstractGraph *g) {
     delete g;
 }
 
@@ -119,7 +119,7 @@ inline void bliss_info_to_igraph(igraph_bliss_info_t *info, const Stats &stats) 
 
 // this is the callback function used with AbstractGraph::find_automorphisms()
 // it collects the group generators into a pointer vector
-void collect_generators(void *generators, unsigned int n, const unsigned int *aut) {
+static void collect_generators(void *generators, unsigned int n, const unsigned int *aut) {
     igraph_vector_ptr_t *gen = static_cast<igraph_vector_ptr_t *>(generators);
     igraph_vector_t *newvector = igraph_Calloc(1, igraph_vector_t);
     igraph_vector_init(newvector, n);

--- a/src/bliss/bignum.hh
+++ b/src/bliss/bignum.hh
@@ -21,7 +21,7 @@
 */
 
 #include <cstdlib>
-#include <cstdio>
+// #include <cstdio>
 #include <cmath>
 #include <cstring>
 #include <sstream>
@@ -111,7 +111,7 @@ public:
   /**
    * Print the number in the file stream \a fp.
    */
-  size_t print(FILE* const fp) const {return fprintf(fp, "%Lg", v); }
+  // size_t print(FILE* const fp) const {return fprintf(fp, "%Lg", v); }
 
   int tostring(char **str) const {
     int size=static_cast<int>( (std::log(std::abs(v))/std::log(10.0))+4 );

--- a/src/bliss/bliss_heap.cc
+++ b/src/bliss/bliss_heap.cc
@@ -1,6 +1,6 @@
-#include <stdlib.h>
-#include <stdio.h>
-#include <limits.h>
+#include <cstdlib>
+//#include <stdio.h>
+#include <climits>
 #include "defs.hh"
 #include "heap.hh"
 

--- a/src/bliss/defs.cc
+++ b/src/bliss/defs.cc
@@ -1,5 +1,6 @@
 #include <cstdlib>
 #include <cstdio>
+#include <stdexcept>
 #include "defs.hh"
 
 /*
@@ -23,20 +24,17 @@
 
 namespace bliss {
 
-#ifndef USING_R
-
 void
 fatal_error(const char* fmt, ...)
 {
+  char buffer[1024];
   va_list ap;
   va_start(ap, fmt);
-  fprintf(stderr,"Bliss fatal error: ");
-  vfprintf(stderr, fmt, ap);
-  fprintf(stderr, "\nAborting!\n");
+  sprintf(buffer, "Bliss fatal error: ");
+  vsprintf(buffer, fmt, ap);
+  throw std::runtime_error(buffer);
   va_end(ap);
   exit(1);
 }
-
-#endif
 
 }

--- a/src/bliss/defs.hh
+++ b/src/bliss/defs.hh
@@ -29,11 +29,6 @@
 #  define BLISS_USE_GMP
 #endif
 
-#ifdef USING_R
-#include <R.h>
-#define fatal_error(...) (error(__VA_ARGS__))
-#endif
-
 namespace bliss {
 
 /**
@@ -47,9 +42,7 @@ static const char * const version = "0.73";
  * There should not be a return from this function but exit or
  * a jump to code that deallocates the AbstractGraph instance that called this.
  */
-#ifndef USING_R
 void fatal_error(const char* fmt, ...);
-#endif
 
 
 #if defined(BLISS_DEBUG)

--- a/src/bliss/graph.cc
+++ b/src/bliss/graph.cc
@@ -1,4 +1,5 @@
-#include <cstdio>
+
+// #include <cstdio>
 #include <cassert>
 #include <climits>
 #include <set>
@@ -13,11 +14,6 @@
 /* use 'and' instead of '&&' */
 #if _MSC_VER
 #include <ciso646>
-#endif
-
-#ifdef USING_R
-#undef stdout
-#define stdout NULL
 #endif
 
 /*
@@ -1036,15 +1032,6 @@ AbstractGraph::search(const bool canonical, Stats& stats)
 		 */
 		if(index == cell->length and all_same_level == current_level+1)
 		  all_same_level = current_level;
-		if(verbstr and verbose_level >= 2) {
-		  fprintf(verbstr,
-			  "Level %u: orbits=%u, index=%u/%u, all_same_level=%u\n",
-			  current_level,
-			  first_path_orbits.nof_orbits(),
-			  index, cell->length,
-			  all_same_level);
-		  fflush(verbstr);
-		}
 	      }
 	    continue;
 	  }
@@ -2082,6 +2069,7 @@ Digraph::permute(const unsigned int* const perm) const
  *-------------------------------------------------------------------------*/
 
 
+#if 0
 void
 Digraph::write_dot(const char* const filename)
 {
@@ -2118,6 +2106,7 @@ Digraph::write_dot(FILE* const fp)
 
   fprintf(fp, "}\n");
 }
+#endif
 
 
 void
@@ -2187,6 +2176,7 @@ Digraph::get_hash()
  *
  *-------------------------------------------------------------------------*/
 
+#if 0
 Digraph*
 Digraph::read_dimacs(FILE* const fp, FILE* const errstr)
 {
@@ -2343,11 +2333,11 @@ Digraph::read_dimacs(FILE* const fp, FILE* const errstr)
     delete g;
   return 0;
 }
+#endif
 
 
 
-
-
+#if 0
 void
 Digraph::write_dimacs(FILE* const fp)
 {
@@ -2389,7 +2379,7 @@ Digraph::write_dimacs(FILE* const fp)
 	}
     }
 }
-
+#endif
 
 
 
@@ -3690,12 +3680,6 @@ Digraph::nucr_find_first_component(const unsigned int level)
       cr_component_elements += cell->length;
     }
 
-  if(verbstr and verbose_level > 2) {
-    fprintf(verbstr, "NU-component with %lu cells and %u vertices\n",
-	    (long unsigned)cr_component.size(), cr_component_elements);
-    fflush(verbstr);
-  }
-
   return true;
 }
 
@@ -3891,12 +3875,6 @@ Digraph::nucr_find_first_component(const unsigned int level,
       component_elements += cell->length;
     }
 
-  if(verbstr and verbose_level > 2) {
-    fprintf(verbstr, "NU-component with %lu cells and %u vertices\n",
-	    (long unsigned)component.size(), component_elements);
-    fflush(verbstr);
-  }
-
   return true;
 }
 
@@ -4036,6 +4014,7 @@ Graph::change_color(const unsigned int vertex, const unsigned int color)
  *
  *-------------------------------------------------------------------------*/
 
+#if 0
 Graph*
 Graph::read_dimacs(FILE* const fp, FILE* const errstr)
 {
@@ -4251,7 +4230,7 @@ Graph::write_dimacs(FILE* const fp)
 	}
     }
 }
-
+#endif
 
 
 void
@@ -4372,6 +4351,7 @@ Graph::permute(const unsigned int* perm) const
  *-------------------------------------------------------------------------*/
 
 
+#if 0
 void
 Graph::write_dot(const char* const filename)
 {
@@ -4409,8 +4389,7 @@ Graph::write_dot(FILE* const fp)
 
   fprintf(fp, "}\n");
 }
-
-
+#endif
 
 
 
@@ -5432,12 +5411,6 @@ Graph::nucr_find_first_component(const unsigned int level)
       cr_component_elements += cell->length;
     }
 
-  if(verbstr and verbose_level > 2) {
-    fprintf(verbstr, "NU-component with %lu cells and %u vertices\n",
-	    (long unsigned)cr_component.size(), cr_component_elements);
-    fflush(verbstr);
-  }
-
   return true;
 }
 
@@ -5595,12 +5568,6 @@ Graph::nucr_find_first_component(const unsigned int level,
       component.push_back(cell->first);
       component_elements += cell->length;
     }
-
-  if(verbstr and verbose_level > 2) {
-    fprintf(verbstr, "NU-component with %lu cells and %u vertices\n",
-	    (long unsigned)component.size(), component_elements);
-    fflush(verbstr);
-  }
 
   return true;
 }

--- a/src/bliss/graph.hh
+++ b/src/bliss/graph.hh
@@ -29,7 +29,7 @@ namespace bliss {
   class AbstractGraph;
 }
 
-#include <cstdio>
+// #include <cstdio>
 #include <vector>
 #include "kstack.hh"
 #include "kqueue.hh"
@@ -81,6 +81,7 @@ private:
 public:
   Stats() { reset(); }
   /** Print the statistics. */
+  /*
   size_t print(FILE* const fp) const
   {
     size_t r = 0;
@@ -94,6 +95,7 @@ public:
     fflush(fp);
     return r;
   }
+  */
   /** An approximation (due to possible overflows/rounding errors) of
    * the size of the automorphism group. */
   long double get_group_size_approx() const {return group_size_approx;}
@@ -241,6 +243,7 @@ public:
 						  const unsigned int* aut),
 				     void* hook_user_param);
 
+#if 0
   /**
    * Write the graph to a file in a variant of the DIMACS format.
    * See the <A href="http://www.tcs.hut.fi/Software/bliss/">bliss website</A>
@@ -264,6 +267,7 @@ public:
    * \param file_name  the name of the file to which the graph is written
    */
   virtual void write_dot(const char * const file_name) = 0;
+#endif
 
   /**
    * Get a hash value for the graph.
@@ -658,6 +662,7 @@ public:
    */
   ~Graph();
 
+#if 0
   /**
    * Read the graph from the file \a fp in a variant of the DIMACS format.
    * See the <A href="http://www.tcs.hut.fi/Software/bliss/">bliss website</A>
@@ -690,6 +695,7 @@ public:
    * \copydoc AbstractGraph::write_dot(const char * const file_name)
    */
   void write_dot(const char* const file_name);
+#endif
 
   /**
    * \copydoc AbstractGraph::is_automorphism(const std::vector<unsigned int>& perm) const
@@ -898,6 +904,7 @@ public:
    */
   ~Digraph();
 
+#if 0
   /**
    * Read the graph from the file \a fp in a variant of the DIMACS format.
    * See the <A href="http://www.tcs.hut.fi/Software/bliss/">bliss website</A>
@@ -928,6 +935,7 @@ public:
    * \copydoc AbstractGraph::write_dot(const char * const file_name)
    */
   void write_dot(const char * const file_name);
+#endif
 
   /**
    * \copydoc AbstractGraph::is_automorphism(const std::vector<unsigned int>& perm) const

--- a/src/bliss/orbit.cc
+++ b/src/bliss/orbit.cc
@@ -1,5 +1,5 @@
-#include <stdlib.h>
-#include <assert.h>
+#include <cstdlib>
+#include <cassert>
 #include "defs.hh"
 #include "orbit.hh"
 

--- a/src/bliss/partition.cc
+++ b/src/bliss/partition.cc
@@ -1,4 +1,4 @@
-#include <assert.h>
+#include <cassert>
 #include <vector>
 #include <list>
 #include "graph.hh"
@@ -344,7 +344,7 @@ Partition::aux_split_in_two(Partition::Cell* const cell,
 } 
 
 
-
+#if 0
 size_t
 Partition::print(FILE* const fp, const bool add_newline) const
 {
@@ -388,7 +388,7 @@ Partition::print_signature(FILE* const fp, const bool add_newline) const
   if(add_newline) r += fprintf(fp, "\n");
   return r;
 }
-
+#endif
 
 
 void

--- a/src/bliss/partition.hh
+++ b/src/bliss/partition.hh
@@ -25,7 +25,7 @@ namespace bliss {
 }
 
 #include <cstdlib>
-#include <cstdio>
+//#include <cstdio>
 #include <climits>
 #include "kstack.hh"
 #include "kqueue.hh"
@@ -186,12 +186,12 @@ public:
   /**
    * Print the partition into the file stream \a fp.
    */
-  size_t print(FILE* const fp, const bool add_newline = true) const;
+  // size_t print(FILE* const fp, const bool add_newline = true) const;
 
   /**
    * Print the partition cell sizes into the file stream \a fp.
    */
-  size_t print_signature(FILE* const fp, const bool add_newline = true) const;
+  // size_t print_signature(FILE* const fp, const bool add_newline = true) const;
 
   /*
    * Splits the Cell \a cell into [cell_1,...,cell_n]

--- a/src/bliss/uintseqhash.hh
+++ b/src/bliss/uintseqhash.hh
@@ -1,7 +1,7 @@
 #ifndef BLISS_UINTSEQHASH_HH
 #define BLISS_UINTSEQHASH_HH
 
-#include <cstdio>
+// #include <cstdio>
 
 /*
   Copyright (c) 2003-2015 Tommi Junttila

--- a/src/bliss/utils.cc
+++ b/src/bliss/utils.cc
@@ -23,6 +23,7 @@
 
 namespace bliss {
 
+#if 0
 void
 print_permutation(FILE* const fp,
 		  const unsigned int N,
@@ -88,6 +89,7 @@ print_permutation(FILE* const fp,
     fprintf(fp, ")");
   }
 }
+#endif
 
 bool
 is_permutation(const unsigned int N, const unsigned int* perm)

--- a/src/bliss/utils.hh
+++ b/src/bliss/utils.hh
@@ -26,11 +26,12 @@
  *
  */
 
-#include <cstdio>
-using namespace std;
+//#include <cstdio>
+#include <vector>
 
 namespace bliss {
 
+#if 0
 /**
  * Print the permutation \a perm of {0,...,N-1} in the cycle format
  * in the file stream \a fp.
@@ -51,6 +52,7 @@ void print_permutation(FILE* fp,
 void print_permutation(FILE* fp,
 		       const std::vector<unsigned int>& perm,
 		       const unsigned int offset = 0);
+#endif
 
 /**
  * Check whether \a perm is a valid permutation on {0,...,N-1}.

--- a/src/drl_layout.cpp
+++ b/src/drl_layout.cpp
@@ -65,6 +65,8 @@ using namespace drl;
 #include "igraph_random.h"
 #include "igraph_interface.h"
 
+#include "igraph_handle_exceptions.h"
+
 namespace drl {
 
 // int main(int argc, char **argv) {
@@ -455,17 +457,19 @@ int igraph_layout_drl(const igraph_t *graph, igraph_matrix_t *res,
                       const igraph_vector_t *weights,
                       const igraph_vector_bool_t *fixed) {
 
-    RNG_BEGIN();
+    IGRAPH_HANDLE_EXCEPTIONS(
+        RNG_BEGIN();
 
-    drl::graph neighbors(graph, options, weights);
-    neighbors.init_parms(options);
-    if (use_seed) {
-        IGRAPH_CHECK(igraph_matrix_resize(res, igraph_vcount(graph), 2));
-        neighbors.read_real(res, fixed);
-    }
-    neighbors.draw_graph(res);
+        drl::graph neighbors(graph, options, weights);
+        neighbors.init_parms(options);
+        if (use_seed) {
+            IGRAPH_CHECK(igraph_matrix_resize(res, igraph_vcount(graph), 2));
+            neighbors.read_real(res, fixed);
+        }
+        neighbors.draw_graph(res);
 
-    RNG_END();
+        RNG_END();
+    );
 
     return 0;
 }

--- a/src/drl_layout_3d.cpp
+++ b/src/drl_layout_3d.cpp
@@ -65,6 +65,8 @@ using namespace drl3d;
 #include "igraph_random.h"
 #include "igraph_interface.h"
 
+#include "igraph_handle_exceptions.h"
+
 /**
  * \function igraph_layout_drl_3d
  * The DrL layout generator, 3d version.
@@ -101,18 +103,19 @@ int igraph_layout_drl_3d(const igraph_t *graph, igraph_matrix_t *res,
                          igraph_layout_drl_options_t *options,
                          const igraph_vector_t *weights,
                          const igraph_vector_bool_t *fixed) {
+    IGRAPH_HANDLE_EXCEPTIONS(
+        RNG_BEGIN();
 
-    RNG_BEGIN();
+        drl3d::graph neighbors(graph, options, weights);
+        neighbors.init_parms(options);
+        if (use_seed) {
+            IGRAPH_CHECK(igraph_matrix_resize(res, igraph_vcount(graph), 3));
+            neighbors.read_real(res, fixed);
+        }
+        neighbors.draw_graph(res);
 
-    drl3d::graph neighbors(graph, options, weights);
-    neighbors.init_parms(options);
-    if (use_seed) {
-        IGRAPH_CHECK(igraph_matrix_resize(res, igraph_vcount(graph), 3));
-        neighbors.read_real(res, fixed);
-    }
-    neighbors.draw_graph(res);
-
-    RNG_END();
+        RNG_END();
+    );
 
     return 0;
 }

--- a/src/gengraph_mr-connected.cpp
+++ b/src/gengraph_mr-connected.cpp
@@ -28,6 +28,8 @@
 #include "igraph_types.h"
 #include "igraph_error.h"
 
+#include "igraph_handle_exceptions.h"
+
 namespace gengraph {
 
 // return negative number if program should exit
@@ -137,48 +139,50 @@ extern "C" {
     int igraph_degree_sequence_game_vl(igraph_t *graph,
                                        const igraph_vector_t *out_seq,
                                        const igraph_vector_t *in_seq) {
-        long int sum = igraph_vector_sum(out_seq);
-        if (sum % 2 != 0) {
-            IGRAPH_ERROR("Sum of degrees should be even", IGRAPH_EINVAL);
-        }
+        IGRAPH_HANDLE_EXCEPTIONS(
+            long int sum = igraph_vector_sum(out_seq);
+            if (sum % 2 != 0) {
+                IGRAPH_ERROR("Sum of degrees should be even", IGRAPH_EINVAL);
+            }
 
-        RNG_BEGIN();
+            RNG_BEGIN();
 
-        if (in_seq && igraph_vector_size(in_seq) != 0) {
-            RNG_END();
-            IGRAPH_ERROR("This generator works with undirected graphs only", IGRAPH_EINVAL);
-        }
+            if (in_seq && igraph_vector_size(in_seq) != 0) {
+                RNG_END();
+                IGRAPH_ERROR("This generator works with undirected graphs only", IGRAPH_EINVAL);
+            }
 
-        degree_sequence *dd = new degree_sequence(out_seq);
+            degree_sequence *dd = new degree_sequence(out_seq);
 
-        graph_molloy_opt *g = new graph_molloy_opt(*dd);
-        delete dd;
+            graph_molloy_opt *g = new graph_molloy_opt(*dd);
+            delete dd;
 
-        if (!g->havelhakimi()) {
+            if (!g->havelhakimi()) {
+                delete g;
+                RNG_END();
+                IGRAPH_ERROR("Cannot realize the given degree sequence as an undirected, simple graph",
+                             IGRAPH_EINVAL);
+            }
+
+            if (!g->make_connected()) {
+                delete g;
+                RNG_END();
+                IGRAPH_ERROR("Cannot make a connected graph from the given degree sequence",
+                             IGRAPH_EINVAL);
+            }
+
+            int *hc = g->hard_copy();
             delete g;
+            graph_molloy_hash *gh = new graph_molloy_hash(hc);
+            delete [] hc;
+
+            gh->shuffle(5 * gh->nbarcs(), 100 * gh->nbarcs(), SHUFFLE_TYPE);
+
+            IGRAPH_CHECK(gh->print(graph));
+            delete gh;
+
             RNG_END();
-            IGRAPH_ERROR("Cannot realize the given degree sequence as an undirected, simple graph",
-                         IGRAPH_EINVAL);
-        }
-
-        if (!g->make_connected()) {
-            delete g;
-            RNG_END();
-            IGRAPH_ERROR("Cannot make a connected graph from the given degree sequence",
-                         IGRAPH_EINVAL);
-        }
-
-        int *hc = g->hard_copy();
-        delete g;
-        graph_molloy_hash *gh = new graph_molloy_hash(hc);
-        delete [] hc;
-
-        gh->shuffle(5 * gh->nbarcs(), 100 * gh->nbarcs(), SHUFFLE_TYPE);
-
-        IGRAPH_CHECK(gh->print(graph));
-        delete gh;
-
-        RNG_END();
+        );
 
         return 0;
     }

--- a/src/igraph_handle_exceptions.h
+++ b/src/igraph_handle_exceptions.h
@@ -1,0 +1,14 @@
+#ifndef IGRAPH_HANDLE_EXCEPTIONS_H
+#define IGRAPH_HANDLE_EXCEPTIONS_H
+
+#include <exception>
+#include <new>
+
+#define IGRAPH_HANDLE_EXCEPTIONS(code) \
+    try { code; } \
+    catch (const std::bad_alloc &e) { IGRAPH_ERROR(e.what(), IGRAPH_ENOMEM); } \
+    catch (const std::exception &e) { IGRAPH_ERROR(e.what(), IGRAPH_FAILURE); } \
+    catch (...) { IGRAPH_ERROR("Unknown exception caught", IGRAPH_FAILURE); }
+
+
+#endif // IGRAPH_HANDLE_EXCEPTIONS_H


### PR DESCRIPTION
This is meant to fix #1178, but I am not completely happy with it. Any comments, @ntamas?

Bliss itself does not seem to ever throw exceptions explicitly, but it may do so implicitly (e.g. out-of-memory condition).

The first commit simply removes/comments any printing to terminal (fprtintf) from the code.