### PR TITLE
Further fixes for building with external blas, internal lapack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
  - `cutoff=0` is no longer interpreted as infinity (i.e. no cutoff) in `betweenness`, `edge_betweenness` and `closeness`. If no cutoff is desired, use a negative value such as `cutoff=-1`.
  - `igraph_realize_degree_sequence()` has an additional argument controlling whether multi-edges or self-loops are allowed.
  - `igraph_is_degree_sequence()` and `igraph_is_graphical_degree_sequence()` are deprecated in favour of the newly added `igraph_is_graphical()`.
+ - `igraph_lapack_ddot()` is renamed to `igraph_blas_ddot()`.
 
 ### Fixed
 

--- a/include/igraph_blas.h
+++ b/include/igraph_blas.h
@@ -60,6 +60,9 @@ DECLDIR void igraph_blas_dgemv_array(igraph_bool_t transpose, igraph_real_t alph
 
 DECLDIR igraph_real_t igraph_blas_dnrm2(const igraph_vector_t *v);
 
+DECLDIR int igraph_blas_ddot(const igraph_vector_t *v1, const igraph_vector_t *v2,
+                               igraph_real_t *res);
+
 __END_DECLS
 
 #endif

--- a/include/igraph_lapack.h
+++ b/include/igraph_lapack.h
@@ -106,9 +106,6 @@ DECLDIR int igraph_lapack_dgehrd(const igraph_matrix_t *A,
                                  int ilo, int ihi,
                                  igraph_matrix_t *result);
 
-DECLDIR int igraph_lapack_ddot(const igraph_vector_t *v1, const igraph_vector_t *v2,
-                               igraph_real_t *res);
-
 __END_DECLS
 
 #endif

--- a/src/blas.c
+++ b/src/blas.c
@@ -108,3 +108,19 @@ igraph_real_t igraph_blas_dnrm2(const igraph_vector_t *v) {
     int one = 1;
     return igraphdnrm2_(&n, VECTOR(*v), &one);
 }
+
+int igraph_blas_ddot(const igraph_vector_t *v1, const igraph_vector_t *v2,
+                       igraph_real_t *res) {
+
+    int n = igraph_vector_size(v1);
+    int one = 1;
+
+    if (igraph_vector_size(v2) != n) {
+        IGRAPH_ERROR("Dot product of vectors with different dimensions",
+                     IGRAPH_EINVAL);
+    }
+
+    *res = igraphddot_(&n, VECTOR(*v1), &one, VECTOR(*v2), &one);
+
+    return 0;
+}

--- a/src/dotproduct.c
+++ b/src/dotproduct.c
@@ -24,7 +24,7 @@
 #include "igraph_games.h"
 #include "igraph_random.h"
 #include "igraph_constructors.h"
-#include "igraph_lapack.h"
+#include "igraph_blas.h"
 
 /**
  * \function igraph_dot_product_game
@@ -80,7 +80,7 @@ int igraph_dot_product_game(igraph_t *graph, const igraph_matrix_t *vecs,
                 continue;
             }
             igraph_vector_view(&v2, &MATRIX(*vecs, 0, j), nrow);
-            igraph_lapack_ddot(&v1, &v2, &prob);
+            igraph_blas_ddot(&v1, &v2, &prob);
             if (prob < 0 && ! warned_neg) {
                 warned_neg = 1;
                 IGRAPH_WARNING("Negative connection probability in "

--- a/src/igraph_blas_internal.h
+++ b/src/igraph_blas_internal.h
@@ -67,4 +67,6 @@ int igraphdgemm_(char *transa, char *transb, int *m, int *n, int *k,
 
 double igraphdnrm2_(int *n, double *x, int *incx);
 
+double igraphddot_(int *n, double *dx, int *incx, double *dy, int *incy);
+
 #endif

--- a/src/igraph_lapack_internal.h
+++ b/src/igraph_lapack_internal.h
@@ -140,7 +140,6 @@
     #define igraph_dlamc3_  dlamc3_
     #define igraph_dlamc4_  dlamc4_
     #define igraph_dlamc5_  dlamc5_
-    #define igraphddot_     ddot_
 #endif
 
 int igraphdgetrf_(int *m, int *n, igraph_real_t *a, int *lda, int *ipiv,

--- a/src/lapack.c
+++ b/src/lapack.c
@@ -23,7 +23,6 @@
 
 #include "igraph_lapack.h"
 #include "igraph_lapack_internal.h"
-#include "igraph_blas_internal.h"
 
 /**
  * \function igraph_lapack_dgetrf
@@ -937,19 +936,4 @@ int igraph_lapack_dgehrd(const igraph_matrix_t *A,
     return 0;
 }
 
-int igraph_lapack_ddot(const igraph_vector_t *v1, const igraph_vector_t *v2,
-                       igraph_real_t *res) {
-
-    int n = igraph_vector_size(v1);
-    int one = 1;
-
-    if (igraph_vector_size(v2) != n) {
-        IGRAPH_ERROR("Dot product of vectors with different dimensions",
-                     IGRAPH_EINVAL);
-    }
-
-    *res = igraphddot_(&n, VECTOR(*v1), &one, VECTOR(*v2), &one);
-
-    return 0;
-}
 

--- a/src/lapack/CMakeLists.txt
+++ b/src/lapack/CMakeLists.txt
@@ -5,7 +5,7 @@ add_library(
   EXCLUDE_FROM_ALL
   dscal.c dswap.c lsame.c dnrm2.c daxpy.c dgemv.c dger.c dgemm.c
   dcopy.c dtrmm.c dtrmv.c drot.c ddot.c dasum.c dsymv.c dsyr2k.c dsyr2.c
-  dtrsm.c dsyrk.c dtrsv.c idamax.c xerbla.c len_trim.c
+  dtrsm.c dsyrk.c dtrsv.c idamax.c
   $<TARGET_OBJECTS:f2c_vendored>
 )
 target_include_directories(
@@ -32,8 +32,8 @@ add_library(
   dlar1v.c dlarrf.c dsterf.c dsytrd.c dlatrd.c dsytd2.c dlanhs.c dgeqr2.c
   dtrsen.c dlacn2.c dtrsyl.c dlasr.c dsteqr.c dgeevx.c dtrsna.c dlaqtr.c
   dgetrf.c dgetf2.c dlaswp.c dgetrs.c dgesv.c dpotrf.c dpotf2.c
-  dlamch.c ../fortran_intrinsics.c
-  $<TARGET_OBJECTS:blas_vendored>
+  xerbla.c len_trim.c
+  dlamch.c ../fortran_intrinsics.c  
   $<TARGET_OBJECTS:f2c_vendored>
 )
 target_include_directories(


### PR DESCRIPTION
More fixes for building with external BLAS, internal LAPACK.

Changes:

 - When building internal LAPACK, do not also include the objects belonging to internal BLAS (internal LAPACK should be able to use external BLAS)
 - `xerbla.c` and `len_trim.c` belong to LAPACK, I believe, not to BLAS, so move them there in CMakeLists.txt
 - `igraph_lapack_ddot` is renamed to `igraph_blas_ddot` and moved to `igraph_blas.c`/`igraph_blas.h`, as this is a BLAS function, not a LAPACK one. This function was exposed publicly, so this is a breaking change.
 - in `igraph_blas_internal.h`, give a prototype to `igraphddot_` (which may be changed by a `#define` to `ddot_`) so that there would be no complaints about missing prototypes. There are already other similar prototypes there.
 - `igraph_blas_internal.h` can now be removed from `lapack.c` (I added it yesterday in https://github.com/igraph/igraph/commit/dada582ba62a39b9dca49eb4566b91ced49ad9b8, but the better fix is to move the ddot stuff to blas.c instead as noted above)
