### PR TITLE
Add sparsemat_iterator_dix unit tests, add docs

### DIFF
--- a/doc/sparsemat.xxml
+++ b/doc/sparsemat.xxml
@@ -38,7 +38,7 @@
 <!-- doxrox-include igraph_sparsemat_nonzero_storage -->
 </section>
 
-<section id="operations-on-sprase-matrices"><title>Operations on sprase matrices</title>
+<section id="operations-on-sparse-matrices"><title>Operations on sparse matrices</title>
 <!-- doxrox-include igraph_sparsemat_entry -->
 <!-- doxrox-include igraph_sparsemat_fkeep -->
 <!-- doxrox-include igraph_sparsemat_dropzeros -->
@@ -52,6 +52,17 @@
 <!-- doxrox-include igraph_sparsemat_add_rows -->
 <!-- doxrox-include igraph_sparsemat_add_cols -->
 <!-- doxrox-include igraph_sparsemat_resize -->
+</section>
+
+<section id="operations-on_sparse_matrix_iterators"><title>Operations on sparse matrix iterators</title>
+<!-- doxrox-include igraph_sparsemat_iterator_init -->
+<!-- doxrox-include igraph_sparsemat_iterator_reset -->
+<!-- doxrox-include igraph_sparsemat_iterator_end -->
+<!-- doxrox-include igraph_sparsemat_iterator_row -->
+<!-- doxrox-include igraph_sparsemat_iterator_col -->
+<!-- doxrox-include igraph_sparsemat_iterator_get -->
+<!-- doxrox-include igraph_sparsemat_iterator_next -->
+<!-- doxrox-include igraph_sparsemat_iterator_idx -->
 </section>
 
 <section id="operations-that-change-the-internal-representation"><title>Operations that change the internal representation</title>

--- a/src/core/sparsemat.c
+++ b/src/core/sparsemat.c
@@ -3060,25 +3060,57 @@ int igraph_sparsemat_neg(igraph_sparsemat_t *A) {
     return 0;
 }
 
+/**
+ * \function igraph_sparsemat_iterator_init
+ * \brief Initialize a sparse matrix iterator.
+ *
+ * \param it A pointer to an uninitialized sparse matrix iterator.
+ * \param sparsemat Pointer to the sparse matrix.
+ * \return Error code. This will always return \c IGRAPH_SUCCESS
+ *
+ * Time complexity: O(n), the number of columns of the sparse matrix.
+ */
+
 int igraph_sparsemat_iterator_init(igraph_sparsemat_iterator_t *it,
                                    igraph_sparsemat_t *sparsemat) {
 
     it->mat = sparsemat;
     igraph_sparsemat_iterator_reset(it);
-    return 0;
+    return IGRAPH_SUCCESS;
 }
+
+/**
+ * \function igraph_sparsemat_iterator_reset
+ * \brief Reset a sparse matrix iterator to the first element.
+ *
+ * \param it A pointer to the sparse matrix iterator.
+ * \return Error code. This will always return \c IGRAPH_SUCCESS
+ *
+ * Time complexity: O(n), the number of columns of the sparse matrix.
+ */
 
 int igraph_sparsemat_iterator_reset(igraph_sparsemat_iterator_t *it) {
     it->pos = 0;
+    it->col = 0;
     if (!igraph_sparsemat_is_triplet(it->mat)) {
-        it->col = 0;
         while (it->col < it->mat->cs->n &&
                it->mat->cs->p[it->col + 1] == it->pos) {
             it->col ++;
         }
     }
-    return 0;
+    return IGRAPH_SUCCESS;
 }
