### PR TITLE
Add a function to check potential connectedness

### DIFF
--- a/doc/structural.xxml
+++ b/doc/structural.xxml
@@ -81,6 +81,7 @@
 <section id="degree-sequences"><title>Degree Sequences</title>
 <!-- doxrox-include igraph_is_graphical -->
 <!-- doxrox-include igraph_is_bigraphical -->
+<!-- doxrox-include igraph_is_potentially_connected_degree_sequence -->
 <!-- doxrox-include igraph_is_degree_sequence -->
 <!-- doxrox-include igraph_is_graphical_degree_sequence -->
 </section>

--- a/examples/tests/is_potentially_connected.c
+++ b/examples/tests/is_potentially_connected.c
@@ -1,0 +1,102 @@
+
+#include <igraph.h>
+
+#include "test_utilities.inc"
+
+void pc_undirected_print_destroy(igraph_vector_t *ds) {
+    igraph_bool_t res;
+    int err;
+
+    printf("\n");
+    print_vector_round(ds, stdout);
+    err = igraph_is_potentially_connected_degree_sequence(ds, NULL, &res);
+    if (err != IGRAPH_SUCCESS) {
+        printf("error!\n"); goto cleanup;
+    }
+    printf("%s\n", res ? "true" : "false");
+
+cleanup:
+    igraph_vector_destroy(ds);
+}
+
+void pc_directed_print_destroy(igraph_vector_t *ods, igraph_vector_t *ids) {
+    igraph_bool_t res;
+    int err;
+
+    printf("\n");
+    print_vector_round(ods, stdout);
+    print_vector_round(ids, stdout);
+    err = igraph_is_potentially_connected_degree_sequence(ods, ids, &res);
+    if (err != IGRAPH_SUCCESS) {
+        printf("error!\n"); goto cleanup;
+    }
+    printf("%s\n", res ? "true" : "false");
+
+cleanup:
+    igraph_vector_destroy(ods);
+    igraph_vector_destroy(ids);
+}
+
+int main() {
+    igraph_vector_t ds, ods, ids;
+
+    printf("Undirected:\n");
+
+    /* Null graph: not potentially connected. */
+    igraph_vector_init_int_end(&ds, -1, -1);
+    pc_undirected_print_destroy(&ds);
+
+    igraph_vector_init_int_end(&ds, -1, 0, -1);
+    pc_undirected_print_destroy(&ds);
+
+    igraph_vector_init_int_end(&ds, -1, 1, -1);
+    pc_undirected_print_destroy(&ds);
+
+    /* Not potentially connected. */
+    igraph_vector_init_int_end(&ds, -1, 1, 1, 1, 1, -1);
+    pc_undirected_print_destroy(&ds);
+
+    igraph_vector_init_int_end(&ds, -1, 1, 2, 3, -1);
+    pc_undirected_print_destroy(&ds);
+
+    igraph_vector_init_int_end(&ds, -1, 1, 2, 3, 0, -1);
+    pc_undirected_print_destroy(&ds);
+
+    /* Non-even sum */
+    igraph_vector_init_int_end(&ds, -1, 3, 2, -1);
+    pc_undirected_print_destroy(&ds);
+
+    /* Negative value */
+    igraph_vector_init_int_end(&ds, -1, -2, 2, -1);
+    pc_undirected_print_destroy(&ds);
+
+    printf("\n\nDirected:\n");
+
+    igraph_vector_init_int_end(&ods, -1, -1);
+    igraph_vector_init_int_end(&ids, -1, -1);
+    pc_directed_print_destroy(&ods, &ids);
+
+    igraph_vector_init_int_end(&ods, -1, 0, -1);
+    igraph_vector_init_int_end(&ids, -1, 0, -1);
+    pc_directed_print_destroy(&ods, &ids);
+
+    igraph_vector_init_int_end(&ods, -1, 0, -1);
+    igraph_vector_init_int_end(&ids, -1, 1, -1);
+    pc_directed_print_destroy(&ods, &ids);
+
+    igraph_vector_init_int_end(&ods, -1, 1, 2, 3, -1);
+    igraph_vector_init_int_end(&ids, -1, 2, 2, 2, -1);
+    pc_directed_print_destroy(&ods, &ids);
+
+    igraph_vector_init_int_end(&ods, -1, 1, 2, 3, -1);
+    igraph_vector_init_int_end(&ids, -1, 2, 4, 0, -1);
+    pc_directed_print_destroy(&ods, &ids);
+
+    igraph_vector_init_int_end(&ods, -1, 1, 2, 3, -1);
+    igraph_vector_init_int_end(&ids, -1, 2, 6, -2, -1);
+    pc_directed_print_destroy(&ods, &ids);
+
+    VERIFY_FINALLY_STACK();
+
+    return 0;
+}

