### PR TITLE
missing include in e/benchmarks header

### DIFF
--- a/examples/benchmarks/bench.h
+++ b/examples/benchmarks/bench.h
@@ -24,6 +24,8 @@
 #ifndef IGRAPH_BENCH_H
 #define IGRAPH_BENCH_H
 
+#include <sys/resource.h>
+
 static inline void igraph_get_cpu_time(igraph_real_t *data) {
 
     struct rusage self, children;


### PR DESCRIPTION
Description: add missing header in `examples/benchnmakrs/bench.h'
 Include sys/resource.h in `e/b/bench.h'.
Origin: debian
Author: Jerome Benoit <calculus@rezozer.net>
Last-Update: 2020-12-20