### PR TITLE
Add unit test for st_mincut_value

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -373,6 +373,12 @@ add_legacy_tests(
   igraph_all_st_mincuts
   igraph_mincut
 )
+
+add_legacy_tests(
+  FOLDER tests/unit NAMES
+  igraph_st_mincut_value
+)
+
 if (BUILD_INTERNAL_TESTS)
   add_legacy_tests(
     FOLDER tests/unit NAMES

--- a/tests/unit/igraph_st_mincut_value.c
+++ b/tests/unit/igraph_st_mincut_value.c
@@ -1,0 +1,46 @@
+/* -*- mode: C -*-  */
+/*
+   IGraph library.
+   Copyright (C) 2007-2012  Gabor Csardi <csardi.gabor@gmail.com>
+   334 Harvard st, Cambridge MA, 02139 USA
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc.,  51 Franklin Street, Fifth Floor, Boston, MA
+   02110-1301 USA
+
+*/
+
+#include <igraph.h>
+
+int main() {
+
+    igraph_t g;
+    igraph_vector_t capacity;
+    igraph_real_t value;
+
+    igraph_small(&g, 6, IGRAPH_DIRECTED,
+                 0, 1, 0, 2, 1, 2, 1, 3, 2, 4, 3, 4, 3, 5, 4, 5, -1);
+    igraph_vector_init_int_end(&capacity, -1, 5, 2, 2, 3, 4, 1, 2, 5, -1);
+
+    igraph_st_mincut_value(&g, &value, 0, 5, &capacity);
+
+    igraph_vector_destroy(&capacity);
+    igraph_destroy(&g);
+
+    if (value == 7) {
+        return 0;
+    } else {
+        return 1;
+    }
+}

--- a/tests/unit/igraph_st_mincut_value.c
+++ b/tests/unit/igraph_st_mincut_value.c
@@ -1,8 +1,6 @@
-/* -*- mode: C -*-  */
 /*
    IGraph library.
-   Copyright (C) 2007-2012  Gabor Csardi <csardi.gabor@gmail.com>
-   334 Harvard st, Cambridge MA, 02139 USA
+   Copyright (C) 2021  The igraph development team <igraph@igraph.org>
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -15,10 +13,7 @@
    GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc.,  51 Franklin Street, Fifth Floor, Boston, MA
-   02110-1301 USA
-
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 #include <igraph.h>


### PR DESCRIPTION
Part of issue #1592.

I was planning to test the actual cut instead of just the value, but usually there are multiple min cuts possible and I didn't want to have a failed test when a different min cut is returned. (A test with only one possible min cut can of course still be added)

The functionality is already tested in maxflow, but this is a simple check to see that everything is correctly connected.