### PR TITLE
 igraph_i_cattribute_combine_vertices: correct mismatching FINALLY calls (part 2)

### DIFF
--- a/src/cattributes.c
+++ b/src/cattributes.c
@@ -1414,7 +1414,6 @@ int igraph_i_cattribute_combine_vertices(const igraph_t *graph,
     }
 
     IGRAPH_CHECK(igraph_vector_ptr_resize(new_val, keepno));
-    IGRAPH_FINALLY(igraph_i_cattribute_permute_free, new_val);
 
     for (i = 0, j = 0; i < valno; i++) {
         igraph_attribute_record_t *newrec, *oldrec = VECTOR(*val)[i];
@@ -1577,8 +1576,7 @@ int igraph_i_cattribute_combine_vertices(const igraph_t *graph,
 
     igraph_free(funcs);
     igraph_free(TODO);
-    igraph_i_cattribute_permute_free(new_val);
-    IGRAPH_FINALLY_CLEAN(3);
+    IGRAPH_FINALLY_CLEAN(2);
 
     return 0;
 }

--- a/src/cattributes.c
+++ b/src/cattributes.c
@@ -1577,7 +1577,8 @@ int igraph_i_cattribute_combine_vertices(const igraph_t *graph,
 
     igraph_free(funcs);
     igraph_free(TODO);
-    IGRAPH_FINALLY_CLEAN(2);
+    igraph_i_cattribute_permute_free(new_val);
+    IGRAPH_FINALLY_CLEAN(3);
 
     return 0;
 }


### PR DESCRIPTION
Continuation of #1485, after it appeared the solution was actually incorrect (see https://github.com/igraph/igraph/pull/1485#issuecomment-713879652).