### PR TITLE
igraph_blas_internal.h: add missing defines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
  - `igraph_i_cattribute_combine_vertices()`: fixed invalid cleanup code that eventually filled up the "finally" stack when combining vertices with attributes extensively.
+ - Fixed building with vendored LAPACK and external BLAS
 
 ### Other
 

--- a/src/igraph_blas_internal.h
+++ b/src/igraph_blas_internal.h
@@ -50,6 +50,10 @@
     #define igraphdtrsm_    dtrsm_
     #define igraphdtrsv_    dtrsv_
     #define igraphdnrm2_    dnrm2_
+    #define igraphdsymv_    dsymv_
+    #define igraphdsyr2_    dsyr2_
+    #define igraphdsyr2k_   dsyr2k_
+    #define igraphdtrmv_    dtrmv_
 #endif
 
 int igraphdgemv_(char *trans, int *m, int *n, igraph_real_t *alpha,


### PR DESCRIPTION
Fixes building with internal LAPACK, external BLAS.

When trying to build the tests, I got: 

```
Undefined symbols for architecture x86_64:
  "_igraphdsymv_", referenced from:
      _dlatrd_ in libigraph.a(dlatrd.c.o)
      _dsytd2_ in libigraph.a(dsytd2.c.o)
  "_igraphdsyr2_", referenced from:
      _dsytd2_ in libigraph.a(dsytd2.c.o)
  "_igraphdsyr2k_", referenced from:
      _dsytrd_ in libigraph.a(dsytrd.c.o)
  "_igraphdtrmv_", referenced from:
      _dlahr2_ in libigraph.a(dlahr2.c.o)
      _dlarft_ in libigraph.a(dlarft.c.o)
ld: symbol(s) not found for architecture x86_64
```

This fixes the problem, at least for the static build.