### PR TITLE
Building shared library on Windows

### DIFF
--- a/etc/cmake/FindGMP.cmake
+++ b/etc/cmake/FindGMP.cmake
@@ -9,7 +9,7 @@
 set(GMP_PREFIX "" CACHE PATH "Path to GMP prefix")
 
 find_path(GMP_INCLUDE_DIR gmp.h PATHS ${GMP_PREFIX}/include /usr/include /usr/local/include)
-find_library(GMP_LIBRARY libgmp.a PATHS ${GMP_PREFIX}/lib /usr/lib /usr/local/lib)
+find_library(GMP_LIBRARY gmp PATHS ${GMP_PREFIX}/lib /usr/lib /usr/local/lib)
 
 if(GMP_INCLUDE_DIR AND GMP_LIBRARY)
   set(GMP_FOUND TRUE)

--- a/etc/cmake/dependencies.cmake
+++ b/etc/cmake/dependencies.cmake
@@ -63,4 +63,6 @@ macro(find_dependencies)
   set(HAVE_GLPK ${GLPK_FOUND})
   set(HAVE_GMP ${GMP_FOUND})
   set(HAVE_LIBXML ${LIBXML2_FOUND})
+
+  find_library(MATH_LIBRARY m)
 endmacro()

--- a/include/igraph_attributes.h
+++ b/include/igraph_attributes.h
@@ -385,7 +385,7 @@ int igraph_i_attribute_get_bool_edge_attr(const igraph_t *graph,
 
 /* Experimental attribute handler in C */
 
-DECLDIR const igraph_attribute_table_t igraph_cattribute_table;
+DECLDIR extern const igraph_attribute_table_t igraph_cattribute_table;
 
 DECLDIR igraph_real_t igraph_cattribute_GAN(const igraph_t *graph, const char *name);
 DECLDIR igraph_bool_t igraph_cattribute_GAB(const igraph_t *graph, const char *name);

--- a/include/igraph_attributes.h
+++ b/include/igraph_attributes.h
@@ -385,7 +385,7 @@ int igraph_i_attribute_get_bool_edge_attr(const igraph_t *graph,
 
 /* Experimental attribute handler in C */
 
-DECLDIR extern const igraph_attribute_table_t igraph_cattribute_table;
+DECLDIR const igraph_attribute_table_t igraph_cattribute_table;
 
 DECLDIR igraph_real_t igraph_cattribute_GAN(const igraph_t *graph, const char *name);
 DECLDIR igraph_bool_t igraph_cattribute_GAB(const igraph_t *graph, const char *name);

--- a/include/igraph_error.h
+++ b/include/igraph_error.h
@@ -678,8 +678,8 @@ typedef igraph_error_handler_t igraph_warning_handler_t;
 
 DECLDIR igraph_warning_handler_t* igraph_set_warning_handler(igraph_warning_handler_t* new_handler);
 
-DECLDIR igraph_warning_handler_t igraph_warning_handler_ignore;
-DECLDIR igraph_warning_handler_t igraph_warning_handler_print;
+extern igraph_warning_handler_t igraph_warning_handler_ignore;
+extern igraph_warning_handler_t igraph_warning_handler_print;
 
 /**
  * \function igraph_warning

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -207,6 +207,10 @@ target_include_directories(
   ${LIBXML2_INCLUDE_DIRS}
 )
 
+if(MATH_LIBRARY)
+    target_link_libraries(igraph PUBLIC ${MATH_LIBRARY})
+endif()
+
 # Link igraph statically to some of the libraries from the subdirectories
 target_link_libraries(
   igraph

--- a/src/bliss/CMakeLists.txt
+++ b/src/bliss/CMakeLists.txt
@@ -19,6 +19,10 @@ target_include_directories(
   ${GMP_INCLUDE_DIR}
 )
 
+if (BUILD_SHARED_LIBS)
+  set_property(TARGET bliss PROPERTY POSITION_INDEPENDENT_CODE ON)
+endif()
+
 # If we are linking igraph to GMP, then Bliss will use GMP for bignums
 if(GMP_FOUND)
   target_link_libraries(

--- a/src/cliquer/CMakeLists.txt
+++ b/src/cliquer/CMakeLists.txt
@@ -14,5 +14,9 @@ target_include_directories(
   ${CMAKE_BINARY_DIR}/src
 )
 
+if (BUILD_SHARED_LIBS)
+  set_property(TARGET cliquer PROPERTY POSITION_INDEPENDENT_CODE ON)
+endif()
+
 # TODO(ntamas): make sure that this works for Cliquer
 # use_all_warnings(cliquer)

--- a/src/f2c/CMakeLists.txt
+++ b/src/f2c/CMakeLists.txt
@@ -79,6 +79,10 @@ if (MSVC)
   )
 endif()
 
+if (BUILD_SHARED_LIBS)
+  set_property(TARGET f2c_vendored PROPERTY POSITION_INDEPENDENT_CODE ON)
+endif()
+
 # Suppress some warnings that occur in the output because we do not want to
 # mess around with the source of f2c too much to fix these
 if(NOT MSVC)

--- a/src/foreign-gml-parser.y
+++ b/src/foreign-gml-parser.y
@@ -138,7 +138,7 @@ keyvalue:   key num
 
 key: KEYWORD { igraph_i_gml_get_keyword(igraph_gml_yyget_text(scanner), 
 					igraph_gml_yyget_leng(scanner), 
-					&$$); USE($1) };
+					&$$); USE($1); };
 num : NUM { $$=igraph_i_gml_get_real(igraph_gml_yyget_text(scanner), 
 				     igraph_gml_yyget_leng(scanner)); };
 

--- a/src/plfit/CMakeLists.txt
+++ b/src/plfit/CMakeLists.txt
@@ -15,4 +15,8 @@ add_library(
   sampling.c
 )
 
+if (BUILD_SHARED_LIBS)
+  set_property(TARGET plfit PROPERTY POSITION_INDEPENDENT_CODE ON)
+endif()
+
 use_all_warnings(plfit)

--- a/src/prpack/CMakeLists.txt
+++ b/src/prpack/CMakeLists.txt
@@ -25,6 +25,10 @@ target_include_directories(
   ${CMAKE_SOURCE_DIR}/include
 )
 
+if (BUILD_SHARED_LIBS)
+  set_property(TARGET prpack PROPERTY POSITION_INDEPENDENT_CODE ON)
+endif()
+
 # Turn on all warnings for GCC, clang and MSVC
 # TODO(ntamas): it does not work yet, gcc errors out with:
 #     ignoring #pragma omp parallel [-Werror=unknown-pragmas]

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,6 +6,12 @@ add_custom_target(build_tests)
 add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} -C ${CMAKE_BUILD_TYPE})
 add_dependencies(check build_tests)
 
+set(BUILD_INTERNAL_TESTS YES)
+
+if (MSVC AND BUILD_SHARED_LIBS)
+  set(BUILD_INTERNAL_TESTS NO)
+endif()
+
 # version.at
 add_legacy_tests(
   FOLDER simple NAMES
@@ -15,18 +21,11 @@ add_legacy_tests(
 # types.at
 add_legacy_tests(
   FOLDER simple NAMES
-  2wheap
-  biguint
-  d_indheap
   dqueue
   heap
   igraph_array
   igraph_complex
-  igraph_hashtable
-  igraph_i_cutheap
-  igraph_marked_queue
   igraph_psumtree
-  igraph_set
   igraph_sparsemat
   igraph_sparsemat2
   igraph_sparsemat3
@@ -40,7 +39,6 @@ add_legacy_tests(
   igraph_sparsemat_minmax
   igraph_sparsemat_which_minmax
   igraph_strvector
-  igraph_trie
   indheap
   matrix
   matrix2
@@ -52,6 +50,19 @@ add_legacy_tests(
   vector3
   vector_ptr
 )
+if (BUILD_INTERNAL_TESTS)
+  add_legacy_tests(
+    FOLDER simple NAMES
+    2wheap
+    biguint
+    d_indheap
+    igraph_hashtable
+    igraph_i_cutheap
+    igraph_marked_queue
+    igraph_set
+    igraph_trie
+  )
+endif()
 
 # basic.at
 add_legacy_tests(
@@ -64,10 +75,15 @@ add_legacy_tests(
   igraph_delete_vertices
   igraph_empty
   igraph_get_eid
-  igraph_get_eids
   igraph_is_directed
   igraph_neighbors
 )
+if (BUILD_INTERNAL_TESTS)
+  add_legacy_tests(
+    FOLDER simple NAMES
+    igraph_get_eids
+  )
+endif()
 
 # iterators.at
 add_legacy_tests(
@@ -126,12 +142,10 @@ add_legacy_tests(
   igraph_convergence_degree
   igraph_density
   igraph_diameter
-  igraph_eccentricity
   igraph_edge_betweenness
   igraph_feedback_arc_set
   igraph_feedback_arc_set_ip
   igraph_get_all_shortest_paths_dijkstra
-  igraph_get_all_simple_paths
   igraph_get_shortest_paths
   igraph_get_shortest_paths2
   igraph_get_shortest_paths_dijkstra
@@ -143,16 +157,23 @@ add_legacy_tests(
   igraph_knn
   igraph_local_transitivity
   igraph_minimum_spanning_tree
-  igraph_pagerank
-  igraph_radius
   igraph_reciprocity
-  igraph_rewire
   igraph_similarity
   igraph_simplify
   igraph_transitive_closure_dag
   igraph_transitivity
-  single_target_shortest_path
 )
+if (BUILD_INTERNAL_TESTS)
+  add_legacy_tests(
+    FOLDER simple NAMES
+    igraph_eccentricity
+    igraph_get_all_simple_paths
+    igraph_pagerank
+    igraph_radius
+    igraph_rewire
+    single_target_shortest_path
+  )
+endif()
 
 add_legacy_tests(
   FOLDER tests NAMES
@@ -176,17 +197,22 @@ add_legacy_tests(
 # layout.at
 add_legacy_tests(
   FOLDER simple NAMES
-  igraph_i_layout_sphere
-  igraph_layout_davidson_harel
   igraph_layout_grid
   igraph_layout_lgl
   igraph_layout_mds
-  igraph_layout_merge
   igraph_layout_merge2
   igraph_layout_merge3
   igraph_layout_reingold_tilford
-  igraph_layout_sugiyama
 )
+if (BUILD_INTERNAL_TESTS)
+  add_legacy_tests(
+    FOLDER simple NAMES
+    igraph_i_layout_sphere
+    igraph_layout_davidson_harel
+    igraph_layout_merge
+    igraph_layout_sugiyama
+  )
+endif()
 
 add_legacy_tests(
   FOLDER tests NAMES
@@ -196,10 +222,16 @@ add_legacy_tests(
 # visitors.at
 add_legacy_tests(
   FOLDER simple NAMES
-  igraph_bfs
+
   igraph_bfs2
   igraph_random_walk
 )
+if (BUILD_INTERNAL_TESTS)
+  add_legacy_tests(
+    FOLDER simple NAMES
+    igraph_bfs
+  )
+endif()
 
 # topology.at
 add_legacy_tests(
@@ -207,10 +239,15 @@ add_legacy_tests(
   VF2-compat
   igraph_isomorphic_bliss
   igraph_isomorphic_vf2
-  igraph_subisomorphic_lad
   isomorphism_test
   topology
 )
+if (BUILD_INTERNAL_TESTS)
+  add_legacy_tests(
+    FOLDER simple NAMES
+    igraph_subisomorphic_lad
+  )
+endif()
 
 add_legacy_tests(
   FOLDER tests NAMES
@@ -227,8 +264,13 @@ add_legacy_tests(
 add_legacy_tests(
   FOLDER simple NAMES
   igraph_motifs_randesu
-  triad_census
 )
+if (BUILD_INTERNAL_TESTS)
+  add_legacy_tests(
+    FOLDER simple NAMES
+    triad_census
+  )
+endif()
 
 # foreign.at
 add_legacy_tests(
@@ -236,7 +278,6 @@ add_legacy_tests(
   dot
   foreign
   gml
-  graphml
   igraph_read_graph_dl
   igraph_read_graph_graphdb
   igraph_read_graph_lgl
@@ -250,6 +291,12 @@ add_legacy_tests(
   pajek_bipartite2
   pajek_signed
 )
+if (BUILD_INTERNAL_TESTS)
+  add_legacy_tests(
+    FOLDER simple NAMES
+    graphml
+  )
+endif()
 
 # other.at
 add_legacy_tests(
@@ -286,11 +333,16 @@ add_legacy_tests(
   even_tarjan
   flow
   flow2
-  igraph_all_st_cuts
   igraph_all_st_mincuts
   igraph_gomory_hu_tree
   igraph_mincut
 )
+if (BUILD_INTERNAL_TESTS)
+  add_legacy_tests(
+    FOLDER simple NAMES
+    igraph_all_st_cuts
+  )
+endif()
 
 # community.at
 add_legacy_tests(
@@ -321,12 +373,17 @@ add_legacy_tests(
   FOLDER simple NAMES
   igraph_cliques
   igraph_independent_sets
-  igraph_maximal_cliques
-  igraph_maximal_cliques2
-  igraph_maximal_cliques3
-  igraph_maximal_cliques4
   igraph_weighted_cliques
 )
+if (BUILD_INTERNAL_TESTS)
+  add_legacy_tests(
+    FOLDER simple NAMES
+    igraph_maximal_cliques
+    igraph_maximal_cliques2
+    igraph_maximal_cliques3
+    igraph_maximal_cliques4
+  )
+endif()
 
 add_legacy_tests(
   FOLDER tests NAMES
@@ -382,10 +439,12 @@ add_legacy_tests(
 )
 
 # centralization.at
-add_legacy_tests(
-  FOLDER simple NAMES
-  centralization
-)
+if (BUILD_INTERNAL_TESTS)
+  add_legacy_tests(
+    FOLDER simple NAMES
+    centralization
+  )
+endif()
 
 # separators.at
 add_legacy_tests(
@@ -443,11 +502,16 @@ add_legacy_tests(
 add_legacy_tests(
   FOLDER simple NAMES
   igraph_fisher_yates_shuffle
-  igraph_random_sample
   igraph_rng_get_exp
   mt
   random_seed
 )
+if (BUILD_INTERNAL_TESTS)
+  add_legacy_tests(
+    FOLDER simple NAMES
+    igraph_random_sample
+  )
+endif()
 
 add_legacy_tests(
   FOLDER tests NAMES
@@ -455,11 +519,13 @@ add_legacy_tests(
 )
 
 # qsort.at
-add_legacy_tests(
-  FOLDER simple NAMES
-  igraph_qsort
-  igraph_qsort_r
-)
+if (BUILD_INTERNAL_TESTS)
+  add_legacy_tests(
+    FOLDER simple NAMES
+    igraph_qsort
+    igraph_qsort_r
+  )
+endif()
 
 # matching.at
 add_legacy_tests(


### PR DESCRIPTION
These commits are an initial attempt at correctly building a shared library on Windows.

Note that there is one problem remaining. The compiled `igraph.dll` cannot be found when simply running `ctest`. When manually copying this file over to the proper test directory, all the tests do run correctly. This should of course not happen, but I don't immediately know how to best configure this in `CMake`. Any suggestions @ntamas ?

I wanted to check what you think of the current solution of how to enable/disable tests that rely on internal functions (i.e. which are not exported when building a shared library on Windows). Is this what you had in mind @ntamas? 

Of course, in the long term, we should correctly export symbols, and as said, we can also start doing this in `gcc` by using  [visibility markers](https://gcc.gnu.org/wiki/Visibility). Even then, we will of course not be able to test internal functions when building a shared library.