### PR TITLE
Improve NaN documentation and fixing various functions for vectors

### DIFF
--- a/include/igraph_vector.h
+++ b/include/igraph_vector.h
@@ -174,7 +174,8 @@ DECLDIR int igraph_vector_order1_int(const igraph_vector_t* v,
 DECLDIR int igraph_vector_order2(igraph_vector_t *v);
 DECLDIR int igraph_vector_rank(const igraph_vector_t *v, igraph_vector_t *res,
                        long int nodes);
-
+DECLDIR int igraph_vector_is_nan(const igraph_vector_t *v,
+                                 igraph_vector_bool_t *is_nan);
 DECLDIR igraph_bool_t igraph_vector_is_any_nan(const igraph_vector_t *v);
 
 __END_DECLS

--- a/src/core/vector.c
+++ b/src/core/vector.c
@@ -469,7 +469,7 @@ int igraph_vector_zapsmall(igraph_vector_t *v, igraph_real_t tol) {
  * </para><para>
  * \param v The \type igraph_vector_t object to check.
  * \param is_nan The resulting boolean vector indicating for each element
- *               whether is is NaN or not.
+ *               whether it is NaN or not.
  * \return Error code,
  *         \c IGRAPH_ENOMEM if there is not enough
  *         memory. Note that this function \em never returns an error

--- a/src/core/vector.c
+++ b/src/core/vector.c
@@ -463,6 +463,36 @@ int igraph_vector_zapsmall(igraph_vector_t *v, igraph_real_t tol) {
 
 /**
  * \ingroup vector
+ * \function igraph_vector_is_nan
+ * \brief Check for each element if it is NaN.
+ *
+ * </para><para>
+ * \param v The \type igraph_vector_t object to check.
+ * \param is_nan The resulting boolean vector indicating for each element
+ *               whether is is NaN or not.
+ * \return Error code,
+ *         \c IGRAPH_ENOMEM if there is not enough
+ *         memory. Note that this function \em never returns an error
+ *         if the vector \p is_nan will already be large enough.
+ * Time complexity: O(n), the number of elements.
+ */
+int igraph_vector_is_nan(const igraph_vector_t *v, igraph_vector_bool_t *is_nan)
+{
+    igraph_real_t *ptr;
+    igraph_bool_t *ptr_nan;
+    IGRAPH_ASSERT(v != NULL);
+    IGRAPH_ASSERT(v->stor_begin != NULL);
+    IGRAPH_ASSERT(is_nan != NULL);
+    IGRAPH_ASSERT(is_nan->stor_begin != NULL);
+    IGRAPH_CHECK(igraph_vector_bool_resize(is_nan, igraph_vector_size(v)));
+    for (ptr = v->stor_begin, ptr_nan = is_nan->stor_begin; ptr < v->end; ptr++, ptr_nan++) {
+        *ptr_nan = igraph_is_nan(*ptr);
+    }
+    return IGRAPH_SUCCESS;
+}
+
+/**
+ * \ingroup vector
  * \function igraph_vector_is_any_nan
  * \brief Check if any element is NaN.
  *

--- a/src/core/vector.pmt
+++ b/src/core/vector.pmt
@@ -2446,6 +2446,7 @@ int FUNCTION(igraph_vector, abs)(TYPE(igraph_vector) *v) {
  *
  * Handy if you want to have both the smallest and largest element of
  * a vector. The vector is only traversed once. The vector must by non-empty.
+ * If a vector contains any NaN, both \c min and \c max will be NaN.
  * \param v The input vector. It must contain at least one element.
  * \param min Pointer to a base type variable, the minimum is stored
  *     here.
@@ -2458,27 +2459,42 @@ int FUNCTION(igraph_vector, abs)(TYPE(igraph_vector) *v) {
 
 int FUNCTION(igraph_vector, minmax)(const TYPE(igraph_vector) *v,
                                     BASE *min, BASE *max) {
-    long int n = FUNCTION(igraph_vector, size)(v);
-    long int i;
-    *min = *max = VECTOR(*v)[0];
-    for (i = 1; i < n; i++) {
-        BASE tmp = VECTOR(*v)[i];
-        if (tmp > *max) {
-            *max = tmp;
-        } else if (tmp < *min) {
-            *min = tmp;
+    BASE* ptr;
+    IGRAPH_ASSERT(v != NULL);
+    IGRAPH_ASSERT(v->stor_begin != NULL);
+    *min = *max = *(v->stor_begin);
+    #if defined(BASE_IGRAPH_REAL) || defined(BASE_FLOAT)
+        if (igraph_is_nan(*min)) { return IGRAPH_SUCCESS; }; /* Result is NaN */
+    #endif
+    ptr = v->stor_begin + 1;
+    while (ptr < v->end) {
+        if (*ptr > *max) {
+            *max = *ptr;
+        } else if (*ptr < *min) {
+            *min = *ptr;
         }
+        #if defined(BASE_IGRAPH_REAL) || defined(BASE_FLOAT)
+        else if (igraph_is_nan(*ptr)) { /* Result is NaN */
+            *min = *max = *ptr;
+            return IGRAPH_SUCCESS;
+        };
+        #endif
+        ptr++;
     }
-    return 0;
+    return IGRAPH_SUCCESS;
 }
 
 /**
  * \function igraph_vector_which_minmax
  * \brief Index of the minimum and maximum elements
  *
+ * </para><para>
  * Handy if you need the indices of the smallest and largest
  * elements. The vector is traversed only once. The vector must to
- * non-empty.
+ * non-empty. If the minimum or maximum is not unique, the index
+ * of respectively the first minimum or the first maximum is returned.
+ * If a vector contains any NaN, both \c which_min and \c which_max
+ * will point to the first NaN value.
  * \param v The input vector. It must contain at least one element.
  * \param which_min The index of the minimum element will be stored
  *   here.
@@ -2491,23 +2507,35 @@ int FUNCTION(igraph_vector, minmax)(const TYPE(igraph_vector) *v,
 
 int FUNCTION(igraph_vector, which_minmax)(const TYPE(igraph_vector) *v,
         long int *which_min, long int *which_max) {
-
-    long int n = FUNCTION(igraph_vector, size)(v);
-    long int i;
-    BASE min, max;
-    *which_min = *which_max = 0;
-    min = max = VECTOR(*v)[0];
-    for (i = 1; i < n; i++) {
-        BASE tmp = VECTOR(*v)[i];
-        if (tmp > max) {
-            max = tmp;
-            *which_max = i;
-        } else if (tmp < min) {
-            min = tmp;
-            *which_min = i;
+    BASE *min, *max;
+    BASE *ptr;
+    IGRAPH_ASSERT(v != NULL);
+    IGRAPH_ASSERT(v->stor_begin != NULL);
+    ptr = v->stor_begin;
+    min = max = ptr;
+    #if defined(BASE_IGRAPH_REAL) || defined(BASE_FLOAT)
+        if (igraph_is_nan(*ptr)) {  /* Result is NaN */
+            *which_min = *which_max = 0;
+            return IGRAPH_SUCCESS;
         }
+    #endif
+    while (ptr < v->end) {
+        if (*ptr > *max) {
+            max = ptr;
+        } else if (*ptr < *min) {
+            min = ptr;
+        }
+#if defined(BASE_IGRAPH_REAL) || defined(BASE_FLOAT)
+        else if (igraph_is_nan(*ptr)) {  /* Result is NaN */
+            *which_min = *which_max  = ptr - v->stor_begin;
+            return IGRAPH_SUCCESS;
+        }
+#endif
+        ptr++;
     }
-    return 0;
+    *which_min = min - v->stor_begin;
+    *which_max = max - v->stor_begin;
+    return IGRAPH_SUCCESS;
 }
 
 #endif

