### PR TITLE
Added libxml dependency on Windows on Azure pipelines

### DIFF
--- a/.azure/build-win.yml
+++ b/.azure/build-win.yml
@@ -39,7 +39,9 @@ parameters:
 steps:
   - script: |
       choco install winflexbison3 ninja
-      %CONDA%\Scripts\activate
+
+      call "%CONDA%\Scripts\activate" base
+
       conda install libxml2
 
     displayName: Install dependencies

--- a/.azure/build-win.yml
+++ b/.azure/build-win.yml
@@ -45,7 +45,7 @@ steps:
       key: >-
         vcpkg
         | $(Agent.Os)
-        | $(parameters.build_shared)
+        | ${{ parameters.build_shared }}
       path: $(VCPKG_INSTALLATION_ROOT)
       cacheHitVar: VcpkgRestoredFromCache
     displayName: Vcpkg Cache

--- a/.azure/build-win.yml
+++ b/.azure/build-win.yml
@@ -45,7 +45,7 @@ steps:
       key: >-
         vcpkg
         | $(Agent.Os)
-        | ${{ parameters.build_shared }}
+        | ${{ parameters.vcpkg_target_triplet }}
       path: $(VCPKG_INSTALLATION_ROOT)
       cacheHitVar: VcpkgRestoredFromCache
     displayName: Vcpkg Cache

--- a/.azure/build-win.yml
+++ b/.azure/build-win.yml
@@ -53,11 +53,14 @@ steps:
   #  - Due to this setup, CMake must also be called in the same script instead of using the CMake task
   #  - We must set CXX and CC so that CMake would not accidentally pick up another compiler.
   #  - With the above, we can use the Ninja generator, which enables much faster build times than the VS one due to better parallelization.
+  #  - We need to add the bin directory to the path to be able to find the libxml2 dependency.
   - script: |
       md build
       cd build
 
       call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64 -vcvars_ver=14.0
+
+      set PATH="%PATH%;%CONDA%\Library\bin"
 
       set CXX=cl.exe
       set CC=cl.exe

--- a/.azure/build-win.yml
+++ b/.azure/build-win.yml
@@ -37,12 +37,19 @@ parameters:
     default: ''
 
 steps:
+  - task: Cache@2
+    inputs:
+      key: '%CONDA%\Scripts\conda --version'
+      path: %CONDA%\Library
+    displayName: Cache conda environment
+
   - script: |
       choco install winflexbison3 ninja
 
       call "%CONDA%\Scripts\activate" base
 
       conda install libxml2
+
 
     displayName: Install dependencies
 
@@ -60,7 +67,11 @@ steps:
 
       call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64 -vcvars_ver=14.0
 
+      echo %PATH%
+
       set PATH="%PATH%;%CONDA%\Library\bin"
+
+      echo %PATH%
 
       set CXX=cl.exe
       set CC=cl.exe

--- a/.azure/build-win.yml
+++ b/.azure/build-win.yml
@@ -37,12 +37,6 @@ parameters:
     default: ''
 
 steps:
-  - task: Cache@2
-    inputs:
-      key: '%CONDA%\Scripts\conda --version'
-      path: %CONDA%\Library
-    displayName: Cache conda environment
-
   - script: |
       choco install winflexbison3 ninja
 

--- a/.azure/build-win.yml
+++ b/.azure/build-win.yml
@@ -63,7 +63,7 @@ steps:
 
       echo %PATH%
 
-      set PATH="%PATH%;%CONDA%\Library\bin"
+      set PATH=%PATH%;%CONDA%\Library\bin
 
       echo %PATH%
 

--- a/.azure/build-win.yml
+++ b/.azure/build-win.yml
@@ -43,7 +43,7 @@ steps:
   - task: Cache@2
     inputs:
       key: >-
-        vcpkg
+        vcpkg-installed
         | $(Agent.Os)
         | ${{ parameters.vcpkg_target_triplet }}
       path: $(VCPKG_INSTALLATION_ROOT)\installed

--- a/.azure/build-win.yml
+++ b/.azure/build-win.yml
@@ -63,7 +63,7 @@ steps:
 
       echo %PATH%
 
