### PR TITLE
Add layout_bipartite unit_tests

### DIFF
--- a/src/layout/bipartite.c
+++ b/src/layout/bipartite.c
@@ -58,12 +58,16 @@ int igraph_layout_bipartite(const igraph_t *graph,
     igraph_vector_t layers;
 
     if (igraph_vector_bool_size(types) != no_of_nodes) {
-        IGRAPH_ERROR("Invalid vertex type vector size", IGRAPH_EINVAL);
+        IGRAPH_ERRORF("The vertex type vector size (%" IGRAPH_PRId ") should be equal to the number of nodes (%" IGRAPH_PRId ").",
+                      IGRAPH_EINVAL, igraph_vector_bool_size(types), no_of_nodes);
+    }
+    if (hgap < 0) {
+        IGRAPH_ERRORF("The horizontal gap cannot be negative, got %f.", IGRAPH_EINVAL, hgap);
     }
 
     IGRAPH_VECTOR_INIT_FINALLY(&layers, no_of_nodes);
     for (i = 0; i < no_of_nodes; i++) {
-        VECTOR(layers)[i] = 1 - VECTOR(*types)[i];
+        VECTOR(layers)[i] = VECTOR(*types)[i] ? 1 : 0;
     }
 
     IGRAPH_CHECK(igraph_layout_sugiyama(graph, res, /*extd_graph=*/ 0,

--- a/src/layout/bipartite.c
+++ b/src/layout/bipartite.c
@@ -27,7 +27,7 @@
 
 /**
  * \function igraph_layout_bipartite
- * Simple layout for bipartite graphs
+ * Simple layout for bipartite graphs.
  *
  * The layout is created by first placing the vertices in two rows,
  * according to their types. Then the positions within the rows are
@@ -77,5 +77,5 @@ int igraph_layout_bipartite(const igraph_t *graph,
     igraph_vector_destroy(&layers);
     IGRAPH_FINALLY_CLEAN(1);
 
-    return 0;
+    return IGRAPH_SUCCESS;
 }

--- a/src/layout/bipartite.c
+++ b/src/layout/bipartite.c
@@ -58,7 +58,7 @@ int igraph_layout_bipartite(const igraph_t *graph,
     igraph_vector_t layers;
 
     if (igraph_vector_bool_size(types) != no_of_nodes) {
-        IGRAPH_ERRORF("The vertex type vector size (%" IGRAPH_PRId ") should be equal to the number of nodes (%" IGRAPH_PRId ").",
+        IGRAPH_ERRORF("The vertex type vector size (%ld) should be equal to the number of nodes (%ld).",
                       IGRAPH_EINVAL, igraph_vector_bool_size(types), no_of_nodes);
     }
     if (hgap < 0) {

--- a/src/layout/bipartite.c
+++ b/src/layout/bipartite.c
@@ -67,7 +67,7 @@ int igraph_layout_bipartite(const igraph_t *graph,
 
     IGRAPH_VECTOR_INIT_FINALLY(&layers, no_of_nodes);
     for (i = 0; i < no_of_nodes; i++) {
-        VECTOR(layers)[i] = VECTOR(*types)[i] ? 1 : 0;
+        VECTOR(layers)[i] = VECTOR(*types)[i] ? 0 : 1;
     }
 
     IGRAPH_CHECK(igraph_layout_sugiyama(graph, res, /*extd_graph=*/ 0,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -249,6 +249,7 @@ add_examples(
 
 add_legacy_tests(
   FOLDER tests/unit NAMES
+  igraph_layout_bipartite
   igraph_layout_fruchterman_reingold
   igraph_layout_grid
   igraph_layout_lgl

--- a/tests/unit/igraph_layout_bipartite.c
+++ b/tests/unit/igraph_layout_bipartite.c
@@ -1,0 +1,110 @@
+/*
+   IGraph library.
+   Copyright (C) 2021  The igraph development team <igraph@igraph.org>
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include <igraph.h>
+#include "test_utilities.inc"
+
+int main() {
+    igraph_t g;
+    igraph_matrix_t result;
+    igraph_vector_bool_t types;
+
+    printf("No vertices:\n");
+    igraph_small(&g, 0, 0, -1);
+    igraph_matrix_init(&result, 0, 0);
+    igraph_vector_bool_init(&types, 0);
+    IGRAPH_ASSERT(igraph_layout_bipartite(&g, &types, &result, /*hgap*/ 1.0, /*vgap*/ 1.0, /*maxiter*/ 100) == IGRAPH_SUCCESS);
+    print_matrix(&result);
+    igraph_vector_bool_destroy(&types);
+    igraph_matrix_destroy(&result);
+    igraph_destroy(&g);
+
+    printf("1 vertex:\n");
+    igraph_small(&g, 1, 0, -1);
+    igraph_matrix_init(&result, 0, 0);
+    igraph_vector_bool_init_int(&types, 1, 0);
+    IGRAPH_ASSERT(igraph_layout_bipartite(&g, &types, &result, /*hgap*/ 1.0, /*vgap*/ 1.0, /*maxiter*/ 100) == IGRAPH_SUCCESS);
+    print_matrix(&result);
+    igraph_vector_bool_destroy(&types);
+    igraph_matrix_destroy(&result);
+    igraph_destroy(&g);
+
+    printf("4 vertices, disconnected, not actually bipartite, with loops and multiple edges:\n");
+    igraph_small(&g, 4, 0, 0,0, 0,0, 0,0, 1,2, 1,2, 1,3, 1,3, 2,3, -1);
+    igraph_matrix_init(&result, 0, 0);
+    igraph_vector_bool_init_int(&types, 4, 0, 1, 0, 1);
+    IGRAPH_ASSERT(igraph_layout_bipartite(&g, &types, &result, /*hgap*/ 1.0, /*vgap*/ 1.0, /*maxiter*/ 100) == IGRAPH_SUCCESS);
+    print_matrix(&result);
+    igraph_vector_bool_destroy(&types);
+    igraph_matrix_destroy(&result);
+    igraph_destroy(&g);
+
+    printf("10 vertices bipartite graph:\n");
+    igraph_small(&g, 10, 0, 0,5, 0,7, 1,6, 1,7, 1,8, 2,5, 3,8, -1);
+    igraph_matrix_init(&result, 0, 0);
+    igraph_vector_bool_init_int(&types, 10, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1);
+    IGRAPH_ASSERT(igraph_layout_bipartite(&g, &types, &result, /*hgap*/ 1.0, /*vgap*/ 1.0, /*maxiter*/100) == IGRAPH_SUCCESS);
+    print_matrix(&result);
+    igraph_vector_bool_destroy(&types);
+    igraph_matrix_destroy(&result);
+    igraph_destroy(&g);
+
+    printf("10 vertices bipartite graph, no iterations:\n");
+    igraph_small(&g, 10, 0, 0,5, 0,7, 1,6, 1,7, 1,8, 2,5, 3,8, -1);
+    igraph_matrix_init(&result, 0, 0);
+    igraph_vector_bool_init_int(&types, 10, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1);
+    IGRAPH_ASSERT(igraph_layout_bipartite(&g, &types, &result, /*hgap*/ 1.0, /*vgap*/ 1.0, /*maxiter*/0) == IGRAPH_SUCCESS);
+    print_matrix(&result);
+    igraph_vector_bool_destroy(&types);
+    igraph_matrix_destroy(&result);
+    igraph_destroy(&g);
+
+    printf("4 vertices with -10 true values for types:\n");
+    igraph_small(&g, 4, 0, 0,1, 1,2, 2,3, 3,0, -1);
+    igraph_matrix_init(&result, 0, 0);
+    igraph_vector_bool_init_int(&types, 4, 0, -10, 0, -10);
+    IGRAPH_ASSERT(igraph_layout_bipartite(&g, &types, &result, /*hgap*/ 1.0, /*vgap*/ 1.0, /*maxiter*/ 100) == IGRAPH_SUCCESS);
+    print_matrix(&result);
+    igraph_vector_bool_destroy(&types);
+    igraph_matrix_destroy(&result);
+    igraph_destroy(&g);
+
+    printf("4 vertices, negative vgaps:\n");
+    igraph_small(&g, 4, 0, 0,1, 1,2, 2,3, 3,0, -1);
+    igraph_matrix_init(&result, 0, 0);
+    igraph_vector_bool_init_int(&types, 4, 0, 1, 0, 1);
+    IGRAPH_ASSERT(igraph_layout_bipartite(&g, &types, &result, /*hgap*/ 1.0, /*vgap*/ -1.0, /*maxiter*/ 100) == IGRAPH_SUCCESS);
+    print_matrix(&result);
+    igraph_vector_bool_destroy(&types);
+    igraph_matrix_destroy(&result);
+    igraph_destroy(&g);
+
+    igraph_set_error_handler(igraph_error_handler_ignore);
+
+    printf("4 vertices, negative hgaps, emits error.\n");
+    igraph_small(&g, 4, 0, 0,1, 1,2, 2,3, 3,0, -1);
+    igraph_matrix_init(&result, 0, 0);
+    igraph_vector_bool_init_int(&types, 4, 0, 1, 0, 1);
+    IGRAPH_ASSERT(igraph_layout_bipartite(&g, &types, &result, /*hgap*/ -1.0, /*vgap*/ 1.0, /*maxiter*/ 100) == IGRAPH_EINVAL);
+    igraph_vector_bool_destroy(&types);
+    igraph_matrix_destroy(&result);
+    igraph_destroy(&g);
+
+    VERIFY_FINALLY_STACK();
+    return 0;
+}

--- a/tests/unit/igraph_layout_bipartite.out
+++ b/tests/unit/igraph_layout_bipartite.out
@@ -1,0 +1,41 @@
+No vertices:
+1 vertex:
+[        0        0 ]
+4 vertices, disconnected, not actually bipartite, with loops and multiple edges:
+[        0        0
+         1        1
+         1        0
+         2        1 ]
+10 vertices bipartite graph:
+[        1        0
+         2        0
+         0        0
+         3        0
+         4        0
+         0        1
+         2        1
+         1        1
+         3        1
+         5        1 ]
+10 vertices bipartite graph, no iterations:
+[     -0.5        0
+         1        0
+         2        0
+         3        0
+         4        0
+         0        1
+         1        1
+         2        1
+         3        1
+         5        1 ]
+4 vertices with -10 true values for types:
+[        0        0
+         0        1
+         1        0
+         1        1 ]
+4 vertices, negative vgaps:
+[        0       -0
+         0       -1
+         1       -0
+         1       -1 ]
+4 vertices, negative hgaps, emits error.

--- a/tests/unit/igraph_layout_bipartite.out
+++ b/tests/unit/igraph_layout_bipartite.out
@@ -1,41 +1,41 @@
 No vertices:
 1 vertex:
-[        0        0 ]
+[        0        1 ]
 4 vertices, disconnected, not actually bipartite, with loops and multiple edges:
-[        0        0
-         1        1
+[        0        1
          1        0
-         2        1 ]
+         1        1
+         2        0 ]
 10 vertices bipartite graph:
-[        1        0
-         2        0
+[        1        1
+         2        1
+         0        1
+         3        1
+         4        1
          0        0
+         2        0
+         1        0
          3        0
-         4        0
-         0        1
-         2        1
-         1        1
-         3        1
-         5        1 ]
+         5        0 ]
 10 vertices bipartite graph, no iterations:
-[     -0.5        0
+[     -0.5        1
+         1        1
+         2        1
+         3        1
+         4        1
+         0        0
          1        0
          2        0
          3        0
-         4        0
-         0        1
-         1        1
-         2        1
-         3        1
-         5        1 ]
+         5        0 ]
 4 vertices with -10 true values for types:
-[        0        0
-         0        1
-         1        0
-         1        1 ]
+[        0        1
+         0        0
+         1        1
+         1        0 ]
 4 vertices, negative vgaps:
-[        0       -0
-         0       -1
-         1       -0
-         1       -1 ]
+[        0       -1
+         0       -0
+         1       -1
+         1       -0 ]
 4 vertices, negative hgaps, emits error.


### PR DESCRIPTION
Part of #1592

Fix: The implementation assumed bools were either 1 or 0.

New error: negative horizontal gaps resulted in x-coordinates that were all zero, so that is excluded.