### PR TITLE
Add le_community_to_membership unit tests

### DIFF
--- a/src/community/leading_eigenvector.c
+++ b/src/community/leading_eigenvector.c
@@ -1007,13 +1007,13 @@ int igraph_le_community_to_membership(const igraph_matrix_t *merges,
     long int components, i;
 
     if (no_of_nodes > 0) {
-            components = (long int) igraph_vector_max(membership) + 1;
+        components = (long int) igraph_vector_max(membership) + 1;
     } else {
         components = 0;
     }
     if (components > no_of_nodes) {
         IGRAPH_ERRORF("Invalid membership vector, number of components is %ld, but should "
-         "not be greather than number of nodes, which is %ld.", IGRAPH_EINVAL, components, no_of_nodes);
+         "not be greater than the number of nodes, which is %ld.", IGRAPH_EINVAL, components, no_of_nodes);
     }
     if (steps >= components) {
         IGRAPH_ERRORF("Number of steps should be smaller than number of components. "

--- a/src/community/leading_eigenvector.c
+++ b/src/community/leading_eigenvector.c
@@ -984,9 +984,10 @@ int igraph_community_leading_eigenvector(const igraph_t *graph,
  * It takes \c membership
  * and performs \c steps merges, according to the supplied
  * \c merges matrix.
- * \param merges The matrix defining the merges to make.
- *     This is usually from the output of the leading eigenvector community
- *     structure detection routines.
+ * \param merges The two-column matrix containing the merge
+ *    operations. See \ref igraph_community_walktrap() for the
+ *    detailed syntax. This is usually from the output of the
+ *    leading eigenvector community structure detection routines.
  * \param steps The number of steps to make according to \c merges.
  * \param membership Initially the starting membership vector,
  *     on output the resulting membership vector, after performing \c steps merges.
@@ -1005,17 +1006,19 @@ int igraph_le_community_to_membership(const igraph_matrix_t *merges,
     igraph_vector_t fake_memb;
     long int components, i;
 
-    if (igraph_matrix_nrow(merges) < steps) {
-        IGRAPH_ERROR("`steps' to big or `merges' matrix too short", IGRAPH_EINVAL);
+    if (no_of_nodes > 0) {
+            components = (long int) igraph_vector_max(membership) + 1;
+    } else {
+        components = 0;
     }
-
-    components = (long int) igraph_vector_max(membership) + 1;
     if (components > no_of_nodes) {
-        IGRAPH_ERROR("Invalid membership vector, too many components", IGRAPH_EINVAL);
+        IGRAPH_ERRORF("Invalid membership vector, number of components is %ld, but should "
+         "not be greather than number of nodes, which is %ld.", IGRAPH_EINVAL, components, no_of_nodes);
     }
     if (steps >= components) {
-        IGRAPH_ERROR("Cannot make `steps' steps from supplied membership vector",
-                     IGRAPH_EINVAL);
+        IGRAPH_ERRORF("Number of steps should be smaller than number of components. "
+                     "Found %" IGRAPH_PRId " steps, %ld components.",
+                     IGRAPH_EINVAL, steps, components);
     }
 
     IGRAPH_VECTOR_INIT_FINALLY(&fake_memb, components);
@@ -1023,13 +1026,13 @@ int igraph_le_community_to_membership(const igraph_matrix_t *merges,
     /* Check membership vector */
     for (i = 0; i < no_of_nodes; i++) {
         if (VECTOR(*membership)[i] < 0) {
-            IGRAPH_ERROR("Invalid membership vector, negative id", IGRAPH_EINVAL);
+            IGRAPH_ERRORF("Invalid membership vector, negative id found: %g.", IGRAPH_EINVAL, VECTOR(*membership)[i]);
         }
         VECTOR(fake_memb)[ (long int) VECTOR(*membership)[i] ] += 1;
     }
     for (i = 0; i < components; i++) {
         if (VECTOR(fake_memb)[i] == 0) {
-            IGRAPH_ERROR("Invalid membership vector, empty cluster", IGRAPH_EINVAL);
+            IGRAPH_ERRORF("Invalid membership vector, empty cluster found, with index %ld.", IGRAPH_EINVAL, i);
         }
     }
 

--- a/src/community/misc.c
+++ b/src/community/misc.c
@@ -106,7 +106,7 @@ int igraph_community_to_membership(const igraph_matrix_t *merges,
     long int components = no_of_nodes - steps;
     long int i, found = 0;
     igraph_vector_t tmp;
-    igraph_vector_t already_merged;
+    igraph_vector_bool_t already_merged;
 
     if (steps > igraph_matrix_nrow(merges)) {
         IGRAPH_ERRORF("Number of steps is greater than number of rows in merges matrix: found %"
@@ -131,7 +131,7 @@ int igraph_community_to_membership(const igraph_matrix_t *merges,
         igraph_vector_null(csize);
     }
 
-    IGRAPH_VECTOR_INIT_FINALLY(&already_merged, steps + no_of_nodes);
+    IGRAPH_VECTOR_BOOL_INIT_FINALLY(&already_merged, steps + no_of_nodes);
     IGRAPH_VECTOR_INIT_FINALLY(&tmp, steps);
 
     for (i = steps - 1; i >= 0; i--) {
@@ -201,7 +201,7 @@ int igraph_community_to_membership(const igraph_matrix_t *merges,
     }
 
     igraph_vector_destroy(&tmp);
-    igraph_vector_destroy(&already_merged);
+    igraph_vector_bool_destroy(&already_merged);
     IGRAPH_FINALLY_CLEAN(2);
 
     return 0;

--- a/src/community/misc.c
+++ b/src/community/misc.c
@@ -139,12 +139,12 @@ int igraph_community_to_membership(const igraph_matrix_t *merges,
         long int c2 = (long int) MATRIX(*merges, i, 1);
 
         if (VECTOR(already_merged)[c1] == 0) {
-                VECTOR(already_merged)[c1] = 1;
+            VECTOR(already_merged)[c1] = 1;
         } else {
             IGRAPH_ERRORF("Merges matrix contains multiple merges of cluster %ld.", IGRAPH_EINVAL, c1);
         }
         if (VECTOR(already_merged)[c2] == 0) {
-                VECTOR(already_merged)[c2] = 1;
+            VECTOR(already_merged)[c2] = 1;
         } else {
             IGRAPH_ERRORF("Merges matrix contains multiple merges of cluster %ld.", IGRAPH_EINVAL, c2);
         }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -440,6 +440,7 @@ add_legacy_tests(
   igraph_community_infomap
   igraph_community_leading_eigenvector2
   igraph_compare_communities
+  igraph_le_community_to_membership
   igraph_modularity
   levc-stress
   spinglass

--- a/tests/unit/igraph_le_community_to_membership.c
+++ b/tests/unit/igraph_le_community_to_membership.c
@@ -1,0 +1,110 @@
+/*
+   IGraph library.
+   Copyright (C) 2021  The igraph development team <igraph@igraph.org>
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include <igraph.h>
+#include "test_utilities.inc"
+
+void print_and_destroy(igraph_vector_t *membership, igraph_vector_t *csize, igraph_matrix_t *mat) {
+    printf("Membership: ");
+    igraph_vector_print(membership);
+    printf("Csize: ");
+    igraph_vector_print(csize);
+    printf("\n");
+    igraph_vector_destroy(membership);
+    igraph_matrix_destroy(mat);
+}
+
+int main() {
+    igraph_matrix_t merges;
+    igraph_vector_t membership;
+    igraph_vector_t csize;
+
+    igraph_vector_init_int(&csize, 0);
+
+    printf("One member:\n");
+    igraph_vector_init_int(&membership, 1, 0);
+    igraph_matrix_init(&merges, 0, 2);
+    IGRAPH_ASSERT(igraph_le_community_to_membership(&merges, /*steps*/ 0, &membership, &csize) == IGRAPH_SUCCESS);
+    print_and_destroy(&membership, &csize, &merges);
+
+    printf("Five singleton clusters, one merge:\n");
+    igraph_vector_init_int(&membership, 5, 0, 1, 2, 3, 4);
+    {
+        int elem[] = {1, 3};
+        matrix_init_int(&merges, 1, 2, elem);
+    }
+    IGRAPH_ASSERT(igraph_le_community_to_membership(&merges, /*steps*/ 1, &membership, &csize) == IGRAPH_SUCCESS);
+    print_and_destroy(&membership, &csize, &merges);
+
+    printf("Six clusters, two merges:\n");
+    igraph_vector_init_int(&membership, 12, 0, 0, 1, 2, 2, 3, 3, 4, 4, 5, 5, 5);
+    {
+        int elem[] = {0,3, 2,5};
+        matrix_init_int(&merges, 2, 2, elem);
+    }
+    IGRAPH_ASSERT(igraph_le_community_to_membership(&merges, /*steps*/ 2, &membership, &csize) == IGRAPH_SUCCESS);
+    print_and_destroy(&membership, &csize, &merges);
+
+
+    printf("These should fail nicely:\n");
+    igraph_set_error_handler(igraph_error_handler_ignore);
+
+    printf("Five singleton clusters, two merges, but second merge refers to singleton which is already merged.\n");
+    igraph_vector_init_int(&membership, 5, 0, 1, 2, 3, 4);
+    {
+        int elem[] = {1,3, 1,4,};
+        matrix_init_int(&merges, 2, 2, elem);
+    }
+    IGRAPH_ASSERT(igraph_le_community_to_membership(&merges, /*steps*/ 2, &membership, &csize) == IGRAPH_EINVAL);
+    igraph_vector_destroy(&membership);
+    igraph_matrix_destroy(&merges);
+
+    printf("Negative cluster index.\n");
+    igraph_vector_init_int(&membership, 5, -1, 0, 1, 2, 3);
+    {
+        int elem[] = {1,2, 3,4,};
+        matrix_init_int(&merges, 2, 2, elem);
+    }
+    IGRAPH_ASSERT(igraph_le_community_to_membership(&merges, /*steps*/ 2, &membership, &csize) == IGRAPH_EINVAL);
+    igraph_vector_destroy(&membership);
+    igraph_matrix_destroy(&merges);
+
+    printf("Skip a cluster index.\n");
+    igraph_vector_init_int(&membership, 5, 0, 0, 2, 3, 4);
+    {
+        int elem[] = {1,2, 3,4,};
+        matrix_init_int(&merges, 2, 2, elem);
+    }
+    IGRAPH_ASSERT(igraph_le_community_to_membership(&merges, /*steps*/ 2, &membership, &csize) == IGRAPH_EINVAL);
+    igraph_vector_destroy(&membership);
+    igraph_matrix_destroy(&merges);
+
+    printf("Too many steps.\n");
+    igraph_vector_init_int(&membership, 5, 0, 1, 2, 3, 4);
+    {
+        int elem[] = {1,2, 3,4,};
+        matrix_init_int(&merges, 2, 2, elem);
+    }
+    IGRAPH_ASSERT(igraph_le_community_to_membership(&merges, /*steps*/ 20, &membership, &csize) == IGRAPH_EINVAL);
+    igraph_vector_destroy(&membership);
+    igraph_matrix_destroy(&merges);
+
+    igraph_vector_destroy(&csize);
+    VERIFY_FINALLY_STACK();
+    return 0;
+}

--- a/tests/unit/igraph_le_community_to_membership.c
+++ b/tests/unit/igraph_le_community_to_membership.c
@@ -46,7 +46,7 @@ int main() {
     igraph_vector_init_int(&membership, 5, 0, 1, 2, 3, 4);
     {
         int elem[] = {1, 3};
-        matrix_init_int(&merges, 1, 2, elem);
+        matrix_init_int_row_major(&merges, 1, 2, elem);
     }
     IGRAPH_ASSERT(igraph_le_community_to_membership(&merges, /*steps*/ 1, &membership, &csize) == IGRAPH_SUCCESS);
     print_and_destroy(&membership, &csize, &merges);
@@ -55,7 +55,7 @@ int main() {
     igraph_vector_init_int(&membership, 12, 0, 0, 1, 2, 2, 3, 3, 4, 4, 5, 5, 5);
     {
         int elem[] = {0,3, 2,5};
-        matrix_init_int(&merges, 2, 2, elem);
+        matrix_init_int_row_major(&merges, 2, 2, elem);
     }
     IGRAPH_ASSERT(igraph_le_community_to_membership(&merges, /*steps*/ 2, &membership, &csize) == IGRAPH_SUCCESS);
     print_and_destroy(&membership, &csize, &merges);
@@ -68,7 +68,7 @@ int main() {
     igraph_vector_init_int(&membership, 5, 0, 1, 2, 3, 4);
     {
         int elem[] = {1,3, 1,4,};
-        matrix_init_int(&merges, 2, 2, elem);
+        matrix_init_int_row_major(&merges, 2, 2, elem);
     }
     IGRAPH_ASSERT(igraph_le_community_to_membership(&merges, /*steps*/ 2, &membership, &csize) == IGRAPH_EINVAL);
     igraph_vector_destroy(&membership);
@@ -78,7 +78,7 @@ int main() {
     igraph_vector_init_int(&membership, 5, -1, 0, 1, 2, 3);
     {
         int elem[] = {1,2, 3,4,};
-        matrix_init_int(&merges, 2, 2, elem);
+        matrix_init_int_row_major(&merges, 2, 2, elem);
     }
     IGRAPH_ASSERT(igraph_le_community_to_membership(&merges, /*steps*/ 2, &membership, &csize) == IGRAPH_EINVAL);
     igraph_vector_destroy(&membership);
@@ -88,7 +88,7 @@ int main() {
     igraph_vector_init_int(&membership, 5, 0, 0, 2, 3, 4);
     {
         int elem[] = {1,2, 3,4,};
-        matrix_init_int(&merges, 2, 2, elem);
+        matrix_init_int_row_major(&merges, 2, 2, elem);
     }
     IGRAPH_ASSERT(igraph_le_community_to_membership(&merges, /*steps*/ 2, &membership, &csize) == IGRAPH_EINVAL);
     igraph_vector_destroy(&membership);
@@ -98,7 +98,7 @@ int main() {
     igraph_vector_init_int(&membership, 5, 0, 1, 2, 3, 4);
     {
         int elem[] = {1,2, 3,4,};
-        matrix_init_int(&merges, 2, 2, elem);
+        matrix_init_int_row_major(&merges, 2, 2, elem);
     }
     IGRAPH_ASSERT(igraph_le_community_to_membership(&merges, /*steps*/ 20, &membership, &csize) == IGRAPH_EINVAL);
     igraph_vector_destroy(&membership);

--- a/tests/unit/igraph_le_community_to_membership.out
+++ b/tests/unit/igraph_le_community_to_membership.out
@@ -1,0 +1,17 @@
+One member:
+Membership: 0
+Csize: 1
+
+Five singleton clusters, one merge:
+Membership: 1 0 2 0 3
+Csize: 2 1 1 1
+
+Six clusters, two merges:
+Membership: 1 1 2 0 0 1 1 3 3 0 0 0
+Csize: 5 4 1 2
+
+These should fail nicely:
+Five singleton clusters, two merges, but second merge refers to singleton which is already merged.
+Negative cluster index.
+Skip a cluster index.
+Too many steps.

--- a/tests/unit/test_utilities.inc
+++ b/tests/unit/test_utilities.inc
@@ -296,7 +296,7 @@ void print_matrix_complex_first_row_positive(const igraph_matrix_complex_t *matr
     igraph_matrix_complex_destroy(&copy);
 }
 
-void matrix_init_int(igraph_matrix_t *mat, int ncol, int nrow, int* elem) {
+void matrix_init_int_row_major(igraph_matrix_t *mat, int ncol, int nrow, int* elem) {
     int c, r;
     int i_elem = 0;
     igraph_matrix_init(mat, ncol, nrow);

--- a/tests/unit/test_utilities.inc
+++ b/tests/unit/test_utilities.inc
@@ -296,6 +296,18 @@ void print_matrix_complex_first_row_positive(const igraph_matrix_complex_t *matr
     igraph_matrix_complex_destroy(&copy);
 }
 
+void matrix_init_int(igraph_matrix_t *mat, int ncol, int nrow, int* elem) {
+    int c, r;
+    int i_elem = 0;
+    igraph_matrix_init(mat, ncol, nrow);
+    for (r = 0; r < nrow; r++) {
+        for (c = 0; c < ncol; c++) {
+            MATRIX(*mat, r, c) = elem[i_elem];
+            i_elem++;
+        }
+    }
+}
+
 #define VERIFY_FINALLY_STACK() \
     if (!IGRAPH_FINALLY_STACK_EMPTY) { \
         printf( \


### PR DESCRIPTION
Part of #1592

I removed the
`igraph_matrix_nrow(merges) < steps`
test from le_community_to membership, because doesn't do any good there and is already tested in community_to_membership.

I added a 'already merged' test to community_to_membership because it shouldn't happen and gives unexpected results.