-      set PATH=%PATH%;%CONDA%\Library\bin
+      set PATH=%PATH%;%CONDA%\Library\bin;%CONDA%\Library\lib
 
       echo %PATH%
 

--- a/.azure/build-win.yml
+++ b/.azure/build-win.yml
@@ -55,7 +55,7 @@ steps:
 
       %VCPKG_INSTALLATION_ROOT%\vcpkg.exe integrate install
 
-      %VCPKG_INSTALLATION_ROOT%\vcpkg.exe install libxml2:${{ vcpkg_target_triplet }}
+      %VCPKG_INSTALLATION_ROOT%\vcpkg.exe install libxml2:${{ parameters.vcpkg_target_triplet }}
 
     displayName: Install dependencies
 
@@ -87,7 +87,7 @@ steps:
                -DBUILD_SHARED_LIBS=${{ parameters.build_shared }} ^
                -DIGRAPH_ENABLE_TLS=${{ parameters.enable_tls }} ^
                -DCMAKE_BUILD_TYPE=${{ parameters.build_type }} ^
-               -DVCPKG_TARGET_TRIPLET=${{ vcpkg_target_triplet }} ^
+               -DVCPKG_TARGET_TRIPLET=${{ parameters.vcpkg_target_triplet }} ^
                -DCMAKE_TOOLCHAIN_FILE=%VCPKG_INSTALLATION_ROOT%/scripts/buildsystems/vcpkg.cmake ^
                ${{ parameters.extra_cmake_args }}
 

--- a/.azure/build-win.yml
+++ b/.azure/build-win.yml
@@ -46,7 +46,7 @@ steps:
         vcpkg
         | $(Agent.Os)
         | ${{ parameters.vcpkg_target_triplet }}
-      path: $(VCPKG_INSTALLATION_ROOT)
+      path: $(VCPKG_INSTALLATION_ROOT)\installed
       cacheHitVar: VcpkgRestoredFromCache
     displayName: Vcpkg Cache
 

--- a/.azure/build-win.yml
+++ b/.azure/build-win.yml
@@ -36,14 +36,26 @@ parameters:
     type: string
     default: ''
 
+variables:
+  - VCPKG_TRIPLET=x64-windows${{ '-static' if parameters.build_shared else '' }}
+
 steps:
+  - task: Cache@2
+    inputs:
+      key: >-
+        vcpkg
+        | $(Agent.Os)
+        | $(parameters.build_shared)
+      path: $(VCPKG_INSTALLATION_ROOT)
+      cacheHitVar: VcpkgRestoredFromCache
+    displayName: Vcpkg Cache
+
   - script: |
       choco install winflexbison3 ninja
 
-      call "%CONDA%\Scripts\activate" base
+      %VCPKG_INSTALLATION_ROOT%\vcpkg.exe integrate install
 
-      conda install libxml2
-
+      %VCPKG_INSTALLATION_ROOT%\vcpkg.exe install libxml2:%VCPKG_TRIPLET%
 
     displayName: Install dependencies
 
@@ -61,16 +73,23 @@ steps:
 
       call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64 -vcvars_ver=14.0
 
-      echo %PATH%
-
-      set PATH=%PATH%;%CONDA%\Library\bin;%CONDA%\Library\lib
-
-      echo %PATH%
-
       set CXX=cl.exe
       set CC=cl.exe
 
