### PR TITLE
Add layout_reingold_tilford_circular unit tests

### DIFF
--- a/src/layout/reingold_tilford.c
+++ b/src/layout/reingold_tilford.c
@@ -682,7 +682,7 @@ int igraph_layout_reingold_tilford(const igraph_t *graph,
     if (igraph_vector_size(proots) == 1) {
         real_root = (long int) VECTOR(*proots)[0];
         if (real_root < 0 || real_root >= no_of_nodes) {
-            IGRAPH_ERROR("invalid vertex id", IGRAPH_EINVVID);
+            IGRAPH_ERROR("Invalid vertex id.", IGRAPH_EINVVID);
         }
 
         /* else, we need to make real_root */
@@ -792,10 +792,7 @@ int igraph_layout_reingold_tilford(const igraph_t *graph,
  *   not trees (i.e. they are unconnected and have tree components). It specifies
  *   the level of the root vertices for every tree in the forest. It is only
  *   considered if not a null pointer and the \p roots argument is also given
- *   (and it is not a null pointer of an empty vector). Note that if you supply
- *   a null pointer here and the graph has multiple components, all of the root
- *   vertices will be mapped to the origin of the coordinate system, which does
- *   not really make sense.
+ *   (and it is not a null pointer or an empty vector).
  * \return Error code.
  *
  * \sa \ref igraph_layout_reingold_tilford().

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -251,6 +251,7 @@ add_legacy_tests(
   igraph_layout_mds
   igraph_layout_merge2
   igraph_layout_merge3
+  igraph_layout_reingold_tilford_circular
   igraph_layout_reingold_tilford_extended
   igraph_layout_star
   igraph_layout_sugiyama

--- a/tests/unit/igraph_layout_reingold_tilford_circular.c
+++ b/tests/unit/igraph_layout_reingold_tilford_circular.c
@@ -1,0 +1,116 @@
+/*
+   IGraph library.
+   Copyright (C) 2021  The igraph development team <igraph@igraph.org>
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include <igraph.h>
+#include "test_utilities.inc"
+
+void chop_print_destroy(igraph_matrix_t *result) {
+    matrix_chop(result, 1e-10);
+    print_matrix(result);
+    igraph_matrix_destroy(result);
+}
+
+int main() {
+    igraph_t g;
+    igraph_matrix_t result;
+    igraph_vector_t roots, rootlevel;
+    igraph_rng_seed(igraph_rng_default(), 42);
+
+    printf("Empty graph check:\n");
+    igraph_small(&g, 0, 0, -1);
+    igraph_matrix_init(&result, 0, 0);
+    IGRAPH_ASSERT(igraph_layout_reingold_tilford_circular(&g, &result, IGRAPH_ALL, /*roots*/ NULL, /*rootlevel*/ NULL) == IGRAPH_SUCCESS);
+    chop_print_destroy(&result);
+    igraph_destroy(&g);
+
+    printf("Singleton graph check:\n");
+    igraph_small(&g, 1, 0, -1);
+    igraph_matrix_init(&result, 0, 0);
+    IGRAPH_ASSERT(igraph_layout_reingold_tilford_circular(&g, &result, IGRAPH_ALL, /*roots*/ NULL, /*rootlevel*/ NULL) == IGRAPH_SUCCESS);
+    chop_print_destroy(&result);
+    igraph_destroy(&g);
+
+    printf("Star graph check with given root:\n");
+    igraph_small(&g, 5, 1, 0,1, 0,2, 0,3, 0,4, -1);
+    igraph_matrix_init(&result, 0, 0);
+    igraph_vector_init_int(&roots, 1, 1);
+    IGRAPH_ASSERT(igraph_layout_reingold_tilford_circular(&g, &result, IGRAPH_OUT, &roots, /*rootlevel*/ NULL) == IGRAPH_SUCCESS);
+    chop_print_destroy(&result);
+    igraph_destroy(&g);
+    igraph_vector_destroy(&roots);
+
+    printf("Star graph check with root found by topological sort:\n");
+    igraph_small(&g, 5, 1, 1,0, 2,0, 3,0, 4,0, -1);
+    igraph_matrix_init(&result, 0, 0);
+    IGRAPH_ASSERT(igraph_layout_reingold_tilford_circular(&g, &result, IGRAPH_IN, NULL, /*rootlevel*/ NULL) == IGRAPH_SUCCESS);
+    chop_print_destroy(&result);
+    igraph_destroy(&g);
+
+    printf("Two minitrees without rootlevel:\n");
+    igraph_small(&g, 6, 1, 0,1, 0,2, 3,4, 3,5, -1);
+    igraph_matrix_init(&result, 0, 0);
+    igraph_vector_init_int(&roots, 2, 0, 3);
+    IGRAPH_ASSERT(igraph_layout_reingold_tilford_circular(&g, &result, IGRAPH_OUT, &roots, NULL) == IGRAPH_SUCCESS);
+    chop_print_destroy(&result);
+    igraph_destroy(&g);
+    igraph_vector_destroy(&roots);
+
+    printf("Two minitrees with rootlevel 10 and 20:\n");
+    igraph_small(&g, 6, 1, 0,1, 0,2, 3,4, 3,5, -1);
+    igraph_matrix_init(&result, 0, 0);
+    igraph_vector_init_int(&roots, 2, 0, 3);
+    igraph_vector_init_int(&rootlevel, 2, 10, 20);
+    IGRAPH_ASSERT(igraph_layout_reingold_tilford_circular(&g, &result, IGRAPH_OUT, &roots, &rootlevel) == IGRAPH_SUCCESS);
+    chop_print_destroy(&result);
+    igraph_destroy(&g);
+    igraph_vector_destroy(&roots);
+    igraph_vector_destroy(&rootlevel);
+
+    printf("Graph with just loops, triple edges and disconnected vertices:\n");
+    igraph_small(&g, 5, 1, 0,0, 0,0, 0,0, 1,2, 1,2, 1,2, -1);
+    igraph_matrix_init(&result, 0, 0);
+    IGRAPH_ASSERT(igraph_layout_reingold_tilford_circular(&g, &result, IGRAPH_ALL, NULL, /*rootlevel*/ NULL) == IGRAPH_SUCCESS);
+    chop_print_destroy(&result);
+    igraph_destroy(&g);
+
+    igraph_set_error_handler(igraph_error_handler_ignore);
+
+    printf("Checking proper error handling:\n");
+    printf("Giving negative root.\n");
+    igraph_small(&g, 5, 1, 0,1, 0,2, 0,3, 0,4, -1);
+    igraph_matrix_init(&result, 0, 0);
+    igraph_vector_init_int(&roots, 1, -1);
+    IGRAPH_ASSERT(igraph_layout_reingold_tilford_circular(&g, &result, IGRAPH_OUT, &roots, /*rootlevel*/ NULL) == IGRAPH_EINVVID);
+    igraph_matrix_destroy(&result);
+    igraph_destroy(&g);
+    igraph_vector_destroy(&roots);
+
+    printf("Giving negative rootlevel.\n");
+    igraph_small(&g, 6, 1, 0,1, 0,2, 3,4, 3,5, -1);
+    igraph_matrix_init(&result, 0, 0);
+    igraph_vector_init_int(&roots, 2, 0, 3);
+    igraph_vector_init_int(&rootlevel, 2, -10, -20);
+    IGRAPH_ASSERT(igraph_layout_reingold_tilford_circular(&g, &result, IGRAPH_OUT, &roots, &rootlevel) == IGRAPH_EINVAL);
+    igraph_matrix_destroy(&result);
+    igraph_destroy(&g);
+    igraph_vector_destroy(&roots);
+    igraph_vector_destroy(&rootlevel);
+
+    VERIFY_FINALLY_STACK();
+    return 0;
+}

--- a/tests/unit/igraph_layout_reingold_tilford_circular.out
+++ b/tests/unit/igraph_layout_reingold_tilford_circular.out
@@ -1,0 +1,38 @@
+Empty graph check:
+Singleton graph check:
+[        0        0 ]
+Star graph check with given root:
+[        1        0
+         0        0
+  -0.104528 0.994522
+  -0.978148 -0.207912
+  0.309017 -0.951057 ]
+Star graph check with root found by topological sort:
+[        0        0
+         1        0
+  -0.104528 0.994522
+  -0.978148 -0.207912
+  0.309017 -0.951057 ]
+Two minitrees without rootlevel:
+[ 0.642788 0.766044
+         2        0
+  -0.347296  1.96962
+  -0.34202 -0.939693
+  -1.87939 -0.68404
+         1 -1.73205 ]
+Two minitrees with rootlevel 10 and 20:
+[      5.5  9.52628
+        12        0
+        -6  10.3923
+     -10.5 -18.1865
+       -22        0
+        11 -19.0526 ]
+Graph with just loops, triple edges and disconnected vertices:
+[        1        0
+  -0.209057  1.98904
+  -0.104528 0.994522
+  -0.978148 -0.207912
+  0.309017 -0.951057 ]
+Checking proper error handling:
+Giving negative root.
+Giving negative rootlevel.


### PR DESCRIPTION
Part of #1592

Removed a comment in the docs which assumed that y=0 for roots of separate trees in reingold_tilford. For two separate trees y=1 which means the roots are also separated for the circular version.