### PR TITLE
igraph_attribute_combination: make compatible with PGI compiler

### DIFF
--- a/src/attributes.c
+++ b/src/attributes.c
@@ -422,11 +422,7 @@ int igraph_attribute_combination(igraph_attribute_combination_t *comb, ...) {
 
         type = (igraph_attribute_combination_type_t)va_arg(ap, int);
         if (type == IGRAPH_ATTRIBUTE_COMBINE_FUNCTION) {
-#if defined(__GNUC__)
-            func = va_arg(ap, void (*)(void));
-#else
-            func = va_arg(ap, void*);
-#endif
+            func = va_arg(ap, igraph_function_pointer_t);
         }
 
         if (strlen(name) == 0) {


### PR DESCRIPTION
The PGI compiler choked on this:

```
/src/attributes.c", line 426: error: expected an
          expression
              func = va_arg(ap, (void (*)(void)) );
                     ^
```

I expect other compilers choked on it too because it was conditioned on the macro `__GCC__`, but the PGI compiler has that macro defined. This version should be more compatible, and works fine with the PGI compiler.