### PR TITLE
Add transitivity barrat unit tests

### DIFF
--- a/src/properties/triangles.c
+++ b/src/properties/triangles.c
@@ -757,7 +757,7 @@ int igraph_transitivity_barrat1(const igraph_t *graph,
                       igraph_vector_size(weights), no_of_edges);
     }
     if (no_of_nodes == 0) {
-        igraph_vector_resize(res, 0);
+        igraph_vector_clear(res);
         return IGRAPH_SUCCESS;
     }
 
@@ -857,7 +857,7 @@ int igraph_transitivity_barrat4(const igraph_t *graph,
                       igraph_vector_size(weights), no_of_edges);
     }
     if (no_of_nodes == 0) {
-        igraph_vector_resize(res, 0);
+        igraph_vector_clear(res);
         return IGRAPH_SUCCESS;
     }
 

--- a/src/properties/triangles.c
+++ b/src/properties/triangles.c
@@ -745,12 +745,20 @@ int igraph_transitivity_barrat1(const igraph_t *graph,
     igraph_vector_t strength;
 
     if (!weights) {
-        IGRAPH_WARNING("No weights given for Barrat's transitivity, unweighted version is used");
+        if (no_of_edges != 0) {
+            IGRAPH_WARNING("No weights given for Barrat's transitivity, unweighted version is used.");
+        }
         return igraph_transitivity_local_undirected(graph, res, vids, mode);
     }
 
     if (igraph_vector_size(weights) != no_of_edges) {
-        IGRAPH_ERROR("Invalid edge weight vector length", IGRAPH_EINVAL);
+        IGRAPH_ERRORF("Edge weight vector length (%ld) not equal to "
+                      "number of edges (%ld).", IGRAPH_EINVAL,
+                      igraph_vector_size(weights), no_of_edges);
+    }
+    if (no_of_nodes == 0) {
+        igraph_vector_resize(res, 0);
+        return IGRAPH_SUCCESS;
     }
 
     IGRAPH_CHECK(igraph_vit_create(graph, vids, &vit));
@@ -818,7 +826,7 @@ int igraph_transitivity_barrat1(const igraph_t *graph,
     igraph_vit_destroy(&vit);
     IGRAPH_FINALLY_CLEAN(5);
 
-    return 0;
+    return IGRAPH_SUCCESS;
 }
 
 int igraph_transitivity_barrat4(const igraph_t *graph,
@@ -838,12 +846,19 @@ int igraph_transitivity_barrat4(const igraph_t *graph,
     long int i, nn;
 
     if (!weights) {
-        IGRAPH_WARNING("No weights given for Barrat's transitivity, unweighted version is used");
+        if (no_of_edges != 0) {
+            IGRAPH_WARNING("No weights given for Barrat's transitivity, unweighted version is used.");
+        }
         return igraph_transitivity_local_undirected(graph, res, vids, mode);
     }
-
     if (igraph_vector_size(weights) != no_of_edges) {
-        IGRAPH_ERROR("Invalid edge weight vector length", IGRAPH_EINVAL);
+        IGRAPH_ERRORF("Edge weight vector length (%ld) not equal to "
+                      "number of edges (%ld).", IGRAPH_EINVAL,
+                      igraph_vector_size(weights), no_of_edges);
+    }
+    if (no_of_nodes == 0) {
+        igraph_vector_resize(res, 0);
+        return IGRAPH_SUCCESS;
     }
 
     IGRAPH_VECTOR_INIT_FINALLY(&order, no_of_nodes);
@@ -930,7 +945,7 @@ int igraph_transitivity_barrat4(const igraph_t *graph,
     igraph_vector_destroy(&order);
     IGRAPH_FINALLY_CLEAN(6);
 
-    return 0;
+    return IGRAPH_SUCCESS;
 }
 
 /**
@@ -976,6 +991,7 @@ int igraph_transitivity_barrat(const igraph_t *graph,
                                const igraph_vs_t vids,
                                const igraph_vector_t *weights,
                                igraph_transitivity_mode_t mode) {
+
     if (igraph_vs_is_all(&vids)) {
         return igraph_transitivity_barrat4(graph, res, vids, weights, mode);
     } else {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -229,6 +229,7 @@ add_legacy_tests(
   FOLDER tests/unit NAMES
   igraph_rewire # Uses internal igraph_i_rewire
   igraph_transitivity_avglocal_undirected
+  igraph_transitivity_barrat
 )
 
 add_legacy_tests(

--- a/tests/unit/igraph_transitivity_barrat.c
+++ b/tests/unit/igraph_transitivity_barrat.c
@@ -1,0 +1,131 @@
+/*
+   IGraph library.
+   Copyright (C) 2021  The igraph development team <igraph@igraph.org>
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include <igraph.h>
+#include "test_utilities.inc"
+
+void warning_handler_print_stdout(const char *reason, const char *file,
+                                  int line, int igraph_errno) {
+    IGRAPH_UNUSED(igraph_errno);
+    IGRAPH_UNUSED(file);
+    IGRAPH_UNUSED(line);
+    fprintf(stdout, "Warning: %s\n", reason);
+}
+
+int main() {
+    igraph_t g_0, g_1, g_simple;
+    igraph_vector_t result, weights_none, weights_simple;
+
+    igraph_small(&g_0, 0, 0, -1);
+    igraph_small(&g_1, 1, 0, -1);
+    igraph_small(&g_simple, 6, 0, 0,1, 0,2, 1,2, 1,3, 2,3, 3,4, -1);
+
+    igraph_vector_init(&result, 0);
+    igraph_vector_init(&weights_none, 0);
+    igraph_vector_init_int(&weights_simple, 6, -1, 0, 1, 2, 3, 4);
+
+    igraph_set_error_handler(igraph_error_handler_ignore);
+    igraph_set_warning_handler(warning_handler_print_stdout);
+
+    printf("No vertices, transitivity zero, NULL weights:\n");
+    IGRAPH_ASSERT(igraph_transitivity_barrat(&g_0, &result, igraph_vss_all(), /*weights*/ NULL, IGRAPH_TRANSITIVITY_ZERO) == IGRAPH_SUCCESS);
+    print_vector(&result);
+    printf("\n");
+
+    printf("No vertices, transitivity zero, NULL weights, no vs:\n");
+    IGRAPH_ASSERT(igraph_transitivity_barrat(&g_0, &result, igraph_vss_none(), /*weights*/ NULL, IGRAPH_TRANSITIVITY_ZERO) == IGRAPH_SUCCESS);
+    print_vector(&result);
+    printf("\n");
+
+    printf("No vertices, transitivity zero, no weights:\n");
+    IGRAPH_ASSERT(igraph_transitivity_barrat(&g_0, &result, igraph_vss_all(), &weights_none, IGRAPH_TRANSITIVITY_ZERO) == IGRAPH_SUCCESS);
+    print_vector(&result);
+    printf("\n");
+
+    printf("No vertices, transitivity zero, no weights, no vs:\n");
+    IGRAPH_ASSERT(igraph_transitivity_barrat(&g_0, &result, igraph_vss_none(), &weights_none, IGRAPH_TRANSITIVITY_ZERO) == IGRAPH_SUCCESS);
+    print_vector(&result);
+    printf("\n");
+
+    printf("No vertices, transitivity NAN:\n");
+    IGRAPH_ASSERT(igraph_transitivity_barrat(&g_0, &result, igraph_vss_all(), NULL, IGRAPH_TRANSITIVITY_NAN) == IGRAPH_SUCCESS);
+    print_vector(&result);
+    printf("\n");
+
+    printf("No vertices, transitivity NAN, no vs:\n");
+    IGRAPH_ASSERT(igraph_transitivity_barrat(&g_0, &result, igraph_vss_none(), NULL, IGRAPH_TRANSITIVITY_NAN) == IGRAPH_SUCCESS);
+    print_vector(&result);
+    printf("\n");
+
+    printf("One vertex, transitivity zero:\n");
+    IGRAPH_ASSERT(igraph_transitivity_barrat(&g_1, &result, igraph_vss_all(), NULL, IGRAPH_TRANSITIVITY_ZERO) == IGRAPH_SUCCESS);
+    print_vector(&result);
+    printf("\n");
+
+    printf("One vertex, transitivity NaN:\n");
+    IGRAPH_ASSERT(igraph_transitivity_barrat(&g_1, &result, igraph_vss_all(), NULL, IGRAPH_TRANSITIVITY_NAN) == IGRAPH_SUCCESS);
+    print_vector(&result);
+    printf("\n");
+
+    printf("One vertex, transitivity zero, vs one:\n");
+    IGRAPH_ASSERT(igraph_transitivity_barrat(&g_1, &result, igraph_vss_1(0), NULL, IGRAPH_TRANSITIVITY_ZERO) == IGRAPH_SUCCESS);
+    print_vector(&result);
+    printf("\n");
+
+    printf("One vertex, transitivity NaN, vs one:\n");
+    IGRAPH_ASSERT(igraph_transitivity_barrat(&g_1, &result, igraph_vss_1(0), NULL, IGRAPH_TRANSITIVITY_NAN) == IGRAPH_SUCCESS);
+    print_vector(&result);
+    printf("\n");
+
+    printf("Simple graph, NULL weights, transitivity NAN:\n");
+    IGRAPH_ASSERT(igraph_transitivity_barrat(&g_simple, &result, igraph_vss_all(), NULL, IGRAPH_TRANSITIVITY_NAN) == IGRAPH_SUCCESS);
+    print_vector(&result);
+    printf("\n");
+
+    printf("Simple graph, with weights, transitivity NAN:\n");
+    IGRAPH_ASSERT(igraph_transitivity_barrat(&g_simple, &result, igraph_vss_all(), &weights_simple, IGRAPH_TRANSITIVITY_NAN) == IGRAPH_SUCCESS);
+    print_vector(&result);
+    printf("\n");
+
+    printf("Simple graph, with weights, transitivity zero:\n");
+    IGRAPH_ASSERT(igraph_transitivity_barrat(&g_simple, &result, igraph_vss_all(), &weights_simple, IGRAPH_TRANSITIVITY_ZERO) == IGRAPH_SUCCESS);
+    print_vector(&result);
+    printf("\n");
+
+    printf("Simple graph, with weights, transitivity zero, vss none:\n");
+    IGRAPH_ASSERT(igraph_transitivity_barrat(&g_simple, &result, igraph_vss_none(), &weights_simple, IGRAPH_TRANSITIVITY_ZERO) == IGRAPH_SUCCESS);
+    print_vector(&result);
+    printf("\n");
+
+    printf("Wrong weight length, vss all:\n");
+    IGRAPH_ASSERT(igraph_transitivity_barrat(&g_simple, &result, igraph_vss_all(), &weights_none, IGRAPH_TRANSITIVITY_ZERO) == IGRAPH_EINVAL);
+
+    printf("Wrong weight length, vss none:\n");
+    IGRAPH_ASSERT(igraph_transitivity_barrat(&g_simple, &result, igraph_vss_none(), &weights_none, IGRAPH_TRANSITIVITY_ZERO) == IGRAPH_EINVAL);
+
+    igraph_destroy(&g_0);
+    igraph_destroy(&g_1);
+    igraph_destroy(&g_simple);
+
+    igraph_vector_destroy(&result);
+    igraph_vector_destroy(&weights_none);
+    igraph_vector_destroy(&weights_simple);
+
+    VERIFY_FINALLY_STACK();
+    return 0;
+}