--- a/examples/tests/is_potentially_connected.out
+++ b/examples/tests/is_potentially_connected.out
@@ -1,0 +1,52 @@
+Undirected:
+
+( )
+false
+
+( 0 )
+true
+
+( 1 )
+false
+
+( 1 1 1 1 )
+false
+
+( 1 2 3 )
+true
+
+( 1 2 3 0 )
+false
+
+( 3 2 )
+false
+
+( -2 2 )
+false
+
+
+Directed:
+
+( )
+( )
+false
+
+( 0 )
+( 0 )
+true
+
+( 0 )
+( 1 )
+false
+
+( 1 2 3 )
+( 2 2 2 )
+true
+
+( 1 2 3 )
+( 2 4 0 )
+false
+
+( 1 2 3 )
+( 2 6 -2 )
+false

--- a/include/igraph_graphicality.h
+++ b/include/igraph_graphicality.h
@@ -49,6 +49,10 @@ DECLDIR int igraph_is_bigraphical(const igraph_vector_t *degrees1,
                                   const igraph_edge_type_sw_t allowed_edge_types,
                                   igraph_bool_t *res);
 
+DECLDIR int igraph_is_potentially_connected_degree_sequence(
+                            const igraph_vector_t *out_degrees,
+                            const igraph_vector_t *in_degrees,
+                            igraph_bool_t *res);
 
 /* Legacy functions (deprecated): */
 

--- a/src/graphicality.c
+++ b/src/graphicality.c
@@ -839,13 +839,16 @@ static int igraph_i_is_bigraphical_simple(const igraph_vector_t *degrees1, const
  * \function igraph_is_potentially_connected_degree_sequence
  * \brief Is there a connected graph with the given degrees?
  *
+ * \experimental
+ *
  * This function determines if the given degree sequence (or pair of out- and in-degree
- * sequences) is <em>potentially connected</em>. In other words, it checks if there is a connected
- * graph with the given degrees.
+ * sequences) is <emphasis>potentially connected</emphasis>. In other words, it checks if
+ * there is a connected graph with the given degrees, or if there is a strongly connected
+ * graph with the given out- and in-degrees.
  *
  * </para><para>
  * In the undirected case, the condition is that the sum of degrees be at least
- * <code>2*(n-1)</code>, where \c n is the number of degrees, and that no degree be zero
+ * <code>2*(n-1)</code>, where \c n is the number of vertices, and that no degree be zero
  * (unless <code>n=1</code>).
  *
  * </para><para>
@@ -853,14 +856,14 @@ static int igraph_i_is_bigraphical_simple(const igraph_vector_t *degrees1, const
  * (unless <code>n=1</code>).
  *
  * </para><para>
- * If <code>n=0</code>, 'false' is returned, as the null graph is considered to be non-connected.
+ * If <code>n=0</code>, false is returned, as the null graph is considered to be non-connected.
  *
  * </para><para>
  * This function also verifies that the sum of degrees is even (undirected case)
  * or the sum of out- and in-degrees is the same (directed case). This is necessary
  * for a (potentially non-simple) graph with these degrees to exist. Additionally,
  * it checks that no degrees are negative. If either condition is violated, it
- * returns 'false'.
+ * returns false.
  *
  * \param out_degrees A vector of integers specifying the degree sequence for
  *     undirected graphs or the out-degree sequence for directed graphs.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -546,3 +546,9 @@ add_legacy_tests(
   FOLDER simple NAMES
   igraph_adjacency_spectral_embedding
 )
+
+# degree sequences
+add_legacy_tests(
+  FOLDER tests NAMES
+  igraph_is_graphical
+)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -551,4 +551,5 @@ add_legacy_tests(
 add_legacy_tests(
   FOLDER tests NAMES
   igraph_is_graphical
+  is_potentially_connected
 )


### PR DESCRIPTION
This PR adds a function to check potential connectedness of a degree sequence.

Which name do you prefer? `igraph_is_potentially_connected` or `igraph_is_potentially_connected_degree_sequence`?

This PR should be merged as normal, _not_ squash-and-merged.