### PR TITLE
Remove nonlinear_barabasi_game declaration

### DIFF
--- a/include/igraph_games.h
+++ b/include/igraph_games.h
@@ -47,13 +47,6 @@ DECLDIR int igraph_barabasi_game(igraph_t *graph, igraph_integer_t n,
                                  igraph_bool_t directed,
                                  igraph_barabasi_algorithm_t algo,
                                  const igraph_t *start_from);
-DECLDIR int igraph_nonlinear_barabasi_game(igraph_t *graph, igraph_integer_t n,
-        igraph_real_t power,
-        igraph_integer_t m,
-        const igraph_vector_t *outseq,
-        igraph_bool_t outpref,
-        igraph_real_t zeroappeal,
-        igraph_bool_t directed);
 DECLDIR int igraph_erdos_renyi_game(igraph_t *graph, igraph_erdos_renyi_t type,
                                     igraph_integer_t n, igraph_real_t p_or_m,
                                     igraph_bool_t directed, igraph_bool_t loops);


### PR DESCRIPTION
It was not implemented, because it had already been moved to
barabasi_game.

See also https://igraph.discourse.group/t/should-undefined-declaration-be-removed/592

igraph_nonlinear_barabasi_game is part of #1592