### PR TITLE
Add compare_communities unit tests

### DIFF
--- a/src/community/misc.c
+++ b/src/community/misc.c
@@ -727,7 +727,7 @@ static int igraph_i_compare_communities_rand(
 
     if (igraph_vector_size(v1) <= 1) {
         IGRAPH_ERRORF("Rand indices not defined for only zero or one vertices. "
-        "Found memberschip vector of size %ld", IGRAPH_EINVAL, igraph_vector_size(v1));
+        "Found membership vector of size %ld", IGRAPH_EINVAL, igraph_vector_size(v1));
     }
 
     /* Calculate the confusion matrix */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -439,6 +439,7 @@ add_legacy_tests(
   community_label_propagation
   igraph_community_infomap
   igraph_community_leading_eigenvector2
+  igraph_compare_communities
   igraph_modularity
   levc-stress
   spinglass

--- a/tests/unit/igraph_compare_communities.c
+++ b/tests/unit/igraph_compare_communities.c
@@ -1,0 +1,101 @@
+/*
+   IGraph library.
+   Copyright (C) 2021  The igraph development team <igraph@igraph.org>
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include <igraph.h>
+#include "test_utilities.inc"
+
+char *names[] = {
+    [IGRAPH_COMMCMP_VI] = "VI",
+    [IGRAPH_COMMCMP_NMI] = "NMI",
+    [IGRAPH_COMMCMP_SPLIT_JOIN] = "Split-join",
+    [IGRAPH_COMMCMP_RAND] = "Rand",
+    [IGRAPH_COMMCMP_ADJUSTED_RAND] = "Adjusted Rand",
+};
+
+
+void compare_and_print(igraph_vector_t *comm1, igraph_vector_t *comm2, igraph_community_comparison_t t, igraph_error_type_t e) {
+    igraph_real_t result;
+    printf("%s result: ", names[t]);
+    IGRAPH_ASSERT(igraph_compare_communities(comm1, comm2, &result, t) == e);
+    if (e == IGRAPH_EINVAL) {
+        printf("failed as expected\n");
+    } else {
+        printf("%g\n", result);
+    }
+}
+
+
+int main() {
+    igraph_vector_t comm1, comm2;
+    igraph_real_t result;
+
+    igraph_set_error_handler(igraph_error_handler_ignore);
+
+    printf("Only one member, both partitions equal to whole set:\n");
+    igraph_vector_init_int(&comm1, 1, 0);
+    igraph_vector_init_int(&comm2, 1, 0);
+
+
+    compare_and_print(&comm1, &comm2, IGRAPH_COMMCMP_VI, IGRAPH_SUCCESS);
+    compare_and_print(&comm1, &comm2, IGRAPH_COMMCMP_RAND, IGRAPH_EINVAL);
+    compare_and_print(&comm1, &comm2, IGRAPH_COMMCMP_ADJUSTED_RAND, IGRAPH_EINVAL);
+    compare_and_print(&comm1, &comm2, IGRAPH_COMMCMP_NMI, IGRAPH_SUCCESS);
+    compare_and_print(&comm1, &comm2, IGRAPH_COMMCMP_SPLIT_JOIN, IGRAPH_SUCCESS);
+
+    igraph_vector_destroy(&comm1);
+    igraph_vector_destroy(&comm2);
+
+    printf("\nEmpty sets:\n");
+    igraph_vector_init(&comm1, 0);
+    igraph_vector_init(&comm2, 0);
+    compare_and_print(&comm1, &comm2, IGRAPH_COMMCMP_VI, IGRAPH_SUCCESS);
+    compare_and_print(&comm1, &comm2, IGRAPH_COMMCMP_RAND, IGRAPH_EINVAL);
+    compare_and_print(&comm1, &comm2, IGRAPH_COMMCMP_ADJUSTED_RAND, IGRAPH_EINVAL);
+    compare_and_print(&comm1, &comm2, IGRAPH_COMMCMP_NMI, IGRAPH_SUCCESS);
+    compare_and_print(&comm1, &comm2, IGRAPH_COMMCMP_SPLIT_JOIN, IGRAPH_SUCCESS);
+
+    igraph_vector_destroy(&comm1);
+    igraph_vector_destroy(&comm2);
+
+    printf("\nTwo equal, differenly labeled partitions:\n");
+    igraph_vector_init_int(&comm1, 2, 0, 1);
+    igraph_vector_init_int(&comm2, 2, 1, 0);
+    compare_and_print(&comm1, &comm2, IGRAPH_COMMCMP_VI, IGRAPH_SUCCESS);
+    compare_and_print(&comm1, &comm2, IGRAPH_COMMCMP_RAND, IGRAPH_SUCCESS);
+    compare_and_print(&comm1, &comm2, IGRAPH_COMMCMP_ADJUSTED_RAND, IGRAPH_SUCCESS);
+    compare_and_print(&comm1, &comm2, IGRAPH_COMMCMP_NMI, IGRAPH_SUCCESS);
+    compare_and_print(&comm1, &comm2, IGRAPH_COMMCMP_SPLIT_JOIN, IGRAPH_SUCCESS);
+
+    igraph_vector_destroy(&comm1);
+    igraph_vector_destroy(&comm2);
+
+    printf("\nTwo different partitions: ((5,1), (8,3,4), (0,6,7,2,9)) and ((5,8), (1,3,4,0), (6,7,2,9))\n");
+    igraph_vector_init_int(&comm1, 10, 2, 0, 2, 1, 1, 0, 2, 2, 1, 2);
+    igraph_vector_init_int(&comm2, 10, 1, 1, 2, 1, 1, 0, 2, 2, 0, 2);
+    compare_and_print(&comm1, &comm2, IGRAPH_COMMCMP_VI, IGRAPH_SUCCESS);
+    compare_and_print(&comm1, &comm2, IGRAPH_COMMCMP_RAND, IGRAPH_SUCCESS);
+    compare_and_print(&comm1, &comm2, IGRAPH_COMMCMP_ADJUSTED_RAND, IGRAPH_SUCCESS);
+    compare_and_print(&comm1, &comm2, IGRAPH_COMMCMP_NMI, IGRAPH_SUCCESS);
+    compare_and_print(&comm1, &comm2, IGRAPH_COMMCMP_SPLIT_JOIN, IGRAPH_SUCCESS);
+
+    igraph_vector_destroy(&comm1);
+    igraph_vector_destroy(&comm2);
+
+    VERIFY_FINALLY_STACK();
+    return 0;
+}

--- a/tests/unit/igraph_compare_communities.c
+++ b/tests/unit/igraph_compare_communities.c
@@ -35,7 +35,8 @@ void compare_and_print(igraph_vector_t *comm1, igraph_vector_t *comm2, igraph_co
     if (e == IGRAPH_EINVAL) {
         printf("failed as expected\n");
     } else {
-        printf("%g\n", result);
+        print_real(stdout, result, "%g");
+        printf("\n");
     }
 }
 

--- a/tests/unit/igraph_compare_communities.out
+++ b/tests/unit/igraph_compare_communities.out
@@ -15,7 +15,7 @@ Split-join result: 0
 Two equal, differenly labeled partitions:
 VI result: 0
 Rand result: 1
-Adjusted Rand result: -nan
+Adjusted Rand result: NaN
 NMI result: 1
 Split-join result: 0
 

--- a/tests/unit/igraph_compare_communities.out
+++ b/tests/unit/igraph_compare_communities.out
@@ -1,0 +1,27 @@
+Only one member, both partitions equal to whole set:
+VI result: 0
+Rand result: failed as expected
+Adjusted Rand result: failed as expected
+NMI result: 1
+Split-join result: 0
+
+Empty sets:
+VI result: 0
+Rand result: failed as expected
+Adjusted Rand result: failed as expected
+NMI result: 1
+Split-join result: 0
+
+Two equal, differenly labeled partitions:
+VI result: 0
+Rand result: 1
+Adjusted Rand result: -nan
+NMI result: 1
+Split-join result: 0
+
+Two different partitions: ((5,1), (8,3,4), (0,6,7,2,9)) and ((5,8), (1,3,4,0), (6,7,2,9))
+VI result: 1.1343
+Rand result: 0.711111
+Adjusted Rand result: 0.312573
+NMI result: 0.455859
+Split-join result: 6


### PR DESCRIPTION
Part of #1592

The Adjusted Rand on 2 vertices in 2 clusters still outputs -NaN,
but that seems correct and a bit excessive to check for up front.

I'm not sure why this function is used instead of just having separate
function calls. Separate function calls would also clear up the
documentation.