-      cmake .. -DCMAKE_PREFIX_PATH=%CONDA%\Library\lib -DIGRAPH_USE_INTERNAL_BLAS=${{ parameters.int_blas }} -DIGRAPH_USE_INTERNAL_LAPACK=${{ parameters.int_lapack }} -DIGRAPH_USE_INTERNAL_ARPACK=${{ parameters.int_arpack }} -DIGRAPH_USE_INTERNAL_GLPK=${{ parameters.int_glpk }} -DIGRAPH_USE_INTERNAL_CXSPARSE=${{ parameters.int_cxsparse }} -DIGRAPH_USE_INTERNAL_GMP=${{ parameters.int_gmp }} -DIGRAPH_VERIFY_FINALLY_STACK=${{ parameters.verify_finally }} -DBUILD_SHARED_LIBS=${{ parameters.build_shared }} -DIGRAPH_ENABLE_TLS=${{ parameters.enable_tls }} -DCMAKE_BUILD_TYPE=${{ parameters.build_type }} ${{ parameters.extra_cmake_args }}
+      cmake .. -DCMAKE_PREFIX_PATH=%CONDA%\Library\lib ^
+               -DIGRAPH_USE_INTERNAL_BLAS=${{ parameters.int_blas }} ^
+               -DIGRAPH_USE_INTERNAL_LAPACK=${{ parameters.int_lapack }} ^
+               -DIGRAPH_USE_INTERNAL_ARPACK=${{ parameters.int_arpack }} ^
+               -DIGRAPH_USE_INTERNAL_GLPK=${{ parameters.int_glpk }} ^
+               -DIGRAPH_USE_INTERNAL_CXSPARSE=${{ parameters.int_cxsparse }} ^
+               -DIGRAPH_USE_INTERNAL_GMP=${{ parameters.int_gmp }} ^
+               -DIGRAPH_VERIFY_FINALLY_STACK=${{ parameters.verify_finally }} ^
+               -DBUILD_SHARED_LIBS=${{ parameters.build_shared }} ^
+               -DIGRAPH_ENABLE_TLS=${{ parameters.enable_tls }} ^
+               -DCMAKE_BUILD_TYPE=${{ parameters.build_type }} ^
+               -DVCPKG_TARGET_TRIPLET=%VCPKG_TRIPLET% ^
+               -DCMAKE_TOOLCHAIN_FILE=%VCPKG_INSTALLATION_ROOT%/scripts/buildsystems/vcpkg.cmake ^
+               ${{ parameters.extra_cmake_args }}
 
       cmake --build . --target build_tests
     displayName: Configure and build

--- a/.azure/build-win.yml
+++ b/.azure/build-win.yml
@@ -52,7 +52,10 @@ steps:
 
       %VCPKG_INSTALLATION_ROOT%\vcpkg.exe integrate install
 
-      %VCPKG_INSTALLATION_ROOT%\vcpkg.exe install libxml2:x64-windows${{ '-static' if parameters.build_shared else '' }}
+      ${{ if parameters.build_shared }}:
+      %VCPKG_INSTALLATION_ROOT%\vcpkg.exe install libxml2:x64-windows
+      ${{ if not(parameters.build_shared) }}:
+      %VCPKG_INSTALLATION_ROOT%\vcpkg.exe install libxml2:x64-windows-static
 
     displayName: Install dependencies
 
@@ -84,7 +87,10 @@ steps:
                -DBUILD_SHARED_LIBS=${{ parameters.build_shared }} ^
                -DIGRAPH_ENABLE_TLS=${{ parameters.enable_tls }} ^
                -DCMAKE_BUILD_TYPE=${{ parameters.build_type }} ^
-               -DVCPKG_TARGET_TRIPLET=x64-windows${{ '-static' if parameters.build_shared else '' }} ^
+               ${{ if parameters.build_shared }}:
+               -DVCPKG_TARGET_TRIPLET=x64-windows ^
+               ${{ if not(parameters.build_shared) }}:
+               -DVCPKG_TARGET_TRIPLET=x64-windows-static ^
                -DCMAKE_TOOLCHAIN_FILE=%VCPKG_INSTALLATION_ROOT%/scripts/buildsystems/vcpkg.cmake ^
                ${{ parameters.extra_cmake_args }}
 

--- a/.azure/build-win.yml
+++ b/.azure/build-win.yml
@@ -22,7 +22,7 @@ parameters:
     default: true
   - name: build_shared
     type: boolean
-    default: true
+    default: false
   - name: enable_tls
     type: boolean
     default: true
@@ -37,7 +37,7 @@ parameters:
     default: ''
   - name: vcpkg_target_triplet
     type: string
-    default: 'x64-windows'
+    default: 'x64-windows-static-md'
 
 steps:
   - task: Cache@2

--- a/.azure/build-win.yml
+++ b/.azure/build-win.yml
@@ -36,9 +36,6 @@ parameters:
     type: string
     default: ''
 
-variables:
-  - VCPKG_TRIPLET=x64-windows${{ '-static' if parameters.build_shared else '' }}
-
 steps:
   - task: Cache@2
     inputs:
