### PR TITLE
Disallowing NaN weights for several path based functions

### DIFF
--- a/include/igraph_vector.h
+++ b/include/igraph_vector.h
@@ -175,6 +175,8 @@ DECLDIR int igraph_vector_order2(igraph_vector_t *v);
 DECLDIR int igraph_vector_rank(const igraph_vector_t *v, igraph_vector_t *res,
                        long int nodes);
 
+DECLDIR igraph_bool_t igraph_vector_is_any_nan(const igraph_vector_t *v);
+
 __END_DECLS
 
 #endif

--- a/src/centrality/betweenness.c
+++ b/src/centrality/betweenness.c
@@ -50,8 +50,8 @@
  * \param directed Logical, if true directed paths will be considered
  *        for directed graphs. It is ignored for undirected graphs.
  * \param weights An optional vector containing edge weights for
- *        calculating weighted betweenness. Supply a null pointer here
- *        for unweighted betweenness.
+ *        calculating weighted betweenness. No edge weight may be NaN.
+ *        Supply a null pointer here for unweighted betweenness.
  * \return Error code:
  *        \c IGRAPH_ENOMEM, not enough memory for
  *        temporary data.
@@ -105,6 +105,8 @@ static int igraph_i_betweenness_cutoff_weighted(
         igraph_real_t minweight = igraph_vector_min(weights);
         if (minweight <= 0) {
             IGRAPH_ERROR("Weight vector must be positive", IGRAPH_EINVAL);
+        } else if (igraph_is_nan(minweight)) {
+            IGRAPH_ERROR("Weight vector must not contain NaN values", IGRAPH_EINVAL);
         } else if (minweight <= eps) {
             IGRAPH_WARNING("Some weights are smaller than epsilon, calculations may suffer from numerical precision.");
         }
@@ -280,8 +282,8 @@ static int igraph_i_betweenness_cutoff_weighted(
  * \param directed Logical, if true directed paths will be considered
  *        for directed graphs. It is ignored for undirected graphs.
  * \param weights An optional vector containing edge weights for
- *        calculating weighted betweenness. Supply a null pointer here
- *        for unweighted betweenness.
+ *        calculating weighted betweenness. No edge weight may be NaN.
+ *        Supply a null pointer here for unweighted betweenness.
  * \param cutoff The maximal length of paths that will be considered.
  *        If negative, the exact betweenness will be calculated, and
  *        there will be no upper limit on path lengths.
@@ -522,8 +524,8 @@ int igraph_betweenness_cutoff(const igraph_t *graph, igraph_vector_t *res,
  *        If negative, the exact betweenness will be calculated, and
  *        there will be no upper limit on path lengths.
  * \param weights An optional vector containing edge weights for
- *        calculating weighted betweenness. Supply a null pointer here
- *        for unweighted betweenness.
+ *        calculating weighted betweenness. No edge weight may be NaN.
+ *        Supply a null pointer here for unweighted betweenness.
  * \return Error code:
  *        \c IGRAPH_ENOMEM, not enough memory for
  *        temporary data.
@@ -578,6 +580,8 @@ static int igraph_i_edge_betweenness_cutoff_weighted(
         igraph_real_t minweight = igraph_vector_min(weights);
         if (minweight <= 0) {
             IGRAPH_ERROR("Weight vector must be positive", IGRAPH_EINVAL);
+        } else if (igraph_is_nan(minweight)) {
+            IGRAPH_ERROR("Weight vector must not contain NaN values", IGRAPH_EINVAL);
         } else if (minweight <= eps) {
             IGRAPH_WARNING("Some weights are smaller than epsilon, calculations may suffer from numerical precision.");
         }
@@ -742,8 +746,8 @@ static int igraph_i_edge_betweenness_cutoff_weighted(
  * \param directed Logical, if true directed paths will be considered
  *        for directed graphs. It is ignored for undirected graphs.
  * \param weights An optional weight vector for weighted edge
- *        betweenness. Supply a null pointer here for the unweighted
- *        version.
+ *        betweenness. No edge weight may be NaN. Supply a null
+ *        pointer here for the unweighted version.
  * \return Error code:
  *        \c IGRAPH_ENOMEM, not enough memory for
  *        temporary data.
@@ -782,8 +786,8 @@ int igraph_edge_betweenness(const igraph_t *graph, igraph_vector_t *result,
  * \param directed Logical, if true directed paths will be considered
  *        for directed graphs. It is ignored for undirected graphs.
  * \param weights An optional weight vector for weighted
- *        betweenness. Supply a null pointer here for unweighted
- *        betweenness.
+ *        betweenness. No edge weight may be NaN. Supply a null
+ *        pointer here for unweighted betweenness.
  * \param cutoff The maximal length of paths that will be considered.
  *        If negative, the exact betweenness will be calculated (no
  *        upper limit on path lengths).
@@ -991,9 +995,9 @@ int igraph_edge_betweenness_cutoff(const igraph_t *graph, igraph_vector_t *resul
  * \param cutoff The maximal length of paths that will be considered.
  *        If negative, the exact betweenness will be calculated (no
  *        upper limit on path lengths).
- * \param weights An optional weight vector for weighted
- *        betweenness. Supply a null pointer here for unweighted
- *        betweenness.
+ * \param weights An optional weight vector for weighted betweenness.
+ *        No edge weight may be NaN. Supply a null pointer here for
+ *        unweighted betweenness.
  * \return Error code:
  *        \c IGRAPH_ENOMEM, not enough memory for
  *        temporary data.

--- a/src/centrality/closeness.c
+++ b/src/centrality/closeness.c
@@ -70,8 +70,8 @@
  *          undirected one for the computation.
  *        \endclist
  * \param weights An optional vector containing edge weights for
- *        weighted closeness. Supply a null pointer here for
- *        traditional, unweighted closeness.
+ *        weighted closeness. No edge weight may be NaN. Supply a null
+ *        pointer here for traditional, unweighted closeness.
  * \param normalized Boolean, whether to normalize results by multiplying
  *        by the number of vertices minus one.
  * \return Error code:
@@ -134,8 +134,11 @@ static int igraph_i_closeness_cutoff_weighted(const igraph_t *graph,
     }
 
     if (no_of_edges > 0) {
-        if (igraph_vector_min(weights) <= 0) {
+        igraph_real_t minweight = igraph_vector_min(weights);
+        if (minweight <= 0) {
             IGRAPH_ERROR("Weight vector must be positive", IGRAPH_EINVAL);
+        } else if (igraph_is_nan(minweight)) {
+            IGRAPH_ERROR("Weight vector must not contain NaN values", IGRAPH_EINVAL);
         }
     }
 
@@ -272,8 +275,8 @@ static int igraph_i_closeness_cutoff_weighted(const igraph_t *graph,
  *        If negative, the exact closeness will be calculated (no upper
  *        limit on path lengths).
  * \param weights An optional vector containing edge weights for
- *        weighted closeness. Supply a null pointer here for
- *        traditional, unweighted closeness.
+ *        weighted closeness. No edge weight may be NaN. Supply a
+ *        null pointer here for traditional, unweighted closeness.
  * \param normalized Boolean, whether to normalize results by multiplying
  *        by the number of vertices minus one.
  * \return Error code:
@@ -337,8 +340,8 @@ int igraph_closeness_estimate(const igraph_t *graph, igraph_vector_t *res,
  *          undirected one for the computation.
  *        \endclist
  * \param weights An optional vector containing edge weights for
- *        weighted closeness. Supply a null pointer here for
- *        traditional, unweighted closeness.
+ *        weighted closeness. No edge weight may be NaN. Supply a null
+ *        pointer here for traditional, unweighted closeness.
  * \param normalized Boolean, whether to normalize results by multiplying
  *        by the number of vertices minus one.
  * \param cutoff The maximal length of paths that will be considered.
@@ -601,8 +604,13 @@ static int igraph_i_harmonic_centrality_weighted(const igraph_t *graph,
         IGRAPH_ERROR("Invalid weight vector length", IGRAPH_EINVAL);
     }
 
-    if (no_of_edges > 0 && igraph_vector_min(weights) <= 0) {
-        IGRAPH_ERROR("Weight vector must be positive", IGRAPH_EINVAL);
+    if (no_of_edges > 0) {
+        igraph_real_t minweight = igraph_vector_min(weights);
+        if (minweight <= 0) {
+            IGRAPH_ERROR("Weight vector must be positive", IGRAPH_EINVAL);
+        } else if (igraph_is_nan(minweight)) {
+            IGRAPH_ERROR("Weight vector must not contain NaN values", IGRAPH_EINVAL);
+        }
     }
 
     IGRAPH_CHECK(igraph_vit_create(graph, vids, &vit));
@@ -711,8 +719,8 @@ static int igraph_i_harmonic_centrality_weighted(const igraph_t *graph,
  *          undirected one for the computation.
  *        \endclist
  * \param weights An optional vector containing edge weights for
- *        weighted harmonic centrality. If \c NULL, all weights are
- *        considered to be one.
+ *        weighted harmonic centrality. No edge weight may be NaN.
+ *        If \c NULL, all weights are considered to be one.
  * \param normalized Boolean, whether to normalize the result. If true,
  *        the result is the mean inverse path length to other vertices.
  *        i.e. it is normalized by the number of vertices minus one.
@@ -794,8 +802,8 @@ int igraph_harmonic_centrality_cutoff(const igraph_t *graph, igraph_vector_t *re
  *          undirected one for the computation.
  *        \endclist
  * \param weights An optional vector containing edge weights for
- *        weighted harmonic centrality. If \c NULL, all weights are
- *        considered to be one.
+ *        weighted harmonic centrality. No edge weight may be NaN.
+ *        If \c NULL, all weights are considered to be one.
  * \param normalized Boolean, whether to normalize the result. If true,
  *        the result is the mean inverse path length to other vertices,
  *        i.e. it is normalized by the number of vertices minus one.

--- a/src/core/vector.c
+++ b/src/core/vector.c
@@ -464,11 +464,11 @@ int igraph_vector_zapsmall(igraph_vector_t *v, igraph_real_t tol) {
 /**
  * \ingroup vector
  * \function igraph_vector_is_any_nan
- * \brief Check if any element is nan.
+ * \brief Check if any element is NaN.
  *
  * </para><para>
  * \param v The \type igraph_vector_t object to check.
- * \return 1 if any element is nan, 0 otherwise.
+ * \return 1 if any element is NaN, 0 otherwise.
  *
  * Time complexity: O(n), the number of elements.
  */

--- a/src/core/vector.c
+++ b/src/core/vector.c
@@ -460,3 +460,29 @@ int igraph_vector_zapsmall(igraph_vector_t *v, igraph_real_t tol) {
     }
     return 0;
 }
+
+/**
+ * \ingroup vector
+ * \function igraph_vector_is_any_nan
+ * \brief Check if any element is nan.
+ *
+ * </para><para>
+ * \param v The \type igraph_vector_t object to check.
+ * \return 1 if any element is nan, 0 otherwise.
+ *
+ * Time complexity: O(n), the number of elements.
+ */
+igraph_bool_t igraph_vector_is_any_nan(const igraph_vector_t *v)
+{
+    igraph_real_t *ptr;
+    IGRAPH_ASSERT(v != NULL);
+    IGRAPH_ASSERT(v->stor_begin != NULL);
+    ptr = v->stor_begin;
+    while (ptr < v->end) {
+        if (igraph_is_nan(*ptr)) {
+            return 1;
+        }
+        ptr++;
+    }
+    return 0;
+}

--- a/src/core/vector.pmt
+++ b/src/core/vector.pmt
@@ -985,12 +985,14 @@ BASE FUNCTION(igraph_vector, max)(const TYPE(igraph_vector)* v) {
     IGRAPH_ASSERT(v != NULL);
     IGRAPH_ASSERT(v->stor_begin != NULL);
     max = *(v->stor_begin);
+    if (max != max) { return max; }; /* Result is NaN */
     ptr = v->stor_begin + 1;
     while (ptr < v->end) {
-        if (!((*ptr) <= max)) {
-            /* Double negation to deal with NaN */
+        if ((*ptr) > max) {
             max = *ptr;
         }
+        else if (*ptr != *ptr)
+            return *ptr; /* Result is NaN */
         ptr++;
     }
     return max;
@@ -1013,27 +1015,30 @@ BASE FUNCTION(igraph_vector, max)(const TYPE(igraph_vector)* v) {
  * Time complexity: O(n), n is the size of the vector.
  */
 long int FUNCTION(igraph_vector, which_max)(const TYPE(igraph_vector)* v) {
-    long int which = -1;
     if (!FUNCTION(igraph_vector, empty)(v)) {
         BASE max;
         BASE *ptr;
-        long int pos;
+        BASE *which;
         IGRAPH_ASSERT(v != NULL);
         IGRAPH_ASSERT(v->stor_begin != NULL);
-        max = *(v->stor_begin); which = 0;
-        ptr = v->stor_begin + 1; pos = 1;
+        ptr = v->stor_begin;
+        if (*ptr != *ptr) { return ptr - v->stor_begin; } /* Result is NaN */
+        which = ptr;
+        max = *which;
+        ptr++;
         while (ptr < v->end) {
-            if (!((*ptr) <= max) && /* Double negation to deal with NaN */
-                !(max != max) /* Ensure that first NaN value is considered */
-                ) {
-
-                max = *ptr;
-                which = pos;
+            if ((*ptr) > max) {
+                which = ptr;
+                max = *which;
             }
-            ptr++; pos++;
+            else if (*ptr != *ptr) {
+                return ptr - v->stor_begin; /* Result is NaN */
+            }
+            ptr++;
         }
+        return which - v->stor_begin;
     }
-    return which;
+    return -1;
 }
 
 /**
@@ -1054,12 +1059,14 @@ BASE FUNCTION(igraph_vector, min)(const TYPE(igraph_vector)* v) {
     IGRAPH_ASSERT(v != NULL);
     IGRAPH_ASSERT(v->stor_begin != NULL);
     min = *(v->stor_begin);
+    if (min != min) { return min; }; /* Result is NaN */
     ptr = v->stor_begin + 1;
     while (ptr < v->end) {
-        if (!((*ptr) >= min)) {
-            /* Double negation to deal with NaN */
+        if ((*ptr) < min) {
             min = *ptr;
         }
+        else if (*ptr != *ptr)
+            return *ptr; /* Result is NaN */
         ptr++;
     }
     return min;
@@ -1080,26 +1087,29 @@ BASE FUNCTION(igraph_vector, min)(const TYPE(igraph_vector)* v) {
  * Time complexity: O(n), the number of elements.
  */
 long int FUNCTION(igraph_vector, which_min)(const TYPE(igraph_vector)* v) {
-    long int which = -1;
     if (!FUNCTION(igraph_vector, empty)(v)) {
         BASE min;
         BASE *ptr;
-        long int pos;
+        BASE *which;
         IGRAPH_ASSERT(v != NULL);
         IGRAPH_ASSERT(v->stor_begin != NULL);
-        min = *(v->stor_begin); which = 0;
-        ptr = v->stor_begin + 1; pos = 1;
+        ptr = v->stor_begin;
+        if (*ptr != *ptr) { return ptr - v->stor_begin; } /* Result is NaN */
+        which = ptr;
+        min = *which;
         while (ptr < v->end) {
-            if (!((*ptr) >= min) && /* Double negation to deal with NaN */
-                !(min != min) /* Ensure that first NaN value is considered */
-                ) {
-                min = *ptr;
-                which = pos;
+            if ((*ptr) < min) {
+                which = ptr;
+                min = *which;
             }
-            ptr++; pos++;
+            else if (*ptr != *ptr) {
+                return ptr - v->stor_begin; /* Result is NaN */
+            }
+            ptr++;
         }
+        return which - v->stor_begin;
     }
-    return which;
+    return -1;
 }
 
 #endif

--- a/src/core/vector.pmt
+++ b/src/core/vector.pmt
@@ -993,14 +993,18 @@ BASE FUNCTION(igraph_vector, max)(const TYPE(igraph_vector)* v) {
     IGRAPH_ASSERT(v != NULL);
     IGRAPH_ASSERT(v->stor_begin != NULL);
     max = *(v->stor_begin);
-    if (max != max) { return max; }; /* Result is NaN */
+#if defined(BASE_IGRAPH_REAL) || defined(BASE_FLOAT)
+    if (igraph_is_nan(max)) { return max; }; /* Result is NaN */
+#endif
     ptr = v->stor_begin + 1;
     while (ptr < v->end) {
         if ((*ptr) > max) {
             max = *ptr;
         }
-        else if (*ptr != *ptr)
+#if defined(BASE_IGRAPH_REAL) || defined(BASE_FLOAT)
+        else if (igraph_is_nan(*ptr))
             return *ptr; /* Result is NaN */
+#endif
         ptr++;
     }
     return max;
@@ -1030,7 +1034,9 @@ long int FUNCTION(igraph_vector, which_max)(const TYPE(igraph_vector)* v) {
         IGRAPH_ASSERT(v != NULL);
         IGRAPH_ASSERT(v->stor_begin != NULL);
         ptr = v->stor_begin;
-        if (*ptr != *ptr) { return ptr - v->stor_begin; } /* Result is NaN */
+#if defined(BASE_IGRAPH_REAL) || defined(BASE_FLOAT)
+        if (igraph_is_nan(*ptr)) { return ptr - v->stor_begin; } /* Result is NaN */
+#endif
         which = ptr;
         max = *which;
         ptr++;
@@ -1039,9 +1045,11 @@ long int FUNCTION(igraph_vector, which_max)(const TYPE(igraph_vector)* v) {
                 which = ptr;
                 max = *which;
             }
-            else if (*ptr != *ptr) {
+#if defined(BASE_IGRAPH_REAL) || defined(BASE_FLOAT)
+            else if (igraph_is_nan(*ptr)) {
                 return ptr - v->stor_begin; /* Result is NaN */
             }
+#endif
             ptr++;
         }
         return which - v->stor_begin;
@@ -1067,14 +1075,19 @@ BASE FUNCTION(igraph_vector, min)(const TYPE(igraph_vector)* v) {
     IGRAPH_ASSERT(v != NULL);
     IGRAPH_ASSERT(v->stor_begin != NULL);
     min = *(v->stor_begin);
-    if (min != min) { return min; }; /* Result is NaN */
+#if defined(BASE_IGRAPH_REAL) || defined(BASE_FLOAT)
+    if (igraph_is_nan(min)) { return min; }; /* Result is NaN */
+#endif
     ptr = v->stor_begin + 1;
     while (ptr < v->end) {
         if ((*ptr) < min) {
             min = *ptr;
         }
-        else if (*ptr != *ptr)
+#if defined(BASE_IGRAPH_REAL) || defined(BASE_FLOAT)
+        else if (igraph_is_nan(*ptr)) {
             return *ptr; /* Result is NaN */
+        }
+#endif
         ptr++;
     }
     return min;
@@ -1102,7 +1115,9 @@ long int FUNCTION(igraph_vector, which_min)(const TYPE(igraph_vector)* v) {
         IGRAPH_ASSERT(v != NULL);
         IGRAPH_ASSERT(v->stor_begin != NULL);
         ptr = v->stor_begin;
-        if (*ptr != *ptr) { return ptr - v->stor_begin; } /* Result is NaN */
+#if defined(BASE_IGRAPH_REAL) || defined(BASE_FLOAT)
+        if (igraph_is_nan(*ptr)) { return ptr - v->stor_begin; } /* Result is NaN */
+#endif
         which = ptr;
         min = *which;
         while (ptr < v->end) {
@@ -1110,9 +1125,11 @@ long int FUNCTION(igraph_vector, which_min)(const TYPE(igraph_vector)* v) {
                 which = ptr;
                 min = *which;
             }
-            else if (*ptr != *ptr) {
+#if defined(BASE_IGRAPH_REAL) || defined(BASE_FLOAT)
+            else if (igraph_is_nan(*ptr)) {
                 return ptr - v->stor_begin; /* Result is NaN */
             }
+#endif
             ptr++;
         }
         return which - v->stor_begin;

--- a/src/core/vector.pmt
+++ b/src/core/vector.pmt
@@ -966,6 +966,14 @@ int FUNCTION(igraph_vector, resize_min)(TYPE(igraph_vector)*v) {
 
 #ifndef NOTORDERED
 
+/* We will use x != x for NaN checks below and Clang does not like it unless
+ * we disable a warning */
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+
 /**
  * \ingroup vector
  * \function igraph_vector_max
@@ -1111,6 +1119,10 @@ long int FUNCTION(igraph_vector, which_min)(const TYPE(igraph_vector)* v) {
     }
     return -1;
 }
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 
 #endif
 

--- a/src/core/vector.pmt
+++ b/src/core/vector.pmt
@@ -969,18 +969,16 @@ int FUNCTION(igraph_vector, resize_min)(TYPE(igraph_vector)*v) {
 /**
  * \ingroup vector
  * \function igraph_vector_max
- * \brief Gives the maximum element of the vector.
+ * \brief Largest element of a vector.
  *
  * </para><para>
  * If the size of the vector is zero, an arbitrary number is
  * returned.
  * \param v The vector object.
- * \return The maximum element.
+ * \return The maximum element of \p v, or NaN if any element is NaN.
  *
- * Time complexity: O(n),
- * n is the size of the vector.
+ * Time complexity: O(n), the number of elements.
  */
-
 BASE FUNCTION(igraph_vector, max)(const TYPE(igraph_vector)* v) {
     BASE max;
     BASE *ptr;
@@ -989,7 +987,8 @@ BASE FUNCTION(igraph_vector, max)(const TYPE(igraph_vector)* v) {
     max = *(v->stor_begin);
     ptr = v->stor_begin + 1;
     while (ptr < v->end) {
-        if ((*ptr) > max) {
+        if (!((*ptr) <= max)) {
+            /* Double negation to deal with NaN */
             max = *ptr;
         }
         ptr++;
@@ -997,21 +996,22 @@ BASE FUNCTION(igraph_vector, max)(const TYPE(igraph_vector)* v) {
     return max;
 }
 
+
 /**
  * \ingroup vector
  * \function igraph_vector_which_max
- * \brief Gives the position of the maximum element of the vector.
+ * \brief Gives the index of the maximum element of the vector.
  *
  * </para><para>
- * If the size of the vector is zero, -1 is
- * returned.
+ * If the size of the vector is zero, -1 is returned. If the largest
+ * element is not unique, then the index of the first is returned.
+ * If the vector contains NaN values, the index of the first NaN value
+ * is returned.
  * \param v The vector object.
- * \return The position of the first maximum element.
+ * \return The index of the first maximum element.
  *
- * Time complexity: O(n),
- * n is the size of the vector.
+ * Time complexity: O(n), n is the size of the vector.
  */
-
 long int FUNCTION(igraph_vector, which_max)(const TYPE(igraph_vector)* v) {
     long int which = -1;
     if (!FUNCTION(igraph_vector, empty)(v)) {
@@ -1023,7 +1023,10 @@ long int FUNCTION(igraph_vector, which_max)(const TYPE(igraph_vector)* v) {
         max = *(v->stor_begin); which = 0;
         ptr = v->stor_begin + 1; pos = 1;
         while (ptr < v->end) {
-            if ((*ptr) > max) {
+            if (!((*ptr) <= max) && /* Double negation to deal with NaN */
+                !(max != max) /* Ensure that first NaN value is considered */
+                ) {
+
                 max = *ptr;
                 which = pos;
             }
@@ -1034,12 +1037,13 @@ long int FUNCTION(igraph_vector, which_max)(const TYPE(igraph_vector)* v) {
 }
 
 /**
+ * \ingroup vector
  * \function igraph_vector_min
  * \brief Smallest element of a vector.
  *
  * The vector must be non-empty.
  * \param v The input vector.
- * \return The smallest element of \p v.
+ * \return The smallest element of \p v, or nan if any element is nan.
  *
  * Time complexity: O(n), the number of elements.
  */
@@ -1052,7 +1056,8 @@ BASE FUNCTION(igraph_vector, min)(const TYPE(igraph_vector)* v) {
     min = *(v->stor_begin);
     ptr = v->stor_begin + 1;
     while (ptr < v->end) {
-        if ((*ptr) < min) {
+        if (!((*ptr) >= min)) {
+            /* Double negation to deal with NaN */
             min = *ptr;
         }
         ptr++;
@@ -1061,18 +1066,19 @@ BASE FUNCTION(igraph_vector, min)(const TYPE(igraph_vector)* v) {
 }
 
 /**
+ * \ingroup vector
  * \function igraph_vector_which_min
  * \brief Index of the smallest element.
  *
- * The vector must be non-empty.
- * If the smallest element is not unique, then the index of the first
- * is returned.
+ * </para><para>
+ * The vector must be non-empty. If the smallest element is not unique,
+ * then the index of the first is returned. If the vector contains NaN
+ * values, the index of the first NaN value is returned.
  * \param v The input vector.
  * \return Index of the smallest element.
  *
  * Time complexity: O(n), the number of elements.
  */
-
 long int FUNCTION(igraph_vector, which_min)(const TYPE(igraph_vector)* v) {
     long int which = -1;
     if (!FUNCTION(igraph_vector, empty)(v)) {
@@ -1084,7 +1090,9 @@ long int FUNCTION(igraph_vector, which_min)(const TYPE(igraph_vector)* v) {
         min = *(v->stor_begin); which = 0;
         ptr = v->stor_begin + 1; pos = 1;
         while (ptr < v->end) {
-            if ((*ptr) < min) {
+            if (!((*ptr) >= min) && /* Double negation to deal with NaN */
+                !(min != min) /* Ensure that first NaN value is considered */
+                ) {
                 min = *ptr;
                 which = pos;
             }

--- a/src/paths/bellman_ford.c
+++ b/src/paths/bellman_ford.c
@@ -46,8 +46,10 @@
  * \param weights The edge weights. There mustn't be any closed loop in
  *    the graph that has a negative total weight (since this would allow
  *    us to decrease the weight of any path containing at least a single
- *    vertex of this loop infinitely). If this is a null pointer, then the
- *    unweighted version, \ref igraph_shortest_paths() is called.
+ *    vertex of this loop infinitely). Additionally, no edge weight may
+ *    be NaN. If either case does not hold, an error is returned. If this
+ *    is a null pointer, then the unweighted version,
+ *    \ref igraph_shortest_paths() is called.
  * \param mode For directed graphs; whether to follow paths along edge
  *    directions (\c IGRAPH_OUT), or the opposite (\c IGRAPH_IN), or
  *    ignore edge directions completely (\c IGRAPH_ALL). It is ignored
@@ -96,6 +98,9 @@ int igraph_shortest_paths_bellman_ford(const igraph_t *graph,
 
     if (igraph_vector_size(weights) != no_of_edges) {
         IGRAPH_ERROR("Weight vector length does not match", IGRAPH_EINVAL);
+    }
+    if (no_of_edges > 0 && igraph_vector_is_any_nan(weights)) {
+        IGRAPH_ERROR("Weight vector must not contain NaN values", IGRAPH_EINVAL);
     }
 
     IGRAPH_CHECK(igraph_vit_create(graph, from, &fromvit));

--- a/src/paths/dijkstra.c
+++ b/src/paths/dijkstra.c
@@ -53,11 +53,11 @@
  * \param from The source vertices.
  * \param to The target vertices. It is not allowed to include a
  *    vertex twice or more.
- * \param weights The edge weights. They must be all non-negative for
- *    Dijkstra's algorithm to work. An error code is returned if there
- *    is a negative edge weight in the weight vector. If this is a null
- *    pointer, then the
- *    unweighted version, \ref igraph_shortest_paths() is called.
+ * \param weights The edge weights. All edge weights must be
+ *    non-negative for Dijkstra's algorithm to work. Additionally, no
+ *    edge weight may be NaN. If either case does not hold, an error
+ *    is returned. If this is a null pointer, then the unweighted
+ *    version, \ref igraph_shortest_paths() is called.
  * \param mode For directed graphs; whether to follow paths along edge
  *    directions (\c IGRAPH_OUT), or the opposite (\c IGRAPH_IN), or
  *    ignore edge directions completely (\c IGRAPH_ALL). It is ignored
@@ -114,8 +114,14 @@ int igraph_shortest_paths_dijkstra(const igraph_t *graph,
     if (igraph_vector_size(weights) != no_of_edges) {
         IGRAPH_ERROR("Weight vector length does not match", IGRAPH_EINVAL);
     }
-    if (no_of_edges > 0 && igraph_vector_min(weights) < 0) {
-        IGRAPH_ERROR("Weight vector must be non-negative", IGRAPH_EINVAL);
+    if (no_of_edges > 0) {
+        igraph_real_t min = igraph_vector_min(weights);
+        if (min < 0) {
+            IGRAPH_ERROR("Weight vector must be non-negative", IGRAPH_EINVAL);
+        }
+        else if (igraph_is_nan(min)) {
+            IGRAPH_ERROR("Weight vector must not contain NaN values", IGRAPH_EINVAL);
+        }
     }
 
     IGRAPH_CHECK(igraph_vit_create(graph, from, &fromvit));
@@ -245,8 +251,11 @@ int igraph_shortest_paths_dijkstra(const igraph_t *graph,
  * \param to Vertex sequence with the ids of the vertices to/from which the
  *        shortest paths will be calculated. A vertex might be given multiple
  *        times.
- * \param weights a vector holding the edge weights. All weights must be
- *        positive.
+* \param weights The edge weights. All edge weights must be
+ *       non-negative for Dijkstra's algorithm to work. Additionally, no
+ *       edge weight may be NaN. If either case does not hold, an error
+ *       is returned. If this is a null pointer, then the unweighted
+ *       version, \ref igraph_get_shortest_paths() is called.
  * \param mode The type of shortest paths to be use for the
  *        calculation in directed graphs. Possible values:
  *        \clist
@@ -341,8 +350,14 @@ int igraph_get_shortest_paths_dijkstra(const igraph_t *graph,
     if (igraph_vector_size(weights) != no_of_edges) {
         IGRAPH_ERROR("Weight vector length does not match", IGRAPH_EINVAL);
     }
-    if (no_of_edges > 0 && igraph_vector_min(weights) < 0) {
-        IGRAPH_ERROR("Weight vector must be non-negative", IGRAPH_EINVAL);
+    if (no_of_edges > 0) {
+        igraph_real_t min = igraph_vector_min(weights);
+        if (min < 0) {
+            IGRAPH_ERROR("Weight vector must be non-negative", IGRAPH_EINVAL);
+        }
+        else if (igraph_is_nan(min)) {
+            IGRAPH_ERROR("Weight vector must not contain NaN values", IGRAPH_EINVAL);
+        }
     }
 
     IGRAPH_CHECK(igraph_vit_create(graph, to, &vit));
@@ -536,9 +551,11 @@ int igraph_get_shortest_paths_dijkstra(const igraph_t *graph,
  *        path are stored here.
  * \param from The id of the source vertex.
  * \param to The id of the target vertex.
- * \param weights Vector of edge weights, in the order of edge
- *        ids. They must be non-negative, otherwise the algorithm does
- *        not work.
+ * \param weights The edge weights. All edge weights must be
+ *       non-negative for Dijkstra's algorithm to work. Additionally, no
+ *       edge weight may be NaN. If either case does not hold, an error
+ *       is returned. If this is a null pointer, then the unweighted
+ *       version, \ref igraph_get_shortest_paths() is called.
  * \param mode A constant specifying how edge directions are
  *        considered in directed graphs. \c IGRAPH_OUT follows edge
  *        directions, \c IGRAPH_IN follows the opposite directions,
@@ -628,8 +645,11 @@ static int igraph_i_vector_tail_cmp(const void* path1, const void* path2) {
  * \param to Vertex sequence with the ids of the vertices to/from which the
  *        shortest paths will be calculated. A vertex might be given multiple
  *        times.
- * \param weights a vector holding the edge weights. All weights must be
- *        non-negative.
+ * \param weights The edge weights. All edge weights must be
+ *       non-negative for Dijkstra's algorithm to work. Additionally, no
+ *       edge weight may be NaN. If either case does not hold, an error
+ *       is returned. If this is a null pointer, then the unweighted
+ *       version, \ref igraph_get_all_shortest_paths() is called.
  * \param mode The type of shortest paths to be use for the
  *        calculation in directed graphs. Possible values:
  *        \clist
@@ -692,8 +712,14 @@ int igraph_get_all_shortest_paths_dijkstra(const igraph_t *graph,
     if (igraph_vector_size(weights) != no_of_edges) {
         IGRAPH_ERROR("Weight vector length does not match", IGRAPH_EINVAL);
     }
-    if (no_of_edges > 0 && igraph_vector_min(weights) < 0) {
-        IGRAPH_ERROR("Weight vector must be non-negative", IGRAPH_EINVAL);
+    if (no_of_edges > 0) {
+        igraph_real_t min = igraph_vector_min(weights);
+        if (min < 0) {
+            IGRAPH_ERROR("Weight vector must be non-negative", IGRAPH_EINVAL);
+        }
+        else if (igraph_is_nan(min)) {
+            IGRAPH_ERROR("Weight vector must not contain NaN values", IGRAPH_EINVAL);
+        }
     }
 
     /* parents stores a vector for each vertex, listing the parent vertices

--- a/src/paths/johnson.c
+++ b/src/paths/johnson.c
@@ -86,6 +86,10 @@ int igraph_shortest_paths_johnson(const igraph_t *graph,
         IGRAPH_ERROR("Weight vector length does not match", IGRAPH_EINVAL);
     }
 
+    if (igraph_vector_is_any_nan(weights)) {
+        IGRAPH_ERROR("Weight vector must not contain NaN values", IGRAPH_EINVAL);
+    }
+
     /* If no negative weights, then we can run Dijkstra's algorithm */
     if (no_of_edges > 0 && igraph_vector_min(weights) >= 0) {
         return igraph_shortest_paths_dijkstra(graph, res, from, to,

--- a/src/paths/random_walk.c
+++ b/src/paths/random_walk.c
@@ -133,12 +133,13 @@ static void vec_destr(igraph_vector_t *vec) {
  *
  * \param graph The input graph, it can be directed or undirected.
  *   Multiple edges are respected, so are loop edges.
- * \param weights A vector of non-negative edge weights.
- *   It is assumed that at least one strictly positive weight is found among the
- *   outgoing edges of each vertex.  If it is a NULL pointer, all edges are considered
- *   to have equal weight.
- * \param edgewalk An initialized vector; the indices of traversed edges are stored here.
- *   It will be resized as needed.
+ * \param weights A vector of non-negative edge weights. It is assumed
+ *   that at least one strictly positive weight is found among the
+ *   outgoing edges of each vertex. Additionally, no edge weight may
+ *   be NaN. If either case does not hold, an error is returned. If it
+ *   is a NULL pointer, all edges are considered to have equal weight.
+ * \param edgewalk An initialized vector; the indices of traversed
+ *   edges are stored here. It will be resized as needed.
  * \param start The start vertex for the walk.
  * \param steps The number of steps to take. If the random walk gets
  *   stuck, then the \p stuck argument specifies what happens.
@@ -190,8 +191,14 @@ int igraph_random_edge_walk(const igraph_t *graph,
         if (igraph_vector_size(weights) != ec) {
             IGRAPH_ERROR("Invalid weight vector length", IGRAPH_EINVAL);
         }
-        if (ec > 0 && igraph_vector_min(weights) < 0) {
-            IGRAPH_ERROR("Weights must be non-negative", IGRAPH_EINVAL);
+        if (ec > 0) {
+            igraph_real_t min = igraph_vector_min(weights);
+            if (min < 0) {
+                IGRAPH_ERROR("Weights must be non-negative", IGRAPH_EINVAL);
+            }
+            else if (igraph_is_nan(min)) {
+                IGRAPH_ERROR("Weights must not contain NaN values", IGRAPH_EINVAL);
+            }
         }
     }
 

--- a/src/paths/shortest_paths.c
+++ b/src/paths/shortest_paths.c
@@ -800,7 +800,6 @@ int igraph_local_efficiency(const igraph_t *graph, igraph_vector_t *res,
  * \param res Pointer to a real number, this will contain the result.
  * \param weights The edge weights. They must be all non-negative.
  *    If a null pointer is given, all weights are assumed to be 1.
- *
  * \param directed Boolean, whether to consider directed paths.
  *    Ignored for undirected graphs.
  * \param mode How to determine the local neighborhood of each vertex

--- a/tests/unit/vector.c
+++ b/tests/unit/vector.c
@@ -25,6 +25,7 @@
 #include <stdlib.h>
 
 #include "test_utilities.inc"
+#include <assert.h>
 
 int main() {
 
@@ -33,16 +34,16 @@ int main() {
     igraph_real_t *ptr;
     long int pos;
 
-    /* simple init */
+    printf("Initialise empty vector\n");
     igraph_vector_init(&v, 0);
     igraph_vector_destroy(&v);
 
-    /* vector of zeros */
+    printf("Initialise vector of length 10\n");
     igraph_vector_init(&v, 10);
     print_vector_format(&v, stdout, "%g");
     igraph_vector_destroy(&v);
 
-    /* VECTOR(), igraph_vector_size */
+    printf("Test VECTOR() and igraph_vector_size\n");
     igraph_vector_init(&v, 10);
     for (i = 0; i < igraph_vector_size(&v); i++) {
         VECTOR(v)[i] = 10 - i;
@@ -50,35 +51,31 @@ int main() {
     print_vector_format(&v, stdout, "%g");
     igraph_vector_destroy(&v);
 
-    /* igraph_vector_reserve, igraph_vector_push_back */
+    printf("Test igraph_vector_reserve and igraph_vector_push_back\n");
     igraph_vector_init(&v, 0);
     igraph_vector_reserve(&v, 10);
     for (i = 0; i < 10; i++) {
         igraph_vector_push_back(&v, i);
     }
 
-    /* igraph_vector_empty, igraph_vector_clear */
-    if (igraph_vector_empty(&v)) {
-        return 1;
-    }
+    printf("Test igraph_vector_empty and igraph_vector_clear\n");
+    assert(!igraph_vector_empty(&v));
     igraph_vector_clear(&v);
-    if (!igraph_vector_empty(&v)) {
-        return 2;
-    }
+    assert(igraph_vector_empty(&v));
     igraph_vector_destroy(&v);
 
-    /* igraph_vector_e, igraph_vector_e_ptr */
+    printf("Test igraph_vector_e and igraph_vector_e_ptr\n");
     igraph_vector_init(&v, 5);
     for (i = 0; i < igraph_vector_size(&v); i++) {
         *igraph_vector_e_ptr(&v, i) = 100 * i;
     }
     for (i = 0; i < igraph_vector_size(&v); i++) {
-        fprintf(stdout, " %li", (long int)igraph_vector_e(&v, i));
+        printf(" %li", (long int)igraph_vector_e(&v, i));
     }
-    fprintf(stdout, "\n");
+    printf("\n");
     igraph_vector_destroy(&v);
 
-    /* igraph_vector_set */
+    printf("Test igraph_vector_set\n");
     igraph_vector_init(&v, 5);
     for (i = 0; i < igraph_vector_size(&v); i++) {
         igraph_vector_set(&v, i, 20 * i);
@@ -86,7 +83,7 @@ int main() {
     print_vector_format(&v, stdout, "%g");
     igraph_vector_destroy(&v);
 
-    /* igraph_vector_null */
+    printf("Test igraph_vector_null\n");
     igraph_vector_init(&v, 0);
     igraph_vector_null(&v);
     igraph_vector_destroy(&v);
@@ -98,19 +95,19 @@ int main() {
     print_vector_format(&v, stdout, "%g");
     igraph_vector_destroy(&v);
 
-    /* igraph_vector_tail, igraph_vector_pop_back */
+    printf("Test igraph_vector_tail, igraph_vector_pop_back\n");
     igraph_vector_init(&v, 10);
     for (i = 0; i < igraph_vector_size(&v); i++) {
         VECTOR(v)[i] = i + 1;
     }
     while (!igraph_vector_empty(&v)) {
-        fprintf(stdout, " %li", (long int)igraph_vector_tail(&v));
-        fprintf(stdout, " %li", (long int)igraph_vector_pop_back(&v));
+        printf(" %li", (long int)igraph_vector_tail(&v));
+        printf(" %li", (long int)igraph_vector_pop_back(&v));
     }
-    fprintf(stdout, "\n");
+    printf("\n");
     igraph_vector_destroy(&v);
 
-    /* igraph_vector_init_seq, igraph_vector_order */
+    printf("Test igraph_vector_init_seq, igraph_vector_order\n");
     igraph_vector_init_seq(&v, 1, 10);
     igraph_vector_init(&v2, 0);
     igraph_vector_order1(&v, &v2, 10);
@@ -118,7 +115,7 @@ int main() {
     igraph_vector_destroy(&v2);
     igraph_vector_destroy(&v);
 
-    /* igraph_vector_resize, igraph_vector_sort */
+    printf("Test igraph_vector_resize, igraph_vector_sort\n");
     igraph_vector_init(&v, 20);
     for (i = 0; i < 10; i++) {
         VECTOR(v)[i] = 10 - i;
@@ -128,17 +125,31 @@ int main() {
     print_vector_format(&v, stdout, "%g");
     igraph_vector_destroy(&v);
 
-    /* igraph_vector_max, igraph_vector_init_copy */
+    printf("Test igraph_vector_{which}_{min, max}\n");
     igraph_vector_init(&v, 10);
     for (i = 0; i < igraph_vector_size(&v); i++) {
         VECTOR(v)[i] = 100 - i;
     }
     for (i = 0; i < 10; i++) {
-        fprintf(stdout, " %li", (long int)VECTOR(v)[i]);
+        printf(" %li", (long int)VECTOR(v)[i]);
     }
-    fprintf(stdout, "\n");
-    fprintf(stdout, " %li\n", (long int)igraph_vector_max(&v));
+    printf("\n");
+    assert(igraph_vector_max(&v) == 100);
+    assert(igraph_vector_which_max(&v) == 0);
+    assert(igraph_vector_min(&v) == 91);
+    assert(igraph_vector_which_min(&v) == 9);
 
+    printf("Test NaN values\n");
+    igraph_vector_push_back(&v, IGRAPH_NAN);
+    igraph_vector_push_back(&v, IGRAPH_NAN);
+    assert(igraph_is_nan(igraph_vector_max(&v)));
+    /* Index should be to first NaN value */
+    assert(igraph_vector_which_max(&v) == 10);
+    assert(igraph_is_nan(igraph_vector_min(&v)));
+    /* Index should be to first NaN value */
+    assert(igraph_vector_which_min(&v) == 10);
+
+    printf("Test igraph_vector_init_copy\n");
     igraph_vector_destroy(&v);
     ptr = (igraph_real_t*) malloc(10 * sizeof(igraph_real_t));
     igraph_vector_init_copy(&v, ptr, 10);
@@ -149,142 +160,111 @@ int main() {
     print_vector_format(&v, stdout, "%g");
     igraph_vector_destroy(&v);
 
-    /* igraph_vector_copy_to */
+    printf("Test igraph_vector_copy_to\n");
     ptr = (igraph_real_t*) malloc(10 * sizeof(igraph_real_t));
     igraph_vector_init_seq(&v, 11, 20);
     igraph_vector_copy_to(&v, ptr);
     for (i = 0; i < 10; i++) {
-        fprintf(stdout, " %li", (long int)ptr[i]);
+        printf(" %li", (long int)ptr[i]);
     }
-    fprintf(stdout, "\n");
+    printf("\n");
     free(ptr);
     igraph_vector_destroy(&v);
 
-    /* igraph_vector_init_seq, igraph_vector_sum, igraph_vector_prod */
+    printf("Test igraph_vector_init_seq, igraph_vector_sum, igraph_vector_prod\n");
     igraph_vector_init_seq(&v, 1, 5);
-    fprintf(stdout, " %li", (long int)igraph_vector_sum(&v));
-    fprintf(stdout, " %li\n", (long int)igraph_vector_prod(&v));
+    printf(" %li", (long int)igraph_vector_sum(&v));
+    printf(" %li\n", (long int)igraph_vector_prod(&v));
 
-    /* igraph_vector_remove_section */
+    printf("Test igraph_vector_remove_section\n");
     igraph_vector_remove_section(&v, 2, 4);
-    fprintf(stdout, " %li", (long int)igraph_vector_sum(&v));
-    fprintf(stdout, " %li\n", (long int)igraph_vector_prod(&v));
+    printf(" %li", (long int)igraph_vector_sum(&v));
+    printf(" %li\n", (long int)igraph_vector_prod(&v));
     igraph_vector_destroy(&v);
 
-    /* igraph_vector_remove */
+    printf("Test igraph_vector_remove\n");
     igraph_vector_init_seq(&v, 1, 10);
     igraph_vector_remove(&v, 9);
     igraph_vector_remove(&v, 0);
     igraph_vector_remove(&v, 4);
-    fprintf(stdout, " %li\n", (long int)igraph_vector_sum(&v));
+    printf(" %li\n", (long int)igraph_vector_sum(&v));
     igraph_vector_destroy(&v);
 
-    /* igraph_vector_move_interval */
+    printf("Test igraph_vector_move_interval\n");
     igraph_vector_init_seq(&v, 0, 9);
     igraph_vector_move_interval(&v, 5, 10, 0);
-    if (igraph_vector_sum(&v) != 70) {
-        return 3;
-    }
+    assert(igraph_vector_sum(&v) == 70);
     igraph_vector_destroy(&v);
 
-    /* igraph_vector_isininterval */
+    printf("Test igraph_vector_isininterval\n");
     igraph_vector_init_seq(&v, 1, 10);
-    if (!igraph_vector_isininterval(&v, 1, 10)) {
-        return 4;
-    }
-    if (igraph_vector_isininterval(&v, 2, 10)) {
-        return 5;
-    }
-    if (igraph_vector_isininterval(&v, 1, 9)) {
-        return 6;
-    }
+    assert(igraph_vector_isininterval(&v, 1, 10));
+    assert(!igraph_vector_isininterval(&v, 2, 10));
+    assert(!igraph_vector_isininterval(&v, 1, 9));
 
-    /* igraph_vector_any_smaller */
-    if (igraph_vector_any_smaller(&v, 1)) {
-        return 7;
-    }
-    if (!igraph_vector_any_smaller(&v, 2)) {
-        return 8;
-    }
+    printf("Test igraph_vector_any_smaller\n");
+    assert(!igraph_vector_any_smaller(&v, 1));
+    assert(igraph_vector_any_smaller(&v, 2));
     igraph_vector_destroy(&v);
 
-    /* igraph_vector_all_e */
+    printf("Test igraph_vector_all_e\n");
 
-    /* igraph_vector_binsearch */
+    printf("Test igraph_vector_binsearch\n");
     igraph_vector_init_seq(&v, 0, 9);
     for (i = 0; i < igraph_vector_size(&v); i++) {
-        if (!igraph_vector_binsearch(&v, 0, 0)) {
-            return 9;
-        }
+        assert(igraph_vector_binsearch(&v, 0, 0));
     }
-    if (igraph_vector_binsearch(&v, 10, 0)) {
-        return 10;
-    }
-    if (igraph_vector_binsearch(&v, -1, 0)) {
-        return 11;
-    }
+    assert(!igraph_vector_binsearch(&v, 10, 0));
+    assert(!igraph_vector_binsearch(&v, -1, 0));
     for (i = 0; i < igraph_vector_size(&v); i++) {
         VECTOR(v)[i] = 2 * i;
     }
     for (i = 0; i < igraph_vector_size(&v); i++) {
         long int pos;
-        if (!igraph_vector_binsearch(&v, VECTOR(v)[i], &pos)) {
-            fprintf(stderr, "cannot find %i\n", (int)VECTOR(v)[i]);
-            return 12;
-        }
-        if (pos != i) {
-            return 13;
-        }
-        if (igraph_vector_binsearch(&v, VECTOR(v)[i] + 1, &pos)) {
-            return 14;
-        }
+        assert(igraph_vector_binsearch(&v, VECTOR(v)[i], &pos));
+        assert(pos == i);
+        assert(!igraph_vector_binsearch(&v, VECTOR(v)[i] + 1, &pos));
     }
     igraph_vector_destroy(&v);
 
-    /* Binsearch in empty vector */
+    printf("Test Binsearch in empty vector\n");
     igraph_vector_init(&v, 0);
-    if (igraph_vector_binsearch2(&v, 0)) {
-        return 16;
-    }
-    if (igraph_vector_binsearch(&v, 1, &pos)) {
-        return 17;
-    }
-    if (pos != 0) {
-        return 18;
-    }
+    assert(!igraph_vector_binsearch2(&v, 0));
+    assert(!igraph_vector_binsearch(&v, 1, &pos));
+    assert(pos == 0);
     igraph_vector_destroy(&v);
 
-    /* igraph_vector_init_real */
+    printf("Test igraph_vector_init_real\n");
     igraph_vector_init_real(&v, 10, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0);
     print_vector_format(&v, stdout, "%g");
     igraph_vector_destroy(&v);
 
-    /* igraph_vector_init_int */
+    printf("Test igraph_vector_init_int\n");
     igraph_vector_init_int(&v, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
     print_vector_format(&v, stdout, "%g");
     igraph_vector_destroy(&v);
 
-    /* igraph_vector_init_real */
+    printf("Test igraph_vector_init_real\n");
     igraph_vector_init_real_end(&v, -1, 1.0, 2.0, 3.0, 4.0, 5.0,
                                 6.0, 7.0, 8.0, 9.0, 10.0, -1.0);
     print_vector_format(&v, stdout, "%g");
     igraph_vector_destroy(&v);
 
-    /* igraph_vector_init_int */
+    printf("Test igraph_vector_init_int\n");
     igraph_vector_init_int_end(&v, -1, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, -1);
     print_vector_format(&v, stdout, "%g");
     igraph_vector_destroy(&v);
 
-    /* igraph_vector_permdelete */
-    /* igraph_vector_remove_negidx */
+    printf("Test igraph_vector_permdelete\n");
+    printf("Test igraph_vector_remove_negidx\n");
 
-    /* order2 */
+    printf("Test order2\n");
     igraph_vector_init_int_end(&v, -1, 10, 9, 8, 7, 6, 7, 8, 9, 10, -1);
     igraph_vector_order2(&v);
     print_vector_format(&v, stdout, "%g");
     igraph_vector_destroy(&v);
 
-    /* filter_smaller, quite special.... */
+    printf("Test filter_smaller, quite special....\n");
     igraph_vector_init_int_end(&v, -1, 0, 1, 2, 3, 4, 4, 4, 4, 5, 6, 7, 8, -1);
     igraph_vector_filter_smaller(&v, 4);
     print_vector_format(&v, stdout, "%g");
@@ -298,7 +278,7 @@ int main() {
     print_vector_format(&v, stdout, "%g");
     igraph_vector_destroy(&v);
 
-    /* rank */
+    printf("Test rank\n");
     igraph_vector_init_int_end(&v, -1, 0, 1, 2, 6, 5, 2, 1, 0, -1);
     igraph_vector_init(&v2, 0);
     igraph_vector_rank(&v, &v2, 7);
@@ -307,7 +287,7 @@ int main() {
     igraph_vector_destroy(&v);
     igraph_vector_destroy(&v2);
 
-    /* order */
+    printf("Test order\n");
     igraph_vector_init_int_end(&v,  -1, 1, 1, 2, 2, -1);
     igraph_vector_init_int_end(&v2, -1, 2, 3, 1, 3, -1);
     igraph_vector_init(&v3, 0);
@@ -317,14 +297,12 @@ int main() {
     igraph_vector_destroy(&v2);
     igraph_vector_destroy(&v3);
 
-    /* fill */
+    printf("Test fill\n");
 
     igraph_vector_init(&v, 100);
     igraph_vector_fill(&v, 1.234567);
     for (i = 0; i < igraph_vector_size(&v); i++) {
-        if (VECTOR(v)[i] != 1.234567) {
-            return 15;
-        }
+        assert(VECTOR(v)[i] == 1.234567);
     }
     igraph_vector_destroy(&v);
 

--- a/tests/unit/vector.c
+++ b/tests/unit/vector.c
@@ -142,6 +142,7 @@ int main() {
     printf("Test NaN values\n");
     igraph_vector_push_back(&v, IGRAPH_NAN);
     igraph_vector_push_back(&v, IGRAPH_NAN);
+    igraph_vector_push_back(&v, 1);
     assert(igraph_is_nan(igraph_vector_max(&v)));
     /* Index should be to first NaN value */
     assert(igraph_vector_which_max(&v) == 10);

--- a/tests/unit/vector.out
+++ b/tests/unit/vector.out
@@ -1,26 +1,60 @@
+Initialise empty vector
+Initialise vector of length 10
 ( 0 0 0 0 0 0 0 0 0 0 )
+Test VECTOR() and igraph_vector_size
 ( 10 9 8 7 6 5 4 3 2 1 )
+Test igraph_vector_reserve and igraph_vector_push_back
+Test igraph_vector_empty and igraph_vector_clear
+Test igraph_vector_e and igraph_vector_e_ptr
  0 100 200 300 400
+Test igraph_vector_set
 ( 0 20 40 60 80 )
+Test igraph_vector_null
 ( 0 0 0 0 0 0 0 0 0 0 )
+Test igraph_vector_tail, igraph_vector_pop_back
  10 10 9 9 8 8 7 7 6 6 5 5 4 4 3 3 2 2 1 1
+Test igraph_vector_init_seq, igraph_vector_order
 ( 0 1 2 3 4 5 6 7 8 9 )
+Test igraph_vector_resize, igraph_vector_sort
 ( 1 2 3 4 5 6 7 8 9 10 )
+Test igraph_vector_{which}_{min, max}
  100 99 98 97 96 95 94 93 92 91
- 100
+Test NaN values
+Test igraph_vector_init_copy
 ( 100 99 98 97 96 95 94 93 92 91 )
+Test igraph_vector_copy_to
  11 12 13 14 15 16 17 18 19 20
+Test igraph_vector_init_seq, igraph_vector_sum, igraph_vector_prod
  15 120
+Test igraph_vector_remove_section
  8 10
+Test igraph_vector_remove
  38
+Test igraph_vector_move_interval
+Test igraph_vector_isininterval
+Test igraph_vector_any_smaller
+Test igraph_vector_all_e
+Test igraph_vector_binsearch
+Test Binsearch in empty vector
+Test igraph_vector_init_real
 ( 1 2 3 4 5 6 7 8 9 10 )
+Test igraph_vector_init_int
 ( 1 2 3 4 5 6 7 8 9 10 )
+Test igraph_vector_init_real
 ( 1 2 3 4 5 6 7 8 9 10 )
+Test igraph_vector_init_int
 ( 1 2 3 4 5 6 7 8 9 10 )
+Test igraph_vector_permdelete
+Test igraph_vector_remove_negidx
+Test order2
 ( 0 8 1 7 6 2 3 5 4 )
+Test filter_smaller, quite special....
 ( 4 4 5 6 7 8 )
 ( 1 2 3 4 4 4 4 5 6 7 8 )
 ( 0 1 2 3 4 4 4 4 5 6 7 8 )
+Test rank
 ( 0 1 2 6 5 2 1 0 )
 ( 1 3 5 7 6 4 2 0 )
+Test order
 ( 0 1 2 3 )
+Test fill


### PR DESCRIPTION
This partially fixes #1560 for path based functions by disallowing NaN edge weights. Although it could theoretically be argued that some functions may still return proper value for some limited NaN edge weights, this quickly becomes quite challenging. This PR ensures that proper errors are returned in case there is any NaN edge weight, and also corrects the documentation.

In addition, the vector functions `igraph_vector_min` and `igraph_vector_max` are now guaranteed to return NaN whenever an NaN value appears anywhere in the vector. Previously, this was only the case if the NaN happened to appear in the first position (i.e. index 0).