### PR TITLE
Replace assert() by IGRAPH_ASSERT()

### DIFF
--- a/src/blas.c
+++ b/src/blas.c
@@ -22,10 +22,9 @@
 
 */
 
+#include "igraph_error.h"
 #include "igraph_blas.h"
 #include "igraph_blas_internal.h"
-
-#include <assert.h>
 
 /**
  * \function igraph_blas_dgemv
@@ -60,8 +59,8 @@ void igraph_blas_dgemv(igraph_bool_t transpose, igraph_real_t alpha,
     m = (int) igraph_matrix_nrow(a);
     n = (int) igraph_matrix_ncol(a);
 
-    assert(igraph_vector_size(x) == transpose ? m : n);
-    assert(igraph_vector_size(y) == transpose ? n : m);
+    IGRAPH_ASSERT(igraph_vector_size(x) == transpose ? m : n);
+    IGRAPH_ASSERT(igraph_vector_size(y) == transpose ? n : m);
 
     igraphdgemv_(&trans, &m, &n, &alpha, VECTOR(a->data), &m,
                  VECTOR(*x), &inc, &beta, VECTOR(*y), &inc);

--- a/src/bliss/CMakeLists.txt
+++ b/src/bliss/CMakeLists.txt
@@ -34,8 +34,13 @@ if(NOT GMP_IS_VENDORED)
   )
 endif()
 
+use_all_warnings(bliss)
+
 if (MSVC)
   target_compile_options(bliss PRIVATE /wd4100) # disable unreferenced parameter warning
+else()
+  target_compile_options(
+    bliss PRIVATE
+    $<$<C_COMPILER_ID:GCC,Clang,AppleClang>:-Wno-unused-variable>
+  )
 endif()
-
-use_all_warnings(bliss)

--- a/src/cliques.c
+++ b/src/cliques.c
@@ -21,6 +21,7 @@
 
 */
 
+#include "igraph_error.h"
 #include "igraph_cliques.h"
 #include "igraph_memory.h"
 #include "igraph_constants.h"
@@ -33,7 +34,6 @@
 #include "igraph_cliquer.h"
 #include "config.h"
 
