### PR TITLE
GLPK: replace explicit "opaque" structs with extern structs

### DIFF
--- a/optional/glpk/glpbfd.h
+++ b/optional/glpk/glpbfd.h
@@ -26,7 +26,7 @@
 #define GLPBFD_H
 
 #ifndef GLPBFD_PRIVATE
-typedef struct { double _opaque_bfd[100]; } BFD;
+typedef struct BFD BFD;
 #endif
 
 /* return codes: */

--- a/optional/glpk/glpbfx.h
+++ b/optional/glpk/glpbfx.h
@@ -29,7 +29,7 @@
 
 #ifndef GLPBFX_DEFINED
 #define GLPBFX_DEFINED
-typedef struct { double _opaque_bfx; } BFX;
+typedef struct BFX BFX;
 #endif
 
 #define bfx_create_binv       _glp_bfx_create_binv

--- a/optional/glpk/glpk.h
+++ b/optional/glpk/glpk.h
@@ -38,7 +38,7 @@ extern "C" {
 
 #ifndef GLP_PROB_DEFINED
 #define GLP_PROB_DEFINED
-typedef struct { double _opaque_prob[100]; } glp_prob;
+typedef struct glp_prob glp_prob;
 /* LP/MIP problem object */
 #endif
 
@@ -149,7 +149,7 @@ typedef struct
 
 #ifndef GLP_TREE_DEFINED
 #define GLP_TREE_DEFINED
-typedef struct { double _opaque_tree[100]; } glp_tree;
+typedef struct glp_tree glp_tree;
 /* branch-and-bound tree */
 #endif
 
@@ -283,7 +283,7 @@ typedef struct
 
 #ifndef GLP_TRAN_DEFINED
 #define GLP_TRAN_DEFINED
-typedef struct { double _opaque_tran[100]; } glp_tran;
+typedef struct glp_tran glp_tran;
 /* MathProg translator workspace */
 #endif
 
@@ -836,7 +836,7 @@ double glp_difftime(glp_long t1, glp_long t0);
 
 #ifndef GLP_DATA_DEFINED
 #define GLP_DATA_DEFINED
-typedef struct { double _opaque_data[100]; } glp_data;
+typedef struct glp_data glp_data;
 /* plain data file */
 #endif
 


### PR DESCRIPTION
The vendored GLPK uses very dubious structs which don't match their original definition. E.g., compare these:

Original: https://github.com/igraph/igraph/blob/master/optional/glpk/glpbfx.c#L31

Substitute: https://github.com/igraph/igraph/blob/master/optional/glpk/glpbfx.h#L32

In C, it is not actually necessary to have a full declaration of a `struct` in order to write prototypes of functions that use that struct. Therefore, I removed these substitutes.

The substitutes were causing many warnings when compiling with LTO with gcc on Linux.