--- a/src/core/vector.pmt
+++ b/src/core/vector.pmt
@@ -773,6 +773,9 @@ int FUNCTION(igraph_vector, reverse_sort_cmp)(const void *a, const void *b) {
  * \function igraph_vector_sort
  * \brief Sorts the elements of the vector into ascending order.
  *
+ * </para><para>
+ * If the vector contains any NaN values, the resulting ordering of
+ * NaN values is undefined and may appear anywhere in the vector.
  * \param v Pointer to an initialized vector object.
  *
  * Time complexity:
@@ -791,6 +794,9 @@ void FUNCTION(igraph_vector, sort)(TYPE(igraph_vector) *v) {
  * \function igraph_vector_reverse_sort
  * \brief Sorts the elements of the vector into descending order.
  *
+ * </para><para>
+ * If the vector contains any NaN values, the resulting ordering of
+ * NaN values is undefined and may appear anywhere in the vector.
  * \param v Pointer to an initialized vector object.
  *
  * Time complexity:
@@ -842,7 +848,8 @@ int FUNCTION(igraph_vector, i_qsort_ind_cmp_desc)(const void *p1, const void *p2
  * indices inds such that v[ inds[i] ], with i increasing from 0, is
  * an ordered array (either ascending or descending, depending on
  * \v order). The order of indices for identical elements is not
- * defined.
+ * defined. If the vector contains any NaN values, the ordering of
+ * NaN values is undefined.
  *
  * \param v the array to be sorted
  * \param inds the output array of indices. this must be initialized,
@@ -1060,7 +1067,7 @@ long int FUNCTION(igraph_vector, which_max)(const TYPE(igraph_vector)* v) {
  *
  * The vector must be non-empty.
  * \param v The input vector.
- * \return The smallest element of \p v, or nan if any element is nan.
+ * \return The smallest element of \p v, or NaN if any element is NaN.
  *
  * Time complexity: O(n), the number of elements.
  */
@@ -1488,7 +1495,8 @@ void FUNCTION(igraph_vector, permdelete)(TYPE(igraph_vector) *v,
  * \param low The lower limit of the interval (inclusive).
  * \param high The higher limit of the interval (inclusive).
  * \return True (positive integer) if all vector elements are in the
- *   interval, false (zero) otherwise.
+ *   interval, false (zero) otherwise. If any element is NaN, it will
+ *   return \c 0 (=false).
  *
  * Time complexity: O(n), the number
  * of elements in the vector.
@@ -1501,7 +1509,7 @@ igraph_bool_t FUNCTION(igraph_vector, isininterval)(const TYPE(igraph_vector) *v
     IGRAPH_ASSERT(v != NULL);
     IGRAPH_ASSERT(v->stor_begin != NULL);
     for (ptr = v->stor_begin; ptr < v->end; ptr++) {
-        if (*ptr < low || *ptr > high) {
+        if (!(*ptr >= low && *ptr <= high)) {
             return 0;
         }
     }
@@ -1596,7 +1604,8 @@ FUNCTION(igraph_vector, is_equal)(const TYPE(igraph_vector) *lhs,
  * \param rhs The second vector.
  * \return Positive integer (=true) if the elements in the \p lhs are all
  *    less than the corresponding elements in \p rhs. Returns \c 0
- *    (=false) if the lengths of the vectors don't match.
+ *    (=false) if the lengths of the vectors don't match. If any element
+ *    is NaN, it will return \c 0 (=false).
  *
  * Time complexity: O(n), the length of the vectors.
  */
@@ -1633,7 +1642,8 @@ igraph_bool_t FUNCTION(igraph_vector, all_l)(const TYPE(igraph_vector) *lhs,
  * \param rhs The second vector.
  * \return Positive integer (=true) if the elements in the \p lhs are all
  *    greater than the corresponding elements in \p rhs. Returns \c 0
- *    (=false) if the lengths of the vectors don't match.
+ *    (=false) if the lengths of the vectors don't match. If any element
+ *    is NaN, it will return \c 0 (=false).
  *
  * Time complexity: O(n), the length of the vectors.
  */
@@ -1672,7 +1682,7 @@ igraph_bool_t FUNCTION(igraph_vector, all_g)(const TYPE(igraph_vector) *lhs,
  * \return Positive integer (=true) if the elements in the \p lhs are all
  *    less than or equal to the corresponding elements in \p
  *    rhs. Returns \c 0 (=false) if the lengths of the vectors don't
- *    match.
+ *    match. If any element is NaN, it will return \c 0 (=false).
  *
  * Time complexity: O(n), the length of the vectors.
  */
@@ -1711,7 +1721,7 @@ FUNCTION(igraph_vector, all_le)(const TYPE(igraph_vector) *lhs,
  * \return Positive integer (=true) if the elements in the \p lhs are all
  *    greater than or equal to the corresponding elements in \p
  *    rhs. Returns \c 0 (=false) if the lengths of the vectors don't
- *    match.
+ *    match.  If any element is NaN, it will return \c 0 (=false).
  *
  * Time complexity: O(n), the length of the vectors.
  */
@@ -1757,7 +1767,8 @@ igraph_bool_t FUNCTION(igraph_i_vector, binsearch_slice)(const TYPE(igraph_vecto
  * It is assumed that the vector is sorted. If the specified element
  * (\p what) is not in the vector, then the
  * position of where it should be inserted (to keep the vector sorted)
- * is returned.
+ * is returned. If the vector contains any NaN values, the returned
+ * value is undefined and \p pos may point to any position.
  * \param v The \type igraph_vector_t object.
  * \param what The element to search for.
  * \param pos Pointer to a \type long int. This is set to the
@@ -1790,7 +1801,9 @@ igraph_bool_t FUNCTION(igraph_vector, binsearch)(const TYPE(igraph_vector) *v,
  * It is assumed that the indicated slice of the vector, from \p start to \p end,
  * is sorted. If the specified element (\p what) is not in the slice of the
  * vector, then the position of where it should be inserted (to keep the vector
- * sorted) is returned.
+ * sorted) is returned. If the indicated slice contains any NaN values, the
+ * returned value is undefined and \c pos may point to any position within
+ * the slice.
  * \param v The \type igraph_vector_t object.
  * \param what The element to search for.
  * \param pos Pointer to a \type long int. This is set to the position of an
@@ -2088,7 +2101,8 @@ int FUNCTION(igraph_vector, get_interval)(const TYPE(igraph_vector) *v,
  *
  * The element with the largest absolute value in \p m1 - \p m2 is
  * returned. Both vectors must be non-empty, but they not need to have
- * the same length, the extra elements in the longer vector are ignored.
+ * the same length, the extra elements in the longer vector are ignored. If
+ * any value is NaN in the shorter vector, the result will be NaN.
  * \param m1 The first vector.
  * \param m2 The second vector.
  * \return The maximum absolute difference of \p m1 and \p m2.
@@ -2111,6 +2125,11 @@ igraph_real_t FUNCTION(igraph_vector, maxdifference)(const TYPE(igraph_vector) *
         if (d > diff) {
             diff = d;
         }
+    #if defined(BASE_IGRAPH_REAL) || defined(BASE_FLOAT)
+        else if (igraph_is_nan(d)) { /* Result is NaN */
+            return d;
+        };
+    #endif
     }
 
     return diff;

--- a/src/core/vector.pmt
+++ b/src/core/vector.pmt
@@ -1028,22 +1028,18 @@ BASE FUNCTION(igraph_vector, max)(const TYPE(igraph_vector)* v) {
  */
 long int FUNCTION(igraph_vector, which_max)(const TYPE(igraph_vector)* v) {
     if (!FUNCTION(igraph_vector, empty)(v)) {
-        BASE max;
+        BASE *max;
         BASE *ptr;
-        BASE *which;
         IGRAPH_ASSERT(v != NULL);
         IGRAPH_ASSERT(v->stor_begin != NULL);
-        ptr = v->stor_begin;
+        max = ptr = v->stor_begin;
 #if defined(BASE_IGRAPH_REAL) || defined(BASE_FLOAT)
         if (igraph_is_nan(*ptr)) { return ptr - v->stor_begin; } /* Result is NaN */
 #endif
-        which = ptr;
-        max = *which;
         ptr++;
         while (ptr < v->end) {
-            if ((*ptr) > max) {
-                which = ptr;
-                max = *which;
+            if (*ptr > *max) {
+                max = ptr;
             }
 #if defined(BASE_IGRAPH_REAL) || defined(BASE_FLOAT)
             else if (igraph_is_nan(*ptr)) {
@@ -1052,7 +1048,7 @@ long int FUNCTION(igraph_vector, which_max)(const TYPE(igraph_vector)* v) {
 #endif
             ptr++;
         }
-        return which - v->stor_begin;
+        return max - v->stor_begin;
     }
     return -1;
 }
@@ -1109,21 +1105,18 @@ BASE FUNCTION(igraph_vector, min)(const TYPE(igraph_vector)* v) {
  */
 long int FUNCTION(igraph_vector, which_min)(const TYPE(igraph_vector)* v) {
     if (!FUNCTION(igraph_vector, empty)(v)) {
-        BASE min;
+        BASE *min;
         BASE *ptr;
-        BASE *which;
         IGRAPH_ASSERT(v != NULL);
         IGRAPH_ASSERT(v->stor_begin != NULL);
-        ptr = v->stor_begin;
+        min = ptr = v->stor_begin;
 #if defined(BASE_IGRAPH_REAL) || defined(BASE_FLOAT)
         if (igraph_is_nan(*ptr)) { return ptr - v->stor_begin; } /* Result is NaN */
 #endif
-        which = ptr;
-        min = *which;
+        ptr++;
         while (ptr < v->end) {
-            if ((*ptr) < min) {
-                which = ptr;
-                min = *which;
+            if (*ptr < *min) {
+                min = ptr;
             }
 #if defined(BASE_IGRAPH_REAL) || defined(BASE_FLOAT)
             else if (igraph_is_nan(*ptr)) {
@@ -1132,7 +1125,7 @@ long int FUNCTION(igraph_vector, which_min)(const TYPE(igraph_vector)* v) {
 #endif
             ptr++;
         }
-        return which - v->stor_begin;
+        return min - v->stor_begin;
     }
     return -1;
 }

--- a/tests/unit/vector.c
+++ b/tests/unit/vector.c
@@ -133,21 +133,66 @@ int main() {
         printf(" %li", (long int)VECTOR(v)[i]);
     }
     printf("\n");
-    IGRAPH_ASSERT(igraph_vector_max(&v) == 100);
-    IGRAPH_ASSERT(igraph_vector_which_max(&v) == 0);
-    IGRAPH_ASSERT(igraph_vector_min(&v) == 91);
-    IGRAPH_ASSERT(igraph_vector_which_min(&v) == 9);
+    igraph_real_t min, max, min2, max2;
+    long int which_min, which_max, which_min2, which_max2;
+
+    min = igraph_vector_min(&v);
+    which_min = igraph_vector_which_min(&v);
+
+    IGRAPH_ASSERT(min == 91);
+    IGRAPH_ASSERT(which_min == 9);
+    IGRAPH_ASSERT(min == VECTOR(v)[which_min]);
+
+    max = igraph_vector_max(&v);
+    which_max = igraph_vector_which_max(&v);
+
+    IGRAPH_ASSERT(max == 100);
+    IGRAPH_ASSERT(which_max == 0);
+    IGRAPH_ASSERT(max == VECTOR(v)[which_max]);
+
+    igraph_vector_minmax(&v, &min2, &max2);
+    igraph_vector_which_minmax(&v, &which_min2, &which_max2);
+
+    IGRAPH_ASSERT(min == min2);
+    IGRAPH_ASSERT(max == max2);
+    IGRAPH_ASSERT(which_min == which_min2);
+    IGRAPH_ASSERT(which_max == which_max2);
+    IGRAPH_ASSERT(min2 == VECTOR(v)[which_min2]);
+    IGRAPH_ASSERT(max2 == VECTOR(v)[which_max2]);
 
     printf("Test NaN values\n");
     igraph_vector_push_back(&v, IGRAPH_NAN);
     igraph_vector_push_back(&v, IGRAPH_NAN);
     igraph_vector_push_back(&v, 1);
-    IGRAPH_ASSERT(igraph_is_nan(igraph_vector_max(&v)));
+
+    min = igraph_vector_min(&v);
+    which_min = igraph_vector_which_min(&v);
+
+    IGRAPH_ASSERT(igraph_is_nan(min));
     /* Index should be to first NaN value */
-    IGRAPH_ASSERT(igraph_vector_which_max(&v) == 10);
-    IGRAPH_ASSERT(igraph_is_nan(igraph_vector_min(&v)));
+    IGRAPH_ASSERT(which_min == 10);
+    IGRAPH_ASSERT(igraph_is_nan(VECTOR(v)[which_min]));
+
+    max = igraph_vector_max(&v);
+    which_max = igraph_vector_which_max(&v);
+
+    IGRAPH_ASSERT(igraph_is_nan(max));
     /* Index should be to first NaN value */
-    IGRAPH_ASSERT(igraph_vector_which_min(&v) == 10);
+    IGRAPH_ASSERT(which_max == 10);
+    /* In case of NaN it should hold that which_max == which_min */
+    IGRAPH_ASSERT(which_max == which_min);
+
+    igraph_vector_minmax(&v, &min2, &max2);
+    igraph_vector_which_minmax(&v, &which_min2, &which_max2);
+
+    IGRAPH_ASSERT(igraph_is_nan(min2));
+    IGRAPH_ASSERT(igraph_is_nan(max2));
+    IGRAPH_ASSERT(which_min == which_min2);
+    IGRAPH_ASSERT(which_max == which_max2);
+    /* In case of NaN it should hold that which_max == which_min */
+    IGRAPH_ASSERT(which_min2 == which_max2);
+    IGRAPH_ASSERT(igraph_is_nan(VECTOR(v)[which_min2]));
+    IGRAPH_ASSERT(igraph_is_nan(VECTOR(v)[which_max2]));
 
     printf("Test igraph_vector_init_copy\n");
     igraph_vector_destroy(&v);

--- a/tests/unit/vector.c
+++ b/tests/unit/vector.c
@@ -32,6 +32,8 @@ int main() {
     int i;
     igraph_real_t *ptr;
     long int pos;
+    igraph_real_t min, max, min2, max2;
+    long int which_min, which_max, which_min2, which_max2;
 
     printf("Initialise empty vector\n");
     igraph_vector_init(&v, 0);
@@ -133,8 +135,6 @@ int main() {
         printf(" %li", (long int)VECTOR(v)[i]);
     }
     printf("\n");
-    igraph_real_t min, max, min2, max2;
-    long int which_min, which_max, which_min2, which_max2;
 
     min = igraph_vector_min(&v);
     which_min = igraph_vector_which_min(&v);
@@ -164,6 +164,8 @@ int main() {
     igraph_vector_push_back(&v, IGRAPH_NAN);
     igraph_vector_push_back(&v, IGRAPH_NAN);
     igraph_vector_push_back(&v, 1);
+
+    IGRAPH_ASSERT(igraph_vector_is_any_nan(&v));
 
     min = igraph_vector_min(&v);
     which_min = igraph_vector_which_min(&v);
@@ -261,6 +263,7 @@ int main() {
     }
     IGRAPH_ASSERT(!igraph_vector_binsearch(&v, 10, 0));
     IGRAPH_ASSERT(!igraph_vector_binsearch(&v, -1, 0));
+
     for (i = 0; i < igraph_vector_size(&v); i++) {
         VECTOR(v)[i] = 2 * i;
     }


### PR DESCRIPTION
This PR fixes some remaining functions of the vector API, as was previously started in #1617, aimed at addressing issue #1560 (although this PR doesn't fix any other functions).

For any function that defines any ordering, or depends on any ordering, I included a note in the documentation that the order is undefined when NaN elements are included (which I think is the best solution). There are still a number of functions that are not documented, I have not touched these.