--- a/tests/unit/igraph_transitivity_barrat.out
+++ b/tests/unit/igraph_transitivity_barrat.out
@@ -1,0 +1,45 @@
+No vertices, transitivity zero, NULL weights:
+( )
+
+No vertices, transitivity zero, NULL weights, no vs:
+( )
+
+No vertices, transitivity zero, no weights:
+( )
+
+No vertices, transitivity zero, no weights, no vs:
+( )
+
+No vertices, transitivity NAN:
+( )
+
+No vertices, transitivity NAN, no vs:
+( )
+
+One vertex, transitivity zero:
+( 0 )
+
+One vertex, transitivity NaN:
+( NaN )
+
+One vertex, transitivity zero, vs one:
+( 0 )
+
+One vertex, transitivity NaN, vs one:
+( NaN )
+
+Simple graph, NULL weights, transitivity NAN:
+Warning: No weights given for Barrat's transitivity, unweighted version is used.
+( 1 0.666667 0.666667 0.333333 NaN NaN )
+
+Simple graph, with weights, transitivity NAN:
+( 1 0.75 0.625 0.277778 NaN NaN )
+
+Simple graph, with weights, transitivity zero:
+( 1 0.75 0.625 0.277778 0 0 )
+
+Simple graph, with weights, transitivity zero, vss none:
+( )
+
+Wrong weight length, vss all:
+Wrong weight length, vss none:


### PR DESCRIPTION
Part of #1592

No longer warns for no edges and no weights.