### PR TITLE
CMake: fix compiling and testing static library on MinGW.

### DIFF
--- a/etc/cmake/test_helpers.cmake
+++ b/etc/cmake/test_helpers.cmake
@@ -10,7 +10,7 @@ function(add_legacy_test FOLDER NAME)
   add_dependencies(build_tests test_${NAME})
   target_link_libraries(test_${NAME} PRIVATE igraph)
 
-  if (MSVC AND NOT BUILD_SHARED_LIBS)
+  if (WIN32 AND NOT BUILD_SHARED_LIBS)
     # Add a compiler definition required to compile igraph in static mode on Windows
     target_compile_definitions(test_${NAME} PRIVATE IGRAPH_STATIC)
   endif()
@@ -58,13 +58,13 @@ function(add_legacy_test FOLDER NAME)
     # add the dir that contains the built igraph.dll to the path environment variable
     # so that igraph.dll is found when running the tests.
     SET(IGRAPH_LIBDIR $<TARGET_FILE_DIR:igraph>)
-    
+
     # The next line is necessitated by MinGW on Windows. MinGW uses forward slashes in
     # IGRAPH_LIBDIR, but we need to supply CTest with backslashes because CTest is executed
     # in a cmd.exe shell. So we simply replace forward slashes with backslases in
     # IGRAPH_LIBDIR.
     string(REPLACE "/" "\\" IGRAPH_LIBDIR ${IGRAPH_LIBDIR})
-    
+
     # Semicolons are used as list separators in CMake so we need to escape them in the PATH,
     # otherwise the PATH envvar gets split by CMake before it passes the PATH on to CTest.
     string(JOIN "\;" CORRECT_PATH $ENV{PATH})

--- a/optional/glpk/CMakeLists.txt
+++ b/optional/glpk/CMakeLists.txt
@@ -36,7 +36,7 @@ target_include_directories(
   ${CMAKE_SOURCE_DIR}/include
 )
 
-if (WIN32 AND BUILD_SHARED_LIBS)
+if (WIN32)
     # Since these are included as object files, they should call the
     # function as is (without declspec)
     target_compile_definitions(glpk_vendored PRIVATE IGRAPH_STATIC)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -242,7 +242,7 @@ target_link_libraries(
 )
 
 if (WIN32)
-  # Define symbols to enable compilation of CSXSparse on Windows using MSVC
+  # Define symbols to enable compilation of CSXSparse on Windows
   target_compile_definitions(igraph PRIVATE NCOMPLEX)
   if (NOT BUILD_SHARED_LIBS)
     # Add a compiler definition required to compile igraph in static mode on Windows

--- a/src/cliquer/CMakeLists.txt
+++ b/src/cliquer/CMakeLists.txt
@@ -17,11 +17,12 @@ target_include_directories(
 
 if (BUILD_SHARED_LIBS)
   set_property(TARGET cliquer PROPERTY POSITION_INDEPENDENT_CODE ON)
-  if (WIN32)
-    # Since these are included as object files, they should call the
-    # function as is (without declspec)
-    target_compile_definitions(cliquer PRIVATE IGRAPH_STATIC)
-  endif()
+endif()
+
+if (WIN32)
+  # Since these are included as object files, they should call the
+  # function as is (without declspec)
+  target_compile_definitions(cliquer PRIVATE IGRAPH_STATIC)
 endif()
 
 # TODO(ntamas): make sure that this works for Cliquer

--- a/src/cs/CMakeLists.txt
+++ b/src/cs/CMakeLists.txt
@@ -35,11 +35,9 @@ target_include_directories(
 # Define symbols to enable compilation of CSXSparse on Windows using MSVC
 if (WIN32)
   target_compile_definitions(cxsparse_vendored PUBLIC NCOMPLEX)
-  if (BUILD_SHARED_LIBS)
-    # Since these are included as object files, they should call the
-    # function as is (without declspec)
-    target_compile_definitions(cxsparse_vendored PRIVATE IGRAPH_STATIC)
-  endif()
+  # Since these are included as object files, they should call the
+  # function as is (without declspec)
+  target_compile_definitions(cxsparse_vendored PRIVATE IGRAPH_STATIC)
 endif()
 
 use_all_warnings(cxsparse_vendored)

--- a/src/prpack/CMakeLists.txt
+++ b/src/prpack/CMakeLists.txt
@@ -27,11 +27,12 @@ target_include_directories(
 
 if (BUILD_SHARED_LIBS)
   set_property(TARGET prpack PROPERTY POSITION_INDEPENDENT_CODE ON)
-  if (WIN32)
-    # Since these are included as object files, they should call the
-    # function as is (without declspec)
-    target_compile_definitions(prpack PRIVATE IGRAPH_STATIC)
-  endif()
+endif()
+
+if (WIN32)
+  # Since these are included as object files, they should call the
+  # function as is (without declspec)
+  target_compile_definitions(prpack PRIVATE IGRAPH_STATIC)
 endif()
 
 # Turn on all warnings for GCC, clang and MSVC


### PR DESCRIPTION
This fixes compiling and testing a static library on MinGW using CMake. At the moment, the symbols were not properly defined, as they actually still used `dllspec` declaration style when compiling a static library. Similarly, `IGRAPH_STATIC` was not properly defined for the tests. After merging this we can definitely close #1495.