+
+/**
+ * \function igraph_sparsemat_iterator_end
+ * \brief Query if the iterator is past the last element.
+ *
+ * \param it A pointer to the sparse matrix iterator.
+ * \return true if the iterator is past the last element, false if it
+ *         points to an element in a sparse matrix.
+ *
+ * Time complexity: O(1).
+ */
 
 igraph_bool_t
 igraph_sparsemat_iterator_end(const igraph_sparsemat_iterator_t *it) {
@@ -3087,9 +3119,29 @@ igraph_sparsemat_iterator_end(const igraph_sparsemat_iterator_t *it) {
     return it->pos >= nz;
 }
 
+/**
+ * \function igraph_sparsemat_iterator_row
+ * \brief Return the row of the iterator.
+ *
+ * \param it A pointer to the sparse matrix iterator.
+ * \return The row of the element at the current iterator position.
+ *
+ * Time complexity: O(1).
+ */
+
 int igraph_sparsemat_iterator_row(const igraph_sparsemat_iterator_t *it) {
     return it->mat->cs->i[it->pos];
 }
+
+/**
+ * \function igraph_sparsemat_iterator_col
+ * \brief Return the column of the iterator.
+ *
+ * \param it A pointer to the sparse matrix iterator.
+ * \return The column of the element at the current iterator position.
+ *
+ * Time complexity: O(1).
+ */
 
 int igraph_sparsemat_iterator_col(const igraph_sparsemat_iterator_t *it) {
     if (igraph_sparsemat_is_triplet(it->mat)) {
@@ -3099,10 +3151,30 @@ int igraph_sparsemat_iterator_col(const igraph_sparsemat_iterator_t *it) {
     }
 }
 
+/**
+ * \function igraph_sparsemat_iterator_get
+ * \brief Return the element at the current iterator position.
+ *
+ * \param it A pointer to the sparse matrix iterator.
+ * \return The value of the element at the current iterator position.
+ *
+ * Time complexity: O(1).
+ */
+
 igraph_real_t
 igraph_sparsemat_iterator_get(const igraph_sparsemat_iterator_t *it) {
     return it->mat->cs->x[it->pos];
 }
+
+/**
+ * \function igraph_sparsemat_iterator_next
+ * \brief Let a sparse matrix iterator go to the next element.
+ *
+ * \param it A pointer to the sparse matrix iterator.
+ * \return The position of the iterator in the element vector.
+ *
+ * Time complexity: O(n), the number of columns of the sparse matrix.
+ */
 
 int igraph_sparsemat_iterator_next(igraph_sparsemat_iterator_t *it) {
     it->pos += 1;
@@ -3112,6 +3184,16 @@ int igraph_sparsemat_iterator_next(igraph_sparsemat_iterator_t *it) {
     }
     return it->pos;
 }
+
+/**
+ * \function igraph_sparsemat_iterator_idx
+ * \brief Returns the element vector index of a sparse matrix iterator.
+ *
+ * \param it A pointer to the sparse matrix iterator.
+ * \return The position of the iterator in the element vector.
+ *
+ * Time complexity: O(1).
+ */
 
 int igraph_sparsemat_iterator_idx(const igraph_sparsemat_iterator_t *it) {
     return it->pos;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -54,6 +54,7 @@ add_legacy_tests(
   igraph_sparsemat_fkeep
   igraph_sparsemat_getelements_sorted
   igraph_sparsemat_is_symmetric
+  igraph_sparsemat_iterator_idx
   igraph_sparsemat_minmax
   igraph_sparsemat_nonzero_storage
   igraph_sparsemat_which_minmax

--- a/tests/unit/igraph_sparsemat_iterator_idx.c
+++ b/tests/unit/igraph_sparsemat_iterator_idx.c
@@ -1,0 +1,56 @@
+/*
+   IGraph library.
+   Copyright (C) 2021  The igraph development team <igraph@igraph.org>
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include <igraph.h>
+#include "test_utilities.inc"
+
+int main() {
+    igraph_sparsemat_t spmat;
+    igraph_sparsemat_t spmat_comp;
+    igraph_sparsemat_iterator_t it;
+    igraph_sparsemat_iterator_t it_comp;
+
+    printf("0x0 matrix.\n");
+    igraph_sparsemat_init(&spmat, 0, 0, /*nzmax*/0);
+    igraph_sparsemat_compress(&spmat, &spmat_comp);
+    igraph_sparsemat_iterator_init(&it, &spmat);
+    igraph_sparsemat_iterator_init(&it_comp, &spmat_comp);
+    IGRAPH_ASSERT(igraph_sparsemat_iterator_idx(&it) == 0);
+    IGRAPH_ASSERT(igraph_sparsemat_iterator_idx(&it_comp) == 0);
+    igraph_sparsemat_destroy(&spmat);
+    igraph_sparsemat_destroy(&spmat_comp);
+
+    printf("3x3 matrix.\n");
+    igraph_sparsemat_init(&spmat, 3, 3, /*nzmax*/0);
+    igraph_sparsemat_entry(&spmat, 0, 0, 5);
+    igraph_sparsemat_entry(&spmat, 3, 3, 6);
+    igraph_sparsemat_entry(&spmat, 3, 3, 6);
+    igraph_sparsemat_compress(&spmat, &spmat_comp);
+    igraph_sparsemat_iterator_init(&it, &spmat);
+    igraph_sparsemat_iterator_init(&it_comp, &spmat_comp);
+    igraph_sparsemat_iterator_next(&it);
+    igraph_sparsemat_iterator_next(&it);
+    igraph_sparsemat_iterator_next(&it_comp);
+    IGRAPH_ASSERT(igraph_sparsemat_iterator_idx(&it) == 2);
+    IGRAPH_ASSERT(igraph_sparsemat_iterator_idx(&it_comp) == 1);
+    igraph_sparsemat_destroy(&spmat);
+    igraph_sparsemat_destroy(&spmat_comp);
+
+    VERIFY_FINALLY_STACK();
+    return 0;
+}


### PR DESCRIPTION
Part of #1592
Bugfix: sparsemat_iterator_reset didn't set the column for triplet
matrices.