### PR TITLE
Added fuzzer and OSS-fuzz build script

### DIFF
--- a/fuzzing/README.md
+++ b/fuzzing/README.md
@@ -1,0 +1,5 @@
+The fuzzing infrastructure of igraph is located in this directory.
+
+The fuzzers are run continuously through OSS-fuzz.
+
+The `build.sh` script is used by OSS-fuzz to build the fuzzers on their platform.

--- a/fuzzing/build.sh
+++ b/fuzzing/build.sh
@@ -1,0 +1,16 @@
+#!/bin/bash -eu
+
+sed 's/use_all_warnings/\#use_all_warnings/g' -i $SRC/igraph/src/CMakeLists.txt
+mkdir build && cd build
+cmake ..
+make -j$(nproc)
+
+# Create seed corpus
+zip $OUT/read_lgl_fuzzer_seed_corpus.zip \
+        $SRC/igraph/examples/simple/karate.gml
+
+cd $SRC/igraph
+
+$CC $CFLAGS -I$SRC/igraph/build/include -I$SRC/igraph/include -o read_lgl_fuzzer.o -c ./fuzzing/read_lgl_fuzzer.c
+$CC $CFLAGS $LIB_FUZZING_ENGINE read_lgl_fuzzer.o \
+        -o $OUT/read_lgl_fuzzer ./build/src/libigraph.a

--- a/fuzzing/read_lgl_fuzzer.c
+++ b/fuzzing/read_lgl_fuzzer.c
@@ -1,0 +1,57 @@
+/*
+   IGraph library.
+   Copyright (C) 2021  The igraph development team
+   
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+   
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+   
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+   02110-1301 USA
+*/
+
+#include <stdint.h>
+#include <string.h>
+#include <stdlib.h>
+#include "igraph.h"
+#include <stdio.h>
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size){
+	if(size<5) return 0;
+
+	igraph_set_error_handler(igraph_error_handler_ignore);
+
+	// Create input file	
+	char filename[256];
+	sprintf(filename, "/tmp/libfuzzer.gml");
+	FILE *fp = fopen(filename, "wb");
+	if (!fp) return 0;
+	fwrite(data, size, 1, fp);
+	fclose(fp);
+	
+	// Read input file
+	FILE *ifile;
+	ifile = fopen("/tmp/libfuzzer.gml", "r");
+	if(ifile == 0){
+		unlink(filename);
+		return 0;
+	}
+	
+	// Do the fuzzing	
+	igraph_t g;
+	igraph_read_graph_gml(&g, ifile);
+	fclose(ifile);
+	
+	// Clean up
+	igraph_destroy(&g);
+	unlink(filename);
+	return 0;
+}


### PR DESCRIPTION
Reopens https://github.com/igraph/igraph/pull/1584 - I apologize for double-posting. Rebasing to `develop` in last PR became a little messy.

This PR adds a fuzzer with build script to run it continuously through OSS-fuzz.

Fuzzing is a way of testing programs whereby pseudo-random data is passed to a target application with the goal of finding bugs and vulnerabilities. I can see that igraph previously has been fuzzed by the community.

OSS-fuzz is a project by Google into which open-source projects can integrate and have their fuzzers run continuously. If bugs are found, maintainers get notified with an email containing a link to a detailed bug report with stack trace and reproducible test case.

The integration files on the OSS-fuzz side have been added here: google/oss-fuzz#4877