### PR TITLE
CMake add path for test on MinGW

### DIFF
--- a/etc/cmake/test_helpers.cmake
+++ b/etc/cmake/test_helpers.cmake
@@ -53,7 +53,7 @@ function(add_legacy_test FOLDER NAME)
     )
     set_property(TEST ${NAME} PROPERTY SKIP_RETURN_CODE 77)
   endif()
-  if (MSVC AND BUILD_SHARED_LIBS)
+  if (WIN32 AND BUILD_SHARED_LIBS)
     # On Windows the built igraph.dll is not automatically found by the tests. We therefore
     # add the dir that contains the built igraph.dll to the path environment variable
     # so that igraph.dll is found when running the tests.


### PR DESCRIPTION
This PR adds the correct path for tests on MinGW. Before this the path was being added only for `MSVC`. This is now generalised to `WIN32`, which also includes MinGW. This fixes #1501.

One important note, which we should also include in the installation instructions (#1497) is that the `mingw64/bin` directory should be added to the *Windows* path. Without this, running `ctest` will fail (even from the `msys2` terminal).