### PR TITLE
Add layout graphopt unit tests

### DIFF
--- a/include/igraph_layout.h
+++ b/include/igraph_layout.h
@@ -123,7 +123,7 @@ IGRAPH_EXPORT int igraph_layout_kamada_kawai_3d(const igraph_t *graph, igraph_ma
 IGRAPH_EXPORT int igraph_layout_graphopt(const igraph_t *graph,
                                          igraph_matrix_t *res, igraph_integer_t niter,
                                          igraph_real_t node_charge, igraph_real_t node_mass,
-                                         igraph_real_t spring_length,
+                                         igraph_integer_t spring_length,
                                          igraph_real_t spring_constant,
                                          igraph_real_t max_sa_movement,
                                          igraph_bool_t use_seed);

--- a/include/igraph_layout.h
+++ b/include/igraph_layout.h
@@ -123,7 +123,7 @@ IGRAPH_EXPORT int igraph_layout_kamada_kawai_3d(const igraph_t *graph, igraph_ma
 IGRAPH_EXPORT int igraph_layout_graphopt(const igraph_t *graph,
                                          igraph_matrix_t *res, igraph_integer_t niter,
                                          igraph_real_t node_charge, igraph_real_t node_mass,
-                                         igraph_integer_t spring_length,
+                                         igraph_real_t spring_length,
                                          igraph_real_t spring_constant,
                                          igraph_real_t max_sa_movement,
                                          igraph_bool_t use_seed);

--- a/src/layout/graphopt.c
+++ b/src/layout/graphopt.c
@@ -372,7 +372,7 @@ int igraph_layout_graphopt(const igraph_t *graph, igraph_matrix_t *res,
     if (use_seed) {
         if (igraph_matrix_nrow(res) != no_of_nodes ||
             igraph_matrix_ncol(res) != 2) {
-            IGRAPH_WARNING("Invalid size for initial matrix, starting from random layout");
+            IGRAPH_WARNING("Invalid size for initial matrix, starting from random layout.");
             IGRAPH_CHECK(igraph_layout_random(graph, res));
         }
     } else {
@@ -441,5 +441,5 @@ int igraph_layout_graphopt(const igraph_t *graph, igraph_matrix_t *res,
     igraph_vector_destroy(&pending_forces_x);
     IGRAPH_FINALLY_CLEAN(2);
 
-    return 0;
+    return IGRAPH_SUCCESS;
 }

--- a/src/layout/graphopt.c
+++ b/src/layout/graphopt.c
@@ -57,7 +57,7 @@ static int igraph_i_determine_spring_axal_forces(
         igraph_real_t *x, igraph_real_t *y,
         igraph_real_t directed_force,
         igraph_real_t distance,
-        igraph_integer_t spring_length,
+        igraph_real_t spring_length,
         long int other_node,
         long int this_node);
 
@@ -66,7 +66,7 @@ static int igraph_i_apply_spring_force(
         igraph_vector_t *pending_forces_x,
         igraph_vector_t *pending_forces_y,
         long int other_node,
-        long int this_node, igraph_integer_t spring_length,
+        long int this_node, igraph_real_t spring_length,
         igraph_real_t spring_constant);
 
 static int igraph_i_move_nodes(
@@ -166,7 +166,7 @@ static int igraph_i_determine_spring_axal_forces(
         igraph_real_t *x, igraph_real_t *y,
         igraph_real_t directed_force,
         igraph_real_t distance,
-        igraph_integer_t spring_length,
+        igraph_real_t spring_length,
         long int other_node, long int this_node) {
 
     // if the spring is just the right size, the forces will be 0, so we can
@@ -205,7 +205,7 @@ static int igraph_i_apply_spring_force(
         igraph_vector_t *pending_forces_x,
         igraph_vector_t *pending_forces_y,
         long int other_node,
-        long int this_node, igraph_integer_t spring_length,
+        long int this_node, igraph_real_t spring_length,
         igraph_real_t spring_constant) {
 
     // determined using Hooke's Law:
@@ -331,7 +331,7 @@ static int igraph_i_move_nodes(
  *    repulsion. The original graphopt default is 0.001.
  * \param node_mass The mass of the vertices, used for the spring forces.
  *    The original graphopt defaults to 30.
- * \param spring_length The length of the springs, an integer number.
+ * \param spring_length The length of the springs.
  *    The original graphopt defaults to zero.
  * \param spring_constant The spring constant, the original graphopt defaults
  *    to one.
@@ -349,7 +349,7 @@ static int igraph_i_move_nodes(
 int igraph_layout_graphopt(const igraph_t *graph, igraph_matrix_t *res,
                            igraph_integer_t niter,
                            igraph_real_t node_charge, igraph_real_t node_mass,
-                           igraph_integer_t spring_length,
+                           igraph_real_t spring_length,
                            igraph_real_t spring_constant,
                            igraph_real_t max_sa_movement,
                            igraph_bool_t use_seed) {

--- a/src/layout/graphopt.c
+++ b/src/layout/graphopt.c
@@ -307,7 +307,7 @@ static int igraph_i_move_nodes(
  * is zero.
  *
  * </para><para>
- * graphopt uses physical analogies for defining attracting and repelling
+ * Graphopt uses physical analogies for defining attracting and repelling
  * forces among the vertices and then the physical system is simulated
  * until it reaches an equilibrium. (There is no simulated annealing or
  * anything like that, so a stable fixed point is not guaranteed.)
@@ -316,17 +316,17 @@ static int igraph_i_move_nodes(
  * See also http://www.schmuhl.org/graphopt/ for the original graphopt.
  * \param graph The input graph.
  * \param res Pointer to an initialized matrix, the result will be stored here
- *    and its initial contents is used the starting point of the simulation
+ *    and its initial contents are used as the starting point of the simulation
  *    if the \p use_seed argument is true. Note that in this case the
  *    matrix should have the proper size, otherwise a warning is issued and
  *    the supplied values are ignored. If no starting positions are given
- *    (or they are invalid) then a random staring position is used.
+ *    (or they are invalid) then a random starting position is used.
  *    The matrix will be resized if needed.
  * \param niter Integer constant, the number of iterations to perform.
  *    Should be a couple of hundred in general. If you have a large graph
  *    then you might want to only do a few iterations and then check the
  *    result. If it is not good enough you can feed it in again in
- *    the \p res argument. The original graphopt default if 500.
+ *    the \p res argument. The original graphopt default is 500.
  * \param node_charge The charge of the vertices, used to calculate electric
  *    repulsion. The original graphopt default is 0.001.
  * \param node_mass The mass of the vertices, used for the spring forces.

--- a/src/layout/graphopt.c
+++ b/src/layout/graphopt.c
@@ -57,7 +57,7 @@ static int igraph_i_determine_spring_axal_forces(
         igraph_real_t *x, igraph_real_t *y,
         igraph_real_t directed_force,
         igraph_real_t distance,
-        int spring_length,
+        igraph_integer_t spring_length,
         long int other_node,
         long int this_node);
 
@@ -66,7 +66,7 @@ static int igraph_i_apply_spring_force(
         igraph_vector_t *pending_forces_x,
         igraph_vector_t *pending_forces_y,
         long int other_node,
-        long int this_node, int spring_length,
+        long int this_node, igraph_integer_t spring_length,
         igraph_real_t spring_constant);
 
 static int igraph_i_move_nodes(
@@ -166,7 +166,7 @@ static int igraph_i_determine_spring_axal_forces(
         igraph_real_t *x, igraph_real_t *y,
         igraph_real_t directed_force,
         igraph_real_t distance,
-        int spring_length,
+        igraph_integer_t spring_length,
         long int other_node, long int this_node) {
 
     // if the spring is just the right size, the forces will be 0, so we can
@@ -205,7 +205,7 @@ static int igraph_i_apply_spring_force(
         igraph_vector_t *pending_forces_x,
         igraph_vector_t *pending_forces_y,
         long int other_node,
-        long int this_node, int spring_length,
+        long int this_node, igraph_integer_t spring_length,
         igraph_real_t spring_constant) {
 
     // determined using Hooke's Law:
@@ -349,14 +349,13 @@ static int igraph_i_move_nodes(
 int igraph_layout_graphopt(const igraph_t *graph, igraph_matrix_t *res,
                            igraph_integer_t niter,
                            igraph_real_t node_charge, igraph_real_t node_mass,
-                           igraph_real_t spring_length,
+                           igraph_integer_t spring_length,
                            igraph_real_t spring_constant,
                            igraph_real_t max_sa_movement,
                            igraph_bool_t use_seed) {
 
     long int no_of_nodes = igraph_vcount(graph);
     long int no_of_edges = igraph_ecount(graph);
-    int my_spring_length = (int) spring_length;
     igraph_vector_t pending_forces_x, pending_forces_y;
     /* Set a flag to calculate (or not) the electrical forces that the nodes */
     /* apply on each other based on if both node types' charges are zero. */
@@ -427,7 +426,7 @@ int igraph_layout_graphopt(const igraph_t *graph, igraph_matrix_t *res,
             long int oother_node = IGRAPH_TO(graph, edge);
             // Apply spring force on both nodes
             igraph_i_apply_spring_force(res, &pending_forces_x, &pending_forces_y,
-                                        oother_node, tthis_node, my_spring_length,
+                                        oother_node, tthis_node, spring_length,
                                         spring_constant);
         }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -250,6 +250,7 @@ add_examples(
 add_legacy_tests(
   FOLDER tests/unit NAMES
   igraph_layout_fruchterman_reingold
+  igraph_layout_graphopt
   igraph_layout_grid
   igraph_layout_lgl
   igraph_layout_mds

--- a/tests/unit/igraph_layout_graphopt.c
+++ b/tests/unit/igraph_layout_graphopt.c
@@ -1,0 +1,98 @@
+/*
+   IGraph library.
+   Copyright (C) 2021  The igraph development team <igraph@igraph.org>
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include <igraph.h>
+#include "test_utilities.inc"
+
+void check_and_destroy(igraph_matrix_t *result, igraph_real_t half_size) {
+    igraph_real_t min, max;
+    igraph_matrix_minmax(result, &min, &max);
+    IGRAPH_ASSERT(min >= -half_size);
+    IGRAPH_ASSERT(max <= half_size);
+    igraph_matrix_destroy(result);
+}
+
+int main() {
+    igraph_t g;
+    igraph_matrix_t result;
+
+    igraph_rng_seed(igraph_rng_default(), 42);
+
+    printf("No vertices:\n");
+    igraph_small(&g, 0, 0, -1);
+    igraph_matrix_init(&result, 0, 0);
+    IGRAPH_ASSERT(igraph_layout_graphopt(&g, &result, /*niter*/ 500, /*node_charge*/ 0.001, /*node_mass*/ 30, /*spring_length*/ 0, /*spring constant*/ 1, /*max_sa_movement*/ 5, /*use seed*/ 0) == IGRAPH_SUCCESS);
+    print_matrix(&result);
+    igraph_matrix_destroy(&result);
+    igraph_destroy(&g);
+
+    printf("One vertex.\n");
+    igraph_small(&g, 1, 0, -1);
+    igraph_matrix_init(&result, 0, 0);
+    IGRAPH_ASSERT(igraph_layout_graphopt(&g, &result, /*niter*/ 500, /*node_charge*/ 0.001, /*node_mass*/ 30, /*spring_length*/ 0, /*spring constant*/ 1, /*max_sa_movement*/ 5, /*use seed*/ 0) == IGRAPH_SUCCESS);
+    check_and_destroy(&result, 1.0);
+    igraph_destroy(&g);
+
+    printf("Full graph of 4 vertices, no loops.\n");
+    igraph_full(&g, 4, 0, 0);
+    igraph_matrix_init(&result, 0, 0);
+    IGRAPH_ASSERT(igraph_layout_graphopt(&g, &result, /*niter*/ 500, /*node_charge*/ 0.001, /*node_mass*/ 30, /*spring_length*/ 0, /*spring constant*/ 1, /*max_sa_movement*/ 5, /*use seed*/ 0) == IGRAPH_SUCCESS);
+    check_and_destroy(&result, 20.0);
+    igraph_destroy(&g);
+
+    printf("4 vertices, disconnected, with loops and multi-edges.\n");
+    igraph_small(&g, 4, 0, 0,0, 0,0, 0,0, 1,2, 1,2, 1,2, -1);
+    igraph_matrix_init(&result, 0, 0);
+    IGRAPH_ASSERT(igraph_layout_graphopt(&g, &result, /*niter*/ 500, /*node_charge*/ 0.001, /*node_mass*/ 30, /*spring_length*/ 0, /*spring constant*/ 1, /*max_sa_movement*/ 5, /*use seed*/ 0) == IGRAPH_SUCCESS);
+    check_and_destroy(&result, 100.0);
+    igraph_destroy(&g);
+
+    printf("Full graph of 4 vertices, no loops with no repulsion.\n");
+    igraph_full(&g, 4, 0, 0);
+    igraph_matrix_init(&result, 0, 0);
+    IGRAPH_ASSERT(igraph_layout_graphopt(&g, &result, /*niter*/ 500, /*node_charge*/ 0.0, /*node_mass*/ 30, /*spring_length*/ 0, /*spring constant*/ 1, /*max_sa_movement*/ 5, /*use seed*/ 0) == IGRAPH_SUCCESS);
+    check_and_destroy(&result, 1.0);
+    igraph_destroy(&g);
+
+    printf("4 vertices in a line, with no repulsion, spring length 1 and a seed:\n");
+    igraph_small(&g, 4, 0, 0,1, 1,2, 2,3, -1);
+    igraph_real_t seed[] = {0.15, -0.15, 0.05, -0.05, -0.05, 0.05, -0.15, 0.15};
+    matrix_init_real_row_major(&result, 4, 2, seed);
+    IGRAPH_ASSERT(igraph_layout_graphopt(&g, &result, /*niter*/ 500, /*node_charge*/ 0.0, /*node_mass*/ 30, /*spring_length*/ 1, /*spring constant*/ 10, /*max_sa_movement*/ 5, /*use seed*/ 1) == IGRAPH_SUCCESS);
+    print_matrix(&result);
+    igraph_matrix_destroy(&result);
+    igraph_destroy(&g);
+
+    printf("4 vertices in a line, with no repulsion, spring length 1 and a seed, no sa_movement:\n");
+    igraph_small(&g, 4, 0, 0,1, 1,2, 2,3, -1);
+    matrix_init_real_row_major(&result, 4, 2, seed);
+    IGRAPH_ASSERT(igraph_layout_graphopt(&g, &result, /*niter*/ 500, /*node_charge*/ 0.0, /*node_mass*/ 30, /*spring_length*/ 1, /*spring constant*/ 10, /*max_sa_movement*/ 0, /*use seed*/ 1) == IGRAPH_SUCCESS);
+    print_matrix(&result);
+    igraph_matrix_destroy(&result);
+    igraph_destroy(&g);
+
+    printf("Wrong size seed.\n");
+    igraph_small(&g, 4, 0, 0,1, 1,2, 2,3, -1);
+    matrix_init_real_row_major(&result, 3, 2, seed);
+    IGRAPH_ASSERT(igraph_layout_graphopt(&g, &result, /*niter*/ 500, /*node_charge*/ 0.0, /*node_mass*/ 30, /*spring_length*/ 1, /*spring constant*/ 10, /*max_sa_movement*/ 0, /*use seed*/ 1) == IGRAPH_SUCCESS);
+    check_and_destroy(&result, 1.0);
+    igraph_destroy(&g);
+
+    VERIFY_FINALLY_STACK();
+    return 0;
+}

--- a/tests/unit/igraph_layout_graphopt.out
+++ b/tests/unit/igraph_layout_graphopt.out
@@ -1,0 +1,16 @@
+No vertices:
+One vertex.
+Full graph of 4 vertices, no loops.
+4 vertices, disconnected, with loops and multi-edges.
+Full graph of 4 vertices, no loops with no repulsion.
+4 vertices in a line, with no repulsion, spring length 1 and a seed:
+[  1.06066 -1.06066
+  0.353553 -0.353553
+  -0.353553 0.353553
+  -1.06066  1.06066 ]
+4 vertices in a line, with no repulsion, spring length 1 and a seed, no sa_movement:
+[     0.15    -0.15
+      0.05    -0.05
+     -0.05     0.05
+     -0.15     0.15 ]
+Wrong size seed.


### PR DESCRIPTION
I changed the interface of graphopt, because I though it would be clearer and would not lead to any actual interface changes. As far as I can tell the same thing should happen for the same arguments (except maybe less overflows if igraph_integer_t is bigger than int).