### PR TITLE
igraph_abort() now prints a stack trace when using AddressSanitizer

### DIFF
--- a/src/core/error.c
+++ b/src/core/error.c
@@ -34,8 +34,12 @@
  * Detecting ASan with Clang:
  *   https://clang.llvm.org/docs/AddressSanitizer.html#conditional-compilation-with-has-feature-address-sanitizer
  */
-#if defined(__SANITIZE_ADDRESS__) || (defined(__has_feature) && __has_feature(address_sanitizer))
-#define IGRAPH_SANITIZER_AVAILABLE 1
+#if defined(__SANITIZE_ADDRESS__)
+#  define IGRAPH_SANITIZER_AVAILABLE 1
+#elif defined(__has_feature)
+#  if __has_feature(address_sanitizer)
+#    define IGRAPH_SANITIZER_AVAILABLE 1
+#  endif
 #endif
 
 #ifdef IGRAPH_SANITIZER_AVAILABLE

--- a/src/core/error.c
+++ b/src/core/error.c
@@ -29,6 +29,19 @@
 #include <stdlib.h>
 #include <stdarg.h>
 
+/* Detecting ASan with GCC:
+ *   https://gcc.gnu.org/onlinedocs/cpp/Common-Predefined-Macros.html
+ * Detecting ASan with Clang:
+ *   https://clang.llvm.org/docs/AddressSanitizer.html#conditional-compilation-with-has-feature-address-sanitizer
+ */
+#if defined(__SANITIZE_ADDRESS__) || (defined(__has_feature) && __has_feature(address_sanitizer))
+#define IGRAPH_SANITIZER_AVAILABLE 1
+#endif
+
+#ifdef IGRAPH_SANITIZER_AVAILABLE
+#include <sanitizer/asan_interface.h>
+#endif
+
 #ifdef USING_R
 #include <R.h>
 #endif
@@ -47,6 +60,10 @@
  */
 static IGRAPH_NORETURN void igraph_abort() {
 #ifndef USING_R
+#ifdef IGRAPH_SANITIZER_AVAILABLE
+    fprintf(stderr, "\nStack trace:\n");
+    __sanitizer_print_stack_trace();
+#endif
     abort();
 #else
     /* R's error() function is declared 'noreturn'. We use it here to satisfy the compiler that igraph_abort() does indeed not return. */

--- a/src/properties/degrees.c
+++ b/src/properties/degrees.c
@@ -377,6 +377,8 @@ int igraph_strength(const igraph_t *graph, igraph_vector_t *res,
     igraph_vector_t neis;
     long int i;
 
+    IGRAPH_ERROR("Example error to test stack trace printing.", IGRAPH_FAILURE);
+
     if (!weights) {
         return igraph_degree(graph, res, vids, mode, loops);
     }

--- a/src/properties/degrees.c
+++ b/src/properties/degrees.c
@@ -377,8 +377,6 @@ int igraph_strength(const igraph_t *graph, igraph_vector_t *res,
     igraph_vector_t neis;
     long int i;
 
-    IGRAPH_ERROR("Example error to test stack trace printing.", IGRAPH_FAILURE);
-
     if (!weights) {
         return igraph_degree(graph, res, vids, mode, loops);
     }


### PR DESCRIPTION
This PR adds printing a stack trace to `igraph_abort()` when using AddressSanitizer. All ways to abort igraph go through `igraph_abort`, including errors (with the default handler, used by tests), `IGRAPH_ASSERT` and fatal errors.

----

Potential problem: This sanitizer API is likely not stable. See also https://stackoverflow.com/q/66184498/695132

----

Example:

I added an `IGRAPH_ERROR` call to `igraph_strength()`, and ran the `example::igraph_knn` test.

```
Error at src/properties/degrees.c:380 : Booyaa! - Failed.

Stack trace:
    #0 0x10d1fcd0f in __sanitizer_print_stack_trace (libasan.6.dylib:x86_64+0x3dd0f)
    #1 0x10c7205f9 in igraph_abort error.c:65
    #2 0x10c72095f in igraph_error_handler_abort error.c:194
    #3 0x10c7206d1 in igraph_error error.c:167
    #4 0x10cb08fc3 in igraph_strength degrees.c:380
    #5 0x10cb06d1f in igraph_i_avg_nearest_neighbor_degree_weighted degrees.c:112
    #6 0x10cb07f5e in igraph_avg_nearest_neighbor_degree degrees.c:271
    #7 0x10c646c78 in main igraph_knn.c:50
    #8 0x7fff776b93d4 in start (libdyld.dylib:x86_64+0x163d4)
```