### PR TITLE
Generalize the closeness centrality computation

### DIFF
--- a/examples/simple/centralization.c
+++ b/examples/simple/centralization.c
@@ -54,17 +54,7 @@ int main() {
         return 2;
     }
 
-    igraph_set_warning_handler(igraph_warning_handler_ignore);
-    igraph_centralization_closeness(&g, /*res=*/ 0,
-                                    IGRAPH_IN, &cent,
-                                    /*theoretical_max=*/ 0,
-                                    /*normalization=*/ 1);
-    igraph_set_warning_handler(igraph_warning_handler_print);
-
-    if (!ALMOST_EQUALS(cent, 1.0)) {
-        fprintf(stderr, "in-star, closeness: %g\n", cent);
-        return 3;
-    }
+    /* Skip closeness, as it is not well-defined for disconnected graphs such as an in-star. */
 
     igraph_destroy(&g);
 
@@ -90,22 +80,12 @@ int main() {
         return 12;
     }
 
-    igraph_set_warning_handler(igraph_warning_handler_ignore);
-    igraph_centralization_closeness(&g, /*res=*/ 0,
-                                    IGRAPH_OUT, &cent,
-                                    /*theoretical_max=*/ 0,
-                                    /*normalization=*/ 1);
-    igraph_set_warning_handler(igraph_warning_handler_print);
-
-    if (!ALMOST_EQUALS(cent, 1.0)) {
-        fprintf(stderr, "out-star, closeness: %g\n", cent);
-        return 13;
-    }
+    /* Skip closeness, as it is not well-defined for disconnected graphs such as an out-star. */
 
     igraph_destroy(&g);
 
     /****************************/
