### PR TITLE
to_directed: add RANDOM and ACYCLIC modes

### DIFF
--- a/examples/tests/igraph_to_directed.c
+++ b/examples/tests/igraph_to_directed.c
@@ -1,0 +1,43 @@
+
+#include <igraph.h>
+
+#include "test_utilities.inc"
+
+int main() {
+    igraph_t ug;
+    igraph_t dg;
+
+    igraph_small(&ug, 6, /* directed= */ 0,
+                 2,0, 1,4, 3,2, 2,3, 0,4, 5,0, 2,3, 5,3, 2,5, 0,1,
+                 -1);
+
+    igraph_copy(&dg, &ug);
+    printf("\nARBITRARY:\n");
+    igraph_to_directed(&dg, IGRAPH_TO_DIRECTED_ARBITRARY);
+    print_graph(&dg, stdout);    
+    igraph_destroy(&dg);
+
+    igraph_copy(&dg, &ug);
+    printf("\nMUTUAL:\n");
+    igraph_to_directed(&dg, IGRAPH_TO_DIRECTED_MUTUAL);
+    print_graph(&dg, stdout);
+    igraph_destroy(&dg);
+
+    igraph_copy(&dg, &ug);
+    printf("\nACYCLIC:\n");
+    igraph_to_directed(&dg, IGRAPH_TO_DIRECTED_ACYCLIC);
+    print_graph(&dg, stdout);
+    igraph_destroy(&dg);
+
+    igraph_copy(&dg, &ug);
+    printf("\nRANDOM (edge count only):\n");
+    igraph_to_directed(&dg, IGRAPH_TO_DIRECTED_RANDOM);
+    printf("%d\n", igraph_ecount(&dg));
+    igraph_destroy(&dg);
+
+    igraph_destroy(&ug);
+
+    VERIFY_FINALLY_STACK();
+
+    return 0;
+}

--- a/examples/tests/igraph_to_directed.out
+++ b/examples/tests/igraph_to_directed.out
@@ -1,0 +1,61 @@
+
+ARBITRARY:
+directed: true
+vcount: 6
+edges: {
+0 2
+1 4
+2 3
+2 3
+0 4
+0 5
+2 3
+3 5
+2 5
+0 1
+}
+
+MUTUAL:
+directed: true
+vcount: 6
+edges: {
+0 2
+1 4
+2 3
+2 3
+0 4
+0 5
+2 3
+3 5
+2 5
+0 1
+2 0
+4 1
+3 2
+3 2
+4 0
+5 0
+3 2
+5 3
+5 2
+1 0
+}
+
+ACYCLIC:
+directed: true
+vcount: 6
+edges: {
+0 2
+1 4
+2 3
+2 3
+0 4
+0 5
+2 3
+3 5
+2 5
+0 1
+}
+
+RANDOM (edge count only):
+10

