### PR TITLE
fix spelling error as reported by lintian

### DIFF
--- a/src/lsap.c
+++ b/src/lsap.c
@@ -109,7 +109,7 @@ int ap_hungarian(AP *p) {
                 ++ok;
             }
         if (ok != 1)
-            IGRAPH_ERROR("ap_hungarian: error in assigment, is not a permutation",
+            IGRAPH_ERROR("ap_hungarian: error in assignment, is not a permutation",
                          IGRAPH_EINVAL);
     }
 


### PR DESCRIPTION
Description: source typo
 Correct spelling errors as reported by lintian in some binaries;
 meant to silence lintian.
Origin: debian
Comment: spelling-error-in-binary
Author: Jerome Benoit <calculus@rezozer.net>
Last-Update: 2020-12-20