@@ -55,7 +52,7 @@ steps:
 
       %VCPKG_INSTALLATION_ROOT%\vcpkg.exe integrate install
 
-      %VCPKG_INSTALLATION_ROOT%\vcpkg.exe install libxml2:%VCPKG_TRIPLET%
+      %VCPKG_INSTALLATION_ROOT%\vcpkg.exe install libxml2:x64-windows${{ '-static' if parameters.build_shared else '' }}
 
     displayName: Install dependencies
 
@@ -87,7 +84,7 @@ steps:
                -DBUILD_SHARED_LIBS=${{ parameters.build_shared }} ^
                -DIGRAPH_ENABLE_TLS=${{ parameters.enable_tls }} ^
                -DCMAKE_BUILD_TYPE=${{ parameters.build_type }} ^
-               -DVCPKG_TARGET_TRIPLET=%VCPKG_TRIPLET% ^
+               -DVCPKG_TARGET_TRIPLET=x64-windows${{ '-static' if parameters.build_shared else '' }} ^
                -DCMAKE_TOOLCHAIN_FILE=%VCPKG_INSTALLATION_ROOT%/scripts/buildsystems/vcpkg.cmake ^
                ${{ parameters.extra_cmake_args }}
 

--- a/.azure/build-win.yml
+++ b/.azure/build-win.yml
@@ -37,11 +37,15 @@ parameters:
     default: ''
 
 steps:
-  - script: choco install winflexbison3 ninja
+  - script: |
+      choco install winflexbison3 ninja
+      %CONDA%\Scripts\activate
+      conda install libxml2
+
     displayName: Install dependencies
 
   # Notes:
-  #  - We call vcvarsall.bat to make sure the compiler (cl.exe) is in the path, and so that we can select the desired MSVC version. 
+  #  - We call vcvarsall.bat to make sure the compiler (cl.exe) is in the path, and so that we can select the desired MSVC version.
   #      https://docs.microsoft.com/en-us/cpp/build/building-on-the-command-line?view=msvc-160#vcvarsall-syntax
   #      This is necessary when not using the Visual Studio CMake generator.
   #  - Due to this setup, CMake must also be called in the same script instead of using the CMake task
@@ -56,7 +60,7 @@ steps:
       set CXX=cl.exe
       set CC=cl.exe
 
-      cmake .. -DIGRAPH_USE_INTERNAL_BLAS=${{ parameters.int_blas }} -DIGRAPH_USE_INTERNAL_LAPACK=${{ parameters.int_lapack }} -DIGRAPH_USE_INTERNAL_ARPACK=${{ parameters.int_arpack }} -DIGRAPH_USE_INTERNAL_GLPK=${{ parameters.int_glpk }} -DIGRAPH_USE_INTERNAL_CXSPARSE=${{ parameters.int_cxsparse }} -DIGRAPH_USE_INTERNAL_GMP=${{ parameters.int_gmp }} -DIGRAPH_VERIFY_FINALLY_STACK=${{ parameters.verify_finally }} -DBUILD_SHARED_LIBS=${{ parameters.build_shared }} -DIGRAPH_ENABLE_TLS=${{ parameters.enable_tls }} -DCMAKE_BUILD_TYPE=${{ parameters.build_type }} ${{ parameters.extra_cmake_args }}
+      cmake .. -DCMAKE_PREFIX_PATH=%CONDA%\Library\lib -DIGRAPH_USE_INTERNAL_BLAS=${{ parameters.int_blas }} -DIGRAPH_USE_INTERNAL_LAPACK=${{ parameters.int_lapack }} -DIGRAPH_USE_INTERNAL_ARPACK=${{ parameters.int_arpack }} -DIGRAPH_USE_INTERNAL_GLPK=${{ parameters.int_glpk }} -DIGRAPH_USE_INTERNAL_CXSPARSE=${{ parameters.int_cxsparse }} -DIGRAPH_USE_INTERNAL_GMP=${{ parameters.int_gmp }} -DIGRAPH_VERIFY_FINALLY_STACK=${{ parameters.verify_finally }} -DBUILD_SHARED_LIBS=${{ parameters.build_shared }} -DIGRAPH_ENABLE_TLS=${{ parameters.enable_tls }} -DCMAKE_BUILD_TYPE=${{ parameters.build_type }} ${{ parameters.extra_cmake_args }}
 
       cmake --build . --target build_tests
     displayName: Configure and build

