### PR TITLE
cmake: Condition warning options on C_COMPILER_ID

### DIFF
--- a/etc/cmake/compilers.cmake
+++ b/etc/cmake/compilers.cmake
@@ -1,11 +1,5 @@
 if(MSVC)
   add_compile_options(/FS)
-else()
-  add_compile_options(
-    # Intel compiler:
-    # Do not print remarks:
-    $<$<C_COMPILER_ID:Intel>:-diag-disable=remark>
-  )
 endif()
 
 macro(use_all_warnings TARGET_NAME)
@@ -13,13 +7,18 @@ macro(use_all_warnings TARGET_NAME)
     target_compile_options(${TARGET_NAME} PRIVATE /W4)
   else()
     target_compile_options(${TARGET_NAME} PRIVATE 
-      -Wall -Wextra -pedantic -Werror -Wno-unused-parameter -Wno-sign-compare
-      $<$<NOT:$<C_COMPILER_ID:Intel>>:-Wno-varargs>
+      # GCC-style compilers:
+      $<$<C_COMPILER_ID:GCC,Clang,AppleClang>:
+        -Wall -Wextra -pedantic -Werror -Wno-unused-parameter -Wno-sign-compare -Wno-varargs
+      >
       # Intel compiler:
-      # disable #279: controlling expression is constant; affecting assert(condition && "message")
-      # disable #188: enumerated type mixed with another type; affecting IGRAPH_CHECK
-      # disable #592: variable "var" is used before its value is set; affecting IGRAPH_UNUSED
-      $<$<C_COMPILER_ID:Intel>:-wd279 -wd188 -wd592>
+      $<$<C_COMPILER_ID:Intel>:
+        -Wall -Wextra -pedantic -Werror -Wno-unused-parameter -Wno-sign-compare
+        # disable #279: controlling expression is constant; affecting assert(condition && "message")
+        # disable #188: enumerated type mixed with another type; affecting IGRAPH_CHECK
+        # disable #592: variable "var" is used before its value is set; affecting IGRAPH_UNUSED
+        -wd279 -wd188 -wd592 -diag-disable=remark
+      >
     )
   endif()
 endmacro()

--- a/optional/glpk/CMakeLists.txt
+++ b/optional/glpk/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Include some compiler-related helper and set global compiler options
+include(compilers)
+
 add_library(
   glpk_vendored
   OBJECT

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Include some compiler-related helper functions
+# Include some compiler-related helper and set global compiler options
 include(compilers)
 
 # Traverse subdirectories

--- a/src/f2c/CMakeLists.txt
+++ b/src/f2c/CMakeLists.txt
@@ -90,11 +90,11 @@ endif()
 # mess around with the source of f2c too much to fix these
 if(NOT MSVC)
   target_compile_options(arithchk PRIVATE 
-    $<$<NOT:$<C_COMPILER_ID:Intel>>:-Wno-format-zero-length>
+    $<$<C_COMPILER_ID:GCC,Clang,AppleClang>:-Wno-format-zero-length>
   )
   target_compile_options(
     f2c_vendored PRIVATE 
-    -Wno-parentheses -Wno-pointer-to-int-cast -Wno-implicit-function-declaration
-    $<$<NOT:$<C_COMPILER_ID:Intel>>:-Wno-format-zero-length>
+    $<$<C_COMPILER_ID:GCC,Clang,AppleClang>:-Wno-parentheses -Wno-pointer-to-int-cast -Wno-implicit-function-declaration -Wno-format-zero-length>
+    $<$<C_COMPILER_ID:Intel>:-Wno-parentheses -Wno-pointer-to-int-cast -Wno-implicit-function-declaration>
   )
 endif()

--- a/src/lapack/CMakeLists.txt
+++ b/src/lapack/CMakeLists.txt
@@ -63,9 +63,9 @@ target_include_directories(
 # mess around with the source of lapack too much to fix these
 if(NOT MSVC)
   target_compile_options(blas_vendored PRIVATE 
-    $<$<NOT:$<C_COMPILER_ID:Intel>>:-Wno-logical-op-parentheses>
+    $<$<C_COMPILER_ID:GCC,Clang,AppleClang>:-Wno-logical-op-parentheses>
   )
   target_compile_options(lapack_vendored PRIVATE 
-    $<$<NOT:$<C_COMPILER_ID:Intel>>:-Wno-logical-op-parentheses -Wno-shift-op-parentheses>
+    $<$<C_COMPILER_ID:GCC,Clang,AppleClang>:-Wno-logical-op-parentheses -Wno-shift-op-parentheses>
   )
 endif()


### PR DESCRIPTION
This PR makes all warning options conditional on the compiler. GCC,Clang,AppleClang are included, as these are what we use, and these usually take the same options.

These options are not actually needed for compilation. They are just a nice to have during development. They alert us to problems.

However, they will also prevent other compilers from working:

 - Compilation failed with the Intel compiler, so options had to be adjusted for that one a bit. Removing them entirely would have worked as well, but adjusting them made it easier for us to make use of the Intel compiler's warning. 

 - Compilation also failed with the PGI compiler. With this PR, it passes (after adjusting the source code a bit, but that's a separate thing). Of course, it shows lots of warning, but igraph does compiler, and the tests pass, and that's what matters.