### PR TITLE
fix prototypes of fortran intrinsics

### DIFF
--- a/src/fortran_intrinsics.c
+++ b/src/fortran_intrinsics.c
@@ -23,31 +23,31 @@
 
 #include <float.h>
 
-double digitsdbl_(double x) {
+double digitsdbl_(double *x) {
     return (double) DBL_MANT_DIG;
 }
 
-double epsilondbl_(double x) {
+double epsilondbl_(double *x) {
     return DBL_EPSILON;
 }
 
-double hugedbl_(double x) {
+double hugedbl_(double *x) {
     return DBL_MAX;
 }
 
-double tinydbl_(double x) {
+double tinydbl_(double *x) {
     return DBL_MIN;
 }
 
-int maxexponentdbl_(double x) {
+int maxexponentdbl_(double *x) {
     return DBL_MAX_EXP;
 }
 
-int minexponentdbl_(double x) {
+int minexponentdbl_(double *x) {
     return DBL_MIN_EXP;
 }
 
-double radixdbl_(double x) {
+double radixdbl_(double *x) {
     return (double) FLT_RADIX;
 }
 


### PR DESCRIPTION
The prototypes of fortran intrinsics seems to be bad. See how they are actually used from LAPACK:

https://github.com/igraph/igraph/blob/master/src/lapack/dlamch.c#L88

As with all fortran functions, the arguments should be pointers.

I found this while compiling with LTO on Linux.

