### PR TITLE
igraph_i_cattribute_combine_vertices: correct mismatching FINALLY calls.

### DIFF
--- a/src/cattributes.c
+++ b/src/cattributes.c
@@ -1577,7 +1577,8 @@ int igraph_i_cattribute_combine_vertices(const igraph_t *graph,
 
     igraph_free(funcs);
     igraph_free(TODO);
-    IGRAPH_FINALLY_CLEAN(2);
+    igraph_i_cattribute_permute_free(new_val);
+    IGRAPH_FINALLY_CLEAN(3);
 
     return 0;
 }


### PR DESCRIPTION
This fixes the problem identified in #1484 of mismatching FINALLY calls in igraph_i_cattribute_combine_vertices.