### PR TITLE
Add sparsemat_view unit tests and doc

### DIFF
--- a/doc/sparsemat.xxml
+++ b/doc/sparsemat.xxml
@@ -18,6 +18,7 @@
 <!-- doxrox-include igraph_sparsemat_destroy -->
 <!-- doxrox-include igraph_sparsemat_eye -->
 <!-- doxrox-include igraph_sparsemat_diag -->
+<!-- doxrox-include igraph_sparsemat_view -->
 </section>
 
 <section id="query-properties-of-a-sparse-matrix"><title>Query properties of a sparse matrix</title>

--- a/src/core/sparsemat.c
+++ b/src/core/sparsemat.c
@@ -2961,6 +2961,40 @@ int igraph_sparsemat_dense_multiply(const igraph_matrix_t *A,
     return 0;
 }
 
+/**
+ * \function igraph_sparsemat_view
+ * \brief Initialize a sparse matrix and set all parameters.
+ *
+ * This function allocates memory for a sparse matrix and sets all its
+ * parameters to the given values. For a simpler way to initialize an
+ * empty sparse matrix, see \ref igraph_sparsemat_init(). Using
+ * \ref igraph_sparsemat_destroy() on the resulting matrix will try
+ * to free \p p, \p i and \p x. To only free memory allocated in this
+ * function, use free() on the \c cs field of A.
+ *
+ * \param A The non-initialized sparse matrix.
+ * \param nzmax The maximum number of entries.
+ * \param m The number of rows.
+ * \param n The number of columns.
+ * \param p The column vector. For a triplet matrix this should contain
+  *         the columns of the elements in \x. For a compressed matrix,
+            if the column index is \c k, then <code>j[k]</code>
+ *          is the index in \p x of the start of the \c k-th column, and
+ *          the last element of \c j is the total number of elements.
+ *          The total number of elements in the \c k-th column is
+ *          therefore <code>j[k+1] - j[k]</code>. For example, if there
+ *          is one element in the first column, and five in the second,
+ *          \c j should be set to <code>{0, 1, 6}</code>.
+ * \param i The row vector. This should contain the row indices of the
+ *          elements in x.
+ * \param x The elements of the sparse matrix.
+ * \param nz For a triplet matrix, this is the number of elements. For
+ *           a compressed matrix, this should be -1.
+ * \return Error code.
+ *
+ * Time complexity: O(1).
+ */
+
 int igraph_sparsemat_view(igraph_sparsemat_t *A, int nzmax, int m, int n,
                           int *p, int *i, double *x, int nz) {
 
@@ -2973,7 +3007,7 @@ int igraph_sparsemat_view(igraph_sparsemat_t *A, int nzmax, int m, int n,
     A->cs->x = x;
     A->cs->nz = nz;
 
-    return 0;
+    return IGRAPH_SUCCESS;
 }
 
 int igraph_i_sparsemat_view(igraph_sparsemat_t *A, int nzmax, int m, int n,

--- a/src/core/sparsemat.c
+++ b/src/core/sparsemat.c
@@ -2977,7 +2977,7 @@ int igraph_sparsemat_dense_multiply(const igraph_matrix_t *A,
  * \param m The number of rows.
  * \param n The number of columns.
  * \param p The column vector. For a triplet matrix this should contain
-  *         the columns of the elements in \x. For a compressed matrix,
+  *         the columns of the elements in \p x. For a compressed matrix,
             if the column index is \c k, then <code>j[k]</code>
  *          is the index in \p x of the start of the \c k-th column, and
  *          the last element of \c j is the total number of elements.
@@ -2986,7 +2986,7 @@ int igraph_sparsemat_dense_multiply(const igraph_matrix_t *A,
  *          is one element in the first column, and five in the second,
  *          \c j should be set to <code>{0, 1, 6}</code>.
  * \param i The row vector. This should contain the row indices of the
- *          elements in x.
+ *          elements in \p x.
  * \param x The elements of the sparse matrix.
  * \param nz For a triplet matrix, this is the number of elements. For
  *           a compressed matrix, this should be -1.

--- a/src/core/sparsemat.c
+++ b/src/core/sparsemat.c
@@ -3014,7 +3014,7 @@ int igraph_sparsemat_dense_multiply(const igraph_matrix_t *A,
 int igraph_sparsemat_view(igraph_sparsemat_t *A, int nzmax, int m, int n,
                           int *p, int *i, double *x, int nz) {
 
-    A->cs = igraph_Calloc(1, sizeof(cs_di));
+    A->cs = igraph_Calloc(1, cs_di);
     A->cs->nzmax = nzmax;
     A->cs->m = m;
     A->cs->n = n;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -54,6 +54,7 @@ add_legacy_tests(
   igraph_sparsemat_is_symmetric
   igraph_sparsemat_minmax
   igraph_sparsemat_nonzero_storage
+  igraph_sparsemat_view
   igraph_sparsemat_which_minmax
   matrix
   matrix2

--- a/tests/unit/igraph_sparsemat_view.c
+++ b/tests/unit/igraph_sparsemat_view.c
@@ -21,15 +21,26 @@
 
 int main() {
     igraph_sparsemat_t spmat;
-    int p = 10;
-    int i = 10;
-    double x = 10.;
+    igraph_matrix_t mat;
+    int p[] = {0, 1, 3};
+    int i[]  = {1, 0, 2};
+    double x[] = {1, 5, 2};
 
+    printf("Empty sparsemat.\n");
+    igraph_matrix_init(&mat, 0, 0);
     igraph_sparsemat_view(&spmat, /*nzmax*/ 0, /*m*/ 0, /*n*/ 0, /*p*/ NULL, /*i*/ NULL, /*x*/ NULL, /*nz*/ 0);
-    igraph_sparsemat_destroy(&spmat);
+    igraph_sparsemat_as_matrix(&mat, &spmat);
+    print_matrix(&mat);
+    igraph_free(spmat.cs);
+    igraph_matrix_destroy(&mat);
 
-    igraph_sparsemat_view(&spmat, /*nzmax*/ 10, /*m*/ 10, /*n*/ 10, &p, &i, &x, /*nz*/ 10);
-    free(spmat.cs);
+    printf("3x2 sparsemat:\n");
+    igraph_matrix_init(&mat, 0, 0);
+    igraph_sparsemat_view(&spmat, /*nzmax*/ 3, /*m*/ 3, /*n*/ 2, p, i, x, /*nz*/ -1);
+    igraph_sparsemat_as_matrix(&mat, &spmat);
+    print_matrix(&mat);
+    igraph_free(spmat.cs);
+    igraph_matrix_destroy(&mat);
 
     VERIFY_FINALLY_STACK();
     return 0;

--- a/tests/unit/igraph_sparsemat_view.c
+++ b/tests/unit/igraph_sparsemat_view.c
@@ -1,0 +1,36 @@
+/*
+   IGraph library.
+   Copyright (C) 2021  The igraph development team <igraph@igraph.org>
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include <igraph.h>
+#include "test_utilities.inc"
+
+int main() {
+    igraph_sparsemat_t spmat;
+    int p = 10;
+    int i = 10;
+    double x = 10.;
+
+    igraph_sparsemat_view(&spmat, /*nzmax*/ 0, /*m*/ 0, /*n*/ 0, /*p*/ NULL, /*i*/ NULL, /*x*/ NULL, /*nz*/ 0);
+    igraph_sparsemat_destroy(&spmat);
+
+    igraph_sparsemat_view(&spmat, /*nzmax*/ 10, /*m*/ 10, /*n*/ 10, &p, &i, &x, /*nz*/ 10);
+    free(spmat.cs);
+
+    VERIFY_FINALLY_STACK();
+    return 0;
+}

--- a/tests/unit/igraph_sparsemat_view.out
+++ b/tests/unit/igraph_sparsemat_view.out
@@ -1,0 +1,5 @@
+Empty sparsemat.
+3x2 sparsemat:
+[        0        5
+         1        0
+         0        2 ]


### PR DESCRIPTION
Part of #1592

This init function does not seem to have a corresponding destroy
function. sparsemat_view calls cs_calloc directly for the struct, but
doesn't allocate the index and element vectors. igraph users don't have
direct access to cs_malloc to allocate their own through the cs
interface. They also don't have access to cs_free through igraph. So
currently there's no proper destruction without assuming cs_free and
cs_malloc use free and malloc as they do now.