### PR TITLE
Use realloc from CXSparse

### DIFF
--- a/src/sparsemat.c
+++ b/src/sparsemat.c
@@ -2734,9 +2734,9 @@ int igraph_sparsemat_add_cols(igraph_sparsemat_t *A, long int n) {
     if (igraph_sparsemat_is_triplet(A)) {
         A->cs->n += n;
     } else {
-        int *newp = realloc(A->cs->p, sizeof(int) * (size_t) (A->cs->n + n + 1));
-        int i;
-        if (!newp) {
+        int realloc_ok = 0, i;
+        int *newp = cs_realloc(A->cs->p, (A->cs->n + n + 1), sizeof(int), &realloc_ok);
+        if (!realloc_ok) {
             IGRAPH_ERROR("Cannot add columns to sparse matrix", IGRAPH_ENOMEM);
         }
         if (newp != A->cs->p) {


### PR DESCRIPTION
This PR changes `igraph_sparsemat_add_cols` to use `cs_realloc` to ensure that the reallocation is happening from the same runtime from `CXSparse`. This ensures that the reallocation is done with the same runtime that originally allocated the memory. If this is not done, this might lead to memory problem such as noted in #1492, which is fixed by this PR.