### PR TITLE
Add missing include

### DIFF
--- a/src/connectivity/components.c
+++ b/src/connectivity/components.c
@@ -30,6 +30,7 @@
 #include "igraph_operators.h"
 #include "igraph_progress.h"
 #include "igraph_stack.h"
+#include "igraph_structural.h"
 #include "igraph_vector.h"
 
 #include "core/interruption.h"


### PR DESCRIPTION
Add a missing include for igraph_structural.h, where the function igraph_subcomponent is declared. Otherwise, the symbol igraph_subcomponent is not exported when building a shared library