--- a/include/igraph_constants.h
+++ b/include/igraph_constants.h
@@ -110,7 +110,9 @@ typedef enum { IGRAPH_EDGEORDER_ID = 0,
              } igraph_edgeorder_type_t;
 
 typedef enum { IGRAPH_TO_DIRECTED_ARBITRARY = 0,
-               IGRAPH_TO_DIRECTED_MUTUAL
+               IGRAPH_TO_DIRECTED_MUTUAL,
+               IGRAPH_TO_DIRECTED_RANDOM,
+               IGRAPH_TO_DIRECTED_ACYCLIC
              } igraph_to_directed_t;
 
 typedef enum { IGRAPH_TO_UNDIRECTED_EACH = 0,

--- a/src/conversion.c
+++ b/src/conversion.c
@@ -373,15 +373,7 @@ int igraph_to_directed(igraph_t *graph,
         IGRAPH_VECTOR_INIT_FINALLY(&edges, size);
         IGRAPH_CHECK(igraph_get_edgelist(graph, &edges, 0));
 
-        if (mode == IGRAPH_TO_DIRECTED_ACYCLIC) {
-            for (i=0; i < no_of_edges; ++i) {
-                if (VECTOR(edges)[2*i] > VECTOR(edges)[2*i+1]) {
-                    igraph_real_t temp = VECTOR(edges)[2*i];
-                    VECTOR(edges)[2*i] = VECTOR(edges)[2*i+1];
-                    VECTOR(edges)[2*i+1] = temp;
-                }
-            }
-        } else if (mode == IGRAPH_TO_DIRECTED_RANDOM) {
+        if (mode == IGRAPH_TO_DIRECTED_RANDOM) {
             RNG_BEGIN();
 
             for (i=0; i < no_of_edges; ++i) {
@@ -393,6 +385,21 @@ int igraph_to_directed(igraph_t *graph,
             }
 
             RNG_END();
+        } else if (mode == IGRAPH_TO_DIRECTED_ACYCLIC) {
+            /* Currently, the endpoints of undirected edges are ordered in the
+               internal graph datastructure, i.e. it is always true that from < to.
+               However, it is not guaranteed that this will not be changed in
+               the future, and this ordering should not be relied on outside of
+               the implementation of the minimal API in type_indexededgelist.c.
+
+               Therefore, we order the edge endpoints anyway in the following loop: */
+            for (i=0; i < no_of_edges; ++i) {
+                if (VECTOR(edges)[2*i] > VECTOR(edges)[2*i+1]) {
+                    igraph_real_t temp = VECTOR(edges)[2*i];
+                    VECTOR(edges)[2*i] = VECTOR(edges)[2*i+1];
+                    VECTOR(edges)[2*i+1] = temp;
+                }
+            }
         }
 
         IGRAPH_CHECK(igraph_create(&newgraph, &edges,

--- a/src/conversion.c
+++ b/src/conversion.c
@@ -368,11 +368,12 @@ int igraph_to_directed(igraph_t *graph,
         igraph_t newgraph;
         igraph_vector_t edges;
         long int size = no_of_edges * 2;
+        long int i;
+
         IGRAPH_VECTOR_INIT_FINALLY(&edges, size);
         IGRAPH_CHECK(igraph_get_edgelist(graph, &edges, 0));
 
         if (mode == IGRAPH_TO_DIRECTED_ACYCLIC) {
-            long int i;
             for (i=0; i < no_of_edges; ++i) {
                 if (VECTOR(edges)[2*i] > VECTOR(edges)[2*i+1]) {
                     igraph_real_t temp = VECTOR(edges)[2*i];
@@ -381,8 +382,6 @@ int igraph_to_directed(igraph_t *graph,
                 }
             }
         } else if (mode == IGRAPH_TO_DIRECTED_RANDOM) {
-            long int i;
-
             RNG_BEGIN();
 
             for (i=0; i < no_of_edges; ++i) {

--- a/src/conversion.c
+++ b/src/conversion.c
@@ -29,6 +29,7 @@
 #include "igraph_structural.h"
 #include "igraph_types_internal.h"
 #include "igraph_sparsemat.h"
+#include "igraph_random.h"
 #include "config.h"
 
 /**
@@ -327,12 +328,23 @@ int igraph_get_edgelist(const igraph_t *graph, igraph_vector_t *res, igraph_bool
  * If the supplied graph is directed, this function does nothing.
  * \param graph The graph object to convert.
  * \param mode Constant, specifies the details of how exactly the
- *        conversion is done. Possible values: \c
- *        IGRAPH_TO_DIRECTED_ARBITRARY: the number of edges in the
+ *        conversion is done. Possible values:
+ *        \clist
+ *        \cli IGRAPH_TO_DIRECTED_ARBITRARY
+ *        The number of edges in the
  *        graph stays the same, an arbitrarily directed edge is
- *        created for each undirected edge;
- *         \c IGRAPH_TO_DIRECTED_MUTUAL: two directed edges are
+ *        created for each undirected edge.
+ *        \cli IGRAPH_TO_DIRECTED_MUTUAL
+ *        Two directed edges are
  *        created for each undirected edge, one in each direction.
+ *        \cli IGRAPH_TO_DIRECTED_RANDOM
+ *        Each undirected edge is converted to a randomly oriented
+ *        directed one.
+ *        \cli IGRAPH_TO_DIRECTED_ACYCLIC
+ *        Each undirected edge is converted to a directed edge oriented
+ *        from a lower index vertex to a higher index one. If no self-loops
+ *        were present, then the result is a directed acyclic graph.
+ *        \endclist
  * \return Error code.
  *
  * Time complexity: O(|V|+|E|), the number of vertices plus the number
@@ -341,25 +353,48 @@ int igraph_get_edgelist(const igraph_t *graph, igraph_vector_t *res, igraph_bool
 
 int igraph_to_directed(igraph_t *graph,
                        igraph_to_directed_t mode) {
-
-    if (mode != IGRAPH_TO_DIRECTED_ARBITRARY &&
-        mode != IGRAPH_TO_DIRECTED_MUTUAL) {
-        IGRAPH_ERROR("Cannot direct graph, invalid mode", IGRAPH_EINVAL);
-    }
+    long int no_of_edges = igraph_ecount(graph);
+    long int no_of_nodes = igraph_vcount(graph);
 
     if (igraph_is_directed(graph)) {
-        return 0;
-    }
+        return IGRAPH_SUCCESS;
+    }   
 
-    if (mode == IGRAPH_TO_DIRECTED_ARBITRARY) {
-
+    switch (mode) {
+    case IGRAPH_TO_DIRECTED_ARBITRARY:
+    case IGRAPH_TO_DIRECTED_RANDOM:
+    case IGRAPH_TO_DIRECTED_ACYCLIC:
+      {
         igraph_t newgraph;
         igraph_vector_t edges;
-        long int no_of_edges = igraph_ecount(graph);
-        long int no_of_nodes = igraph_vcount(graph);
         long int size = no_of_edges * 2;
         IGRAPH_VECTOR_INIT_FINALLY(&edges, size);
         IGRAPH_CHECK(igraph_get_edgelist(graph, &edges, 0));
+
+        if (mode == IGRAPH_TO_DIRECTED_ACYCLIC) {
+            long int i;
+            for (i=0; i < no_of_edges; ++i) {
+                if (VECTOR(edges)[2*i] > VECTOR(edges)[2*i+1]) {
+                    igraph_real_t temp = VECTOR(edges)[2*i];
+                    VECTOR(edges)[2*i] = VECTOR(edges)[2*i+1];
+                    VECTOR(edges)[2*i+1] = temp;
+                }
+            }
+        } else if (mode == IGRAPH_TO_DIRECTED_RANDOM) {
+            long int i;
+
+            RNG_BEGIN();
+
+            for (i=0; i < no_of_edges; ++i) {
+                if (RNG_INTEGER(0,1)) {
+                    igraph_real_t temp = VECTOR(edges)[2*i];
+                    VECTOR(edges)[2*i] = VECTOR(edges)[2*i+1];
+                    VECTOR(edges)[2*i+1] = temp;
+                }
+            }
+
+            RNG_END();
+        }
 
         IGRAPH_CHECK(igraph_create(&newgraph, &edges,
                                    (igraph_integer_t) no_of_nodes,
@@ -372,13 +407,13 @@ int igraph_to_directed(igraph_t *graph,
         igraph_destroy(graph);
         *graph = newgraph;
 
-    } else if (mode == IGRAPH_TO_DIRECTED_MUTUAL) {
-
+        break;
+      }
+    case IGRAPH_TO_DIRECTED_MUTUAL:
+      {
         igraph_t newgraph;
         igraph_vector_t edges;
         igraph_vector_t index;
-        long int no_of_edges = igraph_ecount(graph);
-        long int no_of_nodes = igraph_vcount(graph);
         long int size = no_of_edges * 4;
         long int i;
         IGRAPH_VECTOR_INIT_FINALLY(&edges, 0);
@@ -405,9 +440,14 @@ int igraph_to_directed(igraph_t *graph,
         igraph_destroy(graph);
         IGRAPH_FINALLY_CLEAN(3);
         *graph = newgraph;
+
+        break;
+      }
+    default:
+        IGRAPH_ERROR("Cannot direct graph, invalid mode", IGRAPH_EINVAL);
     }
 
-    return 0;
+    return IGRAPH_SUCCESS;
 }
 
 /**

--- a/src/conversion.c
+++ b/src/conversion.c
@@ -405,11 +405,12 @@ int igraph_to_directed(igraph_t *graph,
         IGRAPH_CHECK(igraph_create(&newgraph, &edges,
                                    (igraph_integer_t) no_of_nodes,
                                    IGRAPH_DIRECTED));
-        IGRAPH_FINALLY(igraph_destroy, &newgraph);
-        igraph_vector_destroy(&edges);
+        IGRAPH_FINALLY(igraph_destroy, &newgraph);        
         IGRAPH_I_ATTRIBUTE_DESTROY(&newgraph);
         IGRAPH_I_ATTRIBUTE_COPY(&newgraph, graph, 1, 1, 1);
+        igraph_vector_destroy(&edges);
         IGRAPH_FINALLY_CLEAN(2);
+
         igraph_destroy(graph);
         *graph = newgraph;
 
@@ -442,9 +443,10 @@ int igraph_to_directed(igraph_t *graph,
         IGRAPH_CHECK(igraph_i_attribute_permute_edges(graph, &newgraph, &index));
 
         igraph_vector_destroy(&index);
-        igraph_vector_destroy(&edges);
-        igraph_destroy(graph);
+        igraph_vector_destroy(&edges);        
         IGRAPH_FINALLY_CLEAN(3);
+
+        igraph_destroy(graph);
         *graph = newgraph;
 
         break;

--- a/tests/conversion.at
+++ b/tests/conversion.at
@@ -27,6 +27,12 @@ AT_COMPILE_CHECK([simple/igraph_to_undirected.c],
 	         [simple/igraph_to_undirected.out])
 AT_CLEANUP
 
+AT_SETUP([Undirected to directed (igraph_to_directed):])
+AT_KEYWORDS([igraph_to_directed directedness undirected directed])
+AT_COMPILE_CHECK([tests/igraph_to_directed.c], 
+	         [tests/igraph_to_directed.out])
+AT_CLEANUP
+
 AT_SETUP([Graphs from adjacency list (igraph_adjlist):])
 AT_KEYWORDS([igraph_adjlist adjacency list adjlist])
 AT_COMPILE_CHECK([simple/adjlist.c])


### PR DESCRIPTION
I don't use this function in the Mma interface, so it would be nice to integrate it into Python for easier testing.

Fixes #1270 