### PR TITLE
Add function igraph_is_same_graph for tests

### DIFF
--- a/doc/basicigraph.xxml
+++ b/doc/basicigraph.xxml
@@ -108,6 +108,7 @@ To eliminate multiple edges from a graph, you can use
 <!-- doxrox-include igraph_neighbors -->
 <!-- doxrox-include igraph_incident -->
 <!-- doxrox-include igraph_is_directed -->
+<!-- doxrox-include igraph_is_same_graph -->
 <!-- doxrox-include igraph_degree -->
 </section>
 

--- a/include/igraph_interface.h
+++ b/include/igraph_interface.h
@@ -73,7 +73,7 @@ DECLDIR int igraph_get_eids_multi(const igraph_t *graph, igraph_vector_t *eids,
                                   igraph_bool_t directed, igraph_bool_t error);
 DECLDIR int igraph_incident(const igraph_t *graph, igraph_vector_t *eids, igraph_integer_t vid,
                             igraph_neimode_t mode);
-DECLDIR igraph_bool_t igraph_is_same_graph(const igraph_t *graph1, const igraph_t *igraph2);
+DECLDIR igraph_bool_t igraph_is_same_graph(const igraph_t *graph1, const igraph_t *igraph2, igraph_bool_t *res);
 
 /**
  * \define IGRAPH_FROM

--- a/include/igraph_interface.h
+++ b/include/igraph_interface.h
@@ -73,7 +73,7 @@ DECLDIR int igraph_get_eids_multi(const igraph_t *graph, igraph_vector_t *eids,
                                   igraph_bool_t directed, igraph_bool_t error);
 DECLDIR int igraph_incident(const igraph_t *graph, igraph_vector_t *eids, igraph_integer_t vid,
                             igraph_neimode_t mode);
-DECLDIR igraph_bool_t igraph_is_same_graph(const igraph_t *graph1, const igraph_t *igraph2, igraph_bool_t *res);
+DECLDIR int igraph_is_same_graph(const igraph_t *graph1, const igraph_t *igraph2, igraph_bool_t *res);
 
 /**
  * \define IGRAPH_FROM

--- a/include/igraph_interface.h
+++ b/include/igraph_interface.h
@@ -73,7 +73,7 @@ DECLDIR int igraph_get_eids_multi(const igraph_t *graph, igraph_vector_t *eids,
                                   igraph_bool_t directed, igraph_bool_t error);
 DECLDIR int igraph_incident(const igraph_t *graph, igraph_vector_t *eids, igraph_integer_t vid,
                             igraph_neimode_t mode);
-DECLDIR int igraph_is_same_graph(const igraph_t *graph1, const igraph_t *igraph2);
+DECLDIR igraph_bool_t igraph_is_same_graph(const igraph_t *graph1, const igraph_t *igraph2);
 
 /**
  * \define IGRAPH_FROM

--- a/include/igraph_interface.h
+++ b/include/igraph_interface.h
@@ -73,6 +73,7 @@ DECLDIR int igraph_get_eids_multi(const igraph_t *graph, igraph_vector_t *eids,
                                   igraph_bool_t directed, igraph_bool_t error);
 DECLDIR int igraph_incident(const igraph_t *graph, igraph_vector_t *eids, igraph_integer_t vid,
                             igraph_neimode_t mode);
+DECLDIR int igraph_is_same_graph(const igraph_t *graph1, const igraph_t *igraph2);
 
 /**
  * \define IGRAPH_FROM

--- a/src/graph/type_indexededgelist.c
+++ b/src/graph/type_indexededgelist.c
@@ -1691,3 +1691,62 @@ int igraph_incident(const igraph_t *graph, igraph_vector_t *eids,
 
     return 0;
 }
+
+
+/**
+ * \function igraph_is_same_graph
+ * \brief Check if two graphs are topologically the same
+ *
+ * \param graph1 The first graph object.
+ * \param graph2 The second graph object.
+ * \return 1 if they are the same, 0 if they are different.
+ *
+ * NOTE: this function is mostly for internal use in unit tests.
+ * Users should not rely on it for production code.</para><para>
+ *
+ * Added in version 0.9.</para><para>
+ *
+ * Time complexity: O(E), the number of edges in the graphs.
+ */
+
+int igraph_is_same_graph(const igraph_t *graph1, const igraph_t *graph2) {
+    long int nv1 = igraph_vcount(graph1);
+    long int nv2 = igraph_vcount(graph2);
+    long int ne1 = igraph_ecount(graph1);
+    long int ne2 = igraph_ecount(graph2);
+    long int i, eid1, eid2;
+
+    /* Check for same number of vertices/edges */
+    if ((nv1 != nv2) || (ne1 != ne2)) {
+        return 0;
+    }
+
+    /* Check for same directedness */
+    if (igraph_is_directed(graph1) != igraph_is_directed(graph2)) {
+        return 0;
+    }
+
+    /* Vertices have no names, so no they must be 0 to nv - 1 */
+
+    /* Edges are double sorted in the current representations ii/oi of
+     * igraph_t (ii: by incoming, then outgoing, oi: vice versa), so
+     * we just need to check them one by one. If that representation
+     * changes, this part will need to change too. */
+    for (i = 0; i < ne1; i++) {
+        eid1 = (long int) VECTOR(graph1->ii)[i];
+        eid2 = (long int) VECTOR(graph2->ii)[i];
+
+        /* check they have the same source */
+        if (IGRAPH_FROM(eid1) != IGRAPH_FROM(eid2)) {
+            return 0;
+        }
+
+        /* check they have the same target */
+        if (IGRAPH_TO(eid1) != IGRAPH_TO(eid2)) {
+            return 0;
+        }
+
+    }
+
+    return 1;
+}

