### PR TITLE
Made paths for testing in Windows more robust

### DIFF
--- a/etc/cmake/test_helpers.cmake
+++ b/etc/cmake/test_helpers.cmake
@@ -64,8 +64,8 @@ function(add_legacy_test FOLDER NAME NAMESPACE)
 
     # The next line is necessitated by MinGW on Windows. MinGW uses forward slashes in
     # IGRAPH_LIBDIR, but we need to supply CTest with backslashes because CTest is executed
-    # in a cmd.exe shell. So we simply replace forward slashes with backslases in
-    # IGRAPH_LIBDIR.
+    # in a cmd.exe shell. We therefore explicitly ensure that that path is transformed to a
+    # native path.
     file(TO_NATIVE_PATH "${IGRAPH_LIBDIR}" IGRAPH_LIBDIR)
 
     # Semicolons are used as list separators in CMake so we need to escape them in the PATH,

--- a/etc/cmake/test_helpers.cmake
+++ b/etc/cmake/test_helpers.cmake
@@ -66,7 +66,7 @@ function(add_legacy_test FOLDER NAME NAMESPACE)
     # IGRAPH_LIBDIR, but we need to supply CTest with backslashes because CTest is executed
     # in a cmd.exe shell. So we simply replace forward slashes with backslases in
     # IGRAPH_LIBDIR.
-    string(REPLACE "/" "\\" IGRAPH_LIBDIR ${IGRAPH_LIBDIR})
+    file(TO_NATIVE_PATH "${IGRAPH_LIBDIR}" IGRAPH_LIBDIR)
 
     # Semicolons are used as list separators in CMake so we need to escape them in the PATH,
     # otherwise the PATH envvar gets split by CMake before it passes the PATH on to CTest.


### PR DESCRIPTION
When building a shared library on Windows, we automatically add the necessary paths to ensure the shared libraries are found when running `ctest`. This does not work well when there are paths included that end with a backslash, because the trailing backslash is then incorrectly interpreted as an escape character. This problem was raised in #1686, and this PR should fix this.

This PR changes the way that the path is constructed to ensure that each path is correctly included in a semi-colon separated string. Presumably, when 3.20 comes out, this can be replaced by a [`TO_NATIVE_PATH_LIST`](https://cmake.org/cmake/help/latest/command/cmake_path.html#to-native-path-list) construct. Of course, we may want to wait until this version of cmake is sufficiently well available. Anyway, as a reminder, I also mentioned this possibility in the comments.

Hopefully, this also still works well with msys. Let's see how the CI does.