### PR TITLE
Add igraph_average_path_length_dijkstra unit tests

### DIFF
--- a/src/paths/shortest_paths.c
+++ b/src/paths/shortest_paths.c
@@ -191,7 +191,9 @@ static int igraph_i_average_path_length_dijkstra(
             IGRAPH_ERROR("Weight vector must not contain NaN values.", IGRAPH_EINVAL);
         }
     }
-    if (no_of_nodes) {
+    
+    /* Avoid returning a negative zero, which would be printed as -0 in tests. */
+    if (no_of_nodes > 0) {
         no_of_pairs = no_of_nodes * (no_of_nodes - 1.0);
     } else {
         no_of_pairs = 0;

--- a/src/paths/shortest_paths.c
+++ b/src/paths/shortest_paths.c
@@ -171,7 +171,7 @@ static int igraph_i_average_path_length_dijkstra(
     igraph_2wheap_t Q;
     igraph_lazy_inclist_t inclist;
     long int source, j;
-    igraph_real_t no_of_pairs = no_of_nodes * (no_of_nodes - 1.0); /* no. of ordered vertex pairs */
+    igraph_real_t no_of_pairs;
     igraph_real_t no_of_conn_pairs = 0.0; /* no. of ordered pairs between which there is a path */
 
     if (!weights) {
@@ -179,18 +179,23 @@ static int igraph_i_average_path_length_dijkstra(
     }
 
     if (igraph_vector_size(weights) != no_of_edges) {
-        IGRAPH_ERROR("Weight vector length does not match the number of edges", IGRAPH_EINVAL);
+        IGRAPH_ERRORF("Weight vector length (%ld) does not match the number of edges (%ld).",
+                      IGRAPH_EINVAL, igraph_vector_size(weights), no_of_edges);
     }
     if (no_of_edges > 0) {
         igraph_real_t min = igraph_vector_min(weights);
         if (min < 0) {
-            IGRAPH_ERROR("Weight vector must be non-negative", IGRAPH_EINVAL);
+            IGRAPH_ERRORF("Weight vector must be non-negative, got %g.", IGRAPH_EINVAL, min);
         }
         else if (igraph_is_nan(min)) {
-            IGRAPH_ERROR("Weight vector must not contain NaN values", IGRAPH_EINVAL);
+            IGRAPH_ERROR("Weight vector must not contain NaN values.", IGRAPH_EINVAL);
         }
     }
-
+    if (no_of_nodes) {
+        no_of_pairs = no_of_nodes * (no_of_nodes - 1.0);
+    } else {
+        no_of_pairs = 0;
+    }
 
     IGRAPH_CHECK(igraph_2wheap_init(&Q, no_of_nodes));
     IGRAPH_FINALLY(igraph_2wheap_destroy, &Q);
@@ -323,16 +328,19 @@ int igraph_average_path_length(const igraph_t *graph,
  * has fewer than two vertices, or if the graph has no edges and \c unconn is set to \c TRUE,
  * NaN is returned.
  *
- * \param weights The edge weights. All edge weights must be
- *       non-negative for Dijkstra's algorithm to work. Additionally, no
- *       edge weight may be NaN. If either case does not hold, an error
- *       is returned. If this is a null pointer, then the unweighted
- *       version, \ref igraph_average_path_length() is called.
+ * </para><para>
+ * All distinct ordered vertex pairs are taken into account.
+ *
  * \param graph The graph object.
  * \param res Pointer to a real number, this will contain the result.
  * \param unconn_pairs Pointer to a real number. If not a null pointer, the number of
  *    ordered vertex pairs where the second vertex is unreachable from the first one
  *    will be stored here.
+ * \param weights The edge weights. All edge weights must be
+ *       non-negative for Dijkstra's algorithm to work. Additionally, no
+ *       edge weight may be NaN. If either case does not hold, an error
+ *       is returned. If this is a null pointer, then the unweighted
+ *       version, \ref igraph_average_path_length() is called.
  * \param directed Boolean, whether to consider directed paths.
  *    Ignored for undirected graphs.
  * \param unconn If \c TRUE, only those pairs are considered for the calculation

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -235,6 +235,7 @@ add_legacy_tests(
   all_shortest_paths
   efficiency
   igraph_are_connected
+  igraph_average_path_length_dijkstra
   igraph_betweenness
   igraph_closeness
   igraph_convergence_degree

--- a/tests/unit/igraph_average_path_length_dijkstra.c
+++ b/tests/unit/igraph_average_path_length_dijkstra.c
@@ -1,0 +1,88 @@
+/*
+   IGraph library.
+   Copyright (C) 2021  The igraph development team <igraph@igraph.org>
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include <igraph.h>
+#include "test_utilities.inc"
+
+void print_and_destroy(igraph_t *graph, igraph_vector_t *weights, igraph_bool_t directed, igraph_bool_t unconn) {
+    igraph_real_t result;
+    igraph_real_t unconn_pairs;
+
+    IGRAPH_ASSERT(igraph_average_path_length_dijkstra(graph, &result, &unconn_pairs, weights,
+                  directed, unconn) == IGRAPH_SUCCESS);
+
+    printf("Result: ");
+    print_real(stdout, result, "%8g");
+    printf("\nUnconnected pairs: ");
+    print_real(stdout, unconn_pairs, "%8g");
+    printf("\n\n");
+}
+
+int main() {
+    igraph_t g_0, g_1, g_2, g_lm;
+    igraph_vector_t weights_0, weights_lm, weights_lm_neg;
+    igraph_real_t result;
+
+    igraph_small(&g_0, 0, 0, -1);
+    igraph_small(&g_1, 1, 0, -1);
+    igraph_small(&g_2, 2, 0, -1);
+    igraph_small(&g_lm, 6, 1, 0,1, 0,2, 1,1, 1,3, 2,0, 2,3, 3,4, 3,4, -1);
+
+    igraph_vector_init(&weights_0, 0);
+    igraph_vector_init_int(&weights_lm, 8, 0, 1, 2, 3, 4, 5, 6, 7);
+    igraph_vector_init_int(&weights_lm_neg, 8, -10, 1, 2, 3, 4, 5, 6, 7);
+
+    printf("No vertices:\n");
+    print_and_destroy(&g_0, &weights_0, 1, 1);
+
+    printf("One vertex:\n");
+    print_and_destroy(&g_1, &weights_0, 1, 1);
+
+    printf("Two vertices:\n");
+    print_and_destroy(&g_2, &weights_0, 1, 1);
+
+    printf("Two vertices, inf for unconnected pairs:\n");
+    print_and_destroy(&g_2, &weights_0, 1, 0);
+
+    printf("Graph with loops and multiple edges:\n");
+    print_and_destroy(&g_lm, &weights_lm, 1, 1);
+
+    printf("Graph with loops and multiple edges, ignoring direction:\n");
+    print_and_destroy(&g_lm, &weights_lm, 0, 1);
+
+    igraph_set_error_handler(igraph_error_handler_ignore);
+
+    printf("Checking incorrect weight length error handling.\n");
+    IGRAPH_ASSERT(igraph_average_path_length_dijkstra(&g_lm, &result, NULL, &weights_0,
+                  1, 1) == IGRAPH_EINVAL);
+
+    printf("Checking negative weight error handling.\n");
+    IGRAPH_ASSERT(igraph_average_path_length_dijkstra(&g_lm, &result, NULL, &weights_lm_neg,
+                  1, 1) == IGRAPH_EINVAL);
+
+    igraph_destroy(&g_0);
+    igraph_destroy(&g_1);
+    igraph_destroy(&g_2);
+    igraph_destroy(&g_lm);
+    igraph_vector_destroy(&weights_0);
+    igraph_vector_destroy(&weights_lm);
+    igraph_vector_destroy(&weights_lm_neg);
+
+    VERIFY_FINALLY_STACK();
+    return 0;
+}

--- a/tests/unit/igraph_average_path_length_dijkstra.out
+++ b/tests/unit/igraph_average_path_length_dijkstra.out
@@ -1,0 +1,26 @@
+No vertices:
+Result: NaN
+Unconnected pairs:        0
+
+One vertex:
+Result: NaN
+Unconnected pairs:        0
+
+Two vertices:
+Result: NaN
+Unconnected pairs:        2
+
+Two vertices, inf for unconnected pairs:
+Result: Inf
+Unconnected pairs:        2
+
+Graph with loops and multiple edges:
+Result:        5
+Unconnected pairs:       19
+
+Graph with loops and multiple edges, ignoring direction:
+Result:      4.6
+Unconnected pairs:       10
+
+Checking incorrect weight length error handling.
+Checking negative weight error handling.


### PR DESCRIPTION
Part of #1592

Micro bugfix: Now returns 0 instead of -0 unconnected pairs for null graph.