--- a/.azure/build-win.yml
+++ b/.azure/build-win.yml
@@ -22,7 +22,7 @@ parameters:
     default: true
   - name: build_shared
     type: boolean
-    default: false
+    default: true
   - name: enable_tls
     type: boolean
     default: true
@@ -35,6 +35,9 @@ parameters:
   - name: extra_ctest_args
     type: string
     default: ''
+  - name: vcpkg_target_triplet
+    type: string
+    default: 'x64-windows'
 
 steps:
   - task: Cache@2
@@ -52,10 +55,7 @@ steps:
 
       %VCPKG_INSTALLATION_ROOT%\vcpkg.exe integrate install
 
-      ${{ if parameters.build_shared }}:
-      %VCPKG_INSTALLATION_ROOT%\vcpkg.exe install libxml2:x64-windows
-      ${{ if not(parameters.build_shared) }}:
-      %VCPKG_INSTALLATION_ROOT%\vcpkg.exe install libxml2:x64-windows-static
+      %VCPKG_INSTALLATION_ROOT%\vcpkg.exe install libxml2:${{ vcpkg_target_triplet }}
 
     displayName: Install dependencies
 
@@ -87,10 +87,7 @@ steps:
                -DBUILD_SHARED_LIBS=${{ parameters.build_shared }} ^
                -DIGRAPH_ENABLE_TLS=${{ parameters.enable_tls }} ^
                -DCMAKE_BUILD_TYPE=${{ parameters.build_type }} ^
-               ${{ if parameters.build_shared }}:
-               -DVCPKG_TARGET_TRIPLET=x64-windows ^
-               ${{ if not(parameters.build_shared) }}:
-               -DVCPKG_TARGET_TRIPLET=x64-windows-static ^
+               -DVCPKG_TARGET_TRIPLET=${{ vcpkg_target_triplet }} ^
                -DCMAKE_TOOLCHAIN_FILE=%VCPKG_INSTALLATION_ROOT%/scripts/buildsystems/vcpkg.cmake ^
                ${{ parameters.extra_cmake_args }}
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -95,6 +95,9 @@ jobs:
 
     steps:
       - template: .azure/build-win.yml
+        parameters:
+          build_shared: false
+          vcpkg_target_triplet: x64-windows-static
 
   - job: windows_shared
     pool:
@@ -102,8 +105,6 @@ jobs:
 
     steps:
       - template: .azure/build-win.yml
-        parameters:
-          build_shared: true
 
   - job: documentation
     steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -95,9 +95,6 @@ jobs:
 
     steps:
       - template: .azure/build-win.yml
-        parameters:
-          build_shared: false
-          vcpkg_target_triplet: x64-windows-static-md
 
   - job: windows_shared
     pool:
@@ -105,6 +102,9 @@ jobs:
 
     steps:
       - template: .azure/build-win.yml
+        parameters:
+          build_shared: true
+          vcpkg_target_triplet: x64-windows
 
   - job: documentation
     steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -97,7 +97,7 @@ jobs:
       - template: .azure/build-win.yml
         parameters:
           build_shared: false
-          vcpkg_target_triplet: x64-windows-static
+          vcpkg_target_triplet: x64-windows-static-md
 
   - job: windows_shared
     pool:

--- a/examples/simple/graphml.c
+++ b/examples/simple/graphml.c
@@ -92,7 +92,6 @@ int main() {
         return 1;
     }
     igraph_set_error_handler(oldhandler);
-
     fclose(ifile);
 
     /* Write it back */

--- a/examples/simple/graphml.c
+++ b/examples/simple/graphml.c
@@ -92,6 +92,7 @@ int main() {
         return 1;
     }
     igraph_set_error_handler(oldhandler);
+
     fclose(ifile);
 
     /* Write it back */


### PR DESCRIPTION
This PR adds the`libxml2` dependency on Windows, hence building with GraphML support. I use `conda` for installing the `libxml2` dependency, as this should enable a faster install than `vcpkg`. Perhaps the `conda` environment can also be cached, that would be a next step to consider. Let's first see how this builds.