### PR TITLE
private functions used in tests are now exported from the shared library

### DIFF
--- a/include/igraph_decls.h
+++ b/include/igraph_decls.h
@@ -13,3 +13,7 @@
 
 /* Include the definition of macros controlling symbol visibility */
 #include "igraph_export.h"
+
+/* Used instead of IGRAPH_EXPORT with functions that need to be tested,
+ * but are not part of the public API. */
+#define IGRAPH_PRIVATE_EXPORT IGRAPH_EXPORT

--- a/include/igraph_flow.h
+++ b/include/igraph_flow.h
@@ -122,18 +122,7 @@ IGRAPH_EXPORT int igraph_residual_graph(const igraph_t *graph,
                                         igraph_t *residual,
                                         igraph_vector_t *residual_capacity,
                                         const igraph_vector_t *flow);
-int igraph_i_residual_graph(const igraph_t *graph,
-                            const igraph_vector_t *capacity,
-                            igraph_t *residual,
-                            igraph_vector_t *residual_capacity,
-                            const igraph_vector_t *flow,
-                            igraph_vector_t *tmp);
 
-int igraph_i_reverse_residual_graph(const igraph_t *graph,
-                                    const igraph_vector_t *capacity,
-                                    igraph_t *residual,
-                                    const igraph_vector_t *flow,
-                                    igraph_vector_t *tmp);
 IGRAPH_EXPORT int igraph_reverse_residual_graph(const igraph_t *graph,
                                                 const igraph_vector_t *capacity,
                                                 igraph_t *residual,

--- a/include/igraph_spmatrix.h
+++ b/include/igraph_spmatrix.h
@@ -89,11 +89,6 @@ IGRAPH_EXPORT int igraph_spmatrix_rowsums(const igraph_spmatrix_t *m, igraph_vec
 IGRAPH_EXPORT int igraph_spmatrix_print(const igraph_spmatrix_t *matrix);
 IGRAPH_EXPORT int igraph_spmatrix_fprint(const igraph_spmatrix_t *matrix, FILE* file);
 
-IGRAPH_EXPORT int igraph_i_spmatrix_get_col_nonzero_indices(const igraph_spmatrix_t *m,
-                                                            igraph_vector_t *res, long int col);
-IGRAPH_EXPORT int igraph_i_spmatrix_clear_row_fast(igraph_spmatrix_t *m, long int row);
-IGRAPH_EXPORT int igraph_i_spmatrix_cleanup(igraph_spmatrix_t *m);
-
 
 typedef struct s_spmatrix_iter {
     const igraph_spmatrix_t *m; /* pointer to the matrix we are iterating over */

--- a/include/igraph_visitor.h
+++ b/include/igraph_visitor.h
@@ -85,9 +85,9 @@ IGRAPH_EXPORT int igraph_bfs(const igraph_t *graph,
                              igraph_vector_t *dist, igraph_bfshandler_t *callback,
                              void *extra);
 
-int igraph_i_bfs(igraph_t *graph, igraph_integer_t vid, igraph_neimode_t mode,
-                 igraph_vector_t *vids, igraph_vector_t *layers,
-                 igraph_vector_t *parents);
+IGRAPH_PRIVATE_EXPORT int igraph_i_bfs(igraph_t *graph, igraph_integer_t vid, igraph_neimode_t mode,
+                                       igraph_vector_t *vids, igraph_vector_t *layers,
+                                       igraph_vector_t *parents);
 
 /**
  * \function igraph_dfshandler_t

--- a/src/core/cutheap.h
+++ b/src/core/cutheap.h
@@ -47,16 +47,16 @@ typedef struct igraph_i_cutheap_t {
     long int dnodes;
 } igraph_i_cutheap_t;
 
-int igraph_i_cutheap_init(igraph_i_cutheap_t *ch, igraph_integer_t nodes);
-void igraph_i_cutheap_destroy(igraph_i_cutheap_t *ch);
-igraph_bool_t igraph_i_cutheap_empty(igraph_i_cutheap_t *ch);
-igraph_integer_t igraph_i_cutheap_active_size(igraph_i_cutheap_t *ch);
-igraph_integer_t igraph_i_cutheap_size(igraph_i_cutheap_t *ch);
-igraph_real_t igraph_i_cutheap_maxvalue(igraph_i_cutheap_t *ch);
-igraph_integer_t igraph_i_cutheap_popmax(igraph_i_cutheap_t *ch);
-int igraph_i_cutheap_update(igraph_i_cutheap_t *ch, igraph_integer_t index,
-                            igraph_real_t add);
-int igraph_i_cutheap_reset_undefine(igraph_i_cutheap_t *ch, long int vertex);
+IGRAPH_PRIVATE_EXPORT int igraph_i_cutheap_init(igraph_i_cutheap_t *ch, igraph_integer_t nodes);
+IGRAPH_PRIVATE_EXPORT void igraph_i_cutheap_destroy(igraph_i_cutheap_t *ch);
+IGRAPH_PRIVATE_EXPORT igraph_bool_t igraph_i_cutheap_empty(igraph_i_cutheap_t *ch);
+IGRAPH_PRIVATE_EXPORT igraph_integer_t igraph_i_cutheap_active_size(igraph_i_cutheap_t *ch);
+IGRAPH_PRIVATE_EXPORT igraph_integer_t igraph_i_cutheap_size(igraph_i_cutheap_t *ch);
+IGRAPH_PRIVATE_EXPORT igraph_real_t igraph_i_cutheap_maxvalue(igraph_i_cutheap_t *ch);
+IGRAPH_PRIVATE_EXPORT igraph_integer_t igraph_i_cutheap_popmax(igraph_i_cutheap_t *ch);
+IGRAPH_PRIVATE_EXPORT int igraph_i_cutheap_update(igraph_i_cutheap_t *ch, igraph_integer_t index,
+                                                  igraph_real_t add);
+IGRAPH_PRIVATE_EXPORT int igraph_i_cutheap_reset_undefine(igraph_i_cutheap_t *ch, long int vertex);
 
 __END_DECLS
 

--- a/src/core/estack.h
+++ b/src/core/estack.h
@@ -32,16 +32,16 @@ typedef struct igraph_estack_t {
     igraph_vector_bool_t isin;
 } igraph_estack_t;
 
-int igraph_estack_init(igraph_estack_t *s, long int setsize,
-                       long int stacksize);
-void igraph_estack_destroy(igraph_estack_t *s);
+IGRAPH_PRIVATE_EXPORT int igraph_estack_init(igraph_estack_t *s, long int setsize,
+                                             long int stacksize);
+IGRAPH_PRIVATE_EXPORT void igraph_estack_destroy(igraph_estack_t *s);
 
-int igraph_estack_push(igraph_estack_t *s,  long int elem);
-long int igraph_estack_pop(igraph_estack_t *s);
-igraph_bool_t igraph_estack_iselement(const igraph_estack_t *s,
-                                      long int elem);
-long int igraph_estack_size(const igraph_estack_t *s);
+IGRAPH_PRIVATE_EXPORT int igraph_estack_push(igraph_estack_t *s, long int elem);
+IGRAPH_PRIVATE_EXPORT long int igraph_estack_pop(igraph_estack_t *s);
+IGRAPH_PRIVATE_EXPORT igraph_bool_t igraph_estack_iselement(const igraph_estack_t *s,
+                                                            long int elem);
+IGRAPH_PRIVATE_EXPORT long int igraph_estack_size(const igraph_estack_t *s);
 
-int igraph_estack_print(const igraph_estack_t *s);
+IGRAPH_PRIVATE_EXPORT int igraph_estack_print(const igraph_estack_t *s);
 
 #endif

--- a/src/core/hashtable.h
+++ b/src/core/hashtable.h
@@ -48,19 +48,19 @@ typedef struct igraph_hashtable_t {
     igraph_strvector_t defaults;
 } igraph_hashtable_t;
 
-int igraph_hashtable_init(igraph_hashtable_t *ht);
-void igraph_hashtable_destroy(igraph_hashtable_t *ht);
-int igraph_hashtable_addset(igraph_hashtable_t *ht,
-                            const char *key, const char *def,
-                            const char *elem);
-int igraph_hashtable_addset2(igraph_hashtable_t *ht,
-                             const char *key, const char *def,
-                             const char *elem, int elemlen);
-int igraph_hashtable_get(igraph_hashtable_t *ht,
-                         const char *key, char **elem);
-int igraph_hashtable_getkeys(igraph_hashtable_t *ht,
-                             const igraph_strvector_t **sv);
-int igraph_hashtable_reset(igraph_hashtable_t *ht);
+IGRAPH_PRIVATE_EXPORT int igraph_hashtable_init(igraph_hashtable_t *ht);
+IGRAPH_PRIVATE_EXPORT void igraph_hashtable_destroy(igraph_hashtable_t *ht);
+IGRAPH_PRIVATE_EXPORT int igraph_hashtable_addset(igraph_hashtable_t *ht,
+                                                  const char *key, const char *def,
+                                                  const char *elem);
+IGRAPH_PRIVATE_EXPORT int igraph_hashtable_addset2(igraph_hashtable_t *ht,
+                                                   const char *key, const char *def,
+                                                   const char *elem, int elemlen);
+IGRAPH_PRIVATE_EXPORT int igraph_hashtable_get(igraph_hashtable_t *ht,
+                                               const char *key, char **elem);
+IGRAPH_PRIVATE_EXPORT int igraph_hashtable_getkeys(igraph_hashtable_t *ht,
+                                                   const igraph_strvector_t **sv);
+IGRAPH_PRIVATE_EXPORT int igraph_hashtable_reset(igraph_hashtable_t *ht);
 
 __END_DECLS
 

--- a/src/core/indheap.h
+++ b/src/core/indheap.h
@@ -102,16 +102,16 @@ typedef struct s_indheap_d {
 
 #define IGRAPH_D_INDHEAP_NULL { 0,0,0,0,0,0 }
 
-int igraph_d_indheap_init           (igraph_d_indheap_t* h, long int size);
-void igraph_d_indheap_destroy        (igraph_d_indheap_t* h);
-igraph_bool_t igraph_d_indheap_empty          (igraph_d_indheap_t* h);
-int igraph_d_indheap_push           (igraph_d_indheap_t* h, igraph_real_t elem,
-                                     long int idx, long int idx2);
-igraph_real_t igraph_d_indheap_max       (igraph_d_indheap_t* h);
-igraph_real_t igraph_d_indheap_delete_max(igraph_d_indheap_t* h);
-long int igraph_d_indheap_size      (igraph_d_indheap_t* h);
-int igraph_d_indheap_reserve        (igraph_d_indheap_t* h, long int size);
-void igraph_d_indheap_max_index(igraph_d_indheap_t *h, long int *idx, long int *idx2);
+IGRAPH_PRIVATE_EXPORT int igraph_d_indheap_init(igraph_d_indheap_t *h, long int size);
+IGRAPH_PRIVATE_EXPORT void igraph_d_indheap_destroy(igraph_d_indheap_t *h);
+IGRAPH_PRIVATE_EXPORT igraph_bool_t igraph_d_indheap_empty(igraph_d_indheap_t *h);
+IGRAPH_PRIVATE_EXPORT int igraph_d_indheap_push(igraph_d_indheap_t *h, igraph_real_t elem,
+                                                long int idx, long int idx2);
+IGRAPH_PRIVATE_EXPORT igraph_real_t igraph_d_indheap_max(igraph_d_indheap_t *h);
+IGRAPH_PRIVATE_EXPORT igraph_real_t igraph_d_indheap_delete_max(igraph_d_indheap_t *h);
+IGRAPH_PRIVATE_EXPORT long int igraph_d_indheap_size(igraph_d_indheap_t *h);
+IGRAPH_PRIVATE_EXPORT int igraph_d_indheap_reserve(igraph_d_indheap_t *h, long int size);
+IGRAPH_PRIVATE_EXPORT void igraph_d_indheap_max_index(igraph_d_indheap_t *h, long int *idx, long int *idx2);
 
 void igraph_d_indheap_i_build(igraph_d_indheap_t* h, long int head);
 void igraph_d_indheap_i_shift_up(igraph_d_indheap_t* h, long int elem);
@@ -134,24 +134,24 @@ typedef struct igraph_2wheap_t {
     igraph_vector_long_t index2;
 } igraph_2wheap_t;
 
-int igraph_2wheap_init(igraph_2wheap_t *h, long int size);
-void igraph_2wheap_destroy(igraph_2wheap_t *h);
-int igraph_2wheap_clear(igraph_2wheap_t *h);
-int igraph_2wheap_push_with_index(igraph_2wheap_t *h,
-                                  long int idx, igraph_real_t elem);
-igraph_bool_t igraph_2wheap_empty(const igraph_2wheap_t *h);
-long int igraph_2wheap_size(const igraph_2wheap_t *h);
-long int igraph_2wheap_max_size(const igraph_2wheap_t *h);
-igraph_real_t igraph_2wheap_max(const igraph_2wheap_t *h);
-long int igraph_2wheap_max_index(const igraph_2wheap_t *h);
-igraph_real_t igraph_2wheap_deactivate_max(igraph_2wheap_t *h);
-igraph_bool_t igraph_2wheap_has_elem(const igraph_2wheap_t *h, long int idx);
-igraph_bool_t igraph_2wheap_has_active(const igraph_2wheap_t *h, long int idx);
-igraph_real_t igraph_2wheap_get(const igraph_2wheap_t *h, long int idx);
-igraph_real_t igraph_2wheap_delete_max(igraph_2wheap_t *h);
-igraph_real_t igraph_2wheap_delete_max_index(igraph_2wheap_t *h, long int *idx);
-int igraph_2wheap_modify(igraph_2wheap_t *h, long int idx, igraph_real_t elem);
-int igraph_2wheap_check(igraph_2wheap_t *h);
+IGRAPH_PRIVATE_EXPORT int igraph_2wheap_init(igraph_2wheap_t *h, long int size);
+IGRAPH_PRIVATE_EXPORT void igraph_2wheap_destroy(igraph_2wheap_t *h);
+IGRAPH_PRIVATE_EXPORT int igraph_2wheap_clear(igraph_2wheap_t *h);
+IGRAPH_PRIVATE_EXPORT int igraph_2wheap_push_with_index(igraph_2wheap_t *h,
+                                                        long int idx, igraph_real_t elem);
+IGRAPH_PRIVATE_EXPORT igraph_bool_t igraph_2wheap_empty(const igraph_2wheap_t *h);
+IGRAPH_PRIVATE_EXPORT long int igraph_2wheap_size(const igraph_2wheap_t *h);
+IGRAPH_PRIVATE_EXPORT long int igraph_2wheap_max_size(const igraph_2wheap_t *h);
+IGRAPH_PRIVATE_EXPORT igraph_real_t igraph_2wheap_max(const igraph_2wheap_t *h);
+IGRAPH_PRIVATE_EXPORT long int igraph_2wheap_max_index(const igraph_2wheap_t *h);
+IGRAPH_PRIVATE_EXPORT igraph_real_t igraph_2wheap_deactivate_max(igraph_2wheap_t *h);
+IGRAPH_PRIVATE_EXPORT igraph_bool_t igraph_2wheap_has_elem(const igraph_2wheap_t *h, long int idx);
+IGRAPH_PRIVATE_EXPORT igraph_bool_t igraph_2wheap_has_active(const igraph_2wheap_t *h, long int idx);
+IGRAPH_PRIVATE_EXPORT igraph_real_t igraph_2wheap_get(const igraph_2wheap_t *h, long int idx);
+IGRAPH_PRIVATE_EXPORT igraph_real_t igraph_2wheap_delete_max(igraph_2wheap_t *h);
+IGRAPH_PRIVATE_EXPORT igraph_real_t igraph_2wheap_delete_max_index(igraph_2wheap_t *h, long int *idx);
+IGRAPH_PRIVATE_EXPORT int igraph_2wheap_modify(igraph_2wheap_t *h, long int idx, igraph_real_t elem);
+IGRAPH_PRIVATE_EXPORT int igraph_2wheap_check(igraph_2wheap_t *h);
 
 __END_DECLS
 

--- a/src/core/marked_queue.h
+++ b/src/core/marked_queue.h
@@ -46,25 +46,25 @@ typedef struct igraph_marked_queue_t {
     long int size;
 } igraph_marked_queue_t;
 
-int igraph_marked_queue_init(igraph_marked_queue_t *q,
-                             long int size);
-void igraph_marked_queue_destroy(igraph_marked_queue_t *q);
-void igraph_marked_queue_reset(igraph_marked_queue_t *q);
+IGRAPH_PRIVATE_EXPORT int igraph_marked_queue_init(igraph_marked_queue_t *q,
+                                                   long int size);
+IGRAPH_PRIVATE_EXPORT void igraph_marked_queue_destroy(igraph_marked_queue_t *q);
+IGRAPH_PRIVATE_EXPORT void igraph_marked_queue_reset(igraph_marked_queue_t *q);
 
-igraph_bool_t igraph_marked_queue_empty(const igraph_marked_queue_t *q);
-long int igraph_marked_queue_size(const igraph_marked_queue_t *q);
-int igraph_marked_queue_print(const igraph_marked_queue_t *q);
-int igraph_marked_queue_fprint(const igraph_marked_queue_t *q, FILE *file);
+IGRAPH_PRIVATE_EXPORT igraph_bool_t igraph_marked_queue_empty(const igraph_marked_queue_t *q);
+IGRAPH_PRIVATE_EXPORT long int igraph_marked_queue_size(const igraph_marked_queue_t *q);
 
-igraph_bool_t igraph_marked_queue_iselement(const igraph_marked_queue_t *q,
-        long int elem);
+IGRAPH_PRIVATE_EXPORT int igraph_marked_queue_print(const igraph_marked_queue_t *q);
+IGRAPH_PRIVATE_EXPORT int igraph_marked_queue_fprint(const igraph_marked_queue_t *q, FILE *file);
 
-int igraph_marked_queue_push(igraph_marked_queue_t *q, long int elem);
+IGRAPH_PRIVATE_EXPORT igraph_bool_t igraph_marked_queue_iselement(const igraph_marked_queue_t *q,
+                                                                  long int elem);
+IGRAPH_PRIVATE_EXPORT int igraph_marked_queue_push(igraph_marked_queue_t *q, long int elem);
 
-int igraph_marked_queue_start_batch(igraph_marked_queue_t *q);
-void igraph_marked_queue_pop_back_batch(igraph_marked_queue_t *q);
+IGRAPH_PRIVATE_EXPORT int igraph_marked_queue_start_batch(igraph_marked_queue_t *q);
+IGRAPH_PRIVATE_EXPORT void igraph_marked_queue_pop_back_batch(igraph_marked_queue_t *q);
 
-int igraph_marked_queue_as_vector(const igraph_marked_queue_t *q,
-                                  igraph_vector_t *vec);
+IGRAPH_PRIVATE_EXPORT int igraph_marked_queue_as_vector(const igraph_marked_queue_t *q,
+                                                        igraph_vector_t *vec);
 
 #endif

--- a/src/core/set.h
+++ b/src/core/set.h
@@ -57,17 +57,17 @@ typedef struct s_set {
     do { IGRAPH_CHECK(igraph_set_init(v, size)); \
         IGRAPH_FINALLY(igraph_set_destroy, v); } while (0)
 
-int igraph_set_init(igraph_set_t* set, long int size);
-void igraph_set_destroy(igraph_set_t* set);
-igraph_bool_t igraph_set_inited(igraph_set_t* set);
-int igraph_set_reserve(igraph_set_t* set, long int size);
-igraph_bool_t igraph_set_empty(const igraph_set_t* set);
-void igraph_set_clear(igraph_set_t* set);
-long int igraph_set_size(const igraph_set_t* set);
-int igraph_set_add(igraph_set_t* v, igraph_integer_t e);
-igraph_bool_t igraph_set_contains(igraph_set_t* set, igraph_integer_t e);
-igraph_bool_t igraph_set_iterate(igraph_set_t* set, long int* state,
-                                 igraph_integer_t* element);
+IGRAPH_PRIVATE_EXPORT int igraph_set_init(igraph_set_t* set, long int size);
+IGRAPH_PRIVATE_EXPORT void igraph_set_destroy(igraph_set_t* set);
+IGRAPH_PRIVATE_EXPORT igraph_bool_t igraph_set_inited(igraph_set_t* set);
+IGRAPH_PRIVATE_EXPORT int igraph_set_reserve(igraph_set_t* set, long int size);
+IGRAPH_PRIVATE_EXPORT igraph_bool_t igraph_set_empty(const igraph_set_t* set);
+IGRAPH_PRIVATE_EXPORT void igraph_set_clear(igraph_set_t* set);
+IGRAPH_PRIVATE_EXPORT long int igraph_set_size(const igraph_set_t* set);
+IGRAPH_PRIVATE_EXPORT int igraph_set_add(igraph_set_t* v, igraph_integer_t e);
+IGRAPH_PRIVATE_EXPORT igraph_bool_t igraph_set_contains(igraph_set_t* set, igraph_integer_t e);
+IGRAPH_PRIVATE_EXPORT igraph_bool_t igraph_set_iterate(igraph_set_t* set, long int* state,
+                                                       igraph_integer_t* element);
 
 __END_DECLS
 

--- a/src/core/spmatrix.c
+++ b/src/core/spmatrix.c
@@ -615,7 +615,9 @@ int igraph_spmatrix_clear_row(igraph_spmatrix_t *m, long int row) {
     return 0;
 }
 
-int igraph_i_spmatrix_clear_row_fast(igraph_spmatrix_t *m, long int row) {
+/* Unused local functions---temporarily disabled */
+#if 0
+static int igraph_i_spmatrix_clear_row_fast(igraph_spmatrix_t *m, long int row) {
     long int ei, n;
 
     IGRAPH_ASSERT(m != NULL);
@@ -628,7 +630,7 @@ int igraph_i_spmatrix_clear_row_fast(igraph_spmatrix_t *m, long int row) {
     return 0;
 }
 
-int igraph_i_spmatrix_cleanup(igraph_spmatrix_t *m) {
+static int igraph_i_spmatrix_cleanup(igraph_spmatrix_t *m) {
     long int ci, ei, i, j, nremove = 0, nremove_old = 0;
     igraph_vector_t permvec;
 
@@ -659,6 +661,7 @@ int igraph_i_spmatrix_cleanup(igraph_spmatrix_t *m) {
     IGRAPH_FINALLY_CLEAN(1);
     return 0;
 }
+#endif
 
 /**
  * \function igraph_spmatrix_clear_col
@@ -859,8 +862,11 @@ igraph_real_t igraph_spmatrix_max(const igraph_spmatrix_t *m,
     return res;
 }
 
-int igraph_i_spmatrix_get_col_nonzero_indices(const igraph_spmatrix_t *m,
-        igraph_vector_t *res, long int col) {
+
+/* Unused function, temporarily disabled */
+/*
+static int igraph_i_spmatrix_get_col_nonzero_indices(const igraph_spmatrix_t *m,
+                                                     igraph_vector_t *res, long int col) {
     long int i, n;
     IGRAPH_ASSERT(m != NULL);
     n = (long int) (VECTOR(m->cidx)[col + 1] - VECTOR(m->cidx)[col]);
@@ -872,6 +878,7 @@ int igraph_i_spmatrix_get_col_nonzero_indices(const igraph_spmatrix_t *m,
         }
     return 0;
 }
+*/
 
 
 /**

--- a/src/core/trie.h
+++ b/src/core/trie.h
@@ -66,15 +66,15 @@ typedef struct s_igraph_trie {
     do { IGRAPH_CHECK(igraph_trie_init(tr, sk)); \
         IGRAPH_FINALLY(igraph_trie_destroy, tr); } while (0)
 
-int igraph_trie_init(igraph_trie_t *t, igraph_bool_t storekeys);
-void igraph_trie_destroy(igraph_trie_t *t);
-int igraph_trie_get(igraph_trie_t *t, const char *key, long int *id);
-int igraph_trie_check(igraph_trie_t *t, const char *key, long int *id);
-int igraph_trie_get2(igraph_trie_t *t, const char *key, long int length,
-                     long int *id);
-void igraph_trie_idx(igraph_trie_t *t, long int idx, char **str);
-int igraph_trie_getkeys(igraph_trie_t *t, const igraph_strvector_t **strv);
-long int igraph_trie_size(igraph_trie_t *t);
+IGRAPH_PRIVATE_EXPORT int igraph_trie_init(igraph_trie_t *t, igraph_bool_t storekeys);
+IGRAPH_PRIVATE_EXPORT void igraph_trie_destroy(igraph_trie_t *t);
+IGRAPH_PRIVATE_EXPORT int igraph_trie_get(igraph_trie_t *t, const char *key, long int *id);
+IGRAPH_PRIVATE_EXPORT int igraph_trie_check(igraph_trie_t *t, const char *key, long int *id);
+IGRAPH_PRIVATE_EXPORT int igraph_trie_get2(igraph_trie_t *t, const char *key, long int length,
+                                           long int *id);
+IGRAPH_PRIVATE_EXPORT void igraph_trie_idx(igraph_trie_t *t, long int idx, char **str);
+IGRAPH_PRIVATE_EXPORT int igraph_trie_getkeys(igraph_trie_t *t, const igraph_strvector_t **strv);
+IGRAPH_PRIVATE_EXPORT long int igraph_trie_size(igraph_trie_t *t);
 
 __END_DECLS
 

--- a/src/flow/flow_internal.h
+++ b/src/flow/flow_internal.h
@@ -27,14 +27,14 @@
 
 __BEGIN_DECLS
 
-int igraph_i_all_st_cuts_pivot(const igraph_t *graph,
-                               const igraph_marked_queue_t *S,
-                               const igraph_estack_t *T,
-                               long int source,
-                               long int target,
-                               long int *v,
-                               igraph_vector_t *Isv,
-                               void *arg);
+IGRAPH_PRIVATE_EXPORT int igraph_i_all_st_cuts_pivot(const igraph_t *graph,
+                                                     const igraph_marked_queue_t *S,
+                                                     const igraph_estack_t *T,
+                                                     long int source,
+                                                     long int target,
+                                                     long int *v,
+                                                     igraph_vector_t *Isv,
+                                                     void *arg);
 
 __END_DECLS
 

--- a/src/flow/st-cuts.c
+++ b/src/flow/st-cuts.c
@@ -39,6 +39,7 @@
 #include "core/math.h"
 #include "core/estack.h"
 #include "core/marked_queue.h"
+#include "flow/flow_internal.h"
 
 typedef int igraph_provan_shier_pivot_t(const igraph_t *graph,
                                         const igraph_marked_queue_t *S,

--- a/src/flow/st-cuts.c
+++ b/src/flow/st-cuts.c
@@ -138,12 +138,12 @@ int igraph_even_tarjan_reduction(const igraph_t *graph, igraph_t *graphbar,
     return 0;
 }
 
-int igraph_i_residual_graph(const igraph_t *graph,
-                            const igraph_vector_t *capacity,
-                            igraph_t *residual,
-                            igraph_vector_t *residual_capacity,
-                            const igraph_vector_t *flow,
-                            igraph_vector_t *tmp) {
+static int igraph_i_residual_graph(const igraph_t *graph,
+                                   const igraph_vector_t *capacity,
+                                   igraph_t *residual,
+                                   igraph_vector_t *residual_capacity,
+                                   const igraph_vector_t *flow,
+                                   igraph_vector_t *tmp) {
 
     long int no_of_nodes = igraph_vcount(graph);
     long int no_of_edges = igraph_ecount(graph);
@@ -207,11 +207,11 @@ int igraph_residual_graph(const igraph_t *graph,
     return 0;
 }
 
-int igraph_i_reverse_residual_graph(const igraph_t *graph,
-                                    const igraph_vector_t *capacity,
-                                    igraph_t *residual,
-                                    const igraph_vector_t *flow,
-                                    igraph_vector_t *tmp) {
+static int igraph_i_reverse_residual_graph(const igraph_t *graph,
+                                           const igraph_vector_t *capacity,
+                                           igraph_t *residual,
+                                           const igraph_vector_t *flow,
+                                           igraph_vector_t *tmp) {
 
     long int no_of_nodes = igraph_vcount(graph);
     long int no_of_edges = igraph_ecount(graph);

--- a/src/layout/layout_internal.h
+++ b/src/layout/layout_internal.h
@@ -29,24 +29,26 @@
 
 __BEGIN_DECLS
 
-int igraph_i_layout_merge_dla(igraph_i_layout_mergegrid_t *grid,
-                              long int actg, igraph_real_t *x, igraph_real_t *y, igraph_real_t r,
-                              igraph_real_t cx, igraph_real_t cy, igraph_real_t startr,
-                              igraph_real_t killr);
-int igraph_i_layout_sphere_2d(igraph_matrix_t *coords, igraph_real_t *x,
-                              igraph_real_t *y, igraph_real_t *r);
-int igraph_i_layout_sphere_3d(igraph_matrix_t *coords, igraph_real_t *x,
-                              igraph_real_t *y, igraph_real_t *z,
-                              igraph_real_t *r);
-float igraph_i_layout_point_segment_dist2(float v_x, float v_y,
-                                          float u1_x, float u1_y,
-                                          float u2_x, float u2_y);
-igraph_bool_t igraph_i_layout_segments_intersect(
-        float p0_x, float p0_y,
-        float p1_x, float p1_y,
-        float p2_x, float p2_y,
-        float p3_x, float p3_y
-);
+IGRAPH_PRIVATE_EXPORT int igraph_i_layout_merge_dla(igraph_i_layout_mergegrid_t *grid,
+                                                    long int actg, igraph_real_t *x, igraph_real_t *y, igraph_real_t r,
+                                                    igraph_real_t cx, igraph_real_t cy, igraph_real_t startr,
+                                                    igraph_real_t killr);
+
+IGRAPH_PRIVATE_EXPORT int igraph_i_layout_sphere_2d(igraph_matrix_t *coords, igraph_real_t *x,
+                                                    igraph_real_t *y, igraph_real_t *r);
+
+IGRAPH_PRIVATE_EXPORT int igraph_i_layout_sphere_3d(igraph_matrix_t *coords, igraph_real_t *x,
+                                                    igraph_real_t *y, igraph_real_t *z,
+                                                    igraph_real_t *r);
+
+IGRAPH_PRIVATE_EXPORT float igraph_i_layout_point_segment_dist2(float v_x, float v_y,
+                                                                float u1_x, float u1_y,
+                                                                float u2_x, float u2_y);
+
+IGRAPH_PRIVATE_EXPORT igraph_bool_t igraph_i_layout_segments_intersect(float p0_x, float p0_y,
+                                                                       float p1_x, float p1_y,
+                                                                       float p2_x, float p2_y,
+                                                                       float p3_x, float p3_y);
 
 __END_DECLS
 

--- a/src/layout/merge_dla.c
+++ b/src/layout/merge_dla.c
@@ -29,19 +29,7 @@
 #include "core/interruption.h"
 #include "core/math.h"
 #include "layout/merge_grid.h"
-
-/* not 'static', used in tests */
-int igraph_i_layout_merge_dla(igraph_i_layout_mergegrid_t *grid,
-                              long int actg, igraph_real_t *x, igraph_real_t *y, igraph_real_t r,
-                              igraph_real_t cx, igraph_real_t cy, igraph_real_t startr,
-                              igraph_real_t killr);
-
-/* TODO: not 'static' because used in tests */
-int igraph_i_layout_sphere_2d(igraph_matrix_t *coords, igraph_real_t *x,
-                              igraph_real_t *y, igraph_real_t *r);
-int igraph_i_layout_sphere_3d(igraph_matrix_t *coords, igraph_real_t *x,
-                              igraph_real_t *y, igraph_real_t *z,
-                              igraph_real_t *r);
+#include "layout/layout_internal.h"
 
 /**
  * \function igraph_layout_merge_dla

--- a/src/layout/merge_grid.h
+++ b/src/layout/merge_grid.h
@@ -37,20 +37,21 @@ typedef struct igraph_i_layout_mergegrid_t {
     igraph_real_t miny, maxy, deltay;
 } igraph_i_layout_mergegrid_t;
 
-int igraph_i_layout_mergegrid_init(igraph_i_layout_mergegrid_t *grid,
-                                   igraph_real_t minx, igraph_real_t maxx, long int stepsx,
-                                   igraph_real_t miny, igraph_real_t maxy, long int stepsy);
-void igraph_i_layout_mergegrid_destroy(igraph_i_layout_mergegrid_t *grid);
+IGRAPH_PRIVATE_EXPORT int igraph_i_layout_mergegrid_init(igraph_i_layout_mergegrid_t *grid,
+                                                         igraph_real_t minx, igraph_real_t maxx, long int stepsx,
+                                                         igraph_real_t miny, igraph_real_t maxy, long int stepsy);
 
-int igraph_i_layout_merge_place_sphere(igraph_i_layout_mergegrid_t *grid,
-                                       igraph_real_t x, igraph_real_t y, igraph_real_t r,
-                                       long int id);
+IGRAPH_PRIVATE_EXPORT void igraph_i_layout_mergegrid_destroy(igraph_i_layout_mergegrid_t *grid);
+
+IGRAPH_PRIVATE_EXPORT int igraph_i_layout_merge_place_sphere(igraph_i_layout_mergegrid_t *grid,
+                                                             igraph_real_t x, igraph_real_t y, igraph_real_t r,
+                                                             long int id);
 
 long int igraph_i_layout_mergegrid_get(igraph_i_layout_mergegrid_t *grid,
                                        igraph_real_t x, igraph_real_t y);
 
 long int igraph_i_layout_mergegrid_get_sphere(igraph_i_layout_mergegrid_t *g,
-        igraph_real_t x, igraph_real_t y, igraph_real_t r);
+                                              igraph_real_t x, igraph_real_t y, igraph_real_t r);
 
 __END_DECLS
 

--- a/src/operators/rewire_internal.h
+++ b/src/operators/rewire_internal.h
@@ -3,6 +3,6 @@
 
 #include "igraph_interface.h"
 
-int igraph_i_rewire(igraph_t *graph, igraph_integer_t n, igraph_rewiring_t mode, igraph_bool_t use_adjlist);
+IGRAPH_PRIVATE_EXPORT int igraph_i_rewire(igraph_t *graph, igraph_integer_t n, igraph_rewiring_t mode, igraph_bool_t use_adjlist);
 
 #endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,11 +24,6 @@ if (HAVE_ENABLE_NEW_DTAGS AND BUILD_SHARED_LIBS)
   set(CMAKE_EXE_LINKER_FLAGS "-Wl,--disable-new-dtags")
 endif()
 
-set(BUILD_INTERNAL_TESTS YES)
-if (BUILD_SHARED_LIBS)
-  set(BUILD_INTERNAL_TESTS NO)
-endif()
-
 # version.at
 add_examples(
   FOLDER examples/simple NAMES
@@ -70,7 +65,7 @@ add_legacy_tests(
   vector_ptr
 )
 
-if (BUILD_INTERNAL_TESTS OR (NOT BLAS_IS_VENDORED AND NOT ARPACK_IS_VENDORED))
+if ((NOT BUILD_SHARED_LIBS) OR (NOT BLAS_IS_VENDORED AND NOT ARPACK_IS_VENDORED))
   add_legacy_tests(
     FOLDER tests/unit NAMES
     igraph_sparsemat2 # Uses ARPACK and BLAS functions which are not publicly available when building with internal ARPACK/BLAS
@@ -581,7 +576,7 @@ if(CMAKE_USE_PTHREADS_INIT)
 
   # tls2 should be added only if we use vendored ARPACK because a non-vendored
   # ARPACK is not guaranteed to be thread-safe
-  if(ARPACK_IS_VENDORED AND BUILD_INTERNAL_TESTS)
+  if(ARPACK_IS_VENDORED AND NOT BUILD_SHARED_LIBS)
     add_legacy_tests(
       FOLDER tests/unit NAMES tls2
       LIBRARIES Threads::Threads

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -75,17 +75,18 @@ if (BUILD_INTERNAL_TESTS)
     FOLDER tests/unit NAMES
     igraph_sparsemat2 # Uses ARPACK and BLAS functions which are not publicly available when building with internal ARPACK/BLAS
   )
-  add_legacy_tests(
-    FOLDER tests/unit NAMES
-    2wheap
-    cutheap
-    d_indheap
-    hashtable
-    marked_queue
-    set
-    trie
-  )
 endif()
+
+add_legacy_tests(
+  FOLDER tests/unit NAMES
+  2wheap
+  cutheap
+  d_indheap
+  hashtable
+  marked_queue
+  set
+  trie
+)
 
 # basic.at
 add_examples(
@@ -196,12 +197,11 @@ add_examples(
   igraph_topological_sorting
   igraph_transitivity
 )
-if (BUILD_INTERNAL_TESTS)
-  add_legacy_tests(
-    FOLDER tests/unit NAMES
-    igraph_rewire # Uses internal igraph_i_rewire
-  )
-endif()
+
+add_legacy_tests(
+  FOLDER tests/unit NAMES
+  igraph_rewire # Uses internal igraph_i_rewire
+)
 
 add_legacy_tests(
   FOLDER tests/unit NAMES
@@ -260,26 +260,24 @@ add_legacy_tests(
   igraph_layout_kamada_kawai_3d_bug_1462
   igraph_layout_reingold_tilford_bug_879
 )
-if (BUILD_INTERNAL_TESTS)
-  add_legacy_tests(
-    FOLDER tests/unit NAMES
-    igraph_i_layout_sphere
-    igraph_layout_davidson_harel # Uses igraph_i_layout_segments_intersect and igraph_i_layout_point_segment_dist2
-    igraph_layout_merge # Uses igraph_i_layout_merge functions
-  )
-endif()
+
+add_legacy_tests(
+  FOLDER tests/unit NAMES
+  igraph_i_layout_sphere
+  igraph_layout_davidson_harel # Uses igraph_i_layout_segments_intersect and igraph_i_layout_point_segment_dist2
+  igraph_layout_merge # Uses igraph_i_layout_merge functions
+)
 
 # visitors.at
 add_examples(
   FOLDER examples/simple NAMES
   igraph_bfs2
 )
-if (BUILD_INTERNAL_TESTS)
-  add_examples(
-    FOLDER examples/simple NAMES
-    igraph_bfs # Uses igraph_i_bfs
-  )
-endif()
+
+add_examples(
+  FOLDER examples/simple NAMES
+  igraph_bfs # Uses igraph_i_bfs
+)
 
 add_legacy_tests(
   FOLDER tests/unit NAMES
@@ -409,12 +407,10 @@ add_legacy_tests(
   igraph_st_mincut
 )
 
-if (BUILD_INTERNAL_TESTS)
-  add_legacy_tests(
-    FOLDER tests/unit NAMES
-    igraph_all_st_cuts # Uses igraph_marked_queue, which is internal.
-  )
-endif()
+add_legacy_tests(
+  FOLDER tests/unit NAMES
+  igraph_all_st_cuts # Uses igraph_marked_queue, which is internal.
+)
 
 add_legacy_tests(
   FOLDER tests/unit NAMES

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -70,7 +70,7 @@ add_legacy_tests(
   vector_ptr
 )
 
-if (BUILD_INTERNAL_TESTS)
+if (BUILD_INTERNAL_TESTS OR (NOT BLAS_IS_VENDORED AND NOT ARPACK_IS_VENDORED))
   add_legacy_tests(
     FOLDER tests/unit NAMES
     igraph_sparsemat2 # Uses ARPACK and BLAS functions which are not publicly available when building with internal ARPACK/BLAS


### PR DESCRIPTION
Private functions used in tests are now exported from the shared library (i.e. you can see them in the `.dylib`/`.so` using the `nm` command and programs linking to the library can use them), but they _do not_ appear in public headers and users have no way of discovering them (other than looking at internals and adding the function prototypes to their programs explicitly).

All of these have `IGRAPH_PRIVATE_EXPORT` instead of `IGRAPH_EXPORT` so it is easy to disable exporting them if we want to do that.

Exceptionally, `igraph_i_bfs` gets `IGRAPH_PRIVATE_EXPORT` in a public header. This is the only use of `IGRAPH_PRIVATE_EXPORT` in a public header. This function is in a public header because the Python interface uses it (see #1301). I assume Debian wants its version of the Python interface to link to the C/igraph shared library. Thus for `igraph_i_bfs` maybe a plain `IGRAPH_EXPORT` makes more sense.