### PR TITLE
CMake: create parsers/lexers before packaging.

### DIFF
--- a/etc/cmake/packaging.cmake
+++ b/etc/cmake/packaging.cmake
@@ -13,6 +13,8 @@ add_custom_target(dist
   USES_TERMINAL
 )
 
+add_dependencies(dist parsersources)
+
 #############################################################################
 ## Configuration of the source package
 #############################################################################
@@ -31,6 +33,7 @@ set(
 	"${CMAKE_SOURCE_DIR}/include;/include"
 	"${CMAKE_SOURCE_DIR}/msvc/include;/msvc/include"
 	"${CMAKE_SOURCE_DIR}/optional;/optional"
+	"${CMAKE_BINARY_DIR}/src/parsers/;/src/parsers"
 	"${CMAKE_SOURCE_DIR}/src;/src"
 	"${CMAKE_SOURCE_DIR}/tests;/tests"
 )
@@ -45,6 +48,8 @@ set(CPACK_INSTALL_SCRIPT "${CMAKE_SOURCE_DIR}/etc/cmake/cpack_install_script.cma
 set(
 	CPACK_SOURCE_IGNORE_FILES
 	"\\\\..*/"
+	"\.l$"
+	"\.y$"
 	"${CMAKE_SOURCE_DIR}/build"
 	"${CMAKE_SOURCE_DIR}/optional/simpleraytracer"
 	"Makefile.am"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,23 +12,25 @@ add_subdirectory(prpack)
 
 # Generate lexers and parsers
 set(PARSER_SOURCES)
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/parsers/)
 foreach(FORMAT dl gml lgl ncol pajek)
-  if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/foreign-${FORMAT}-parser.c)
+  if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/parsers/foreign-${FORMAT}-parser.c)
     list(APPEND PARSER_SOURCES
-      ${CMAKE_CURRENT_SOURCE_DIR}/foreign-${FORMAT}-lexer.c
-      ${CMAKE_CURRENT_SOURCE_DIR}/foreign-${FORMAT}-parser.c
+      ${CMAKE_CURRENT_SOURCE_DIR}/parsers/foreign-${FORMAT}-lexer.c
+      ${CMAKE_CURRENT_SOURCE_DIR}/parsers/foreign-${FORMAT}-parser.c
     )
   else()
     bison_target(
-      ${FORMAT}_parser foreign-${FORMAT}-parser.y ${CMAKE_CURRENT_BINARY_DIR}/foreign-${FORMAT}-parser.c
+      ${FORMAT}_parser foreign-${FORMAT}-parser.y ${CMAKE_CURRENT_BINARY_DIR}/parsers/foreign-${FORMAT}-parser.c
     )
     flex_target(
-      ${FORMAT}_lexer foreign-${FORMAT}-lexer.l ${CMAKE_CURRENT_BINARY_DIR}/foreign-${FORMAT}-lexer.c
+      ${FORMAT}_lexer foreign-${FORMAT}-lexer.l ${CMAKE_CURRENT_BINARY_DIR}/parsers/foreign-${FORMAT}-lexer.c
     )
     add_flex_bison_dependency(${FORMAT}_lexer ${FORMAT}_parser)
     list(APPEND PARSER_SOURCES ${BISON_${FORMAT}_parser_OUTPUTS} ${FLEX_${FORMAT}_lexer_OUTPUTS})
   endif()
 endforeach()
+add_custom_target(parsersources SOURCES ${PARSER_SOURCES})
 
 # Declare the files needed to compile the igraph library
 add_library(


### PR DESCRIPTION
This PR adds a separate target to build the parser sources, called `parsersources`. The built parsers (i.e. the `.c` files) are placed in a separate directory `parsers` in the `src` folder in the build tree, and are hence used from there in the build tree. Hence, you can also separately (only) build the parser sources by calling `cmake --build . --target parsersources`.

Note that the separate `parsers` folder was necessary to make it easier to include the entire directory.

This PR now also excludes the parser (`.y`) and lexer (`.l`) files from the packaged source.

We might think about moving the original parser sources also to a separate `parser` directory in the original `src` directory to avoid confusion.