### PR TITLE
Properly fix path problems with CTest on MinGW

### DIFF
--- a/etc/cmake/test_helpers.cmake
+++ b/etc/cmake/test_helpers.cmake
@@ -58,7 +58,9 @@ function(add_legacy_test FOLDER NAME)
     # add the dir that contains the built igraph.dll to the path environment variable
     # so that igraph.dll is found when running the tests.
     SET(IGRAPH_LIBDIR $<TARGET_FILE_DIR:igraph>)
-    SET_TESTS_PROPERTIES( ${NAME} PROPERTIES ENVIRONMENT "PATH=${IGRAPH_LIBDIR};$ENV{PATH}" )
+    string(REPLACE "/" "\\" IGRAPH_LIBDIR ${IGRAPH_LIBDIR})
+    string(JOIN "\;" CORRECT_PATH $ENV{PATH})
+    SET_TESTS_PROPERTIES( ${NAME} PROPERTIES ENVIRONMENT "PATH=${IGRAPH_LIBDIR}\;${CORRECT_PATH}" )
   endif()
 endfunction()
 

--- a/etc/cmake/test_helpers.cmake
+++ b/etc/cmake/test_helpers.cmake
@@ -58,7 +58,15 @@ function(add_legacy_test FOLDER NAME)
     # add the dir that contains the built igraph.dll to the path environment variable
     # so that igraph.dll is found when running the tests.
     SET(IGRAPH_LIBDIR $<TARGET_FILE_DIR:igraph>)
+    
+    # The next line is necessitated by MinGW on Windows. MinGW uses forward slashes in
+    # IGRAPH_LIBDIR, but we need to supply CTest with backslashes because CTest is executed
+    # in a cmd.exe shell. So we simply replace forward slashes with backslases in
+    # IGRAPH_LIBDIR.
     string(REPLACE "/" "\\" IGRAPH_LIBDIR ${IGRAPH_LIBDIR})
+    
+    # Semicolons are used as list separators in CMake so we need to escape them in the PATH,
+    # otherwise the PATH envvar gets split by CMake before it passes the PATH on to CTest.
     string(JOIN "\;" CORRECT_PATH $ENV{PATH})
     SET_TESTS_PROPERTIES( ${NAME} PROPERTIES ENVIRONMENT "PATH=${IGRAPH_LIBDIR}\;${CORRECT_PATH}" )
   endif()


### PR DESCRIPTION
This is a continuation of #1504. There were some further problems with paths on MinGW, see https://github.com/igraph/igraph/issues/1501#issuecomment-717322063 for some more details. This now finally properly fixes #1501.