### PR TITLE
[develop/cmake] Github Workflow for MSYS2's MINGW32/MINGW64

### DIFF
--- a/.github/workflows/msys2-build.yml
+++ b/.github/workflows/msys2-build.yml
@@ -1,0 +1,46 @@
+name: MINGW32 / MINGW64 (MSYS2) - cmake build
+
+# TODO: Check the BRANCHES element when merging the branch 'develop' to, say, 'master'.
+on:
+  push:
+    branches:
+      - develop
+  pull_request:
+    branches:
+      - develop
+
+jobs:
+  build:
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include: [
+          { msystem: MINGW32, arch: i686   },
+          { msystem: MINGW64, arch: x86_64 }
+          ]
+
+    defaults:
+      run:
+        shell: msys2 {0}
+
+    steps:
+      - name: Init ${{ matrix.msystem }}-System
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: ${{ matrix.msystem }}
+          install: git base-devel mingw-w64-${{ matrix.arch }}-cmake mingw-w64-${{ matrix.arch }}-toolchain mingw-w64-${{ matrix.arch }}-glpk mingw-w64-${{ matrix.arch }}-gmp mingw-w64-${{ matrix.arch }}-zlib mingw-w64-${{ matrix.arch }}-libxml2 mingw-w64-${{ matrix.arch }}-suitesparse
+          update: true
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Configuration
+        run: |
+          mkdir -p build-${{ matrix.arch }}
+          cd build-${{ matrix.arch }}
+          cmake .. -G 'MSYS Makefiles' -DIGRAPH_GLPK_SUPPORT=1 -DIGRAPH_GRAPHML_SUPPORT=1 -DIGRAPH_VERIFY_FINALLY_STACK=1
+      - name: Build
+        run: make
+        working-directory: build-${{ matrix.arch }}
+      - name: Test
+        run: make check
+        working-directory: build-${{ matrix.arch }}


### PR DESCRIPTION
Here as a start a github workflow for MSYS2's MINGW32/MINGW64 
* static library only
* tests fail due to unresolvable symbol with names beginning with `__imp`, so the known MINGW issue to be fixed.

To be done:
* add shared library build
* add various scenarios for -D flags (?)  