-    /* undricted star */
+    /* undirected star */
     igraph_star(&g, 10, IGRAPH_STAR_UNDIRECTED, /*center=*/ 0);
 
     igraph_centralization_degree(&g, /*res=*/ 0,

--- a/include/igraph_centrality.h
+++ b/include/igraph_centrality.h
@@ -38,9 +38,11 @@ __BEGIN_DECLS
 /* -------------------------------------------------- */
 
 DECLDIR int igraph_closeness(const igraph_t *graph, igraph_vector_t *res,
+                             igraph_vector_t *reachable_count, igraph_bool_t *all_reachable,
                              const igraph_vs_t vids, igraph_neimode_t mode,
                              const igraph_vector_t *weights, igraph_bool_t normalized);
 DECLDIR int igraph_closeness_cutoff(const igraph_t *graph, igraph_vector_t *res,
+                                    igraph_vector_t *reachable_count, igraph_bool_t *all_reachable,
                                     const igraph_vs_t vids, igraph_neimode_t mode,
                                     const igraph_vector_t *weights,
                                     igraph_bool_t normalized,

--- a/interfaces/functions.def
+++ b/interfaces/functions.def
@@ -410,7 +410,9 @@ igraph_minimum_spanning_tree_prim:
         IGNORE: RR, RC, RNamespace
 
 igraph_closeness:
-        PARAMS: GRAPH graph, OUT VECTOR res, VERTEXSET vids=ALL, \
+        PARAMS: GRAPH graph, OUT VECTOR res, \
+                OUT VECTOR_OR_0 reachable_count, OUT BOOLEANPTR_OR_0 all_reachable, \
+                VERTEXSET vids=ALL, \
                 NEIMODE mode=OUT, EDGEWEIGHTS weights=NULL, \
                 BOOLEAN normalized=False
         DEPS: vids ON graph, weights ON graph
@@ -418,7 +420,9 @@ igraph_closeness:
         IGNORE: RR
 
 igraph_closeness_cutoff:
-        PARAMS: GRAPH graph, OUT VERTEXINDEX res, VERTEXSET vids=ALL, \
+        PARAMS: GRAPH graph, OUT VERTEXINDEX res, \
+                OUT VECTOR_OR_0 reachable_count, OUT BOOLEANPTR_OR_0 all_reachable, \
+                VERTEXSET vids=ALL, \
                 NEIMODE mode=OUT, EDGEWEIGHTS weights=NULL, \
                 BOOLEAN normalized=False, REAL cutoff
         DEPS: vids ON graph, weights ON graph, res ON graph vids

--- a/src/centrality/centralization.c
+++ b/src/centrality/centralization.c
@@ -425,7 +425,7 @@ int igraph_centralization_closeness(const igraph_t *graph,
         IGRAPH_VECTOR_INIT_FINALLY(scores, 0);
     }
 
-    IGRAPH_CHECK(igraph_closeness(graph, scores, igraph_vss_all(), mode,
+    IGRAPH_CHECK(igraph_closeness(graph, scores, NULL, NULL, igraph_vss_all(), mode,
                                   /*weights=*/ 0, /*normalize=*/ 1));
 
     IGRAPH_CHECK(igraph_centralization_closeness_tmax(graph, 0, mode,

--- a/src/centrality/closeness.c
+++ b/src/centrality/closeness.c
@@ -572,7 +572,7 @@ int igraph_i_harmonic_centrality_unweighted(const igraph_t *graph, igraph_vector
         IGRAPH_CHECK(igraph_dqueue_push(&q, 0));
         VECTOR(already_counted)[source] = i + 1;
 
-        IGRAPH_PROGRESS("Harmonic centrality: ", 100.0 * i / no_of_nodes, NULL);
+        IGRAPH_PROGRESS("Harmonic centrality: ", 100.0 * i / nodes_to_calc, NULL);
         IGRAPH_ALLOW_INTERRUPTION();
 
         while (!igraph_dqueue_empty(&q)) {

--- a/src/centrality/closeness.c
+++ b/src/centrality/closeness.c
@@ -647,15 +647,15 @@ static int igraph_i_harmonic_centrality_weighted(const igraph_t *graph,
     igraph_real_t mindist = 0;
 
     if (igraph_vector_size(weights) != no_of_edges) {
-        IGRAPH_ERROR("Invalid weight vector length", IGRAPH_EINVAL);
+        IGRAPH_ERROR("Invalid weight vector length.", IGRAPH_EINVAL);
     }
 
     if (no_of_edges > 0) {
         igraph_real_t minweight = igraph_vector_min(weights);
         if (minweight <= 0) {
-            IGRAPH_ERROR("Weight vector must be positive", IGRAPH_EINVAL);
+            IGRAPH_ERROR("Weight vector must be positive.", IGRAPH_EINVAL);
         } else if (igraph_is_nan(minweight)) {
-            IGRAPH_ERROR("Weight vector must not contain NaN values", IGRAPH_EINVAL);
+            IGRAPH_ERROR("Weight vector must not contain NaN values.", IGRAPH_EINVAL);
         }
     }
 

--- a/tests/unit/igraph_closeness.c
+++ b/tests/unit/igraph_closeness.c
@@ -16,23 +16,22 @@ void simple_test_case_no_weights_undirected() {
 
     /* NOT NORMALISED TEST BELOW */
 
-    igraph_closeness_cutoff(&g, &vector_actual_results /*store results here*/,
-                              NULL, NULL,
-                              /*calculating for all vectors in the graph*/ igraph_vss_all(),
-                              IGRAPH_ALL  /*graph is "undirected"*/,
-                              NULL /*unweighted*/, /*not normalised*/ 0, /*cutoff*/
-                              -1 /*calculating exact centrality*/);
+    igraph_closeness(&g, &vector_actual_results /*store results here*/,
+                      NULL, NULL,
+                      /*calculating for all vectors in the graph*/ igraph_vss_all(),
+                      IGRAPH_ALL  /*graph is "undirected"*/,
+                      NULL /*unweighted*/, /*not normalised*/ 0);
 
     printf("Non normalised results below\n");
     print_vector(&vector_actual_results);
 
     /* NORMALISED TEST BELOW */
 
-    igraph_closeness_cutoff(&g, &vector_actual_results /*store results here*/,
-                              NULL, NULL,
-                              /*calculating for all vectors in the graph*/ igraph_vss_all(),
-                              IGRAPH_ALL  /*graph is "undirected"*/,
-                              NULL, /*normalised*/ 1, /*cutoff*/ -1 /*calculating exact centrality*/);
+    igraph_closeness(&g, &vector_actual_results /*store results here*/,
+                      NULL, NULL,
+                      /*calculating for all vectors in the graph*/ igraph_vss_all(),
+                      IGRAPH_ALL  /*graph is "undirected"*/,
+                      NULL, /*normalised*/ 1);
 
     printf("\nNormalised results below\n");
     print_vector(&vector_actual_results);
@@ -60,11 +59,11 @@ void simple_test_case_with_weights_undirected() {
 
     /* NOT NORMALISED TEST BELOW */
 
-    igraph_closeness_cutoff(&g, &vector_actual_results /*store results here*/,
-                              NULL, NULL,
-                              /*calculating for all vectors in the graph*/ igraph_vss_all(),
-                              IGRAPH_ALL  /*graph is "undirected"*/,
-                              &vector_weights, /*not normalised*/ 0, /*cutoff*/ -1 /*calculating exact centrality*/);
+    igraph_closeness(&g, &vector_actual_results /*store results here*/,
+                      NULL, NULL,
+                      /*calculating for all vectors in the graph*/ igraph_vss_all(),
+                      IGRAPH_ALL  /*graph is "undirected"*/,
+                      &vector_weights, /*not normalised*/ 0);
  
     printf("Non normalised test below\n"); 
     
@@ -74,11 +73,11 @@ void simple_test_case_with_weights_undirected() {
 
     printf("\nNormalised test below\n");
 
-    igraph_closeness_cutoff(&g, &vector_actual_results /*store results here*/,
-                              NULL, NULL,
-                              /*calculating for all vectors in the graph*/ igraph_vss_all(),
-                              IGRAPH_ALL  /*graph is "undirected"*/,
-                              &vector_weights, /*normalised*/ 1, /*cutoff*/ -1 /*calculating exact centrality*/);
+    igraph_closeness(&g, &vector_actual_results /*store results here*/,
+                      NULL, NULL,
+                      /*calculating for all vectors in the graph*/ igraph_vss_all(),
+                      IGRAPH_ALL  /*graph is "undirected"*/,
+                      &vector_weights, /*normalised*/ 1);
 
     print_vector(&vector_actual_results);
 
@@ -105,11 +104,11 @@ void advanced_test_case_no_weights_undirected() {
 
     printf("Non normalised test below\n");
 
-    igraph_closeness_cutoff(&g, &vector_actual_results /*store results here*/,
-                              NULL, NULL,
-                              /*calculating for all vectors in the graph*/ igraph_vss_all(),
-                              IGRAPH_ALL  /*graph is "undirected"*/,
-                              NULL, /*not normalised*/ 0, /*cutoff*/ -1 /*calculating exact centrality*/);
+    igraph_closeness(&g, &vector_actual_results /*store results here*/,
+                      NULL, NULL,
+                      /*calculating for all vectors in the graph*/ igraph_vss_all(),
+                      IGRAPH_ALL  /*graph is "undirected"*/,
+                      NULL, /*not normalised*/ 0);
 
     print_vector(&vector_actual_results);
  
@@ -117,11 +116,11 @@ void advanced_test_case_no_weights_undirected() {
 
     printf("\nNormalised test below\n");
 
-    igraph_closeness_cutoff(&g, &vector_actual_results /*store results here*/,
-                              NULL, NULL,
-                              /*calculating for all vectors in the graph*/ igraph_vss_all(),
-                              IGRAPH_ALL  /*graph is "undirected"*/,
-                              NULL, /*normalised*/ 1, /*cutoff*/ -1 /*calculating exact centrality*/);
+    igraph_closeness(&g, &vector_actual_results /*store results here*/,
+                      NULL, NULL,
+                      /*calculating for all vectors in the graph*/ igraph_vss_all(),
+                      IGRAPH_ALL  /*graph is "undirected"*/,
+                      NULL, /*normalised*/ 1);
 
     print_vector(&vector_actual_results);
 
@@ -152,11 +151,11 @@ void advanced_test_case_with_weights() {
 
     printf("Undirected graph test below\n");
 
-    igraph_closeness_cutoff(&g, &vector_actual_results /*store results here*/,
-                              NULL, NULL,
-                              /*calculating for all vectors in the graph*/ igraph_vss_all(),
-                              IGRAPH_ALL  /*graph is "undirected"*/,
-                              &vector_weights, /*not normalised*/ 0, /*cutoff*/ -1 /*calculating exact centrality*/);
+    igraph_closeness(&g, &vector_actual_results /*store results here*/,
+                      NULL, NULL,
+                      /*calculating for all vectors in the graph*/ igraph_vss_all(),
+                      IGRAPH_ALL  /*graph is "undirected"*/,
+                      &vector_weights, /*not normalised*/ 0);
 
     print_vector(&vector_actual_results);
 
@@ -165,11 +164,11 @@ void advanced_test_case_with_weights() {
 
     printf("\nDirected graph test below for OUT\n");
 
-    igraph_closeness_cutoff(&g, &vector_actual_results /*store results here*/,
-                              NULL, NULL,
-                              /*calculating for all vectors in the graph*/ igraph_vss_all(),
-                              IGRAPH_OUT  /*graph is "out directed"*/,
-                              &vector_weights, /*not normalised*/ 0, /*cutoff*/ -1 /*calculating exact centrality*/);
+    igraph_closeness(&g, &vector_actual_results /*store results here*/,
+                      NULL, NULL,
+                      /*calculating for all vectors in the graph*/ igraph_vss_all(),
+                      IGRAPH_OUT  /*graph is "out directed"*/,
+                      &vector_weights, /*not normalised*/ 0);
 
     print_vector(&vector_actual_results);
 
@@ -177,16 +176,149 @@ void advanced_test_case_with_weights() {
 
     printf("\nDirected graph test below for IN\n");
 
-    igraph_closeness_cutoff(&g, &vector_actual_results /*store results here*/,
-                              NULL, NULL,
-                              /*calculating for all vectors in the graph*/ igraph_vss_all(),
-                              IGRAPH_IN  /*graph is "in directed"*/,
-                              &vector_weights, /*not normalised*/ 0, /*cutoff*/ -1 /*calculating exact centrality*/);
+    igraph_closeness(&g, &vector_actual_results /*store results here*/,
+                      NULL, NULL,
+                      /*calculating for all vectors in the graph*/ igraph_vss_all(),
+                      IGRAPH_IN  /*graph is "in directed"*/,
+                      &vector_weights, /*not normalised*/ 0);
 
     print_vector(&vector_actual_results);
 
     igraph_vector_destroy(&vector_actual_results);
     igraph_destroy(&g);
+}
+
+void test_cutoff() {
+
+    igraph_t g;
+    igraph_vector_t closeness, reachable;
+    igraph_bool_t all_reachable;
+    size_t i;
+    igraph_real_t cutoff_vec[] = { -1.0, 0.0, 1.0, 2.9, 3.0, 3.1 };
+
+    printf("\n\nUnweighted undirected with cutoff\n");
+
+    igraph_ring(&g, 4, IGRAPH_UNDIRECTED, 0, 0);
+
+    igraph_vector_init(&closeness, 0);
+    igraph_vector_init(&reachable, 0);
+
+    for (i=0; i < sizeof(cutoff_vec) / sizeof(igraph_real_t); ++i) {
+        printf("\nRange-limited closeness with cutoff %g\n", cutoff_vec[i]);
+        igraph_closeness_cutoff(&g, &closeness, &reachable, &all_reachable,
+                                igraph_vss_all(), IGRAPH_ALL, NULL, /* normalized */ 1,
+                                cutoff_vec[i]);
+        printf("Closeness: ");
+        print_vector(&closeness);
+        printf("Reachable: ");
+        print_vector_round(&reachable);
+        printf("All reachable: %s\n", all_reachable ? "true" : "false");
+    }
+
+    igraph_vector_destroy(&reachable);
+    igraph_vector_destroy(&closeness);
+
+    igraph_destroy(&g);
+}
+
+void test_cutoff_directed() {
+
+    igraph_t g;
+    igraph_vector_t closeness, reachable;
+    igraph_bool_t all_reachable;
+    size_t i;
+    igraph_real_t cutoff_vec[] = { -1.0, 0.0, 1.0, 2.9, 3.0, 3.1 };
+
+    printf("\n\nUnweighted directed with cutoff\n");
+
+    igraph_ring(&g, 4, IGRAPH_DIRECTED, 0, 0);
+
+    igraph_vector_init(&closeness, 0);
+    igraph_vector_init(&reachable, 0);
+
+    for (i=0; i < sizeof(cutoff_vec) / sizeof(igraph_real_t); ++i) {
+        printf("\nRange-limited directed closeness with cutoff %g\n", cutoff_vec[i]);
+        igraph_closeness_cutoff(&g, &closeness, &reachable, &all_reachable,
+                                igraph_vss_all(), IGRAPH_OUT, NULL, /* normalized */ 1,
+                                cutoff_vec[i]);
+        printf("Closeness: ");
+        print_vector(&closeness);
+        printf("Reachable: ");
+        print_vector_round(&reachable);
+        printf("All reachable: %s\n", all_reachable ? "true" : "false");
+    }
+
+    igraph_vector_destroy(&reachable);
+    igraph_vector_destroy(&closeness);
+
+    igraph_destroy(&g);
+}
+
+void test_cutoff_weighted() {
+
+    igraph_t g;
+    igraph_vector_t closeness, reachable;
+    igraph_bool_t all_reachable;
+    size_t i;
+    igraph_real_t cutoff_vec[] = { -1.0, 0.0, 1.0, 2.9, 3.0, 5.0, 6.0 };
+    igraph_vector_t weights;
+
+    printf("\n\nWeighted undirected with cutoff\n");
+
+    igraph_ring(&g, 4, IGRAPH_UNDIRECTED, 0, 0);
+
+    igraph_vector_init(&closeness, 0);
+    igraph_vector_init(&reachable, 0);
+    igraph_vector_init_seq(&weights, 1, 3);
+
+    for (i=0; i < sizeof(cutoff_vec) / sizeof(igraph_real_t); ++i) {
+        printf("\nRange-limited weighted closeness with cutoff %g\n", cutoff_vec[i]);
+        igraph_closeness_cutoff(&g, &closeness, &reachable, &all_reachable,
+                                igraph_vss_all(), IGRAPH_ALL, &weights, /* normalized */ 1,
+                                cutoff_vec[i]);
+        printf("Closeness: ");
+        print_vector(&closeness);
+        printf("Reachable: ");
+        print_vector_round(&reachable);
+        printf("All reachable: %s\n", all_reachable ? "true" : "false");
+    }
+
+    igraph_vector_destroy(&weights);
+    igraph_vector_destroy(&reachable);
+    igraph_vector_destroy(&closeness);
+
+    igraph_destroy(&g);
+}
+
+void test_edge_cases() {
+
+    igraph_t g;
+    igraph_vector_t closeness, reachable;
+    igraph_bool_t all_reachable;
+    int n;
+
+    printf("\n\nEdgeless graphs\n");
+
+    igraph_vector_init(&closeness, 0);
+    igraph_vector_init(&reachable, 0);
+
+    for (n=0; n <= 2; ++n) {
+        printf("\nEdgeless graph with %d vertices\n", n);
+        igraph_empty(&g, n, IGRAPH_UNDIRECTED);
+
+        igraph_closeness(&g, &closeness, &reachable, &all_reachable, igraph_vss_all(), IGRAPH_ALL, NULL, 1);
+        printf("Closeness: ");
+        print_vector(&closeness);
+        printf("Reachable: ");
+        print_vector_round(&reachable);
+        printf("All reachable: %s\n", all_reachable ? "true" : "false");
+
+        igraph_destroy(&g);
+    }
+
+    igraph_vector_destroy(&reachable);
+    igraph_vector_destroy(&closeness);
+
 }
 
 int main() {
@@ -195,6 +327,12 @@ int main() {
     simple_test_case_with_weights_undirected();
     advanced_test_case_no_weights_undirected();
     advanced_test_case_with_weights();
+
+    test_cutoff();
+    test_cutoff_directed();
+    test_cutoff_weighted();
+
+    test_edge_cases();
 
     VERIFY_FINALLY_STACK();
 

--- a/tests/unit/igraph_closeness.c
+++ b/tests/unit/igraph_closeness.c
@@ -17,6 +17,7 @@ void simple_test_case_no_weights_undirected() {
     /* NOT NORMALISED TEST BELOW */
 
     igraph_closeness_cutoff(&g, &vector_actual_results /*store results here*/,
+                              NULL, NULL,
                               /*calculating for all vectors in the graph*/ igraph_vss_all(),
                               IGRAPH_ALL  /*graph is "undirected"*/,
                               NULL /*unweighted*/, /*not normalised*/ 0, /*cutoff*/
@@ -28,6 +29,7 @@ void simple_test_case_no_weights_undirected() {
     /* NORMALISED TEST BELOW */
 
     igraph_closeness_cutoff(&g, &vector_actual_results /*store results here*/,
+                              NULL, NULL,
                               /*calculating for all vectors in the graph*/ igraph_vss_all(),
                               IGRAPH_ALL  /*graph is "undirected"*/,
                               NULL, /*normalised*/ 1, /*cutoff*/ -1 /*calculating exact centrality*/);
@@ -59,6 +61,7 @@ void simple_test_case_with_weights_undirected() {
     /* NOT NORMALISED TEST BELOW */
 
     igraph_closeness_cutoff(&g, &vector_actual_results /*store results here*/,
+                              NULL, NULL,
                               /*calculating for all vectors in the graph*/ igraph_vss_all(),
                               IGRAPH_ALL  /*graph is "undirected"*/,
                               &vector_weights, /*not normalised*/ 0, /*cutoff*/ -1 /*calculating exact centrality*/);
@@ -72,6 +75,7 @@ void simple_test_case_with_weights_undirected() {
     printf("\nNormalised test below\n");
 
     igraph_closeness_cutoff(&g, &vector_actual_results /*store results here*/,
+                              NULL, NULL,
                               /*calculating for all vectors in the graph*/ igraph_vss_all(),
                               IGRAPH_ALL  /*graph is "undirected"*/,
                               &vector_weights, /*normalised*/ 1, /*cutoff*/ -1 /*calculating exact centrality*/);
@@ -102,6 +106,7 @@ void advanced_test_case_no_weights_undirected() {
     printf("Non normalised test below\n");
 
     igraph_closeness_cutoff(&g, &vector_actual_results /*store results here*/,
+                              NULL, NULL,
                               /*calculating for all vectors in the graph*/ igraph_vss_all(),
                               IGRAPH_ALL  /*graph is "undirected"*/,
                               NULL, /*not normalised*/ 0, /*cutoff*/ -1 /*calculating exact centrality*/);
@@ -113,6 +118,7 @@ void advanced_test_case_no_weights_undirected() {
     printf("\nNormalised test below\n");
 
     igraph_closeness_cutoff(&g, &vector_actual_results /*store results here*/,
+                              NULL, NULL,
                               /*calculating for all vectors in the graph*/ igraph_vss_all(),
                               IGRAPH_ALL  /*graph is "undirected"*/,
                               NULL, /*normalised*/ 1, /*cutoff*/ -1 /*calculating exact centrality*/);
@@ -147,6 +153,7 @@ void advanced_test_case_with_weights() {
     printf("Undirected graph test below\n");
 
     igraph_closeness_cutoff(&g, &vector_actual_results /*store results here*/,
+                              NULL, NULL,
                               /*calculating for all vectors in the graph*/ igraph_vss_all(),
                               IGRAPH_ALL  /*graph is "undirected"*/,
                               &vector_weights, /*not normalised*/ 0, /*cutoff*/ -1 /*calculating exact centrality*/);
@@ -159,6 +166,7 @@ void advanced_test_case_with_weights() {
     printf("\nDirected graph test below for OUT\n");
 
     igraph_closeness_cutoff(&g, &vector_actual_results /*store results here*/,
+                              NULL, NULL,
                               /*calculating for all vectors in the graph*/ igraph_vss_all(),
                               IGRAPH_OUT  /*graph is "out directed"*/,
                               &vector_weights, /*not normalised*/ 0, /*cutoff*/ -1 /*calculating exact centrality*/);
@@ -170,6 +178,7 @@ void advanced_test_case_with_weights() {
     printf("\nDirected graph test below for IN\n");
 
     igraph_closeness_cutoff(&g, &vector_actual_results /*store results here*/,
+                              NULL, NULL,
                               /*calculating for all vectors in the graph*/ igraph_vss_all(),
                               IGRAPH_IN  /*graph is "in directed"*/,
                               &vector_weights, /*not normalised*/ 0, /*cutoff*/ -1 /*calculating exact centrality*/);

--- a/tests/unit/igraph_closeness.out
+++ b/tests/unit/igraph_closeness.out
@@ -28,3 +28,125 @@ Directed graph test below for OUT
 
 Directed graph test below for IN
 ( 0.0128205 0.0158730 0.0158730 0.00980392 0.0188679 0.00751880 0.0263158 0.00751880 )
+
+
+Unweighted undirected with cutoff
+
+Range-limited closeness with cutoff -1
+Closeness: ( 0.500000 0.750000 0.750000 0.500000 )
+Reachable: ( 3 3 3 3 )
+All reachable: true
+
+Range-limited closeness with cutoff 0
+Closeness: ( NaN NaN NaN NaN )
+Reachable: ( 0 0 0 0 )
+All reachable: false
+
+Range-limited closeness with cutoff 1
+Closeness: ( 1.00000 1.00000 1.00000 1.00000 )
+Reachable: ( 1 2 2 1 )
+All reachable: false
+
+Range-limited closeness with cutoff 2.9
+Closeness: ( 0.666667 0.750000 0.750000 0.666667 )
+Reachable: ( 2 3 3 2 )
+All reachable: false
+
+Range-limited closeness with cutoff 3
+Closeness: ( 0.500000 0.750000 0.750000 0.500000 )
+Reachable: ( 3 3 3 3 )
+All reachable: true
+
+Range-limited closeness with cutoff 3.1
+Closeness: ( 0.500000 0.750000 0.750000 0.500000 )
+Reachable: ( 3 3 3 3 )
+All reachable: true
+
+
+Unweighted directed with cutoff
+
+Range-limited directed closeness with cutoff -1
+Closeness: ( 0.500000 0.666667 1.00000 NaN )
+Reachable: ( 3 2 1 0 )
+All reachable: false
+
+Range-limited directed closeness with cutoff 0
+Closeness: ( NaN NaN NaN NaN )
+Reachable: ( 0 0 0 0 )
+All reachable: false
+
+Range-limited directed closeness with cutoff 1
+Closeness: ( 1.00000 1.00000 1.00000 NaN )
+Reachable: ( 1 1 1 0 )
+All reachable: false
+
+Range-limited directed closeness with cutoff 2.9
+Closeness: ( 0.666667 0.666667 1.00000 NaN )
+Reachable: ( 2 2 1 0 )
+All reachable: false
+
+Range-limited directed closeness with cutoff 3
+Closeness: ( 0.500000 0.666667 1.00000 NaN )
+Reachable: ( 3 2 1 0 )
+All reachable: false
+
+Range-limited directed closeness with cutoff 3.1
+Closeness: ( 0.500000 0.666667 1.00000 NaN )
+Reachable: ( 3 2 1 0 )
+All reachable: false
+
+
+Weighted undirected with cutoff
+
+Range-limited weighted closeness with cutoff -1
+Closeness: ( 0.300000 0.375000 0.375000 0.214286 )
+Reachable: ( 3 3 3 3 )
+All reachable: true
+
+Range-limited weighted closeness with cutoff 0
+Closeness: ( NaN NaN NaN NaN )
+Reachable: ( 0 0 0 0 )
+All reachable: false
+
+Range-limited weighted closeness with cutoff 1
+Closeness: ( 1.00000 1.00000 NaN NaN )
+Reachable: ( 1 1 0 0 )
+All reachable: false
+
+Range-limited weighted closeness with cutoff 2.9
+Closeness: ( 1.00000 0.666667 0.500000 NaN )
+Reachable: ( 1 2 1 0 )
+All reachable: false
+
+Range-limited weighted closeness with cutoff 3
+Closeness: ( 0.500000 0.666667 0.375000 0.333333 )
+Reachable: ( 2 2 3 1 )
+All reachable: false
+
+Range-limited weighted closeness with cutoff 5
+Closeness: ( 0.500000 0.375000 0.375000 0.250000 )
+Reachable: ( 2 3 3 2 )
+All reachable: false
+
+Range-limited weighted closeness with cutoff 6
+Closeness: ( 0.300000 0.375000 0.375000 0.214286 )
+Reachable: ( 3 3 3 3 )
+All reachable: true
+
+
+Edgeless graphs
+
+Edgeless graph with 0 vertices
+Closeness: ( )
+Reachable: ( )
+All reachable: true
+
+Edgeless graph with 1 vertices
+Closeness: ( NaN )
+Reachable: ( 0 )
+All reachable: true
+
+Edgeless graph with 2 vertices
+Closeness: ( NaN NaN )
+Reachable: ( 0 0 )
+All reachable: false


### PR DESCRIPTION
This PR generalizes the closeness calculation and addresses #1053.

Reminder: closeness is the inverse of the mean distance to all other vertices.

In short, closeness centrality is problematic for disconnected graphs. Currently, igraph takes the distance to non-reachable nodes to be `n` (the number of vertices). This is an ad-hoc choice that makes no sense for the weighted case.

The simplest solution would be to throw an error for disconnected graphs, but: (1) this is not useful for `closeness_cutoff`, where some vertices are always unreachable for a low-enough cutoff (2) doesn't serve users the best.

Here are possible ways to deal with this issue:

 1. igraph's current approach (not good).
 2. Use the mean distance to reachable vertices, not all vertices. In the undirected case, this effectively computes the closeness per-component. Problem: the centrality scores will be much larger in small components, and not comparable to those in large components.
 3. Refuse to work with disconnected graphs and throw an error. Problems: (1) not useful with `closeness_cutoff` (2) in the directed case, when computing the closeness only for some vertices, we can't immediately detect if the graph is connected. Note that igraph currently does show a warning if it detects that the graph is disconnected (but it won't always detect this).
 4. There are approaches which first use the mean distance only to reachable vertices, but then re-scale the scores using some function of the number of vertices that could be reached. I've seen more than one way. [networkx](https://networkx.org/documentation/stable/reference/algorithms/generated/networkx.algorithms.centrality.closeness_centrality.html) does this and points to a certain reference (Wasserman and Faust). Problem: The Wasserman and Faust approach effectively assumes that the mean distance scales linearly with the graph size (component size) and attempt to correct for this. This is simply not true. Consider a spatial network: the scaling depends on the spatial dimension.

My conclusion: There are many way to handle this and igraph should not choose to use one. Instead, it should provide maximum flexibility to use either of them.

My solution:

 - Use the mean distance to reachable vertices (not all vertices).
 - Also return the number of vertices that could be reached.

With this information, one can easily get the result of any of approaches 1-4 from above.  I would leave it to high-level interfaces to make a choice on what to implement, or provide multiple options.