### PR TITLE
CMake: MSVC warning C4273: inconsistent DLL linkage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,8 @@ check_function_exists(stpcpy HAVE_STPCPY)
 check_function_exists(strcasecmp HAVE_STRCASECMP)
 check_function_exists(_stricmp HAVE__STRICMP)
 check_function_exists(expm1 HAVE_EXPM1)
+check_function_exists(rint HAVE_RINT)
+check_function_exists(rintf HAVE_RINTF)
 check_symbol_exists(stpcpy "string.h" HAVE_STPCPY_SIGNATURE)
 check_symbol_exists(strdup "string.h" HAVE_STRDUP)
 

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -7,6 +7,8 @@
 #cmakedefine HAVE__STRICMP 1
 #cmakedefine HAVE_STRDUP 1
 #cmakedefine HAVE_EXPM1 1
+#cmakedefine HAVE_RINT 1
+#cmakedefine HAVE_RINTF 1
 
 #cmakedefine HAVE_GLPK 1
 #cmakedefine HAVE_GMP 1


### PR DESCRIPTION
Regarding `warning C4273: inconsistent dll linkage` in #1507, the problem is that these functions are defined multiple times. Most often these occur in `f2c`, but also once in `random.c`. For `random.c` there is already a solution, we simply detect whether `rint` and `rintf` already exist. This PR corrects that.

For `f2c` the situation is slightly more complicated. The relevant functions (`erf`, `erfc` and `ungetc`) are defined in the MSVC libraries (`cmath`). Of course, it is defined there with a (correct) `declspec` declaration, while in `f2c` it is not defined as such (only with `extern`). There are multiple possible solutions: (a) simply remove the relevant definitions (of `erf`, `erfc` and `ungetc`) completely; or (b) add the correct `declspec` declarations. What option do you think would be better? Or are there perhaps other options still?
`