--- a/src/graph/type_indexededgelist.c
+++ b/src/graph/type_indexededgelist.c
@@ -1736,12 +1736,12 @@ int igraph_is_same_graph(const igraph_t *graph1, const igraph_t *graph2) {
         eid1 = (long int) VECTOR(graph1->ii)[i];
         eid2 = (long int) VECTOR(graph2->ii)[i];
 
-        /* check they have the same source */
+        /* Check they have the same source */
         if (IGRAPH_FROM(graph1, eid1) != IGRAPH_FROM(graph2, eid2)) {
             return 0;
         }
 
-        /* check they have the same target */
+        /* Check they have the same target */
         if (IGRAPH_TO(graph1, eid1) != IGRAPH_TO(graph2, eid2)) {
             return 0;
         }

--- a/src/graph/type_indexededgelist.c
+++ b/src/graph/type_indexededgelist.c
@@ -1737,12 +1737,12 @@ int igraph_is_same_graph(const igraph_t *graph1, const igraph_t *graph2) {
         eid2 = (long int) VECTOR(graph2->ii)[i];
 
         /* check they have the same source */
-        if (IGRAPH_FROM(eid1) != IGRAPH_FROM(eid2)) {
+        if (IGRAPH_FROM(graph1, eid1) != IGRAPH_FROM(graph2, eid2)) {
             return 0;
         }
 
         /* check they have the same target */
-        if (IGRAPH_TO(eid1) != IGRAPH_TO(eid2)) {
+        if (IGRAPH_TO(graph1, eid1) != IGRAPH_TO(graph2, eid2)) {
             return 0;
         }
 

--- a/src/graph/type_indexededgelist.c
+++ b/src/graph/type_indexededgelist.c
@@ -1709,7 +1709,7 @@ int igraph_incident(const igraph_t *graph, igraph_vector_t *eids,
  * Time complexity: O(E), the number of edges in the graphs.
  */
 
-int igraph_is_same_graph(const igraph_t *graph1, const igraph_t *graph2) {
+igraph_bool_t igraph_is_same_graph(const igraph_t *graph1, const igraph_t *graph2) {
     long int nv1 = igraph_vcount(graph1);
     long int nv2 = igraph_vcount(graph2);
     long int ne1 = igraph_ecount(graph1);

--- a/src/graph/type_indexededgelist.c
+++ b/src/graph/type_indexededgelist.c
@@ -1701,12 +1701,12 @@ int igraph_incident(const igraph_t *graph, igraph_vector_t *eids,
  * Graphs which are the same may have multiple different representations in igraph,
  * hence the need for this function.
  *
- * <para></para>
+ * </para><para>
  * This function verifies that the two graphs have the same directnedness, the same
  * number of vertices, and that they contain precise the same edges (regardless of their ordering)
  * when written in terms of vertex indices. Graph attributes are not taken into account.
  *
- * <para></para>
+ * </para><para>
  * This concept is different from isomorphism. For example, the graphs
  * <code>0-1, 2-1</code> and <code>1-2, 0-1</code> are considered the same
  * because they only differ in the ordering of their edge lists and the ordering

--- a/src/graph/type_indexededgelist.c
+++ b/src/graph/type_indexededgelist.c
@@ -1706,7 +1706,7 @@ int igraph_incident(const igraph_t *graph, igraph_vector_t *eids,
  * number of vertices, and that they contain precise the same edges (regardless of their ordering)
  * when written in terms of vertex indices. Graph attributes are not taken into account.
  *
- * <para></para<
+ * <para></para>
  * This concept is different from isomorphism. For example, the graphs
  * <code>0-1, 2-1</code> and <code>1-2, 0-1</code> are considered the same
  * because they only differ in the ordering of their edge lists and the ordering
@@ -1732,7 +1732,7 @@ int igraph_is_same_graph(const igraph_t *graph1, const igraph_t *graph2, igraph_
     long int ne2 = igraph_ecount(graph2);
     long int i, eid1, eid2;
 
-    *res = 0; /* Assume failure */
+    *res = 0; /* Assume that the graphs differ */
 
     /* Check for same number of vertices/edges */
     if ((nv1 != nv2) || (ne1 != ne2)) {
@@ -1768,9 +1768,8 @@ int igraph_is_same_graph(const igraph_t *graph1, const igraph_t *graph2, igraph_
         if (IGRAPH_TO(graph1, eid1) != IGRAPH_TO(graph2, eid2)) {
             return IGRAPH_SUCCESS;
         }
-
     }
 
-    *res = 1; /* no difference was found, graphs are the same */
+    *res = 1; /* No difference was found, graphs are the same */
     return IGRAPH_SUCCESS;
 }

--- a/src/graph/type_indexededgelist.c
+++ b/src/graph/type_indexededgelist.c
@@ -1702,8 +1702,8 @@ int igraph_incident(const igraph_t *graph, igraph_vector_t *eids,
  * hence the need for this function.
  *
  * </para><para>
- * This function verifies that the two graphs have the same directnedness, the same
- * number of vertices, and that they contain precise the same edges (regardless of their ordering)
+ * This function verifies that the two graphs have the same directedness, the same
+ * number of vertices, and that they contain precisely the same edges (regardless of their ordering)
  * when written in terms of vertex indices. Graph attributes are not taken into account.
  *
  * </para><para>
@@ -1713,7 +1713,7 @@ int igraph_incident(const igraph_t *graph, igraph_vector_t *eids,
  * of vertices in an undirected edge. However, they are not the same as
  * <code>0-2, 1-2</code>, even though they are isomorphic to it.
  * Note that this latter graph contains the edge <code>0-2</code>
- * while the former two do not—thus their edge sets differ.
+ * while the former two do not — thus their edge sets differ.
  *
  * \param graph1 The first graph object.
  * \param graph2 The second graph object.
@@ -1744,7 +1744,7 @@ int igraph_is_same_graph(const igraph_t *graph1, const igraph_t *graph2, igraph_
         return IGRAPH_SUCCESS;
     }
 
-    /* Vertices have no names, so no they must be 0 to nv - 1 */
+    /* Vertices have no names, so they must be 0 to nv - 1 */
 
     /* Edges are double sorted in the current representations ii/oi of
      * igraph_t (ii: by incoming, then outgoing, oi: vice versa), so

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -103,6 +103,11 @@ add_legacy_tests(
   igraph_neighbors
 )
 
+add_legacy_tests(
+  FOLDER tests/unit NAMES
+  igraph_is_same_graph
+)
+
 # iterators.at
 add_legacy_tests(
   FOLDER examples/simple NAMES

--- a/tests/unit/igraph_is_same_graph.c
+++ b/tests/unit/igraph_is_same_graph.c
@@ -1,3 +1,20 @@
+/*
+   IGraph library.
+   Copyright (C) 2021  The igraph development team <igraph@igraph.org>
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
 
 #include <igraph.h>
 #include <assert.h>
@@ -15,12 +32,12 @@ int main() {
                  1, 0, 1, 2, 2, 3, 3, 0, -1);
 
     /* a graph is always same as itself */
-    res = igraph_is_same_graph(&g1, &g1);
+    igraph_is_same_graph(&g1, &g1, &res);
     assert(res);
 
     /* undirected graphs should be the same no matter
      * the direction of the edges (one is swapped in g2 */
-    res = igraph_is_same_graph(&g1, &g2);
+    igraph_is_same_graph(&g1, &g2, &res);
     assert(res);
 
     /* end of undirected */
@@ -35,7 +52,7 @@ int main() {
 
     /* directed graphs should not be the same if an
      * edge has the opposite direction */
-    res = igraph_is_same_graph(&g1, &g2);
+    igraph_is_same_graph(&g1, &g2, &res);
     assert(!res);
 
     igraph_destroy(&g2);
@@ -43,7 +60,7 @@ int main() {
     /* change order of edges, they should be reordered by graph->ii */
     igraph_small(&g2, 4, 1,
                  1, 2, 0, 1, 2, 3, 3, 0, -1);
-    res = igraph_is_same_graph(&g1, &g2);
+    igraph_is_same_graph(&g1, &g2, &res);
     assert(res);
 
     /* end of directed */
@@ -55,7 +72,7 @@ int main() {
                  0, 1, 1, 2, 2, 3, 3, 0, -1);
     igraph_small(&g2, 4, 1,
                  0, 1, 1, 2, 2, 3, 3, 0, -1);
-    res = igraph_is_same_graph(&g1, &g2);
+    igraph_is_same_graph(&g1, &g2, &res);
     assert(!res);
 
     /* end of undirected vs directed */

--- a/tests/unit/igraph_is_same_graph.c
+++ b/tests/unit/igraph_is_same_graph.c
@@ -1,0 +1,68 @@
+
+#include <igraph.h>
+#include <assert.h>
+
+#include "test_utilities.inc"
+
+int main() {
+    igraph_t g1, g2;
+    igraph_bool_t res;
+
+    /* undirected graphs */
+    igraph_small(&g1, 4, 0,
+                 0, 1, 1, 2, 2, 3, 3, 0, -1);
+    igraph_small(&g2, 4, 0,
+                 1, 0, 1, 2, 2, 3, 3, 0, -1);
+
+    /* a graph is always same as itself */
+    res = igraph_is_same_graph(&g1, &g1);
+    assert(res);
+
+    /* undirected graphs should be the same no matter
+     * the direction of the edges (one is swapped in g2 */
+    res = igraph_is_same_graph(&g1, &g2);
+    assert(res);
+
+    /* end of undirected */
+    igraph_destroy(&g1);
+    igraph_destroy(&g2);
+
+    /* directed graphs */
+    igraph_small(&g1, 4, 1,
+                 0, 1, 1, 2, 2, 3, 3, 0, -1);
+    igraph_small(&g2, 4, 1,
+                 1, 0, 1, 2, 2, 3, 3, 0, -1);
+
+    /* directed graphs should not be the same if an
+     * edge has the opposite direction */
+    res = igraph_is_same_graph(&g1, &g2);
+    assert(!res);
+
+    igraph_destroy(&g2);
+
+    /* change order of edges, they should be reordered by graph->ii */
+    igraph_small(&g2, 4, 1,
+                 1, 2, 0, 1, 2, 3, 3, 0, -1);
+    res = igraph_is_same_graph(&g1, &g2);
+    assert(res);
+
+    /* end of directed */
+    igraph_destroy(&g1);
+    igraph_destroy(&g2);
+
+    /* undirected vs directed */
+    igraph_small(&g1, 4, 0,
+                 0, 1, 1, 2, 2, 3, 3, 0, -1);
+    igraph_small(&g2, 4, 1,
+                 0, 1, 1, 2, 2, 3, 3, 0, -1);
+    res = igraph_is_same_graph(&g1, &g2);
+    assert(!res);
+
+    /* end of undirected vs directed */
+    igraph_destroy(&g1);
+    igraph_destroy(&g2);
+
+    VERIFY_FINALLY_STACK();
+
+    return 0;
+}

--- a/tests/unit/igraph_is_same_graph.c
+++ b/tests/unit/igraph_is_same_graph.c
@@ -24,6 +24,7 @@
 int main() {
     igraph_t g1, g2;
     igraph_bool_t res;
+    int err;
 
     /* undirected graphs */
     igraph_small(&g1, 4, 0,
@@ -32,13 +33,15 @@ int main() {
                  1, 0, 1, 2, 2, 3, 3, 0, -1);
 
     /* a graph is always same as itself */
-    igraph_is_same_graph(&g1, &g1, &res);
+    err = igraph_is_same_graph(&g1, &g1, &res);
+    assert(!err);
     assert(res);
 
     /* undirected graphs should be the same no matter
      * the direction of the edges (one is swapped in g2 */
-    igraph_is_same_graph(&g1, &g2, &res);
-    assert(res);
+    err = igraph_is_same_graph(&g1, &g2, &res);
+    assert(!err);
+    assert(res);    
 
     /* end of undirected */
     igraph_destroy(&g1);
@@ -52,7 +55,8 @@ int main() {
 
     /* directed graphs should not be the same if an
      * edge has the opposite direction */
-    igraph_is_same_graph(&g1, &g2, &res);
+    err = igraph_is_same_graph(&g1, &g2, &res);
+    assert(!err);
     assert(!res);
 
     igraph_destroy(&g2);
@@ -60,7 +64,8 @@ int main() {
     /* change order of edges, they should be reordered by graph->ii */
     igraph_small(&g2, 4, 1,
                  1, 2, 0, 1, 2, 3, 3, 0, -1);
-    igraph_is_same_graph(&g1, &g2, &res);
+    err = igraph_is_same_graph(&g1, &g2, &res);
+    assert(!err);
     assert(res);
 
     /* end of directed */
@@ -72,7 +77,8 @@ int main() {
                  0, 1, 1, 2, 2, 3, 3, 0, -1);
     igraph_small(&g2, 4, 1,
                  0, 1, 1, 2, 2, 3, 3, 0, -1);
-    igraph_is_same_graph(&g1, &g2, &res);
+    err = igraph_is_same_graph(&g1, &g2, &res);
+    assert(!err);
     assert(!res);
 
     /* end of undirected vs directed */


### PR DESCRIPTION
Addressing #1599.

This relies on `graph->ii` which is a vector of edge ids, double sorted by source and target vertices. If that representation goes, we should adapt this function. The easiest way to do that would be to sort the edges ourselves in the same way inside the function.

edit: I should put a header somewhere. Which header file would be appropriate for this to be considered internal?