-#include <assert.h>
 #include <string.h>    /* memset */
 
 static void igraph_i_cliques_free_res(igraph_vector_ptr_t *res) {
@@ -1121,7 +1121,7 @@ static int igraph_i_maximal_cliques(const igraph_t *graph, igraph_i_maximal_cliq
     igraph_vector_int_t new_cand, new_fini, cn, best_cand_nbrs,
                         best_fini_cand_nbrs;
     igraph_bool_t cont = 1;
-    int assret;
+    igraph_bool_t found;
 
     if (directed) {
         IGRAPH_WARNING("directionality of edges is ignored for directed graphs");
@@ -1210,11 +1210,11 @@ static int igraph_i_maximal_cliques(const igraph_t *graph, igraph_i_maximal_cliq
         IGRAPH_CHECK(igraph_vector_push_back(&clique, i));
 
         /* Remove the node from the candidate list */
-        assret = igraph_vector_int_binsearch(&frame.cand, i, &j); assert(assret);
+        found = igraph_vector_int_binsearch(&frame.cand, i, &j); IGRAPH_ASSERT(found);
         igraph_vector_int_remove(&frame.cand, j);
 
         /* Add the node to the finished list */
-        assret = !igraph_vector_int_binsearch(&frame.fini, i, &j); assert(assret);
+        found = igraph_vector_int_binsearch(&frame.fini, i, &j); IGRAPH_ASSERT(!found);
         IGRAPH_CHECK(igraph_vector_int_insert(&frame.fini, j, i));
 
         /* Create new_cand and new_fini */

--- a/src/dqueue.pmt
+++ b/src/dqueue.pmt
@@ -25,7 +25,6 @@
 #include "igraph_error.h"
 #include "config.h"
 
-#include <assert.h>
 #include <string.h>         /* memcpy & co. */
 #include <stdlib.h>
 
@@ -56,7 +55,7 @@
  */
 
 int FUNCTION(igraph_dqueue, init) (TYPE(igraph_dqueue)* q, long int size) {
-    assert(q != 0);
+    IGRAPH_ASSERT(q != 0);
     if (size <= 0 ) {
         size = 1;
     }
@@ -82,7 +81,7 @@ int FUNCTION(igraph_dqueue, init) (TYPE(igraph_dqueue)* q, long int size) {
  */
 
 void FUNCTION(igraph_dqueue, destroy) (TYPE(igraph_dqueue)* q) {
-    assert(q != 0);
+    IGRAPH_ASSERT(q != 0);
     if (q->stor_begin != 0) {
         igraph_Free(q->stor_begin);
         q->stor_begin = 0;
@@ -102,8 +101,8 @@ void FUNCTION(igraph_dqueue, destroy) (TYPE(igraph_dqueue)* q) {
  */
 
 igraph_bool_t FUNCTION(igraph_dqueue, empty) (const TYPE(igraph_dqueue)* q) {
-    assert(q != 0);
-    assert(q->stor_begin != 0);
+    IGRAPH_ASSERT(q != 0);
+    IGRAPH_ASSERT(q->stor_begin != 0);
     return q->end == NULL;
 }
 
@@ -118,8 +117,8 @@ igraph_bool_t FUNCTION(igraph_dqueue, empty) (const TYPE(igraph_dqueue)* q) {
  */
 
 void FUNCTION(igraph_dqueue, clear)   (TYPE(igraph_dqueue)* q) {
-    assert(q != 0);
-    assert(q->stor_begin != 0);
+    IGRAPH_ASSERT(q != 0);
+    IGRAPH_ASSERT(q->stor_begin != 0);
     q->begin = q->stor_begin;
     q->end = NULL;
 }
@@ -138,8 +137,8 @@ void FUNCTION(igraph_dqueue, clear)   (TYPE(igraph_dqueue)* q) {
  */
 
 igraph_bool_t FUNCTION(igraph_dqueue, full) (TYPE(igraph_dqueue)* q) {
-    assert(q != 0);
-    assert(q->stor_begin != 0);
+    IGRAPH_ASSERT(q != 0);
+    IGRAPH_ASSERT(q->stor_begin != 0);
     return q->begin == q->end;
 }
 
@@ -155,8 +154,8 @@ igraph_bool_t FUNCTION(igraph_dqueue, full) (TYPE(igraph_dqueue)* q) {
  */
 
 long int FUNCTION(igraph_dqueue, size) (const TYPE(igraph_dqueue)* q) {
-    assert(q != 0);
-    assert(q->stor_begin != 0);
+    IGRAPH_ASSERT(q != 0);
+    IGRAPH_ASSERT(q->stor_begin != 0);
     if (q->end == NULL) {
         return 0;
     } else if (q->begin < q->end) {
@@ -179,8 +178,8 @@ long int FUNCTION(igraph_dqueue, size) (const TYPE(igraph_dqueue)* q) {
  */
 
 BASE FUNCTION(igraph_dqueue, head) (const TYPE(igraph_dqueue)* q) {
-    assert(q != 0);
-    assert(q->stor_begin != 0);
+    IGRAPH_ASSERT(q != 0);
+    IGRAPH_ASSERT(q->stor_begin != 0);
     return *(q->begin);
 }
 
@@ -197,8 +196,8 @@ BASE FUNCTION(igraph_dqueue, head) (const TYPE(igraph_dqueue)* q) {
  */
 
 BASE FUNCTION(igraph_dqueue, back) (const TYPE(igraph_dqueue)* q) {
-    assert(q != 0);
-    assert(q->stor_begin != 0);
+    IGRAPH_ASSERT(q != 0);
+    IGRAPH_ASSERT(q->stor_begin != 0);
     if (q->end == q->stor_begin) {
         return *(q->stor_end - 1);
     }
@@ -220,8 +219,8 @@ BASE FUNCTION(igraph_dqueue, back) (const TYPE(igraph_dqueue)* q) {
 
 BASE FUNCTION(igraph_dqueue, pop) (TYPE(igraph_dqueue)* q) {
     BASE tmp = *(q->begin);
-    assert(q != 0);
-    assert(q->stor_begin != 0);
+    IGRAPH_ASSERT(q != 0);
+    IGRAPH_ASSERT(q->stor_begin != 0);
     (q->begin)++;
     if (q->begin == q->stor_end) {
         q->begin = q->stor_begin;
@@ -248,8 +247,8 @@ BASE FUNCTION(igraph_dqueue, pop) (TYPE(igraph_dqueue)* q) {
 
 BASE FUNCTION(igraph_dqueue, pop_back) (TYPE(igraph_dqueue)* q) {
     BASE tmp;
-    assert(q != 0);
-    assert(q->stor_begin != 0);
+    IGRAPH_ASSERT(q != 0);
+    IGRAPH_ASSERT(q->stor_begin != 0);
     if (q->end != q->stor_begin) {
         tmp = *((q->end) - 1);
         q->end = (q->end) - 1;
@@ -282,8 +281,8 @@ BASE FUNCTION(igraph_dqueue, pop_back) (TYPE(igraph_dqueue)* q) {
  */
 
 int FUNCTION(igraph_dqueue, push) (TYPE(igraph_dqueue)* q, BASE elem) {
-    assert(q != 0);
-    assert(q->stor_begin != 0);
+    IGRAPH_ASSERT(q != 0);
+    IGRAPH_ASSERT(q->stor_begin != 0);
     if (q->begin != q->end) {
         /* not full */
         if (q->end == NULL) {

--- a/src/heap.c
+++ b/src/heap.c
@@ -28,7 +28,6 @@
 #include "igraph_math.h"
 #include "config.h"
 
-#include <assert.h>
 #include <string.h>         /* memcpy & co. */
 #include <stdlib.h>
 
@@ -114,7 +113,7 @@ int igraph_indheap_init_array     (igraph_indheap_t *h, igraph_real_t* data, lon
  */
 
 void igraph_indheap_destroy        (igraph_indheap_t* h) {
-    assert(h != 0);
+    IGRAPH_ASSERT(h != 0);
     if (h->destroy) {
         if (h->stor_begin != 0) {
             igraph_Free(h->stor_begin);
@@ -133,8 +132,8 @@ void igraph_indheap_destroy        (igraph_indheap_t* h) {
  */
 
 igraph_bool_t igraph_indheap_empty          (igraph_indheap_t* h) {
-    assert(h != 0);
-    assert(h->stor_begin != 0);
+    IGRAPH_ASSERT(h != 0);
+    IGRAPH_ASSERT(h->stor_begin != 0);
     return h->stor_begin == h->end;
 }
 
@@ -144,8 +143,8 @@ igraph_bool_t igraph_indheap_empty          (igraph_indheap_t* h) {
  */
 
 int igraph_indheap_push           (igraph_indheap_t* h, igraph_real_t elem) {
-    assert(h != 0);
-    assert(h->stor_begin != 0);
+    IGRAPH_ASSERT(h != 0);
+    IGRAPH_ASSERT(h->stor_begin != 0);
 
     /* full, allocate more storage */
     if (h->stor_end == h->end) {
@@ -172,8 +171,8 @@ int igraph_indheap_push           (igraph_indheap_t* h, igraph_real_t elem) {
  */
 
 int igraph_indheap_push_with_index(igraph_indheap_t* h, long int idx, igraph_real_t elem) {
-    assert(h != 0);
-    assert(h->stor_begin != 0);
+    IGRAPH_ASSERT(h != 0);
+    IGRAPH_ASSERT(h->stor_begin != 0);
 
     /* full, allocate more storage */
     if (h->stor_end == h->end) {
@@ -202,8 +201,8 @@ int igraph_indheap_push_with_index(igraph_indheap_t* h, long int idx, igraph_rea
 int igraph_indheap_modify(igraph_indheap_t* h, long int idx, igraph_real_t elem) {
     long int i, n;
 
-    assert(h != 0);
-    assert(h->stor_begin != 0);
+    IGRAPH_ASSERT(h != 0);
+    IGRAPH_ASSERT(h->stor_begin != 0);
 
     n = igraph_indheap_size(h);
     for (i = 0; i < n; i++)
@@ -228,9 +227,9 @@ int igraph_indheap_modify(igraph_indheap_t* h, long int idx, igraph_real_t elem)
  */
 
 igraph_real_t igraph_indheap_max       (igraph_indheap_t* h) {
-    assert(h != NULL);
-    assert(h->stor_begin != NULL);
-    assert(h->stor_begin != h->end);
+    IGRAPH_ASSERT(h != NULL);
+    IGRAPH_ASSERT(h->stor_begin != NULL);
+    IGRAPH_ASSERT(h->stor_begin != h->end);
 
     return h->stor_begin[0];
 }
@@ -243,8 +242,8 @@ igraph_real_t igraph_indheap_max       (igraph_indheap_t* h) {
 igraph_real_t igraph_indheap_delete_max(igraph_indheap_t* h) {
     igraph_real_t tmp;
 
-    assert(h != NULL);
-    assert(h->stor_begin != NULL);
+    IGRAPH_ASSERT(h != NULL);
+    IGRAPH_ASSERT(h->stor_begin != NULL);
 
     tmp = h->stor_begin[0];
     igraph_indheap_i_switch(h, 0, igraph_indheap_size(h) - 1);
@@ -260,8 +259,8 @@ igraph_real_t igraph_indheap_delete_max(igraph_indheap_t* h) {
  */
 
 long int igraph_indheap_size      (igraph_indheap_t* h) {
-    assert(h != 0);
-    assert(h->stor_begin != 0);
+    IGRAPH_ASSERT(h != 0);
+    IGRAPH_ASSERT(h->stor_begin != 0);
     return h->end - h->stor_begin;
 }
 
@@ -277,8 +276,8 @@ int igraph_indheap_reserve        (igraph_indheap_t* h, long int size) {
     long int actual_size = igraph_indheap_size(h);
     igraph_real_t *tmp1;
     long int *tmp2;
-    assert(h != 0);
-    assert(h->stor_begin != 0);
+    IGRAPH_ASSERT(h != 0);
+    IGRAPH_ASSERT(h->stor_begin != 0);
 
     if (size <= actual_size) {
         return 0;
@@ -314,8 +313,8 @@ int igraph_indheap_reserve        (igraph_indheap_t* h, long int size) {
  */
 
 long int igraph_indheap_max_index(igraph_indheap_t *h) {
-    assert(h != 0);
-    assert(h->stor_begin != 0);
+    IGRAPH_ASSERT(h != 0);
+    IGRAPH_ASSERT(h->stor_begin != 0);
     return h->index_begin[0];
 }
 
@@ -450,7 +449,7 @@ int igraph_d_indheap_init           (igraph_d_indheap_t* h, long int alloc_size)
  */
 
 void igraph_d_indheap_destroy        (igraph_d_indheap_t* h) {
-    assert(h != 0);
+    IGRAPH_ASSERT(h != 0);
     if (h->destroy) {
         if (h->stor_begin != 0) {
             igraph_Free(h->stor_begin);
@@ -473,8 +472,8 @@ void igraph_d_indheap_destroy        (igraph_d_indheap_t* h) {
  */
 
 igraph_bool_t igraph_d_indheap_empty          (igraph_d_indheap_t* h) {
-    assert(h != 0);
-    assert(h->stor_begin != 0);
+    IGRAPH_ASSERT(h != 0);
+    IGRAPH_ASSERT(h->stor_begin != 0);
     return h->stor_begin == h->end;
 }
 
@@ -485,8 +484,8 @@ igraph_bool_t igraph_d_indheap_empty          (igraph_d_indheap_t* h) {
 
 int igraph_d_indheap_push           (igraph_d_indheap_t* h, igraph_real_t elem,
                                      long int idx, long int idx2) {
-    assert(h != 0);
-    assert(h->stor_begin != 0);
+    IGRAPH_ASSERT(h != 0);
+    IGRAPH_ASSERT(h->stor_begin != 0);
 
     /* full, allocate more storage */
     if (h->stor_end == h->end) {
@@ -514,9 +513,9 @@ int igraph_d_indheap_push           (igraph_d_indheap_t* h, igraph_real_t elem,
  */
 
 igraph_real_t igraph_d_indheap_max       (igraph_d_indheap_t* h) {
-    assert(h != NULL);
-    assert(h->stor_begin != NULL);
-    assert(h->stor_begin != h->end);
+    IGRAPH_ASSERT(h != NULL);
+    IGRAPH_ASSERT(h->stor_begin != NULL);
+    IGRAPH_ASSERT(h->stor_begin != h->end);
 
     return h->stor_begin[0];
 }
@@ -529,8 +528,8 @@ igraph_real_t igraph_d_indheap_max       (igraph_d_indheap_t* h) {
 igraph_real_t igraph_d_indheap_delete_max(igraph_d_indheap_t* h) {
     igraph_real_t tmp;
 
-    assert(h != NULL);
-    assert(h->stor_begin != NULL);
+    IGRAPH_ASSERT(h != NULL);
+    IGRAPH_ASSERT(h->stor_begin != NULL);
 
     tmp = h->stor_begin[0];
     igraph_d_indheap_i_switch(h, 0, igraph_d_indheap_size(h) - 1);
@@ -546,8 +545,8 @@ igraph_real_t igraph_d_indheap_delete_max(igraph_d_indheap_t* h) {
  */
 
 long int igraph_d_indheap_size      (igraph_d_indheap_t* h) {
-    assert(h != 0);
-    assert(h->stor_begin != 0);
+    IGRAPH_ASSERT(h != 0);
+    IGRAPH_ASSERT(h->stor_begin != 0);
     return h->end - h->stor_begin;
 }
 
@@ -563,8 +562,8 @@ int igraph_d_indheap_reserve        (igraph_d_indheap_t* h, long int size) {
     long int actual_size = igraph_d_indheap_size(h);
     igraph_real_t *tmp1;
     long int *tmp2, *tmp3;
-    assert(h != 0);
-    assert(h->stor_begin != 0);
+    IGRAPH_ASSERT(h != 0);
+    IGRAPH_ASSERT(h->stor_begin != 0);
 
     if (size <= actual_size) {
         return 0;
@@ -609,8 +608,8 @@ int igraph_d_indheap_reserve        (igraph_d_indheap_t* h, long int size) {
  */
 
 void igraph_d_indheap_max_index(igraph_d_indheap_t *h, long int *idx, long int *idx2) {
-    assert(h != 0);
-    assert(h->stor_begin != 0);
+    IGRAPH_ASSERT(h != 0);
+    IGRAPH_ASSERT(h->stor_begin != 0);
     (*idx) = h->index_begin[0];
     (*idx2) = h->index2_begin[0];
 }

--- a/src/heap.pmt
+++ b/src/heap.pmt
@@ -25,7 +25,6 @@
 #include "igraph_error.h"
 #include "config.h"
 
-#include <assert.h>
 #include <string.h>         /* memcpy & co. */
 #include <stdlib.h>
 
@@ -130,8 +129,8 @@ void FUNCTION(igraph_heap, destroy)(TYPE(igraph_heap)* h) {
  */
 
 igraph_bool_t FUNCTION(igraph_heap, empty)(TYPE(igraph_heap)* h) {
-    assert(h != NULL);
-    assert(h->stor_begin != NULL);
+    IGRAPH_ASSERT(h != NULL);
+    IGRAPH_ASSERT(h->stor_begin != NULL);
     return h->stor_begin == h->end;
 }
 
@@ -151,8 +150,8 @@ igraph_bool_t FUNCTION(igraph_heap, empty)(TYPE(igraph_heap)* h) {
  */
 
 int FUNCTION(igraph_heap, push)(TYPE(igraph_heap)* h, BASE elem) {
-    assert(h != NULL);
-    assert(h->stor_begin != NULL);
+    IGRAPH_ASSERT(h != NULL);
+    IGRAPH_ASSERT(h->stor_begin != NULL);
 
     /* full, allocate more storage */
     if (h->stor_end == h->end) {
@@ -187,9 +186,9 @@ int FUNCTION(igraph_heap, push)(TYPE(igraph_heap)* h, BASE elem) {
  */
 
 BASE FUNCTION(igraph_heap, top)(TYPE(igraph_heap)* h) {
-    assert(h != NULL);
-    assert(h->stor_begin != NULL);
-    assert(h->stor_begin != h->end);
+    IGRAPH_ASSERT(h != NULL);
+    IGRAPH_ASSERT(h->stor_begin != NULL);
+    IGRAPH_ASSERT(h->stor_begin != h->end);
 
     return h->stor_begin[0];
 }
@@ -211,8 +210,8 @@ BASE FUNCTION(igraph_heap, top)(TYPE(igraph_heap)* h) {
 BASE FUNCTION(igraph_heap, delete_top)(TYPE(igraph_heap)* h) {
     BASE tmp;
 
-    assert(h != NULL);
-    assert(h->stor_begin != NULL);
+    IGRAPH_ASSERT(h != NULL);
+    IGRAPH_ASSERT(h->stor_begin != NULL);
 
     tmp = h->stor_begin[0];
     FUNCTION(igraph_heap, i_switch)(h->stor_begin, 0, FUNCTION(igraph_heap, size)(h) - 1);
@@ -235,8 +234,8 @@ BASE FUNCTION(igraph_heap, delete_top)(TYPE(igraph_heap)* h) {
  */
 
 long int FUNCTION(igraph_heap, size)(TYPE(igraph_heap)* h) {
-    assert(h != NULL);
-    assert(h->stor_begin != NULL);
+    IGRAPH_ASSERT(h != NULL);
+    IGRAPH_ASSERT(h->stor_begin != NULL);
     return h->end - h->stor_begin;
 }
 
@@ -259,8 +258,8 @@ long int FUNCTION(igraph_heap, size)(TYPE(igraph_heap)* h) {
 int FUNCTION(igraph_heap, reserve)(TYPE(igraph_heap)* h, long int size) {
     long int actual_size = FUNCTION(igraph_heap, size)(h);
     BASE *tmp;
-    assert(h != NULL);
-    assert(h->stor_begin != NULL);
+    IGRAPH_ASSERT(h != NULL);
+    IGRAPH_ASSERT(h->stor_begin != NULL);
 
     if (size <= actual_size) {
         return 0;

--- a/src/igraph_cliquer.c
+++ b/src/igraph_cliquer.c
@@ -1,12 +1,11 @@
 
 #include "igraph_cliquer.h"
+#include "igraph_error.h"
 #include "igraph_memory.h"
 #include "igraph_constants.h"
 #include "igraph_interrupt_internal.h"
 #include "cliquer/cliquer.h"
 #include "config.h"
-
-#include <assert.h>
 
 
 /* Call this to allow for interruption in Cliquer callback functions */
@@ -77,7 +76,7 @@ static void igraph_to_cliquer(const igraph_t *ig, graph_t **cg) {
 static int set_weights(const igraph_vector_t *vertex_weights, graph_t *g) {
     int i;
 
-    assert(vertex_weights != NULL);
+    IGRAPH_ASSERT(vertex_weights != NULL);
 
     if (igraph_vector_size(vertex_weights) != g->n) {
         IGRAPH_ERROR("Invalid vertex weight vector length", IGRAPH_EINVAL);

--- a/src/igraph_error.c
+++ b/src/igraph_error.c
@@ -27,7 +27,6 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <assert.h>
 #include <stdarg.h>
 
 #ifdef USING_R
@@ -216,8 +215,8 @@ IGRAPH_THREAD_LOCAL struct igraph_i_protectedPtr igraph_i_finally_stack[100];
 
 void IGRAPH_FINALLY_REAL(void (*func)(void*), void* ptr) {
     int no = igraph_i_finally_stack[0].all;
-    assert (no < 100);
-    assert (no >= 0);
+    IGRAPH_ASSERT(no < 100);
+    IGRAPH_ASSERT(no >= 0);
     igraph_i_finally_stack[no].ptr = ptr;
     igraph_i_finally_stack[no].func = func;
     igraph_i_finally_stack[0].all ++;

--- a/src/igraph_set.c
+++ b/src/igraph_set.c
@@ -27,7 +27,6 @@
 #include "igraph_types_internal.h"
 #include "config.h"
 
-#include <assert.h>
 #include <string.h>     /* memmove */
 
 #define SET(s) ((s).stor_begin)
@@ -68,7 +67,7 @@ int igraph_set_init(igraph_set_t *set, int long size) {
  * Time complexity: operating system dependent.
  */
 void igraph_set_destroy(igraph_set_t* set) {
-    assert(set != 0);
+    IGRAPH_ASSERT(set != 0);
     if (set->stor_begin != 0) {
         igraph_Free(set->stor_begin);
         set->stor_begin = NULL;
@@ -108,8 +107,8 @@ igraph_bool_t igraph_set_inited(igraph_set_t* set) {
 int igraph_set_reserve(igraph_set_t* set, long int size) {
     long int actual_size = igraph_set_size(set);
     igraph_integer_t *tmp;
-    assert(set != NULL);
-    assert(set->stor_begin != NULL);
+    IGRAPH_ASSERT(set != NULL);
+    IGRAPH_ASSERT(set->stor_begin != NULL);
     if (size <= actual_size) {
         return 0;
     }
@@ -137,8 +136,8 @@ int igraph_set_reserve(igraph_set_t* set, long int size) {
  * Time complexity: O(1).
  */
 igraph_bool_t igraph_set_empty(const igraph_set_t* set) {
-    assert(set != NULL);
-    assert(set->stor_begin != NULL);
+    IGRAPH_ASSERT(set != NULL);
+    IGRAPH_ASSERT(set->stor_begin != NULL);
     return set->stor_begin == set->end;
 }
 
@@ -156,8 +155,8 @@ igraph_bool_t igraph_set_empty(const igraph_set_t* set) {
  * Time complexity: O(1).
  */
 void igraph_set_clear(igraph_set_t* set) {
-    assert(set != NULL);
-    assert(set->stor_begin != NULL);
+    IGRAPH_ASSERT(set != NULL);
+    IGRAPH_ASSERT(set->stor_begin != NULL);
     set->end = set->stor_begin;
 }
 
@@ -174,8 +173,8 @@ void igraph_set_clear(igraph_set_t* set) {
  */
 
 long int igraph_set_size(const igraph_set_t* set) {
-    assert(set != NULL);
-    assert(set->stor_begin != NULL);
+    IGRAPH_ASSERT(set != NULL);
+    IGRAPH_ASSERT(set->stor_begin != NULL);
     return set->end - set->stor_begin;
 }
 
@@ -195,8 +194,8 @@ long int igraph_set_size(const igraph_set_t* set) {
 int igraph_set_add(igraph_set_t* set, igraph_integer_t e) {
     long int left, right, middle;
     long int size;
-    assert(set != NULL);
-    assert(set->stor_begin != NULL);
+    IGRAPH_ASSERT(set != NULL);
+    IGRAPH_ASSERT(set->stor_begin != NULL);
 
     size = igraph_set_size(set);
 
@@ -258,8 +257,8 @@ int igraph_set_add(igraph_set_t* set, igraph_integer_t e) {
 int igraph_set_contains(igraph_set_t* set, igraph_integer_t e) {
     long int left, right, middle;
 
-    assert(set != NULL);
-    assert(set->stor_begin != NULL);
+    IGRAPH_ASSERT(set != NULL);
+    IGRAPH_ASSERT(set->stor_begin != NULL);
 
     left = 0;
     right = igraph_set_size(set) - 1;
@@ -303,10 +302,10 @@ int igraph_set_contains(igraph_set_t* set, igraph_integer_t e) {
  */
 igraph_bool_t igraph_set_iterate(igraph_set_t* set, long int* state,
                                  igraph_integer_t* element) {
-    assert(set != 0);
-    assert(set->stor_begin != 0);
-    assert(state != 0);
-    assert(element != 0);
+    IGRAPH_ASSERT(set != 0);
+    IGRAPH_ASSERT(set->stor_begin != 0);
+    IGRAPH_ASSERT(state != 0);
+    IGRAPH_ASSERT(element != 0);
 
     if (*state < igraph_set_size(set)) {
         *element = set->stor_begin[*state];

--- a/src/igraph_stack.c
+++ b/src/igraph_stack.c
@@ -21,6 +21,7 @@
 
 */
 
+#include "igraph_error.h"
 #include "igraph_types.h"
 #include "igraph_stack.h"
 
@@ -67,8 +68,8 @@
 
 void igraph_stack_ptr_free_all   (igraph_stack_ptr_t* v) {
     void **ptr;
-    assert(v != 0);
-    assert(v->stor_begin != 0);
+    IGRAPH_ASSERT(v != 0);
+    IGRAPH_ASSERT(v->stor_begin != 0);
     for (ptr = v->stor_begin; ptr < v->end; ptr++) {
         igraph_Free(*ptr);
     }
@@ -80,8 +81,8 @@ void igraph_stack_ptr_free_all   (igraph_stack_ptr_t* v) {
  */
 
 void igraph_stack_ptr_destroy_all   (igraph_stack_ptr_t* v) {
-    assert(v != 0);
-    assert(v->stor_begin != 0);
+    IGRAPH_ASSERT(v != 0);
+    IGRAPH_ASSERT(v->stor_begin != 0);
     igraph_stack_ptr_free_all(v);
     igraph_stack_ptr_destroy(v);
 }

--- a/src/igraph_strvector.c
+++ b/src/igraph_strvector.c
@@ -27,7 +27,6 @@
 #include "igraph_error.h"
 #include "config.h"
 
-#include <assert.h>
 #include <string.h>         /* memcpy & co. */
 #include <stdlib.h>
 
@@ -94,7 +93,7 @@ int igraph_strvector_init(igraph_strvector_t *sv, long int len) {
 
 void igraph_strvector_destroy(igraph_strvector_t *sv) {
     long int i;
-    assert(sv != 0);
+    IGRAPH_ASSERT(sv != 0);
     if (sv->data != 0) {
         for (i = 0; i < sv->len; i++) {
             if (sv->data[i] != 0) {
@@ -122,9 +121,9 @@ void igraph_strvector_destroy(igraph_strvector_t *sv) {
 
 void igraph_strvector_get(const igraph_strvector_t *sv, long int idx,
                           char **value) {
-    assert(sv != 0);
-    assert(sv->data != 0);
-    assert(sv->data[idx] != 0);
+    IGRAPH_ASSERT(sv != 0);
+    IGRAPH_ASSERT(sv->data != 0);
+    IGRAPH_ASSERT(sv->data[idx] != 0);
     *value = sv->data[idx];
 }
 
@@ -146,8 +145,8 @@ void igraph_strvector_get(const igraph_strvector_t *sv, long int idx,
 
 int igraph_strvector_set(igraph_strvector_t *sv, long int idx,
                          const char *value) {
-    assert(sv != 0);
-    assert(sv->data != 0);
+    IGRAPH_ASSERT(sv != 0);
+    IGRAPH_ASSERT(sv->data != 0);
     if (sv->data[idx] == 0) {
         sv->data[idx] = igraph_Calloc(strlen(value) + 1, char);
         if (sv->data[idx] == 0) {
@@ -183,8 +182,8 @@ int igraph_strvector_set(igraph_strvector_t *sv, long int idx,
  */
 int igraph_strvector_set2(igraph_strvector_t *sv, long int idx,
                           const char *value, int len) {
-    assert(sv != 0);
-    assert(sv->data != 0);
+    IGRAPH_ASSERT(sv != 0);
+    IGRAPH_ASSERT(sv->data != 0);
     if (sv->data[idx] == 0) {
         sv->data[idx] = igraph_Calloc(len + 1, char);
         if (sv->data[idx] == 0) {
@@ -215,8 +214,8 @@ void igraph_strvector_remove_section(igraph_strvector_t *v, long int from,
     long int i;
     /*   char **tmp; */
 
-    assert(v != 0);
-    assert(v->data != 0);
+    IGRAPH_ASSERT(v != 0);
+    IGRAPH_ASSERT(v->data != 0);
 
     for (i = from; i < to; i++) {
         if (v->data[i] != 0) {
@@ -249,8 +248,8 @@ void igraph_strvector_remove_section(igraph_strvector_t *v, long int from,
  */
 
 void igraph_strvector_remove(igraph_strvector_t *v, long int elem) {
-    assert(v != 0);
-    assert(v->data != 0);
+    IGRAPH_ASSERT(v != 0);
+    IGRAPH_ASSERT(v->data != 0);
     igraph_strvector_remove_section(v, elem, elem + 1);
 }
 
@@ -263,8 +262,8 @@ void igraph_strvector_remove(igraph_strvector_t *v, long int elem) {
 void igraph_strvector_move_interval(igraph_strvector_t *v, long int begin,
                                     long int end, long int to) {
     long int i;
-    assert(v != 0);
-    assert(v->data != 0);
+    IGRAPH_ASSERT(v != 0);
+    IGRAPH_ASSERT(v->data != 0);
     for (i = to; i < to + end - begin; i++) {
         if (v->data[i] != 0) {
             igraph_Free(v->data[i]);
@@ -296,8 +295,8 @@ int igraph_strvector_copy(igraph_strvector_t *to,
                           const igraph_strvector_t *from) {
     long int i;
     char *str;
-    assert(from != 0);
-    /*   assert(from->data != 0); */
+    IGRAPH_ASSERT(from != 0);
+    /*   IGRAPH_ASSERT(from->data != 0); */
     to->data = igraph_Calloc(from->len, char*);
     if (to->data == 0) {
         IGRAPH_ERROR("Cannot copy string vector", IGRAPH_ENOMEM);
@@ -403,8 +402,8 @@ int igraph_strvector_resize(igraph_strvector_t* v, long int newsize) {
         reallocsize = 1;
     }
 
-    assert(v != 0);
-    assert(v->data != 0);
+    IGRAPH_ASSERT(v != 0);
+    IGRAPH_ASSERT(v->data != 0);
     /*   printf("resize %li to %li\n", v->len, newsize); */
     if (newsize < v->len) {
         for (i = newsize; i < v->len; i++) {
@@ -464,8 +463,8 @@ int igraph_strvector_resize(igraph_strvector_t* v, long int newsize) {
  */
 
 long int igraph_strvector_size(const igraph_strvector_t *sv) {
-    assert(sv != 0);
-    assert(sv->data != 0);
+    IGRAPH_ASSERT(sv != 0);
+    IGRAPH_ASSERT(sv->data != 0);
     return sv->len;
 }
 
@@ -485,8 +484,8 @@ long int igraph_strvector_size(const igraph_strvector_t *sv) {
 int igraph_strvector_add(igraph_strvector_t *v, const char *value) {
     long int s = igraph_strvector_size(v);
     char **tmp;
-    assert(v != 0);
-    assert(v->data != 0);
+    IGRAPH_ASSERT(v != 0);
+    IGRAPH_ASSERT(v->data != 0);
     tmp = igraph_Realloc(v->data, (size_t) s + 1, char*);
     if (tmp == 0) {
         IGRAPH_ERROR("cannot add string to string vector", IGRAPH_ENOMEM);
@@ -512,8 +511,8 @@ void igraph_strvector_permdelete(igraph_strvector_t *v, const igraph_vector_t *i
                                  long int nremove) {
     long int i;
     char **tmp;
-    assert(v != 0);
-    assert(v->data != 0);
+    IGRAPH_ASSERT(v != 0);
+    IGRAPH_ASSERT(v->data != 0);
 
     for (i = 0; i < igraph_strvector_size(v); i++) {
         if (VECTOR(*index)[i] != 0) {
@@ -541,8 +540,8 @@ void igraph_strvector_remove_negidx(igraph_strvector_t *v, const igraph_vector_t
                                     long int nremove) {
     long int i, idx = 0;
     char **tmp;
-    assert(v != 0);
-    assert(v->data != 0);
+    IGRAPH_ASSERT(v != 0);
+    IGRAPH_ASSERT(v->data != 0);
     for (i = 0; i < igraph_strvector_size(v); i++) {
         if (VECTOR(*neg)[i] >= 0) {
             v->data[idx++] = v->data[i];

--- a/src/igraph_trie.c
+++ b/src/igraph_trie.c
@@ -28,7 +28,6 @@
 #include "igraph_error.h"
 #include "config.h"
 
-#include <assert.h>
 #include <string.h>         /* memcpy & co. */
 #include <stdlib.h>
 

--- a/src/matrix.pmt
+++ b/src/matrix.pmt
@@ -25,7 +25,6 @@
 #include "igraph_random.h"
 #include "igraph_error.h"
 
-#include <assert.h>
 #include <string.h>         /* memcpy & co. */
 #include <stdlib.h>
 

--- a/src/microscopic_update.c
+++ b/src/microscopic_update.c
@@ -24,8 +24,7 @@
 #include "igraph_microscopic_update.h"
 #include "igraph_nongraph.h"
 #include "igraph_random.h"
-
-#include <assert.h>
+#include "igraph_error.h"
 
 /*
  * Internal use only.
@@ -804,7 +803,7 @@ int igraph_moran_process(const igraph_t *graph,
         IGRAPH_VIT_NEXT(vA);
     }
     /* By now we should have chosen a vertex for reproduction. Check this. */
-    assert(a >= 0);
+    IGRAPH_ASSERT(a >= 0);
 
     /* Cumulative proportionate weights. We are using the local perspective */
     /* with respect to vertex a, which has been chosen for reproduction. */
@@ -845,7 +844,7 @@ int igraph_moran_process(const igraph_t *graph,
             } else {
                 b = u;
             }
-            assert(a != b);  /* always true if G is simple */
+            IGRAPH_ASSERT(a != b);  /* always true if G is simple */
             break;
         }
         i++;
@@ -856,7 +855,7 @@ int igraph_moran_process(const igraph_t *graph,
     /* for death. Check that b has indeed been chosen. Clone vertex a and kill */
     /* vertex b. Let the clone c have the vertex ID of b, and the strategy and */
     /* quantity of a. */
-    assert(b >= 0);
+    IGRAPH_ASSERT(b >= 0);
     VECTOR(*quantities)[b] = VECTOR(*quantities)[a];
     VECTOR(*strategies)[b] = VECTOR(*strategies)[a];
 

--- a/src/mini-gmp/CMakeLists.txt
+++ b/src/mini-gmp/CMakeLists.txt
@@ -26,5 +26,10 @@ if(MSVC)
     /wd4146  # unary minus operator applied to unsigned type
     /wd4189  # local variable is initialized but not referenced
   )
+else()
+  target_compile_options(
+    gmp_vendored PRIVATE
+    $<$<C_COMPILER_ID:GCC,Clang,AppleClang>:-Wno-unused-variable>
+  )
 endif()
 

--- a/src/spmatrix.c
+++ b/src/spmatrix.c
@@ -27,7 +27,6 @@
 #include "igraph_error.h"
 #include "config.h"
 
-#include <assert.h>
 #include <string.h>     /* memcpy & co. */
 
 /**
@@ -54,7 +53,7 @@
  */
 
 int igraph_spmatrix_init(igraph_spmatrix_t *m, long int nrow, long int ncol) {
-    assert(m != NULL);
+    IGRAPH_ASSERT(m != NULL);
     IGRAPH_VECTOR_INIT_FINALLY(&m->ridx, 0);
     IGRAPH_VECTOR_INIT_FINALLY(&m->cidx, ncol + 1);
     IGRAPH_VECTOR_INIT_FINALLY(&m->data, 0);
@@ -79,7 +78,7 @@ int igraph_spmatrix_init(igraph_spmatrix_t *m, long int nrow, long int ncol) {
  */
 
 void igraph_spmatrix_destroy(igraph_spmatrix_t *m) {
-    assert(m != NULL);
+    IGRAPH_ASSERT(m != NULL);
     igraph_vector_destroy(&m->ridx);
     igraph_vector_destroy(&m->cidx);
     igraph_vector_destroy(&m->data);
@@ -102,8 +101,8 @@ void igraph_spmatrix_destroy(igraph_spmatrix_t *m) {
  */
 
 int igraph_spmatrix_copy(igraph_spmatrix_t *to, const igraph_spmatrix_t *from) {
-    assert(from != NULL);
-    assert(to != NULL);
+    IGRAPH_ASSERT(from != NULL);
+    IGRAPH_ASSERT(to != NULL);
     to->nrow = from->nrow;
     to->ncol = from->ncol;
     IGRAPH_CHECK(igraph_vector_copy(&to->ridx, &from->ridx));
@@ -133,7 +132,7 @@ igraph_real_t igraph_spmatrix_e(const igraph_spmatrix_t *m,
                                 long int row, long int col) {
     long int start, end;
 
-    assert(m != NULL);
+    IGRAPH_ASSERT(m != NULL);
     start = (long) VECTOR(m->cidx)[col];
     end = (long) VECTOR(m->cidx)[col + 1] - 1;
 
@@ -182,7 +181,7 @@ int igraph_spmatrix_set(igraph_spmatrix_t *m, long int row, long int col,
                         igraph_real_t value) {
     long int start, end;
 
-    assert(m != NULL);
+    IGRAPH_ASSERT(m != NULL);
     start = (long) VECTOR(m->cidx)[col];
     end = (long) VECTOR(m->cidx)[col + 1] - 1;
 
@@ -281,7 +280,7 @@ int igraph_spmatrix_add_e(igraph_spmatrix_t *m, long int row, long int col,
                           igraph_real_t value) {
     long int start, end;
 
-    assert(m != NULL);
+    IGRAPH_ASSERT(m != NULL);
     start = (long) VECTOR(m->cidx)[col];
     end = (long) VECTOR(m->cidx)[col + 1] - 1;
 
@@ -399,7 +398,7 @@ int igraph_spmatrix_add_col_values(igraph_spmatrix_t *m, long int to, long int f
 
 int igraph_spmatrix_resize(igraph_spmatrix_t *m, long int nrow, long int ncol) {
     long int i, j, ci, ei, mincol;
-    assert(m != NULL);
+    IGRAPH_ASSERT(m != NULL);
     /* Iterating through the matrix data and deleting unnecessary data. */
     /* At the same time, we create the new indices as well */
     if (nrow < m->nrow) {
@@ -441,7 +440,7 @@ int igraph_spmatrix_resize(igraph_spmatrix_t *m, long int nrow, long int ncol) {
  */
 
 long int igraph_spmatrix_count_nonzero(const igraph_spmatrix_t *m) {
-    assert(m != NULL);
+    IGRAPH_ASSERT(m != NULL);
     return igraph_vector_size(&m->data);
 }
 
@@ -458,7 +457,7 @@ long int igraph_spmatrix_count_nonzero(const igraph_spmatrix_t *m) {
  */
 
 long int igraph_spmatrix_size(const igraph_spmatrix_t *m) {
-    assert(m != NULL);
+    IGRAPH_ASSERT(m != NULL);
     return (m->nrow) * (m->ncol);
 }
 
@@ -474,7 +473,7 @@ long int igraph_spmatrix_size(const igraph_spmatrix_t *m) {
  */
 
 long int igraph_spmatrix_nrow(const igraph_spmatrix_t *m) {
-    assert(m != NULL);
+    IGRAPH_ASSERT(m != NULL);
     return m->nrow;
 }
 
@@ -490,7 +489,7 @@ long int igraph_spmatrix_nrow(const igraph_spmatrix_t *m) {
  */
 
 long int igraph_spmatrix_ncol(const igraph_spmatrix_t *m) {
-    assert(m != NULL);
+    IGRAPH_ASSERT(m != NULL);
     return m->ncol;
 }
 
@@ -536,7 +535,7 @@ int igraph_spmatrix_copy_to(const igraph_spmatrix_t *m, igraph_real_t *to) {
  */
 
 int igraph_spmatrix_null(igraph_spmatrix_t *m) {
-    assert(m != NULL);
+    IGRAPH_ASSERT(m != NULL);
     igraph_vector_clear(&m->data);
     igraph_vector_clear(&m->ridx);
     igraph_vector_null(&m->cidx);
@@ -588,7 +587,7 @@ int igraph_spmatrix_clear_row(igraph_spmatrix_t *m, long int row) {
     long int ci, ei, i, j, nremove = 0, nremove_old = 0;
     igraph_vector_t permvec;
 
-    assert(m != NULL);
+    IGRAPH_ASSERT(m != NULL);
     IGRAPH_VECTOR_INIT_FINALLY(&permvec, igraph_vector_size(&m->data));
     for (ci = 0, i = 0, j = 1; ci < m->ncol; ci++) {
         for (ei = (long int) VECTOR(m->cidx)[ci]; ei < VECTOR(m->cidx)[ci + 1]; ei++) {
@@ -619,7 +618,7 @@ int igraph_spmatrix_clear_row(igraph_spmatrix_t *m, long int row) {
 int igraph_i_spmatrix_clear_row_fast(igraph_spmatrix_t *m, long int row) {
     long int ei, n;
 
-    assert(m != NULL);
+    IGRAPH_ASSERT(m != NULL);
     n = igraph_vector_size(&m->data);
     for (ei = 0; ei < n; ei++) {
         if (VECTOR(m->ridx)[ei] == row) {
@@ -633,7 +632,7 @@ int igraph_i_spmatrix_cleanup(igraph_spmatrix_t *m) {
     long int ci, ei, i, j, nremove = 0, nremove_old = 0;
     igraph_vector_t permvec;
 
-    assert(m != NULL);
+    IGRAPH_ASSERT(m != NULL);
     IGRAPH_VECTOR_INIT_FINALLY(&permvec, igraph_vector_size(&m->data));
     for (ci = 0, i = 0, j = 1; ci < m->ncol; ci++) {
         for (ei = (long int) VECTOR(m->cidx)[ci]; ei < VECTOR(m->cidx)[ci + 1]; ei++) {
@@ -673,7 +672,7 @@ int igraph_i_spmatrix_cleanup(igraph_spmatrix_t *m) {
 
 int igraph_spmatrix_clear_col(igraph_spmatrix_t *m, long int col) {
     long int i, n;
-    assert(m != NULL);
+    IGRAPH_ASSERT(m != NULL);
     n = (long)VECTOR(m->cidx)[col + 1] - (long)VECTOR(m->cidx)[col];
     if (n == 0) {
         return 0;
@@ -698,7 +697,7 @@ int igraph_spmatrix_clear_col(igraph_spmatrix_t *m, long int col) {
  */
 
 void igraph_spmatrix_scale(igraph_spmatrix_t *m, igraph_real_t by) {
-    assert(m != NULL);
+    IGRAPH_ASSERT(m != NULL);
     igraph_vector_scale(&m->data, by);
 }
 
@@ -714,7 +713,7 @@ void igraph_spmatrix_scale(igraph_spmatrix_t *m, igraph_real_t by) {
 
 int igraph_spmatrix_colsums(const igraph_spmatrix_t *m, igraph_vector_t *res) {
     long int i, c;
-    assert(m != NULL);
+    IGRAPH_ASSERT(m != NULL);
     IGRAPH_CHECK(igraph_vector_resize(res, m->ncol));
     igraph_vector_null(res);
     for (c = 0; c < m->ncol; c++) {
@@ -737,7 +736,7 @@ int igraph_spmatrix_colsums(const igraph_spmatrix_t *m, igraph_vector_t *res) {
 
 int igraph_spmatrix_rowsums(const igraph_spmatrix_t *m, igraph_vector_t *res) {
     long int i, n;
-    assert(m != NULL);
+    IGRAPH_ASSERT(m != NULL);
 
     IGRAPH_CHECK(igraph_vector_resize(res, m->nrow));
     n = igraph_vector_size(&m->data);
@@ -764,7 +763,7 @@ igraph_real_t igraph_spmatrix_max_nonzero(const igraph_spmatrix_t *m,
     igraph_real_t res;
     long int i, n, maxidx;
 
-    assert(m != NULL);
+    IGRAPH_ASSERT(m != NULL);
     n = igraph_vector_size(&m->data);
     if (n == 0) {
         return 0.0;
@@ -811,7 +810,7 @@ igraph_real_t igraph_spmatrix_max(const igraph_spmatrix_t *m,
     igraph_real_t res;
     long int i, j, k, maxidx;
 
-    assert(m != NULL);
+    IGRAPH_ASSERT(m != NULL);
     i = igraph_vector_size(&m->data);
     if (i == 0) {
         return 0.0;
@@ -863,7 +862,7 @@ igraph_real_t igraph_spmatrix_max(const igraph_spmatrix_t *m,
 int igraph_i_spmatrix_get_col_nonzero_indices(const igraph_spmatrix_t *m,
         igraph_vector_t *res, long int col) {
     long int i, n;
-    assert(m != NULL);
+    IGRAPH_ASSERT(m != NULL);
     n = (long int) (VECTOR(m->cidx)[col + 1] - VECTOR(m->cidx)[col]);
     IGRAPH_CHECK(igraph_vector_resize(res, n));
     for (i = (long int) VECTOR(m->cidx)[col], n = 0;
@@ -918,7 +917,7 @@ int igraph_spmatrix_iter_create(igraph_spmatrix_iter_t *mit, const igraph_spmatr
  * Time complexity: O(1).
  */
 int igraph_spmatrix_iter_reset(igraph_spmatrix_iter_t *mit) {
-    assert(mit->m);
+    IGRAPH_ASSERT(mit->m);
 
     if (igraph_spmatrix_count_nonzero(mit->m) == 0) {
         mit->pos = mit->ri = mit->ci = -1L;

--- a/src/stack.pmt
+++ b/src/stack.pmt
@@ -26,7 +26,6 @@
 #include "igraph_error.h"
 #include "config.h"
 
-#include <assert.h>
 #include <string.h>         /* memcpy & co. */
 #include <stdlib.h>
 
@@ -45,7 +44,7 @@
 
 int FUNCTION(igraph_stack, init)       (TYPE(igraph_stack)* s, long int size) {
     long int alloc_size = size > 0 ? size : 1;
-    assert (s != NULL);
+    IGRAPH_ASSERT(s != NULL);
     if (size < 0) {
         size = 0;
     }
@@ -73,7 +72,7 @@ int FUNCTION(igraph_stack, init)       (TYPE(igraph_stack)* s, long int size) {
  */
 
 void FUNCTION(igraph_stack, destroy)    (TYPE(igraph_stack)* s) {
-    assert( s != NULL);
+    IGRAPH_ASSERT(s != NULL);
     if (s->stor_begin != 0) {
         igraph_Free(s->stor_begin);
         s->stor_begin = NULL;
@@ -99,8 +98,8 @@ void FUNCTION(igraph_stack, destroy)    (TYPE(igraph_stack)* s) {
 int FUNCTION(igraph_stack, reserve)    (TYPE(igraph_stack)* s, long int size) {
     long int actual_size = FUNCTION(igraph_stack, size)(s);
     BASE *tmp;
-    assert(s != NULL);
-    assert(s->stor_begin != NULL);
+    IGRAPH_ASSERT(s != NULL);
+    IGRAPH_ASSERT(s->stor_begin != NULL);
 
     if (size <= actual_size) {
         return 0;
@@ -130,9 +129,9 @@ int FUNCTION(igraph_stack, reserve)    (TYPE(igraph_stack)* s, long int size) {
  */
 
 igraph_bool_t FUNCTION(igraph_stack, empty)      (TYPE(igraph_stack)* s) {
-    assert (s != NULL);
-    assert (s->stor_begin != NULL);
-    assert (s->end != NULL);
+    IGRAPH_ASSERT(s != NULL);
+    IGRAPH_ASSERT(s->stor_begin != NULL);
+    IGRAPH_ASSERT(s->end != NULL);
     return s->stor_begin == s->end;
 }
 
@@ -148,8 +147,8 @@ igraph_bool_t FUNCTION(igraph_stack, empty)      (TYPE(igraph_stack)* s) {
  */
 
 long int FUNCTION(igraph_stack, size)       (const TYPE(igraph_stack)* s) {
-    assert (s != NULL);
-    assert (s->stor_begin != NULL);
+    IGRAPH_ASSERT(s != NULL);
+    IGRAPH_ASSERT(s->stor_begin != NULL);
     return s->end - s->stor_begin;
 }
 
@@ -164,8 +163,8 @@ long int FUNCTION(igraph_stack, size)       (const TYPE(igraph_stack)* s) {
  */
 
 void FUNCTION(igraph_stack, clear)      (TYPE(igraph_stack)* s) {
-    assert (s != NULL);
-    assert (s->stor_begin != NULL);
+    IGRAPH_ASSERT(s != NULL);
+    IGRAPH_ASSERT(s->stor_begin != NULL);
     s->end = s->stor_begin;
 }
 
@@ -185,8 +184,8 @@ void FUNCTION(igraph_stack, clear)      (TYPE(igraph_stack)* s) {
  */
 
 int FUNCTION(igraph_stack, push)(TYPE(igraph_stack)* s, BASE elem) {
-    assert (s != NULL);
-    assert (s->stor_begin != NULL);
+    IGRAPH_ASSERT(s != NULL);
+    IGRAPH_ASSERT(s->stor_begin != NULL);
     if (s->end == s->stor_end) {
         /* full, allocate more storage */
 
@@ -229,10 +228,10 @@ int FUNCTION(igraph_stack, push)(TYPE(igraph_stack)* s, BASE elem) {
 
 BASE FUNCTION(igraph_stack, pop)        (TYPE(igraph_stack)* s) {
 
-    assert (s != NULL);
-    assert (s->stor_begin != NULL);
-    assert (s->end != NULL);
-    assert (s->end != s->stor_begin);
+    IGRAPH_ASSERT(s != NULL);
+    IGRAPH_ASSERT(s->stor_begin != NULL);
+    IGRAPH_ASSERT(s->end != NULL);
+    IGRAPH_ASSERT(s->end != s->stor_begin);
 
     (s->end)--;
 
@@ -254,10 +253,10 @@ BASE FUNCTION(igraph_stack, pop)        (TYPE(igraph_stack)* s) {
 
 BASE FUNCTION(igraph_stack, top)        (const TYPE(igraph_stack)* s) {
 
-    assert (s != NULL);
-    assert (s->stor_begin != NULL);
-    assert (s->end != NULL);
-    assert (s->end != s->stor_begin);
+    IGRAPH_ASSERT(s != NULL);
+    IGRAPH_ASSERT(s->stor_begin != NULL);
+    IGRAPH_ASSERT(s->end != NULL);
+    IGRAPH_ASSERT(s->end != s->stor_begin);
 
     return *(s->end - 1);
 }

--- a/src/structural_properties.c
+++ b/src/structural_properties.c
@@ -42,10 +42,10 @@
 #include "igraph_neighborhood.h"
 #include "igraph_topology.h"
 #include "igraph_qsort.h"
+#include "igraph_error.h"
 #include "config.h"
 #include "structural_properties_internal.h"
 
-#include <assert.h>
 #include <string.h>
 #include <limits.h>
 
@@ -4799,7 +4799,7 @@ int igraph_get_all_shortest_paths_dijkstra(const igraph_t *graph,
                 printf("  Considering parent: %ld\n", parent_node);
                 printf("  Paths to parent start at index %ld in res\n", parent_path_idx);
                 */
-                assert(parent_path_idx >= 0);
+                IGRAPH_ASSERT(parent_path_idx >= 0);
                 for (; parent_path_idx < path_count; parent_path_idx++) {
                     parent_path = (igraph_vector_t*)VECTOR(*res)[parent_path_idx];
                     if (igraph_vector_tail(parent_path) != parent_node) {

--- a/src/vector.c
+++ b/src/vector.c
@@ -21,6 +21,7 @@
 
 */
 
+#include "igraph_error.h"
 #include "igraph_types.h"
 #include "igraph_types_internal.h"
 #include "igraph_complex.h"
@@ -144,8 +145,8 @@ int igraph_vector_order(const igraph_vector_t* v,
     igraph_vector_t rad;
     long int i, j;
 
-    assert(v != NULL);
-    assert(v->stor_begin != NULL);
+    IGRAPH_ASSERT(v != NULL);
+    IGRAPH_ASSERT(v->stor_begin != NULL);
 
     IGRAPH_VECTOR_INIT_FINALLY(&ptr, (long int) nodes + 1);
     IGRAPH_VECTOR_INIT_FINALLY(&rad, edges);
@@ -209,8 +210,8 @@ int igraph_vector_order1(const igraph_vector_t* v,
     igraph_vector_t rad;
     long int i, j;
 
-    assert(v != NULL);
-    assert(v->stor_begin != NULL);
+    IGRAPH_ASSERT(v != NULL);
+    IGRAPH_ASSERT(v->stor_begin != NULL);
 
     IGRAPH_VECTOR_INIT_FINALLY(&ptr, (long int) nodes + 1);
     IGRAPH_VECTOR_INIT_FINALLY(&rad, edges);
@@ -251,8 +252,8 @@ int igraph_vector_order1_int(const igraph_vector_t* v,
     igraph_vector_t rad;
     long int i, j;
 
-    assert(v != NULL);
-    assert(v->stor_begin != NULL);
+    IGRAPH_ASSERT(v != NULL);
+    IGRAPH_ASSERT(v->stor_begin != NULL);
 
     IGRAPH_VECTOR_INIT_FINALLY(&ptr, (long int) nodes + 1);
     IGRAPH_VECTOR_INIT_FINALLY(&rad, edges);
@@ -425,10 +426,10 @@ igraph_bool_t igraph_vector_e_tol(const igraph_vector_t *lhs,
                                   const igraph_vector_t *rhs,
                                   igraph_real_t tol) {
     long int i, s;
-    assert(lhs != 0);
-    assert(rhs != 0);
-    assert(lhs->stor_begin != 0);
-    assert(rhs->stor_begin != 0);
+    IGRAPH_ASSERT(lhs != 0);
+    IGRAPH_ASSERT(rhs != 0);
+    IGRAPH_ASSERT(lhs->stor_begin != 0);
+    IGRAPH_ASSERT(rhs->stor_begin != 0);
 
     s = igraph_vector_size(lhs);
     if (s != igraph_vector_size(rhs)) {

--- a/src/vector.pmt
+++ b/src/vector.pmt
@@ -26,7 +26,6 @@
 #include "igraph_random.h"
 #include "igraph_qsort.h"
 
-#include <assert.h>
 #include <string.h>         /* memcpy & co. */
 #include <stdlib.h>
 #include <stdarg.h>     /* va_start & co */
@@ -161,7 +160,7 @@ const TYPE(igraph_vector)*FUNCTION(igraph_vector, view) (const TYPE(igraph_vecto
         long int length) {
     TYPE(igraph_vector) *v2 = (TYPE(igraph_vector)*)v;
 
-    assert(data != 0);
+    IGRAPH_ASSERT(data != 0);
 
     v2->stor_begin = (BASE*)data;
     v2->stor_end = (BASE*)data + length;
@@ -376,7 +375,7 @@ int FUNCTION(igraph_vector_init, int_end)(TYPE(igraph_vector) *v, int endmark, .
  */
 
 void FUNCTION(igraph_vector, destroy)   (TYPE(igraph_vector)* v) {
-    assert(v != 0);
+    IGRAPH_ASSERT(v != 0);
     if (v->stor_begin != 0) {
         igraph_Free(v->stor_begin);
         v->stor_begin = NULL;
@@ -435,8 +434,8 @@ long int FUNCTION(igraph_vector, capacity)(const TYPE(igraph_vector)*v) {
 int FUNCTION(igraph_vector, reserve)   (TYPE(igraph_vector)* v, long int size) {
     long int actual_size = FUNCTION(igraph_vector, size)(v);
     BASE *tmp;
-    assert(v != NULL);
-    assert(v->stor_begin != NULL);
+    IGRAPH_ASSERT(v != NULL);
+    IGRAPH_ASSERT(v->stor_begin != NULL);
     if (size <= FUNCTION(igraph_vector, size)(v)) {
         return 0;
     }
@@ -465,8 +464,8 @@ int FUNCTION(igraph_vector, reserve)   (TYPE(igraph_vector)* v, long int size) {
  */
 
 igraph_bool_t FUNCTION(igraph_vector, empty)     (const TYPE(igraph_vector)* v) {
-    assert(v != NULL);
-    assert(v->stor_begin != NULL);
+    IGRAPH_ASSERT(v != NULL);
+    IGRAPH_ASSERT(v->stor_begin != NULL);
     return v->stor_begin == v->end;
 }
 
@@ -482,8 +481,8 @@ igraph_bool_t FUNCTION(igraph_vector, empty)     (const TYPE(igraph_vector)* v) 
  */
 
 long int FUNCTION(igraph_vector, size)      (const TYPE(igraph_vector)* v) {
-    assert(v != NULL);
-    assert(v->stor_begin != NULL);
+    IGRAPH_ASSERT(v != NULL);
+    IGRAPH_ASSERT(v->stor_begin != NULL);
     return v->end - v->stor_begin;
 }
 
@@ -502,8 +501,8 @@ long int FUNCTION(igraph_vector, size)      (const TYPE(igraph_vector)* v) {
  */
 
 void FUNCTION(igraph_vector, clear)     (TYPE(igraph_vector)* v) {
-    assert(v != NULL);
-    assert(v->stor_begin != NULL);
+    IGRAPH_ASSERT(v != NULL);
+    IGRAPH_ASSERT(v->stor_begin != NULL);
     v->end = v->stor_begin;
 }
 
@@ -533,8 +532,8 @@ void FUNCTION(igraph_vector, clear)     (TYPE(igraph_vector)* v) {
  */
 
 int FUNCTION(igraph_vector, push_back) (TYPE(igraph_vector)* v, BASE e) {
-    assert(v != NULL);
-    assert(v->stor_begin != NULL);
+    IGRAPH_ASSERT(v != NULL);
+    IGRAPH_ASSERT(v->stor_begin != NULL);
 
     /* full, allocate more storage */
     if (v->stor_end == v->end) {
@@ -610,8 +609,8 @@ int FUNCTION(igraph_vector, insert)(TYPE(igraph_vector) *v, long int pos,
  */
 
 BASE FUNCTION(igraph_vector, e)         (const TYPE(igraph_vector)* v, long int pos) {
-    assert(v != NULL);
-    assert(v->stor_begin != NULL);
+    IGRAPH_ASSERT(v != NULL);
+    IGRAPH_ASSERT(v->stor_begin != NULL);
     return * (v->stor_begin + pos);
 }
 
@@ -629,8 +628,8 @@ BASE FUNCTION(igraph_vector, e)         (const TYPE(igraph_vector)* v, long int 
  */
 
 BASE* FUNCTION(igraph_vector, e_ptr)  (const TYPE(igraph_vector)* v, long int pos) {
-    assert(v != NULL);
-    assert(v->stor_begin != NULL);
+    IGRAPH_ASSERT(v != NULL);
+    IGRAPH_ASSERT(v->stor_begin != NULL);
     return v->stor_begin + pos;
 }
 
@@ -646,8 +645,8 @@ BASE* FUNCTION(igraph_vector, e_ptr)  (const TYPE(igraph_vector)* v, long int po
 
 void FUNCTION(igraph_vector, set)       (TYPE(igraph_vector)* v,
         long int pos, BASE value) {
-    assert(v != NULL);
-    assert(v->stor_begin != NULL);
+    IGRAPH_ASSERT(v != NULL);
+    IGRAPH_ASSERT(v->stor_begin != NULL);
     *(v->stor_begin + pos) = value;
 }
 
@@ -668,8 +667,8 @@ void FUNCTION(igraph_vector, set)       (TYPE(igraph_vector)* v,
  */
 
 void FUNCTION(igraph_vector, null)      (TYPE(igraph_vector)* v) {
-    assert(v != NULL);
-    assert(v->stor_begin != NULL);
+    IGRAPH_ASSERT(v != NULL);
+    IGRAPH_ASSERT(v->stor_begin != NULL);
     if (FUNCTION(igraph_vector, size)(v) > 0) {
         memset(v->stor_begin, 0,
                sizeof(BASE) * (size_t) FUNCTION(igraph_vector, size)(v));
@@ -689,8 +688,8 @@ void FUNCTION(igraph_vector, null)      (TYPE(igraph_vector)* v) {
 
 void FUNCTION(igraph_vector, fill)      (TYPE(igraph_vector)* v, BASE e) {
     BASE *ptr;
-    assert(v != NULL);
-    assert(v->stor_begin != NULL);
+    IGRAPH_ASSERT(v != NULL);
+    IGRAPH_ASSERT(v->stor_begin != NULL);
     for (ptr = v->stor_begin; ptr < v->end; ptr++) {
         *ptr = e;
     }
@@ -711,8 +710,8 @@ void FUNCTION(igraph_vector, fill)      (TYPE(igraph_vector)* v, BASE e) {
  */
 
 BASE FUNCTION(igraph_vector, tail)(const TYPE(igraph_vector) *v) {
-    assert(v != NULL);
-    assert(v->stor_begin != NULL);
+    IGRAPH_ASSERT(v != NULL);
+    IGRAPH_ASSERT(v->stor_begin != NULL);
     return *((v->end) - 1);
 }
 
@@ -731,9 +730,9 @@ BASE FUNCTION(igraph_vector, tail)(const TYPE(igraph_vector) *v) {
 
 BASE FUNCTION(igraph_vector, pop_back)(TYPE(igraph_vector)* v) {
     BASE tmp;
-    assert(v != NULL);
-    assert(v->stor_begin != NULL);
-    assert(v->end != v->stor_begin);
+    IGRAPH_ASSERT(v != NULL);
+    IGRAPH_ASSERT(v->stor_begin != NULL);
+    IGRAPH_ASSERT(v->end != v->stor_begin);
     tmp = FUNCTION(igraph_vector, e)(v, FUNCTION(igraph_vector, size)(v) - 1);
     v->end -= 1;
     return tmp;
@@ -781,8 +780,8 @@ int FUNCTION(igraph_vector, reverse_sort_cmp)(const void *a, const void *b) {
  */
 
 void FUNCTION(igraph_vector, sort)(TYPE(igraph_vector) *v) {
-    assert(v != NULL);
-    assert(v->stor_begin != NULL);
+    IGRAPH_ASSERT(v != NULL);
+    IGRAPH_ASSERT(v->stor_begin != NULL);
     igraph_qsort(v->stor_begin, (size_t) FUNCTION(igraph_vector, size)(v),
                  sizeof(BASE), FUNCTION(igraph_vector, sort_cmp));
 }
@@ -799,8 +798,8 @@ void FUNCTION(igraph_vector, sort)(TYPE(igraph_vector) *v) {
  */
 
 void FUNCTION(igraph_vector, reverse_sort)(TYPE(igraph_vector) *v) {
-    assert(v != NULL);
-    assert(v->stor_begin != NULL);
+    IGRAPH_ASSERT(v != NULL);
+    IGRAPH_ASSERT(v->stor_begin != NULL);
     igraph_qsort(v->stor_begin, (size_t) FUNCTION(igraph_vector, size)(v),
                  sizeof(BASE), FUNCTION(igraph_vector, reverse_sort_cmp));
 }
@@ -923,8 +922,8 @@ long int FUNCTION(igraph_vector, qsort_ind)(TYPE(igraph_vector) *v,
  */
 
 int FUNCTION(igraph_vector, resize)(TYPE(igraph_vector)* v, long int newsize) {
-    assert(v != NULL);
-    assert(v->stor_begin != NULL);
+    IGRAPH_ASSERT(v != NULL);
+    IGRAPH_ASSERT(v->stor_begin != NULL);
     IGRAPH_CHECK(FUNCTION(igraph_vector, reserve)(v, newsize));
     v->end = v->stor_begin + newsize;
     return 0;
@@ -985,8 +984,8 @@ int FUNCTION(igraph_vector, resize_min)(TYPE(igraph_vector)*v) {
 BASE FUNCTION(igraph_vector, max)(const TYPE(igraph_vector)* v) {
     BASE max;
     BASE *ptr;
-    assert(v != NULL);
-    assert(v->stor_begin != NULL);
+    IGRAPH_ASSERT(v != NULL);
+    IGRAPH_ASSERT(v->stor_begin != NULL);
     max = *(v->stor_begin);
     ptr = v->stor_begin + 1;
     while (ptr < v->end) {
@@ -1019,8 +1018,8 @@ long int FUNCTION(igraph_vector, which_max)(const TYPE(igraph_vector)* v) {
         BASE max;
         BASE *ptr;
         long int pos;
-        assert(v != NULL);
-        assert(v->stor_begin != NULL);
+        IGRAPH_ASSERT(v != NULL);
+        IGRAPH_ASSERT(v->stor_begin != NULL);
         max = *(v->stor_begin); which = 0;
         ptr = v->stor_begin + 1; pos = 1;
         while (ptr < v->end) {
@@ -1048,8 +1047,8 @@ long int FUNCTION(igraph_vector, which_max)(const TYPE(igraph_vector)* v) {
 BASE FUNCTION(igraph_vector, min)(const TYPE(igraph_vector)* v) {
     BASE min;
     BASE *ptr;
-    assert(v != NULL);
-    assert(v->stor_begin != NULL);
+    IGRAPH_ASSERT(v != NULL);
+    IGRAPH_ASSERT(v->stor_begin != NULL);
     min = *(v->stor_begin);
     ptr = v->stor_begin + 1;
     while (ptr < v->end) {
@@ -1080,8 +1079,8 @@ long int FUNCTION(igraph_vector, which_min)(const TYPE(igraph_vector)* v) {
         BASE min;
         BASE *ptr;
         long int pos;
-        assert(v != NULL);
-        assert(v->stor_begin != NULL);
+        IGRAPH_ASSERT(v != NULL);
+        IGRAPH_ASSERT(v->stor_begin != NULL);
         min = *(v->stor_begin); which = 0;
         ptr = v->stor_begin + 1; pos = 1;
         while (ptr < v->end) {
@@ -1141,8 +1140,8 @@ int FUNCTION(igraph_vector, init_copy)(TYPE(igraph_vector) *v,
 
 void FUNCTION(igraph_vector, copy_to)(const TYPE(igraph_vector) *v, BASE *to) {
 
-    assert(v != NULL);
-    assert(v->stor_begin != NULL);
+    IGRAPH_ASSERT(v != NULL);
+    IGRAPH_ASSERT(v->stor_begin != NULL);
     if (v->end != v->stor_begin) {
         memcpy(to, v->stor_begin, sizeof(BASE) * (size_t) (v->end - v->stor_begin));
     }
@@ -1168,8 +1167,8 @@ void FUNCTION(igraph_vector, copy_to)(const TYPE(igraph_vector) *v, BASE *to) {
 
 int FUNCTION(igraph_vector, copy)(TYPE(igraph_vector) *to,
                                   const TYPE(igraph_vector) *from) {
-    assert(from != NULL);
-    assert(from->stor_begin != NULL);
+    IGRAPH_ASSERT(from != NULL);
+    IGRAPH_ASSERT(from->stor_begin != NULL);
     to->stor_begin = igraph_Calloc(FUNCTION(igraph_vector, size)(from), BASE);
     if (to->stor_begin == 0) {
         IGRAPH_ERROR("cannot copy vector", IGRAPH_ENOMEM);
@@ -1199,8 +1198,8 @@ int FUNCTION(igraph_vector, copy)(TYPE(igraph_vector) *to,
 BASE FUNCTION(igraph_vector, sum)(const TYPE(igraph_vector) *v) {
     BASE res = ZERO;
     BASE *p;
-    assert(v != NULL);
-    assert(v->stor_begin != NULL);
+    IGRAPH_ASSERT(v != NULL);
+    IGRAPH_ASSERT(v->stor_begin != NULL);
     for (p = v->stor_begin; p < v->end; p++) {
 #ifdef SUM
         SUM(res, res, *p);
@@ -1214,8 +1213,8 @@ BASE FUNCTION(igraph_vector, sum)(const TYPE(igraph_vector) *v) {
 igraph_real_t FUNCTION(igraph_vector, sumsq)(const TYPE(igraph_vector) *v) {
     igraph_real_t res = 0.0;
     BASE *p;
-    assert(v != NULL);
-    assert(v->stor_begin != NULL);
+    IGRAPH_ASSERT(v != NULL);
+    IGRAPH_ASSERT(v->stor_begin != NULL);
     for (p = v->stor_begin; p < v->end; p++) {
 #ifdef SQ
         res += SQ(*p);
@@ -1243,8 +1242,8 @@ igraph_real_t FUNCTION(igraph_vector, sumsq)(const TYPE(igraph_vector) *v) {
 BASE FUNCTION(igraph_vector, prod)(const TYPE(igraph_vector) *v) {
     BASE res = ONE;
     BASE *p;
-    assert(v != NULL);
-    assert(v->stor_begin != NULL);
+    IGRAPH_ASSERT(v != NULL);
+    IGRAPH_ASSERT(v->stor_begin != NULL);
     for (p = v->stor_begin; p < v->end; p++) {
 #ifdef PROD
         PROD(res, res, *p);
@@ -1275,10 +1274,10 @@ int FUNCTION(igraph_vector, cumsum)(TYPE(igraph_vector) *to,
     BASE res = ZERO;
     BASE *p, *p2;
 
-    assert(from != NULL);
-    assert(from->stor_begin != NULL);
-    assert(to != NULL);
-    assert(to->stor_begin != NULL);
+    IGRAPH_ASSERT(from != NULL);
+    IGRAPH_ASSERT(from->stor_begin != NULL);
+    IGRAPH_ASSERT(to != NULL);
+    IGRAPH_ASSERT(to->stor_begin != NULL);
 
     IGRAPH_CHECK(FUNCTION(igraph_vector, resize)(to, FUNCTION(igraph_vector, size)(from)));
 
@@ -1347,8 +1346,8 @@ int FUNCTION(igraph_vector, init_seq)(TYPE(igraph_vector) *v,
 
 void FUNCTION(igraph_vector, remove_section)(TYPE(igraph_vector) *v,
         long int from, long int to) {
-    assert(v != NULL);
-    assert(v->stor_begin != NULL);
+    IGRAPH_ASSERT(v != NULL);
+    IGRAPH_ASSERT(v->stor_begin != NULL);
     /* Not removing from the end? */
     if (to < FUNCTION(igraph_vector, size)(v)) {
         memmove(v->stor_begin + from, v->stor_begin + to,
@@ -1372,8 +1371,8 @@ void FUNCTION(igraph_vector, remove_section)(TYPE(igraph_vector) *v,
  */
 
 void FUNCTION(igraph_vector, remove)(TYPE(igraph_vector) *v, long int elem) {
-    assert(v != NULL);
-    assert(v->stor_begin != NULL);
+    IGRAPH_ASSERT(v != NULL);
+    IGRAPH_ASSERT(v->stor_begin != NULL);
     FUNCTION(igraph_vector, remove_section)(v, elem, elem + 1);
 }
 
@@ -1398,8 +1397,8 @@ void FUNCTION(igraph_vector, remove)(TYPE(igraph_vector) *v, long int elem) {
 int FUNCTION(igraph_vector, move_interval)(TYPE(igraph_vector) *v,
         long int begin, long int end,
         long int to) {
-    assert(v != NULL);
-    assert(v->stor_begin != NULL);
+    IGRAPH_ASSERT(v != NULL);
+    IGRAPH_ASSERT(v->stor_begin != NULL);
     memcpy(v->stor_begin + to, v->stor_begin + begin,
            sizeof(BASE) * (size_t) (end - begin));
 
@@ -1409,8 +1408,8 @@ int FUNCTION(igraph_vector, move_interval)(TYPE(igraph_vector) *v,
 int FUNCTION(igraph_vector, move_interval2)(TYPE(igraph_vector) *v,
         long int begin, long int end,
         long int to) {
-    assert(v != NULL);
-    assert(v->stor_begin != NULL);
+    IGRAPH_ASSERT(v != NULL);
+    IGRAPH_ASSERT(v->stor_begin != NULL);
     memmove(v->stor_begin + to, v->stor_begin + begin,
             sizeof(BASE) * (size_t) (end - begin));
 
@@ -1426,8 +1425,8 @@ int FUNCTION(igraph_vector, move_interval2)(TYPE(igraph_vector) *v,
 void FUNCTION(igraph_vector, permdelete)(TYPE(igraph_vector) *v,
         const igraph_vector_t *index, long int nremove) {
     long int i, n;
-    assert(v != NULL);
-    assert(v->stor_begin != NULL);
+    IGRAPH_ASSERT(v != NULL);
+    IGRAPH_ASSERT(v->stor_begin != NULL);
     n = FUNCTION(igraph_vector, size)(v);
     for (i = 0; i < n; i++) {
         if (VECTOR(*index)[i] != 0) {
@@ -1459,8 +1458,8 @@ igraph_bool_t FUNCTION(igraph_vector, isininterval)(const TYPE(igraph_vector) *v
         BASE low,
         BASE high) {
     BASE *ptr;
-    assert(v != NULL);
-    assert(v->stor_begin != NULL);
+    IGRAPH_ASSERT(v != NULL);
+    IGRAPH_ASSERT(v->stor_begin != NULL);
     for (ptr = v->stor_begin; ptr < v->end; ptr++) {
         if (*ptr < low || *ptr > high) {
             return 0;
@@ -1487,8 +1486,8 @@ igraph_bool_t FUNCTION(igraph_vector, isininterval)(const TYPE(igraph_vector) *v
 igraph_bool_t FUNCTION(igraph_vector, any_smaller)(const TYPE(igraph_vector) *v,
         BASE limit) {
     BASE *ptr;
-    assert(v != NULL);
-    assert(v->stor_begin != NULL);
+    IGRAPH_ASSERT(v != NULL);
+    IGRAPH_ASSERT(v->stor_begin != NULL);
     for (ptr = v->stor_begin; ptr < v->end; ptr++) {
         if (*ptr < limit) {
             return 1;
@@ -1516,10 +1515,10 @@ igraph_bool_t FUNCTION(igraph_vector, any_smaller)(const TYPE(igraph_vector) *v,
 igraph_bool_t FUNCTION(igraph_vector, all_e)(const TYPE(igraph_vector) *lhs,
         const TYPE(igraph_vector) *rhs) {
     long int i, s;
-    assert(lhs != 0);
-    assert(rhs != 0);
-    assert(lhs->stor_begin != 0);
-    assert(rhs->stor_begin != 0);
+    IGRAPH_ASSERT(lhs != 0);
+    IGRAPH_ASSERT(rhs != 0);
+    IGRAPH_ASSERT(lhs->stor_begin != 0);
+    IGRAPH_ASSERT(rhs->stor_begin != 0);
 
     s = FUNCTION(igraph_vector, size)(lhs);
     if (s != FUNCTION(igraph_vector, size)(rhs)) {
@@ -1565,10 +1564,10 @@ FUNCTION(igraph_vector, is_equal)(const TYPE(igraph_vector) *lhs,
 igraph_bool_t FUNCTION(igraph_vector, all_l)(const TYPE(igraph_vector) *lhs,
         const TYPE(igraph_vector) *rhs) {
     long int i, s;
-    assert(lhs != 0);
-    assert(rhs != 0);
-    assert(lhs->stor_begin != 0);
-    assert(rhs->stor_begin != 0);
+    IGRAPH_ASSERT(lhs != 0);
+    IGRAPH_ASSERT(rhs != 0);
+    IGRAPH_ASSERT(lhs->stor_begin != 0);
+    IGRAPH_ASSERT(rhs->stor_begin != 0);
 
     s = FUNCTION(igraph_vector, size)(lhs);
     if (s != FUNCTION(igraph_vector, size)(rhs)) {
@@ -1603,10 +1602,10 @@ igraph_bool_t FUNCTION(igraph_vector, all_g)(const TYPE(igraph_vector) *lhs,
         const TYPE(igraph_vector) *rhs) {
 
     long int i, s;
-    assert(lhs != 0);
-    assert(rhs != 0);
-    assert(lhs->stor_begin != 0);
-    assert(rhs->stor_begin != 0);
+    IGRAPH_ASSERT(lhs != 0);
+    IGRAPH_ASSERT(rhs != 0);
+    IGRAPH_ASSERT(lhs->stor_begin != 0);
+    IGRAPH_ASSERT(rhs->stor_begin != 0);
 
     s = FUNCTION(igraph_vector, size)(lhs);
     if (s != FUNCTION(igraph_vector, size)(rhs)) {
@@ -1642,10 +1641,10 @@ igraph_bool_t
 FUNCTION(igraph_vector, all_le)(const TYPE(igraph_vector) *lhs,
                                 const TYPE(igraph_vector) *rhs) {
     long int i, s;
-    assert(lhs != 0);
-    assert(rhs != 0);
-    assert(lhs->stor_begin != 0);
-    assert(rhs->stor_begin != 0);
+    IGRAPH_ASSERT(lhs != 0);
+    IGRAPH_ASSERT(rhs != 0);
+    IGRAPH_ASSERT(lhs->stor_begin != 0);
+    IGRAPH_ASSERT(rhs->stor_begin != 0);
 
     s = FUNCTION(igraph_vector, size)(lhs);
     if (s != FUNCTION(igraph_vector, size)(rhs)) {
@@ -1681,10 +1680,10 @@ igraph_bool_t
 FUNCTION(igraph_vector, all_ge)(const TYPE(igraph_vector) *lhs,
                                 const TYPE(igraph_vector) *rhs) {
     long int i, s;
-    assert(lhs != 0);
-    assert(rhs != 0);
-    assert(lhs->stor_begin != 0);
-    assert(rhs->stor_begin != 0);
+    IGRAPH_ASSERT(lhs != 0);
+    IGRAPH_ASSERT(rhs != 0);
+    IGRAPH_ASSERT(lhs->stor_begin != 0);
+    IGRAPH_ASSERT(rhs->stor_begin != 0);
 
     s = FUNCTION(igraph_vector, size)(lhs);
     if (s != FUNCTION(igraph_vector, size)(rhs)) {

--- a/src/vector_ptr.c
+++ b/src/vector_ptr.c
@@ -28,7 +28,6 @@
 #include "igraph_error.h"
 #include "config.h"
 
-#include <assert.h>
 #include <string.h>         /* memcpy & co. */
 #include <stdlib.h>
 
@@ -90,7 +89,7 @@
 
 int igraph_vector_ptr_init      (igraph_vector_ptr_t* v, int long size) {
     long int alloc_size = size > 0 ? size : 1;
-    assert(v != NULL);
+    IGRAPH_ASSERT(v != NULL);
     if (size < 0) {
         size = 0;
     }
@@ -134,7 +133,7 @@ const igraph_vector_ptr_t *igraph_vector_ptr_view (const igraph_vector_ptr_t *v,
  */
 
 void igraph_vector_ptr_destroy   (igraph_vector_ptr_t* v) {
-    assert(v != 0);
+    IGRAPH_ASSERT(v != 0);
     if (v->stor_begin != 0) {
         igraph_Free(v->stor_begin);
         v->stor_begin = NULL;
@@ -173,8 +172,8 @@ void igraph_i_vector_ptr_call_item_destructor_all(igraph_vector_ptr_t* v) {
 
 void igraph_vector_ptr_free_all   (igraph_vector_ptr_t* v) {
     void **ptr;
-    assert(v != 0);
-    assert(v->stor_begin != 0);
+    IGRAPH_ASSERT(v != 0);
+    IGRAPH_ASSERT(v->stor_begin != 0);
 
     igraph_i_vector_ptr_call_item_destructor_all(v);
     for (ptr = v->stor_begin; ptr < v->end; ptr++) {
@@ -201,8 +200,8 @@ void igraph_vector_ptr_free_all   (igraph_vector_ptr_t* v) {
  */
 
 void igraph_vector_ptr_destroy_all   (igraph_vector_ptr_t* v) {
-    assert(v != 0);
-    assert(v->stor_begin != 0);
+    IGRAPH_ASSERT(v != 0);
+    IGRAPH_ASSERT(v->stor_begin != 0);
     igraph_vector_ptr_free_all(v);
     igraph_vector_ptr_set_item_destructor(v, 0);
     igraph_vector_ptr_destroy(v);
@@ -219,8 +218,8 @@ void igraph_vector_ptr_destroy_all   (igraph_vector_ptr_t* v) {
 int igraph_vector_ptr_reserve   (igraph_vector_ptr_t* v, long int size) {
     long int actual_size = igraph_vector_ptr_size(v);
     void **tmp;
-    assert(v != NULL);
-    assert(v->stor_begin != NULL);
+    IGRAPH_ASSERT(v != NULL);
+    IGRAPH_ASSERT(v->stor_begin != NULL);
 
     if (size <= igraph_vector_ptr_size(v)) {
         return 0;
@@ -243,8 +242,8 @@ int igraph_vector_ptr_reserve   (igraph_vector_ptr_t* v, long int size) {
  */
 
 igraph_bool_t igraph_vector_ptr_empty     (const igraph_vector_ptr_t* v) {
-    assert(v != NULL);
-    assert(v->stor_begin != NULL);
+    IGRAPH_ASSERT(v != NULL);
+    IGRAPH_ASSERT(v->stor_begin != NULL);
     return v->stor_begin == v->end;
 }
 
@@ -260,8 +259,8 @@ igraph_bool_t igraph_vector_ptr_empty     (const igraph_vector_ptr_t* v) {
  */
 
 long int igraph_vector_ptr_size      (const igraph_vector_ptr_t* v) {
-    assert(v != NULL);
-    /*  assert(v->stor_begin != NULL);       */ /* TODO */
+    IGRAPH_ASSERT(v != NULL);
+    /*  IGRAPH_ASSERT(v->stor_begin != NULL);       */ /* TODO */
     return v->end - v->stor_begin;
 }
 
@@ -289,8 +288,8 @@ long int igraph_vector_ptr_size      (const igraph_vector_ptr_t* v) {
  */
 
 void igraph_vector_ptr_clear     (igraph_vector_ptr_t* v) {
-    assert(v != NULL);
-    assert(v->stor_begin != NULL);
+    IGRAPH_ASSERT(v != NULL);
+    IGRAPH_ASSERT(v->stor_begin != NULL);
     igraph_i_vector_ptr_call_item_destructor_all(v);
     v->end = v->stor_begin;
 }
@@ -312,8 +311,8 @@ void igraph_vector_ptr_clear     (igraph_vector_ptr_t* v) {
  */
 
 int igraph_vector_ptr_push_back (igraph_vector_ptr_t* v, void* e) {
-    assert(v != NULL);
-    assert(v->stor_begin != NULL);
+    IGRAPH_ASSERT(v != NULL);
+    IGRAPH_ASSERT(v->stor_begin != NULL);
 
     /* full, allocate more storage */
     if (v->stor_end == v->end) {
@@ -331,9 +330,9 @@ int igraph_vector_ptr_push_back (igraph_vector_ptr_t* v, void* e) {
 }
 
 void *igraph_vector_ptr_pop_back (igraph_vector_ptr_t *v) {
-    assert(v != NULL);
-    assert(v->stor_begin != NULL);
-    assert(v->stor_begin != v->end);
+    IGRAPH_ASSERT(v != NULL);
+    IGRAPH_ASSERT(v->stor_begin != NULL);
+    IGRAPH_ASSERT(v->stor_begin != v->end);
     v->end -= 1;
     return *(v->end);
 }
@@ -376,8 +375,8 @@ int igraph_vector_ptr_insert(igraph_vector_ptr_t* v, long int pos, void* e) {
  */
 
 void* igraph_vector_ptr_e         (const igraph_vector_ptr_t* v, long int pos) {
-    assert(v != NULL);
-    assert(v->stor_begin != NULL);
+    IGRAPH_ASSERT(v != NULL);
+    IGRAPH_ASSERT(v->stor_begin != NULL);
     return * (v->stor_begin + pos);
 }
 
@@ -394,8 +393,8 @@ void* igraph_vector_ptr_e         (const igraph_vector_ptr_t* v, long int pos) {
  */
 
 void igraph_vector_ptr_set       (igraph_vector_ptr_t* v, long int pos, void* value) {
-    assert(v != NULL);
-    assert(v->stor_begin != NULL);
+    IGRAPH_ASSERT(v != NULL);
+    IGRAPH_ASSERT(v->stor_begin != NULL);
     *(v->stor_begin + pos) = value;
 }
 
@@ -405,8 +404,8 @@ void igraph_vector_ptr_set       (igraph_vector_ptr_t* v, long int pos, void* va
  */
 
 void igraph_vector_ptr_null      (igraph_vector_ptr_t* v) {
-    assert(v != NULL);
-    assert(v->stor_begin != NULL);
+    IGRAPH_ASSERT(v != NULL);
+    IGRAPH_ASSERT(v->stor_begin != NULL);
     if (igraph_vector_ptr_size(v) > 0) {
         memset(v->stor_begin, 0, sizeof(void*) *
                (size_t) igraph_vector_ptr_size(v));
@@ -465,8 +464,8 @@ int igraph_vector_ptr_init_copy(igraph_vector_ptr_t *v, void * *data, long int l
  */
 
 void igraph_vector_ptr_copy_to(const igraph_vector_ptr_t *v, void** to) {
-    assert(v != NULL);
-    assert(v->stor_begin != NULL);
+    IGRAPH_ASSERT(v != NULL);
+    IGRAPH_ASSERT(v->stor_begin != NULL);
     if (v->end != v->stor_begin) {
         memcpy(to, v->stor_begin, sizeof(void*) *
                (size_t) (v->end - v->stor_begin));
@@ -500,8 +499,8 @@ void igraph_vector_ptr_copy_to(const igraph_vector_ptr_t *v, void** to) {
  */
 
 int igraph_vector_ptr_copy(igraph_vector_ptr_t *to, const igraph_vector_ptr_t *from) {
-    assert(from != NULL);
-    /*   assert(from->stor_begin != NULL); */ /* TODO */
+    IGRAPH_ASSERT(from != NULL);
+    /*   IGRAPH_ASSERT(from->stor_begin != NULL); */ /* TODO */
     to->stor_begin = igraph_Calloc(igraph_vector_ptr_size(from), void*);
     if (to->stor_begin == 0) {
         IGRAPH_ERROR("cannot copy ptr vector", IGRAPH_ENOMEM);
@@ -521,8 +520,8 @@ int igraph_vector_ptr_copy(igraph_vector_ptr_t *to, const igraph_vector_ptr_t *f
  */
 
 void igraph_vector_ptr_remove(igraph_vector_ptr_t *v, long int pos) {
-    assert(v != NULL);
-    assert(v->stor_begin != NULL);
+    IGRAPH_ASSERT(v != NULL);
+    IGRAPH_ASSERT(v->stor_begin != NULL);
     if (pos + 1 < igraph_vector_ptr_size(v)) { /* TOOD: why is this needed */
         memmove(v->stor_begin + pos, v->stor_begin + pos + 1,
                 sizeof(void*) * (size_t) (igraph_vector_ptr_size(v) - pos - 1));
@@ -623,6 +622,6 @@ igraph_finally_func_t* igraph_vector_ptr_set_item_destructor(
  * Time complexity: O(1).
  */
 igraph_finally_func_t* igraph_vector_ptr_get_item_destructor(const igraph_vector_ptr_t *v) {
-    assert(v != 0);
+    IGRAPH_ASSERT(v != 0);
     return v->item_destructor;
 }


### PR DESCRIPTION
As the title says, this PR replaces `assert()` by `IGRAPH_ASSERT()` in the sources, except in C++ code and in source borrowed from elsewhere (e.g. bliss).

The one exception is a minor variables renaming in `cliques.c`.