### PR TITLE
Add simple_interconnected_islands_game unit tests

### DIFF
--- a/src/games/islands.c
+++ b/src/games/islands.c
@@ -68,16 +68,16 @@ int igraph_simple_interconnected_islands_game(
     long int vsize;
 
     if (islands_n < 0) {
-        IGRAPH_ERROR("Invalid number of islands", IGRAPH_EINVAL);
+        IGRAPH_ERRORF("Number of islands cannot be negative, got %" IGRAPH_PRId ".", IGRAPH_EINVAL, islands_n);
     }
     if (islands_size < 0) {
-        IGRAPH_ERROR("Invalid size for islands", IGRAPH_EINVAL);
+        IGRAPH_ERRORF("Size of islands cannot be negative, got %" IGRAPH_PRId ".", IGRAPH_EINVAL, islands_size);
     }
     if (islands_pin < 0 || islands_pin > 1) {
-        IGRAPH_ERROR("Invalid probability for islands", IGRAPH_EINVAL);
+        IGRAPH_ERRORF("Edge probability within islands should be between 0 and 1, got %g.", IGRAPH_EINVAL, islands_pin);
     }
-    if ( (n_inter < 0) || (n_inter > islands_size) ) {
-        IGRAPH_ERROR("Invalid number of inter-islands links", IGRAPH_EINVAL);
+    if (n_inter < 0) {
+        IGRAPH_ERRORF("Number of inter-island links cannot be negative, got %" IGRAPH_PRId ".", IGRAPH_EINVAL, n_inter);
     }
 
     /* how much memory ? */
@@ -85,7 +85,7 @@ int igraph_simple_interconnected_islands_game(
     maxpossibleedgesPerIsland = ((double)islands_size * ((double)islands_size - (double)1)) / (double)2;
     maxedgesPerIsland = islands_pin * maxpossibleedgesPerIsland;
     nbEdgesInterIslands = n_inter * (islands_n * (islands_n - 1)) / 2;
-    maxedges = maxedgesPerIsland * islands_n + nbEdgesInterIslands;    
+    maxedges = maxedgesPerIsland * islands_n + nbEdgesInterIslands;
 
     /* reserve enough space for all the edges */
     IGRAPH_VECTOR_INIT_FINALLY(&edges, 0);
@@ -94,10 +94,10 @@ int igraph_simple_interconnected_islands_game(
     RNG_BEGIN();
 
     /* first create all the islands */
-    for (is = 1; is <= islands_n; is++) { /* for each island */
+    for (is = 0; is < islands_n; is++) { /* for each island */
 
         /* index for start and end of nodes in this island */
-        startIsland = islands_size * (is - 1);
+        startIsland = islands_size * is;
         endIsland = startIsland + islands_size - 1;
 
         /* create the random numbers to be used (into s) */
@@ -132,11 +132,11 @@ int igraph_simple_interconnected_islands_game(
 
 
         /* create the links with other islands */
-        for (i = is + 1; i <= islands_n; i++) { /* for each other island (not the previous ones) */
+        for (i = is + 1; i < islands_n; i++) { /* for each other island (not the previous ones) */
 
             for (j = 0; j < n_inter; j++) { /* for each link between islands */
-                long int from = (long int) RNG_UNIF(startIsland, endIsland);
-                long int to = (long int) RNG_UNIF((i - 1) * islands_size, i * islands_size);
+                long int from = RNG_INTEGER(startIsland, endIsland);
+                long int to = RNG_INTEGER(i * islands_size, (i + 1) * islands_size - 1);
 
                 igraph_vector_push_back(&edges, from);
                 igraph_vector_push_back(&edges, to);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -185,6 +185,7 @@ add_legacy_tests(
   igraph_realize_degree_sequence
   igraph_recent_degree_aging_game
   igraph_recent_degree_game
+  igraph_simple_interconnected_islands_game
   tree
   tree_game
   ring

--- a/tests/unit/igraph_simple_interconnected_islands_game.c
+++ b/tests/unit/igraph_simple_interconnected_islands_game.c
@@ -1,0 +1,81 @@
+/*
+   IGraph library.
+   Copyright (C) 2021  The igraph development team <igraph@igraph.org>
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include <igraph.h>
+#include "test_utilities.inc"
+
+int main() {
+    igraph_t g;
+
+    igraph_rng_seed(igraph_rng_default(), 42);
+
+    printf("No islands:\n");
+    IGRAPH_ASSERT(igraph_simple_interconnected_islands_game(&g, /*number of islands*/0, /*size of islands*/ 1,
+                  /*islands_pin*/ 1, /*number of edges between two islands*/ 1) == IGRAPH_SUCCESS);
+    print_graph_canon(&g);
+    igraph_destroy(&g);
+
+    printf("One island, no edges:\n");
+    IGRAPH_ASSERT(igraph_simple_interconnected_islands_game(&g, /*number of islands*/1, /*size of islands*/ 4,
+                  /*islands_pin*/ 0, /*number of edges between two islands*/ 2) == IGRAPH_SUCCESS);
+    print_graph_canon(&g);
+    igraph_destroy(&g);
+
+    printf("One island, full graph:\n");
+    IGRAPH_ASSERT(igraph_simple_interconnected_islands_game(&g, /*number of islands*/1, /*size of islands*/ 4,
+                  /*islands_pin*/ 1, /*number of edges between two islands*/ 2) == IGRAPH_SUCCESS);
+    print_graph_canon(&g);
+    igraph_destroy(&g);
+
+    printf("Two islands, full graphs, no connections between islands:\n");
+    IGRAPH_ASSERT(igraph_simple_interconnected_islands_game(&g, /*number of islands*/2, /*size of islands*/ 4,
+                  /*islands_pin*/ 1, /*number of edges between two islands*/ 0) == IGRAPH_SUCCESS);
+    print_graph_canon(&g);
+    igraph_destroy(&g);
+
+    printf("Three islands, full graphs, 20 connections between islands.\n");
+    IGRAPH_ASSERT(igraph_simple_interconnected_islands_game(&g, /*number of islands*/3, /*size of islands*/ 4,
+                  /*islands_pin*/ 1, /*number of edges between two islands*/ 20) == IGRAPH_SUCCESS);
+    IGRAPH_ASSERT(igraph_ecount(&g) == 18 + 60);
+    igraph_destroy(&g);
+
+    igraph_set_error_handler(igraph_error_handler_ignore);
+
+    printf("Negative number of islands.\n");
+    IGRAPH_ASSERT(igraph_simple_interconnected_islands_game(&g, /*number of islands*/-2, /*size of islands*/ 4,
+                  /*islands_pin*/ 1, /*number of edges between two islands*/ 0) == IGRAPH_EINVAL);
+    igraph_destroy(&g);
+
+    printf("Negative island size.\n");
+    IGRAPH_ASSERT(igraph_simple_interconnected_islands_game(&g, /*number of islands*/2, /*size of islands*/ -4,
+                  /*islands_pin*/ 1, /*number of edges between two islands*/ 0) == IGRAPH_EINVAL);
+    igraph_destroy(&g);
+
+    printf("Probability out of range.\n");
+    IGRAPH_ASSERT(igraph_simple_interconnected_islands_game(&g, /*number of islands*/2, /*size of islands*/ 4,
+                  /*islands_pin*/ 2, /*number of edges between two islands*/ 0) == IGRAPH_EINVAL);
+    igraph_destroy(&g);
+
+    printf("Negative number of edges between islands.\n");
+    IGRAPH_ASSERT(igraph_simple_interconnected_islands_game(&g, /*number of islands*/2, /*size of islands*/ 4,
+                  /*islands_pin*/ 1, /*number of edges between two islands*/ -3) == IGRAPH_EINVAL);
+    igraph_destroy(&g);
+
+    VERIFY_FINALLY_STACK();
+    return 0;
+}

--- a/tests/unit/igraph_simple_interconnected_islands_game.out
+++ b/tests/unit/igraph_simple_interconnected_islands_game.out
@@ -1,0 +1,43 @@
+No islands:
+directed: false
+vcount: 0
+edges: {
+}
+One island, no edges:
+directed: false
+vcount: 4
+edges: {
+}
+One island, full graph:
+directed: false
+vcount: 4
+edges: {
+0 1
+0 2
+0 3
+1 2
+1 3
+2 3
+}
+Two islands, full graphs, no connections between islands:
+directed: false
+vcount: 8
+edges: {
+0 1
+0 2
+0 3
+1 2
+1 3
+2 3
+4 5
+4 6
+4 7
+5 6
+5 7
+6 7
+}
+Three islands, full graphs, 20 connections between islands.
+Negative number of islands.
+Negative island size.
+Probability out of range.
+Negative number of edges between islands.


### PR DESCRIPTION
Part of #1592 

Fix: removed limit on interconnections, wasn't necessary
Fix: random connections between islands used floats instead of ints,
    which caused some nodes to never be linked with other islands.