### PR TITLE
DECLDIR cleanup

### DIFF
--- a/include/igraph_decls.h
+++ b/include/igraph_decls.h
@@ -8,9 +8,12 @@
     #define __END_DECLS /* empty */
 #endif
 
+/* _WIN32 is always defined on Windows (both 32- and 64-bit systems).
+ * It is defined by the compiler itself, thus it does not depend on the inclusion of headers.
+ * Reference: https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros */
 #undef DECLDIR
-#if defined (_WIN32) || defined (WIN32) || defined (_WIN64) || defined (WIN64)
-    #if defined (__MINGW32__) || defined (__CYGWIN32__)
+#if defined (_WIN32)
+    #if defined (__CYGWIN__)
         #define DECLDIR /**/
     #else
         #ifdef IGRAPH_EXPORTS

--- a/src/prpack/prpack_utils.cpp
+++ b/src/prpack/prpack_utils.cpp
@@ -16,7 +16,7 @@ using namespace std;
 #include "igraph_error.h"
 #endif
 
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>


### PR DESCRIPTION
Justification:

 - `_WIN32` is defined both on 32-bit and 64-bit Windows. It is define by the compiler itself, and does not depend on the inclusion of any header. It appears to me that it is the correct way to test for Windows. Reference: https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=vs-2019

 - `WIN32` is not a standard macro (it may be defined by some headers though). We don't need it. Reference: see above and https://stackoverflow.com/q/9025708/695132 and https://stackoverflow.com/q/662084/695132 

 - `declspec` is supported by MINGW, so no need to exclude it from MINGW. Reference: https://stackoverflow.com/q/22285240/695132

 - Cygwin is pretending to be Unix as much as possible, and does not actually define `_WIN32`, unless using the `-mwin32` option. However, there are suggestion that in the past it did, so it is better to keep explicitly excluding it. Reference: https://stackoverflow.com/q/47150492/695132 and https://cygwin.com/faq/faq.html#faq.programming.preprocessor

 - While `__CYGWIN32__` exists (both on 32- and 64-bit), the Cygwin documentation suggests using `__CYGWIN__`.  Reference: https://cygwin.com/faq/faq.html#faq.programming.preprocessor