### PR TITLE
cmake: disable uninteresting MSVC warnings

### DIFF
--- a/etc/cmake/compilers.cmake
+++ b/etc/cmake/compilers.cmake
@@ -4,7 +4,13 @@ endif()
 
 macro(use_all_warnings TARGET_NAME)
   if(MSVC)
-    target_compile_options(${TARGET_NAME} PRIVATE /W4)
+    target_compile_options(${TARGET_NAME} PRIVATE 
+      /W4 # enable most warnings, then disable:
+      /wd4244 # 'conversion' conversion from 'type1' to 'type2', possible loss of data
+      /wd4267 # 'var' : conversion from 'size_t' to 'type', possible loss of data 
+      /wd4996 # deprecated functions, e.g. 'sprintf': This function or variable may be unsafe. Consider using sprintf_s instead.
+      /wd4456 # declaration of 'identifier' hides previous local declaration
+    )
   else()
     target_compile_options(${TARGET_NAME} PRIVATE 
       # GCC-style compilers:

--- a/src/bliss/CMakeLists.txt
+++ b/src/bliss/CMakeLists.txt
@@ -33,4 +33,8 @@ if(GMP_FOUND)
   )
 endif()
 
+if (MSVC)
+  target_compile_options(bliss PRIVATE /wd4100) # disable unreferenced parameter warning
+endif()
+
 use_all_warnings(bliss)

--- a/src/cs/CMakeLists.txt
+++ b/src/cs/CMakeLists.txt
@@ -40,4 +40,8 @@ if (WIN32)
   target_compile_definitions(cxsparse_vendored PRIVATE IGRAPH_STATIC)
 endif()
 
+if (MSVC)
+  target_compile_options(cxsparse_vendored PRIVATE /wd4100) # disable unreferenced parameter warning
+endif()
+
 use_all_warnings(cxsparse_vendored)

--- a/src/plfit/CMakeLists.txt
+++ b/src/plfit/CMakeLists.txt
@@ -20,4 +20,8 @@ if (BUILD_SHARED_LIBS)
   set_property(TARGET plfit PROPERTY POSITION_INDEPENDENT_CODE ON)
 endif()
 
+if (MSVC)
+  target_compile_options(plfit PRIVATE /wd4100) # disable unreferenced parameter warning
+endif()
+
 use_all_warnings(plfit)


### PR DESCRIPTION
This disables some uninteresting warnings from MSVC. See #1507 