### PR TITLE
Make zero allocs consistent

### DIFF
--- a/examples/simple/igraph_minimal_separators.c
+++ b/examples/simple/igraph_minimal_separators.c
@@ -50,7 +50,7 @@ int main() {
     for (i = 0; i < n; i++) {
         igraph_vector_t *v = VECTOR(separators)[i];
         igraph_vector_destroy(v);
-        igraph_Free(v);
+        IGRAPH_FREE(v);
     }
     igraph_vector_ptr_destroy(&separators);
 

--- a/examples/simple/igraph_union.c
+++ b/examples/simple/igraph_union.c
@@ -40,7 +40,7 @@ int print_free_vector_ptr(igraph_vector_ptr_t *v) {
     for (i = 0; i < l; i++) {
         print_vector(VECTOR(*v)[i]);
         igraph_vector_destroy(VECTOR(*v)[i]);
-        igraph_Free(VECTOR(*v)[i]);
+        IGRAPH_FREE(VECTOR(*v)[i]);
     }
     printf("===\n");
     return 0;

--- a/include/igraph_memory.h
+++ b/include/igraph_memory.h
@@ -29,9 +29,9 @@
 
 __BEGIN_DECLS
 
-#define igraph_Calloc(n,t)    (t*) calloc( (size_t)((n) + 1), sizeof(t) )
-#define igraph_Realloc(p,n,t) (t*) realloc((void*)(p), (size_t)(((n) + 1)*sizeof(t)))
-#define igraph_Free(p)        (free( (void *)(p) ), (p) = NULL)
+#define IGRAPH_CALLOC(n,t)    (t*) calloc( (n) > 0 ? (size_t)(n) : (size_t)1, sizeof(t) )
+#define IGRAPH_REALLOC(p,n,t) (t*) realloc((void*)(p), (n) > 0 ? (size_t)((n)*sizeof(t)) : (size_t)1)
+#define IGRAPH_FREE(p)        (free( (void *)(p) ), (p) = NULL)
 
 IGRAPH_EXPORT void igraph_free(void *p);
 IGRAPH_EXPORT void *igraph_malloc(size_t n);

--- a/include/igraph_memory.h
+++ b/include/igraph_memory.h
@@ -33,6 +33,10 @@ __BEGIN_DECLS
 #define IGRAPH_REALLOC(p,n,t) (t*) realloc((void*)(p), (n) > 0 ? (size_t)((n)*sizeof(t)) : (size_t)1)
 #define IGRAPH_FREE(p)        (free( (void *)(p) ), (p) = NULL)
 
+#define igraph_Calloc IGRAPH_CALLOC
+#define igraph_Realloc IGRAPH_REALLOC
+#define igraph_Free IGRAPH_FREE
+
 IGRAPH_EXPORT void igraph_free(void *p);
 IGRAPH_EXPORT void *igraph_malloc(size_t n);
 

--- a/include/igraph_memory.h
+++ b/include/igraph_memory.h
@@ -29,8 +29,8 @@
 
 __BEGIN_DECLS
 
-#define igraph_Calloc(n,t)    (t*) calloc( (size_t)(n), sizeof(t) )
-#define igraph_Realloc(p,n,t) (t*) realloc((void*)(p), (size_t)((n)*sizeof(t)))
+#define igraph_Calloc(n,t)    (t*) calloc( (size_t)((n) + 1), sizeof(t) )
+#define igraph_Realloc(p,n,t) (t*) realloc((void*)(p), (size_t)(((n) + 1)*sizeof(t)))
 #define igraph_Free(p)        (free( (void *)(p) ), (p) = NULL)
 
 IGRAPH_EXPORT void igraph_free(void *p);

--- a/src/centrality/betweenness.c
+++ b/src/centrality/betweenness.c
@@ -366,17 +366,17 @@ int igraph_betweenness_cutoff(const igraph_t *graph, igraph_vector_t *res,
         igraph_vector_int_clear(igraph_adjlist_get(adjlist_in_p, j));
     }
 
-    distance = igraph_Calloc(no_of_nodes, long int);
+    distance = IGRAPH_CALLOC(no_of_nodes, long int);
     if (distance == 0) {
         IGRAPH_ERROR("Insufficient memory for betweenness calculation.", IGRAPH_ENOMEM);
     }
     IGRAPH_FINALLY(igraph_free, distance);
-    nrgeo = igraph_Calloc(no_of_nodes, double);
+    nrgeo = IGRAPH_CALLOC(no_of_nodes, double);
     if (nrgeo == 0) {
         IGRAPH_ERROR("Insufficient memory for betweenness calculation.", IGRAPH_ENOMEM);
     }
     IGRAPH_FINALLY(igraph_free, nrgeo);
-    tmpscore = igraph_Calloc(no_of_nodes, double);
+    tmpscore = IGRAPH_CALLOC(no_of_nodes, double);
     if (tmpscore == 0) {
         IGRAPH_ERROR("Insufficient memory for betweenness calculation.", IGRAPH_ENOMEM);
     }
@@ -457,9 +457,9 @@ int igraph_betweenness_cutoff(const igraph_t *graph, igraph_vector_t *res,
     IGRAPH_PROGRESS("Betweenness centrality: ", 100.0, 0);
 
     /* clean  */
-    igraph_Free(distance);
-    igraph_Free(nrgeo);
-    igraph_Free(tmpscore);
+    IGRAPH_FREE(distance);
+    IGRAPH_FREE(nrgeo);
+    IGRAPH_FREE(tmpscore);
 
     igraph_dqueue_destroy(&q);
     igraph_stack_destroy(&stack);
@@ -842,17 +842,17 @@ int igraph_edge_betweenness_cutoff(const igraph_t *graph, igraph_vector_t *resul
         elist_out_p = elist_in_p = &elist_out;
     }
 
-    distance = igraph_Calloc(no_of_nodes, long int);
+    distance = IGRAPH_CALLOC(no_of_nodes, long int);
     if (distance == 0) {
         IGRAPH_ERROR("Insufficient memory for edge betweenness calculation.", IGRAPH_ENOMEM);
     }
     IGRAPH_FINALLY(igraph_free, distance);
-    nrgeo = igraph_Calloc(no_of_nodes, double);
+    nrgeo = IGRAPH_CALLOC(no_of_nodes, double);
     if (nrgeo == 0) {
         IGRAPH_ERROR("Insufficient memory for edge betweenness calculation.", IGRAPH_ENOMEM);
     }
     IGRAPH_FINALLY(igraph_free, nrgeo);
-    tmpscore = igraph_Calloc(no_of_nodes, double);
+    tmpscore = IGRAPH_CALLOC(no_of_nodes, double);
     if (tmpscore == 0) {
         IGRAPH_ERROR("Insufficient memory for edge betweenness calculation.", IGRAPH_ENOMEM);
     }
@@ -946,9 +946,9 @@ int igraph_edge_betweenness_cutoff(const igraph_t *graph, igraph_vector_t *resul
     IGRAPH_PROGRESS("Edge betweenness centrality: ", 100.0, 0);
 
     /* clean and return */
-    igraph_Free(distance);
-    igraph_Free(nrgeo);
-    igraph_Free(tmpscore);
+    IGRAPH_FREE(distance);
+    IGRAPH_FREE(nrgeo);
+    IGRAPH_FREE(tmpscore);
     igraph_dqueue_destroy(&q);
     igraph_stack_destroy(&stack);
     IGRAPH_FINALLY_CLEAN(5);

--- a/src/centrality/coreness.c
+++ b/src/centrality/coreness.c
@@ -81,12 +81,12 @@ int igraph_coreness(const igraph_t *graph, igraph_vector_t *cores,
         return IGRAPH_SUCCESS;
     }
 
-    vert = igraph_Calloc(no_of_nodes, long int);
+    vert = IGRAPH_CALLOC(no_of_nodes, long int);
     if (vert == 0) {
         IGRAPH_ERROR("Cannot calculate k-cores", IGRAPH_ENOMEM);
     }
     IGRAPH_FINALLY(igraph_free, vert);
-    pos = igraph_Calloc(no_of_nodes, long int);
+    pos = IGRAPH_CALLOC(no_of_nodes, long int);
     if (pos == 0) {
         IGRAPH_ERROR("Cannot calculate k-cores", IGRAPH_ENOMEM);
     }
@@ -97,7 +97,7 @@ int igraph_coreness(const igraph_t *graph, igraph_vector_t *cores,
                                IGRAPH_LOOPS));
     maxdeg = (long int) igraph_vector_max(cores);
 
-    bin = igraph_Calloc(maxdeg + 1, long int);
+    bin = IGRAPH_CALLOC(maxdeg + 1, long int);
     if (bin == 0) {
         IGRAPH_ERROR("Cannot calculate k-cores", IGRAPH_ENOMEM);
     }

--- a/src/cliques/cliques.c
+++ b/src/cliques/cliques.c
@@ -66,7 +66,7 @@ static int igraph_i_find_k_cliques(
     igraph_bool_t ok;
 
     /* Allocate the storage */
-    *new_member_storage = igraph_Realloc(*new_member_storage,
+    *new_member_storage = IGRAPH_REALLOC(*new_member_storage,
                                          (size_t) (size * old_clique_count),
                                          igraph_real_t);
     if (*new_member_storage == 0) {
@@ -165,7 +165,7 @@ static int igraph_i_find_k_cliques(
                 /* See if new_member_storage is full. If so, reallocate */
                 if (m == new_member_storage_size) {
                     IGRAPH_FINALLY_CLEAN(1);
-                    *new_member_storage = igraph_Realloc(*new_member_storage,
+                    *new_member_storage = IGRAPH_REALLOC(*new_member_storage,
                                                          (size_t) new_member_storage_size * 2,
                                                          igraph_real_t);
                     if (*new_member_storage == 0) {
@@ -217,14 +217,14 @@ static int igraph_i_cliques(const igraph_t *graph, igraph_vector_ptr_t *res,
     IGRAPH_FINALLY(igraph_i_cliques_free_res, res);
 
     /* Will be resized later, if needed. */
-    member_storage = igraph_Calloc(1, igraph_real_t);
+    member_storage = IGRAPH_CALLOC(1, igraph_real_t);
     if (member_storage == 0) {
         IGRAPH_ERROR("cliques failed", IGRAPH_ENOMEM);
     }
     IGRAPH_FINALLY(igraph_free, member_storage);
 
     /* Find all 1-cliques: every vertex will be a clique */
-    new_member_storage = igraph_Calloc(no_of_nodes, igraph_real_t);
+    new_member_storage = IGRAPH_CALLOC(no_of_nodes, igraph_real_t);
     if (new_member_storage == 0) {
         IGRAPH_ERROR("cliques failed", IGRAPH_ENOMEM);
     }
@@ -241,7 +241,7 @@ static int igraph_i_cliques(const igraph_t *graph, igraph_vector_ptr_t *res,
         IGRAPH_CHECK(igraph_vector_ptr_resize(res, no_of_nodes));
         igraph_vector_ptr_null(res);
         for (i = 0; i < no_of_nodes; i++) {
-            igraph_vector_t *p = igraph_Calloc(1, igraph_vector_t);
+            igraph_vector_t *p = IGRAPH_CALLOC(1, igraph_vector_t);
             if (p == 0) {
                 IGRAPH_ERROR("cliques failed", IGRAPH_ENOMEM);
             }
@@ -280,7 +280,7 @@ static int igraph_i_cliques(const igraph_t *graph, igraph_vector_ptr_t *res,
         /* Add the cliques just found to the result if requested */
         if (i >= min_size && i <= max_size) {
             for (j = 0, k = 0; j < clique_count; j++, k += i) {
-                igraph_vector_t *p = igraph_Calloc(1, igraph_vector_t);
+                igraph_vector_t *p = IGRAPH_CALLOC(1, igraph_vector_t);
                 if (p == 0) {
                     IGRAPH_ERROR("cliques failed", IGRAPH_ENOMEM);
                 }
@@ -634,7 +634,7 @@ static int igraph_i_maximal_independent_vertex_sets_backtrack(
         igraph_integer_t size = 0;
         if (res) {
             igraph_vector_t *vec;
-            vec = igraph_Calloc(1, igraph_vector_t);
+            vec = IGRAPH_CALLOC(1, igraph_vector_t);
             if (vec == 0) {
                 IGRAPH_ERROR("igraph_i_maximal_independent_vertex_sets failed", IGRAPH_ENOMEM);
             }
@@ -768,7 +768,7 @@ static void igraph_i_free_set_array(igraph_set_t* array) {
         igraph_set_destroy(array + i);
         i++;
     }
-    igraph_Free(array);
+    IGRAPH_FREE(array);
 }
 
 /**
@@ -824,7 +824,7 @@ int igraph_maximal_independent_vertex_sets(const igraph_t *graph,
     ));
     IGRAPH_FINALLY(igraph_adjlist_destroy, &clqdata.adj_list);
 
-    clqdata.IS = igraph_Calloc(no_of_nodes, igraph_integer_t);
+    clqdata.IS = IGRAPH_CALLOC(no_of_nodes, igraph_integer_t);
     if (clqdata.IS == 0) {
         IGRAPH_ERROR("igraph_maximal_independent_vertex_sets failed", IGRAPH_ENOMEM);
     }
@@ -835,7 +835,7 @@ int igraph_maximal_independent_vertex_sets(const igraph_t *graph,
         VECTOR(clqdata.deg)[i] = igraph_vector_int_size(igraph_adjlist_get(&clqdata.adj_list, i));
     }
 
-    clqdata.buckets = igraph_Calloc(no_of_nodes + 1, igraph_set_t);
+    clqdata.buckets = IGRAPH_CALLOC(no_of_nodes + 1, igraph_set_t);
     if (clqdata.buckets == 0) {
         IGRAPH_ERROR("igraph_maximal_independent_vertex_sets failed", IGRAPH_ENOMEM);
     }
@@ -903,7 +903,7 @@ int igraph_independence_number(const igraph_t *graph, igraph_integer_t *no) {
     ));
     IGRAPH_FINALLY(igraph_adjlist_destroy, &clqdata.adj_list);
 
-    clqdata.IS = igraph_Calloc(no_of_nodes, igraph_integer_t);
+    clqdata.IS = IGRAPH_CALLOC(no_of_nodes, igraph_integer_t);
     if (clqdata.IS == 0) {
         IGRAPH_ERROR("igraph_independence_number failed", IGRAPH_ENOMEM);
     }
@@ -914,7 +914,7 @@ int igraph_independence_number(const igraph_t *graph, igraph_integer_t *no) {
         VECTOR(clqdata.deg)[i] = igraph_vector_int_size(igraph_adjlist_get(&clqdata.adj_list, i));
     }
 
-    clqdata.buckets = igraph_Calloc(no_of_nodes + 1, igraph_set_t);
+    clqdata.buckets = IGRAPH_CALLOC(no_of_nodes + 1, igraph_set_t);
     if (clqdata.buckets == 0) {
         IGRAPH_ERROR("igraph_independence_number failed", IGRAPH_ENOMEM);
     }
@@ -962,7 +962,7 @@ static int igraph_i_maximal_cliques_store(const igraph_vector_t* clique, void* d
     igraph_vector_t* vec;
 
     IGRAPH_UNUSED(cont);
-    vec = igraph_Calloc(1, igraph_vector_t);
+    vec = IGRAPH_CALLOC(1, igraph_vector_t);
     if (vec == 0) {
         IGRAPH_ERROR("cannot allocate memory for storing next clique", IGRAPH_ENOMEM);
     }
@@ -983,7 +983,7 @@ static int igraph_i_maximal_cliques_store_size_check(const igraph_vector_t* cliq
         return IGRAPH_SUCCESS;
     }
 
-    vec = igraph_Calloc(1, igraph_vector_t);
+    vec = IGRAPH_CALLOC(1, igraph_vector_t);
     if (vec == 0) {
         IGRAPH_ERROR("cannot allocate memory for storing next clique", IGRAPH_ENOMEM);
     }
@@ -1017,7 +1017,7 @@ static int igraph_i_largest_cliques_store(const igraph_vector_t* clique, void* d
         }
     }
 
-    vec = igraph_Calloc(1, igraph_vector_t);
+    vec = IGRAPH_CALLOC(1, igraph_vector_t);
     if (vec == 0) {
         IGRAPH_ERROR("cannot allocate memory for storing next clique", IGRAPH_ENOMEM);
     }
@@ -1294,7 +1294,7 @@ static int igraph_i_maximal_cliques(const igraph_t *graph, igraph_i_maximal_cliq
         }
 
         /* Create a new stack frame in case we back out later */
-        new_frame_ptr = igraph_Calloc(1, igraph_i_maximal_cliques_stack_frame);
+        new_frame_ptr = IGRAPH_CALLOC(1, igraph_i_maximal_cliques_stack_frame);
         if (new_frame_ptr == 0) {
             IGRAPH_ERROR("cannot allocate new stack frame", IGRAPH_ENOMEM);
         }
@@ -1361,7 +1361,7 @@ static int igraph_i_maximal_or_largest_cliques_or_indsets(const igraph_t *graph,
     }
     IGRAPH_FINALLY(igraph_adjlist_destroy, &clqdata.adj_list);
 
-    clqdata.IS = igraph_Calloc(no_of_nodes, igraph_integer_t);
+    clqdata.IS = IGRAPH_CALLOC(no_of_nodes, igraph_integer_t);
     if (clqdata.IS == 0) {
         IGRAPH_ERROR("igraph_i_maximal_or_largest_cliques_or_indsets failed", IGRAPH_ENOMEM);
     }
@@ -1372,7 +1372,7 @@ static int igraph_i_maximal_or_largest_cliques_or_indsets(const igraph_t *graph,
         VECTOR(clqdata.deg)[i] = igraph_vector_int_size(igraph_adjlist_get(&clqdata.adj_list, i));
     }
 
-    clqdata.buckets = igraph_Calloc(no_of_nodes + 1, igraph_set_t);
+    clqdata.buckets = IGRAPH_CALLOC(no_of_nodes + 1, igraph_set_t);
     if (clqdata.buckets == 0) {
         IGRAPH_ERROR("igraph_maximal_or_largest_cliques_or_indsets failed", IGRAPH_ENOMEM);
     }

--- a/src/cliques/glet.c
+++ b/src/cliques/glet.c
@@ -86,7 +86,7 @@ static void igraph_i_subclique_next_free(void *ptr) {
                 igraph_vector_int_destroy(data->resultids + i);
             }
         }
-        igraph_Free(data->resultids);
+        IGRAPH_FREE(data->resultids);
     }
     if (data->result) {
         for (i = 0; i < data->nc; i++) {
@@ -94,7 +94,7 @@ static void igraph_i_subclique_next_free(void *ptr) {
                 igraph_destroy(data->result + i);
             }
         }
-        igraph_Free(data->result);
+        IGRAPH_FREE(data->result);
     }
     if (data->resultweights) {
         for (i = 0; i < data->nc; i++) {
@@ -102,7 +102,7 @@ static void igraph_i_subclique_next_free(void *ptr) {
                 igraph_vector_destroy(data->resultweights + i);
             }
         }
-        igraph_Free(data->resultweights);
+        IGRAPH_FREE(data->resultweights);
     }
 }
 
@@ -156,17 +156,17 @@ static int igraph_i_subclique_next(const igraph_t *graph,
     }
 
     IGRAPH_FINALLY(igraph_i_subclique_next_free, &freedata);
-    *resultids = igraph_Calloc(nc, igraph_vector_int_t);
+    *resultids = IGRAPH_CALLOC(nc, igraph_vector_int_t);
     if (!*resultids) {
         IGRAPH_ERROR("Cannot calculate next cliques", IGRAPH_ENOMEM);
     }
     freedata.resultids = *resultids;
-    *resultweights = igraph_Calloc(nc, igraph_vector_t);
+    *resultweights = IGRAPH_CALLOC(nc, igraph_vector_t);
     if (!*resultweights) {
         IGRAPH_ERROR("Cannot calculate next cliques", IGRAPH_ENOMEM);
     }
     freedata.resultweights = *resultweights;
-    *result = igraph_Calloc(nc, igraph_t);
+    *result = IGRAPH_CALLOC(nc, igraph_t);
     if (!*result) {
         IGRAPH_ERROR("Cannot calculate next cliques", IGRAPH_ENOMEM);
     }

--- a/src/cliques/maximal_cliques_template.h
+++ b/src/cliques/maximal_cliques_template.h
@@ -26,7 +26,7 @@
 #define RESNAME res
 #define SUFFIX
 #define RECORD do {                         \
-        igraph_vector_t *cl=igraph_Calloc(1, igraph_vector_t);      \
+        igraph_vector_t *cl=IGRAPH_CALLOC(1, igraph_vector_t);      \
         int j;                              \
         if (!cl) {                              \
             IGRAPH_ERROR("Cannot list maximal cliques", IGRAPH_ENOMEM);   \
@@ -73,7 +73,7 @@
 #define SUFFIX _subset
 #define RECORD do {                         \
         if (res) {                                \
-            igraph_vector_t *cl=igraph_Calloc(1, igraph_vector_t);      \
+            igraph_vector_t *cl=IGRAPH_CALLOC(1, igraph_vector_t);      \
             int j;                              \
             if (!cl) {                              \
                 IGRAPH_ERROR("Cannot list maximal cliques", IGRAPH_ENOMEM);   \
@@ -107,7 +107,7 @@
 #define RESNAME cliquehandler_fn, arg
 #define SUFFIX _callback
 #define RECORD do { \
-        igraph_vector_t *cl=igraph_Calloc(1, igraph_vector_t); \
+        igraph_vector_t *cl=IGRAPH_CALLOC(1, igraph_vector_t); \
         long j; \
         if (!cl) { \
             IGRAPH_ERROR("Cannot list maximal cliques", IGRAPH_ENOMEM); \
@@ -156,7 +156,7 @@ static void igraph_i_maximal_cliques_free(void *ptr) {
     for (i = 0; i < n; i++) {
         igraph_vector_t *v = VECTOR(*res)[i];
         if (v) {
-            igraph_Free(v);
+            IGRAPH_FREE(v);
             igraph_vector_destroy(v);
         }
     }
@@ -172,7 +172,7 @@ static void igraph_i_maximal_cliques_free_full(void *ptr) {
         for (i = 0; i < n; i++) {
             igraph_vector_t *v = VECTOR(*res)[i];
             if (v) {
-                igraph_Free(v);
+                IGRAPH_FREE(v);
                 igraph_vector_destroy(v);
             }
         }

--- a/src/community/edge_betweenness.c
+++ b/src/community/edge_betweenness.c
@@ -422,7 +422,7 @@ int igraph_community_edge_betweenness(const igraph_t *graph,
     igraph_2wheap_t heap;
 
     if (result == 0) {
-        result = igraph_Calloc(1, igraph_vector_t);
+        result = IGRAPH_CALLOC(1, igraph_vector_t);
         if (result == 0) {
             IGRAPH_ERROR("Edge betweenness community structure failed.", IGRAPH_ENOMEM);
         }
@@ -445,17 +445,17 @@ int igraph_community_edge_betweenness(const igraph_t *graph,
         elist_out_p = elist_in_p = &elist_out;
     }
 
-    distance = igraph_Calloc(no_of_nodes, double);
+    distance = IGRAPH_CALLOC(no_of_nodes, double);
     if (distance == 0) {
         IGRAPH_ERROR("Edge betweenness community structure failed.", IGRAPH_ENOMEM);
     }
     IGRAPH_FINALLY(igraph_free, distance);
-    nrgeo = igraph_Calloc(no_of_nodes, double);
+    nrgeo = IGRAPH_CALLOC(no_of_nodes, double);
     if (nrgeo == 0) {
         IGRAPH_ERROR("Edge betweenness community structure failed.", IGRAPH_ENOMEM);
     }
     IGRAPH_FINALLY(igraph_free, nrgeo);
-    tmpscore = igraph_Calloc(no_of_nodes, double);
+    tmpscore = IGRAPH_CALLOC(no_of_nodes, double);
     if (tmpscore == 0) {
         IGRAPH_ERROR("Edge betweenness community structure failed.", IGRAPH_ENOMEM);
     }
@@ -512,7 +512,7 @@ int igraph_community_edge_betweenness(const igraph_t *graph,
 
     IGRAPH_VECTOR_INIT_FINALLY(&eb, no_of_edges);
 
-    passive = igraph_Calloc(no_of_edges, char);
+    passive = IGRAPH_CALLOC(no_of_edges, char);
     if (!passive) {
         IGRAPH_ERROR("Edge betweenness community structure failed.", IGRAPH_ENOMEM);
     }
@@ -742,7 +742,7 @@ int igraph_community_edge_betweenness(const igraph_t *graph,
 
     if (result_owned) {
         igraph_vector_destroy(result);
-        igraph_Free(result);
+        IGRAPH_FREE(result);
         IGRAPH_FINALLY_CLEAN(2);
     }
 

--- a/src/community/fast_modularity.c
+++ b/src/community/fast_modularity.c
@@ -148,12 +148,12 @@ static void igraph_i_fastgreedy_community_list_destroy(
     for (i = 0; i < list->n; i++) {
         igraph_vector_ptr_destroy(&list->e[i].neis);
     }
-    igraph_Free(list->e);
+    IGRAPH_FREE(list->e);
     if (list->heapindex != 0) {
-        igraph_Free(list->heapindex);
+        IGRAPH_FREE(list->heapindex);
     }
     if (list->heap != 0) {
-        igraph_Free(list->heap);
+        IGRAPH_FREE(list->heap);
     }
 }
 
@@ -1031,7 +1031,7 @@ int igraph_community_fastgreedy(const igraph_t *graph,
     if (no_of_joins < total_joins) {
         long int *ivec;
         long int merges_nrow = igraph_matrix_nrow(merges);
-        ivec = igraph_Calloc(merges_nrow, long int);
+        ivec = igraph_CALLOC(merges_nrow, long int);
         if (ivec == 0) {
             IGRAPH_ERROR("Insufficient memory for fast greedy community detection.", IGRAPH_ENOMEM);
         }
@@ -1040,7 +1040,7 @@ int igraph_community_fastgreedy(const igraph_t *graph,
             ivec[i] = i + 1;
         }
         igraph_matrix_permdelete_rows(merges, ivec, total_joins - no_of_joins);
-        igraph_Free(ivec);
+        IGRAPH_FREE(ivec);
         IGRAPH_FINALLY_CLEAN(1);
     }
     IGRAPH_PROGRESS("Fast greedy community detection", 100.0, 0);
@@ -1051,8 +1051,8 @@ int igraph_community_fastgreedy(const igraph_t *graph,
     }
 
     debug("Freeing memory\n");
-    igraph_Free(pairs);
-    igraph_Free(dq);
+    IGRAPH_FREE(pairs);
+    IGRAPH_FREE(dq);
     igraph_i_fastgreedy_community_list_destroy(&communities);
     igraph_vector_destroy(&a);
     IGRAPH_FINALLY_CLEAN(4);

--- a/src/community/fast_modularity.c
+++ b/src/community/fast_modularity.c
@@ -1031,7 +1031,7 @@ int igraph_community_fastgreedy(const igraph_t *graph,
     if (no_of_joins < total_joins) {
         long int *ivec;
         long int merges_nrow = igraph_matrix_nrow(merges);
-        ivec = igraph_CALLOC(merges_nrow, long int);
+        ivec = IGRAPH_CALLOC(merges_nrow, long int);
         if (ivec == 0) {
             IGRAPH_ERROR("Insufficient memory for fast greedy community detection.", IGRAPH_ENOMEM);
         }

--- a/src/community/leading_eigenvector.c
+++ b/src/community/leading_eigenvector.c
@@ -594,7 +594,7 @@ int igraph_community_leading_eigenvector(const igraph_t *graph,
             IGRAPH_CHECK(igraph_vector_push_back(eigenvalues, IGRAPH_NAN));
         }
         if (eigenvectors) {
-            igraph_vector_t *v = igraph_Calloc(1, igraph_vector_t);
+            igraph_vector_t *v = IGRAPH_CALLOC(1, igraph_vector_t);
             if (!v) {
                 IGRAPH_ERROR("Cannot do leading eigenvector community detection",
                              IGRAPH_ENOMEM);
@@ -813,7 +813,7 @@ int igraph_community_leading_eigenvector(const igraph_t *graph,
         }
 
         if (eigenvectors) {
-            igraph_vector_t *v = igraph_Calloc(1, igraph_vector_t);
+            igraph_vector_t *v = IGRAPH_CALLOC(1, igraph_vector_t);
             if (!v) {
                 IGRAPH_ERROR("Cannot do leading eigenvector community detection",
                              IGRAPH_ENOMEM);

--- a/src/community/leiden.c
+++ b/src/community/leiden.c
@@ -499,7 +499,7 @@ static int igraph_i_community_get_clusters(const igraph_vector_t *membership, ig
 
         /* No cluster vector exists yet, so we create a new one */
         if (!cluster) {
-            cluster = igraph_Calloc(1, igraph_vector_t);
+            cluster = IGRAPH_CALLOC(1, igraph_vector_t);
             if (cluster == 0) {
                 IGRAPH_ERROR("Cannot allocate memory for assigning cluster", IGRAPH_ENOMEM);
             }
@@ -1017,7 +1017,7 @@ int igraph_community_leiden(const igraph_t *graph,
 
     /* Check edge weights to possibly use default */
     if (!edge_weights) {
-        i_edge_weights = igraph_Calloc(1, igraph_vector_t);
+        i_edge_weights = IGRAPH_CALLOC(1, igraph_vector_t);
         if (i_edge_weights == 0) {
             IGRAPH_ERROR("Leiden algorithm failed, could not allocate memory for edge weights", IGRAPH_ENOMEM);
         }
@@ -1031,7 +1031,7 @@ int igraph_community_leiden(const igraph_t *graph,
 
     /* Check edge weights to possibly use default */
     if (!node_weights) {
-        i_node_weights = igraph_Calloc(1, igraph_vector_t);
+        i_node_weights = IGRAPH_CALLOC(1, igraph_vector_t);
         if (i_node_weights == 0) {
             IGRAPH_ERROR("Leiden algorithm failed, could not allocate memory for node weights", IGRAPH_ENOMEM);
         }
@@ -1050,13 +1050,13 @@ int igraph_community_leiden(const igraph_t *graph,
 
     if (!edge_weights) {
         igraph_vector_destroy(i_edge_weights);
-        igraph_Free(i_edge_weights);
+        IGRAPH_FREE(i_edge_weights);
         IGRAPH_FINALLY_CLEAN(2);
     }
 
     if (!node_weights) {
         igraph_vector_destroy(i_node_weights);
-        igraph_Free(i_node_weights);
+        IGRAPH_FREE(i_node_weights);
         IGRAPH_FINALLY_CLEAN(2);
     }
 

--- a/src/community/louvain.c
+++ b/src/community/louvain.c
@@ -93,7 +93,7 @@ static int igraph_i_multilevel_simplify_multiple(igraph_t *graph, igraph_vector_
     /* Make sure there's enough space in eids to store the new edge IDs */
     IGRAPH_CHECK(igraph_vector_resize(eids, ecount));
 
-    links = igraph_Calloc(ecount, igraph_i_multilevel_link);
+    links = IGRAPH_CALLOC(ecount, igraph_i_multilevel_link);
     if (links == 0) {
         IGRAPH_ERROR("multi-level community structure detection failed", IGRAPH_ENOMEM);
     }
@@ -128,7 +128,7 @@ static int igraph_i_multilevel_simplify_multiple(igraph_t *graph, igraph_vector_
         VECTOR(*eids)[links[i].id] = l;
     }
 
-    igraph_Free(links);
+    IGRAPH_FREE(links);
     IGRAPH_FINALLY_CLEAN(1);
 
     igraph_destroy(graph);
@@ -185,7 +185,7 @@ static int igraph_i_multilevel_community_links(
     igraph_incident(graph, edges, vertex, IGRAPH_ALL);
 
     n = igraph_vector_size(edges);
-    links = igraph_Calloc(n, igraph_i_multilevel_community_link);
+    links = IGRAPH_CALLOC(n, igraph_i_multilevel_community_link);
     if (links == 0) {
         IGRAPH_ERROR("multi-level community structure detection failed", IGRAPH_ENOMEM);
     }
@@ -381,7 +381,7 @@ static int igraph_i_community_multilevel_step(
     communities.weights = weights;
     communities.weight_sum = 2 * igraph_vector_sum(weights);
     communities.membership = membership;
-    communities.item = igraph_Calloc(vcount, igraph_i_multilevel_community);
+    communities.item = IGRAPH_CALLOC(vcount, igraph_i_multilevel_community);
     if (communities.item == 0) {
         IGRAPH_ERROR("multi-level community structure detection failed", IGRAPH_ENOMEM);
     }

--- a/src/community/misc.c
+++ b/src/community/misc.c
@@ -522,12 +522,12 @@ static int igraph_i_entropy_and_mutual_information(const igraph_vector_t* v1,
     }
     k1 = (long int)igraph_vector_max(v1) + 1;
     k2 = (long int)igraph_vector_max(v2) + 1;
-    p1 = igraph_Calloc(k1, double);
+    p1 = IGRAPH_CALLOC(k1, double);
     if (p1 == 0) {
         IGRAPH_ERROR("igraph_i_entropy_and_mutual_information failed", IGRAPH_ENOMEM);
     }
     IGRAPH_FINALLY(igraph_free, p1);
-    p2 = igraph_Calloc(k2, double);
+    p2 = IGRAPH_CALLOC(k2, double);
     if (p2 == 0) {
         IGRAPH_ERROR("igraph_i_entropy_and_mutual_information failed", IGRAPH_ENOMEM);
     }
@@ -579,7 +579,7 @@ static int igraph_i_entropy_and_mutual_information(const igraph_vector_t* v1,
 
     igraph_spmatrix_iter_destroy(&mit);
     igraph_spmatrix_destroy(&m);
-    igraph_Free(p1); igraph_Free(p2);
+    IGRAPH_FREE(p1); IGRAPH_FREE(p2);
 
     IGRAPH_FINALLY_CLEAN(4);
 

--- a/src/connectivity/cohesive_blocks.c
+++ b/src/connectivity/cohesive_blocks.c
@@ -304,7 +304,7 @@ int igraph_cohesive_blocks(const igraph_t *graph,
     IGRAPH_FINALLY(igraph_vector_long_destroy, &components);
 
     /* Put the input graph in the queue */
-    graph_copy = igraph_Calloc(1, igraph_t);
+    graph_copy = IGRAPH_CALLOC(1, igraph_t);
     if (!graph_copy) {
         IGRAPH_ERROR("Cannot do cohesive blocking", IGRAPH_ENOMEM);
     }
@@ -391,13 +391,13 @@ int igraph_cohesive_blocks(const igraph_t *graph,
                 IGRAPH_CHECK(igraph_vector_push_back(&compvertices, v));
             }
 
-            newmapping = igraph_Calloc(1, igraph_vector_t);
+            newmapping = IGRAPH_CALLOC(1, igraph_vector_t);
             if (!newmapping) {
                 IGRAPH_ERROR("Cannot do cohesive blocking", IGRAPH_ENOMEM);
             }
             IGRAPH_FINALLY(igraph_free, newmapping);
             IGRAPH_VECTOR_INIT_FINALLY(newmapping, 0);
-            newgraph = igraph_Calloc(1, igraph_t);
+            newgraph = IGRAPH_CALLOC(1, igraph_t);
             if (!newgraph) {
                 IGRAPH_ERROR("Cannot do cohesive blocking", IGRAPH_ENOMEM);
             }
@@ -563,7 +563,7 @@ int igraph_cohesive_blocks(const igraph_t *graph,
 
         /* Plus the original graph */
         if (blocks) {
-            igraph_vector_t *orig = igraph_Calloc(1, igraph_vector_t);
+            igraph_vector_t *orig = IGRAPH_CALLOC(1, igraph_vector_t);
             if (!orig) {
                 IGRAPH_ERROR("Cannot do cohesive blocking", IGRAPH_ENOMEM);
             }

--- a/src/connectivity/components.c
+++ b/src/connectivity/components.c
@@ -98,7 +98,7 @@ static int igraph_i_clusters_weak(const igraph_t *graph, igraph_vector_t *member
     long int i;
     igraph_vector_t neis = IGRAPH_VECTOR_NULL;
 
-    already_added = igraph_Calloc(no_of_nodes, char);
+    already_added = IGRAPH_CALLOC(no_of_nodes, char);
     if (already_added == 0) {
         IGRAPH_ERROR("Cannot calculate clusters", IGRAPH_ENOMEM);
     }
@@ -159,7 +159,7 @@ static int igraph_i_clusters_weak(const igraph_t *graph, igraph_vector_t *member
         *no = (igraph_integer_t) no_of_clusters - 1;
     }
 
-    igraph_Free(already_added);
+    IGRAPH_FREE(already_added);
     igraph_dqueue_destroy(&q);
     igraph_vector_destroy(&neis);
     IGRAPH_FINALLY_CLEAN(3);
@@ -411,7 +411,7 @@ int igraph_is_connected_weak(const igraph_t *graph, igraph_bool_t *res) {
         return IGRAPH_SUCCESS;
     }
 
-    already_added = igraph_Calloc(no_of_nodes, char);
+    already_added = IGRAPH_CALLOC(no_of_nodes, char);
     if (already_added == 0) {
         IGRAPH_ERROR("is connected (weak) failed", IGRAPH_ENOMEM);
     }
@@ -444,7 +444,7 @@ int igraph_is_connected_weak(const igraph_t *graph, igraph_bool_t *res) {
     /* Connected? */
     *res = (j == no_of_nodes);
 
-    igraph_Free(already_added);
+    IGRAPH_FREE(already_added);
     igraph_dqueue_destroy(&q);
     igraph_vector_destroy(&neis);
     IGRAPH_FINALLY_CLEAN(3);
@@ -551,7 +551,7 @@ static int igraph_i_decompose_weak(const igraph_t *graph,
     IGRAPH_FINALLY(igraph_decompose_destroy, components);
 
     /* already_added keeps track of what nodes made it into a graph already */
-    already_added = igraph_Calloc(no_of_nodes, char);
+    already_added = IGRAPH_CALLOC(no_of_nodes, char);
     if (already_added == 0) {
         IGRAPH_ERROR("Cannot decompose graph", IGRAPH_ENOMEM);
     }
@@ -604,7 +604,7 @@ static int igraph_i_decompose_weak(const igraph_t *graph,
             continue;
         }
 
-        newg = igraph_Calloc(1, igraph_t);
+        newg = IGRAPH_CALLOC(1, igraph_t);
         if (newg == 0) {
             IGRAPH_ERROR("Cannot decompose graph", IGRAPH_ENOMEM);
         }
@@ -619,7 +619,7 @@ static int igraph_i_decompose_weak(const igraph_t *graph,
     igraph_vector_destroy(&neis);
     igraph_vector_destroy(&verts);
     igraph_dqueue_destroy(&q);
-    igraph_Free(already_added);
+    IGRAPH_FREE(already_added);
     IGRAPH_FINALLY_CLEAN(5);  /* + components */
 
     return 0;
@@ -804,7 +804,7 @@ static int igraph_i_decompose_strong(const igraph_t *graph,
             continue;
         }
 
-        newg = igraph_Calloc(1, igraph_t);
+        newg = IGRAPH_CALLOC(1, igraph_t);
         if (newg == 0) {
             IGRAPH_ERROR("Cannot decompose graph", IGRAPH_ENOMEM);
         }
@@ -862,7 +862,7 @@ void igraph_i_free_vectorlist(igraph_vector_ptr_t *list) {
         igraph_vector_t *v = VECTOR(*list)[i];
         if (v) {
             igraph_vector_destroy(v);
-            igraph_Free(v);
+            IGRAPH_FREE(v);
         }
     }
     igraph_vector_ptr_destroy(list);
@@ -1047,7 +1047,7 @@ int igraph_biconnected_components(const igraph_t *graph,
                             igraph_vector_t *v = 0, *v2 = 0;
                             comps++;
                             if (tree_edges) {
-                                v = igraph_Calloc(1, igraph_vector_t);
+                                v = IGRAPH_CALLOC(1, igraph_vector_t);
                                 if (!v) {
                                     IGRAPH_ERROR("Out of memory", IGRAPH_ENOMEM);
                                 }
@@ -1055,7 +1055,7 @@ int igraph_biconnected_components(const igraph_t *graph,
                                 IGRAPH_FINALLY(igraph_vector_destroy, v);
                             }
                             if (mycomponents) {
-                                v2 = igraph_Calloc(1, igraph_vector_t);
+                                v2 = IGRAPH_CALLOC(1, igraph_vector_t);
                                 if (!v2) {
                                     IGRAPH_ERROR("Out of memory", IGRAPH_ENOMEM);
                                 }
@@ -1095,7 +1095,7 @@ int igraph_biconnected_components(const igraph_t *graph,
                             }
                             if (component_edges) {
                                 igraph_vector_t *nodes = VECTOR(*mycomponents)[comps - 1];
-                                igraph_vector_t *vv = igraph_Calloc(1, igraph_vector_t);
+                                igraph_vector_t *vv = IGRAPH_CALLOC(1, igraph_vector_t);
                                 long int ii, no_vert = igraph_vector_size(nodes);
                                 if (!vv) {
                                     IGRAPH_ERROR("Out of memory", IGRAPH_ENOMEM);
@@ -1319,7 +1319,7 @@ int igraph_subcomponent(const igraph_t *graph, igraph_vector_t *res, igraph_real
         IGRAPH_ERROR("invalid mode argument", IGRAPH_EINVMODE);
     }
 
-    already_added = igraph_Calloc(no_of_nodes, char);
+    already_added = IGRAPH_CALLOC(no_of_nodes, char);
     if (already_added == 0) {
         IGRAPH_ERROR("subcomponent failed", IGRAPH_ENOMEM);
     }
@@ -1356,7 +1356,7 @@ int igraph_subcomponent(const igraph_t *graph, igraph_vector_t *res, igraph_real
 
     igraph_dqueue_destroy(&q);
     igraph_vector_destroy(&tmp);
-    igraph_Free(already_added);
+    IGRAPH_FREE(already_added);
     IGRAPH_FINALLY_CLEAN(3);
 
     return 0;

--- a/src/connectivity/separators.c
+++ b/src/connectivity/separators.c
@@ -372,7 +372,7 @@ static int igraph_i_separators_store(igraph_vector_ptr_t *separators,
         /* Add it to the list of separators, if it is new */
 
         if (igraph_i_separators_newsep(separators, sorter)) {
-            igraph_vector_t *newc = igraph_Calloc(1, igraph_vector_t);
+            igraph_vector_t *newc = IGRAPH_CALLOC(1, igraph_vector_t);
             if (!newc) {
                 IGRAPH_ERROR("Cannot calculate minimal separators", IGRAPH_ENOMEM);
             }
@@ -393,7 +393,7 @@ static void igraph_i_separators_free(igraph_vector_ptr_t *separators) {
         igraph_vector_t *vec = VECTOR(*separators)[i];
         if (vec) {
             igraph_vector_destroy(vec);
-            igraph_Free(vec);
+            IGRAPH_FREE(vec);
         }
     }
 }
@@ -693,7 +693,7 @@ int igraph_minimum_size_separators(const igraph_t *graph,
         IGRAPH_CHECK(igraph_vector_ptr_resize(separators, n));
         igraph_vector_ptr_null(separators);
         for (i = 0; i < n; i++) {
-            igraph_vector_t *v = igraph_Calloc(1, igraph_vector_t);
+            igraph_vector_t *v = IGRAPH_CALLOC(1, igraph_vector_t);
             if (!v) {
                 IGRAPH_ERROR("Minimum size separators failed", IGRAPH_ENOMEM);
             }
@@ -710,7 +710,7 @@ int igraph_minimum_size_separators(const igraph_t *graph,
         IGRAPH_CHECK(igraph_vector_ptr_resize(separators, no_of_nodes));
         igraph_vector_ptr_null(separators);
         for (i = 0; i < no_of_nodes; i++) {
-            igraph_vector_t *v = igraph_Calloc(1, igraph_vector_t);
+            igraph_vector_t *v = IGRAPH_CALLOC(1, igraph_vector_t);
             if (!v) {
                 IGRAPH_ERROR("Cannot list minimum size separators", IGRAPH_ENOMEM);
             }
@@ -741,7 +741,7 @@ int igraph_minimum_size_separators(const igraph_t *graph,
     IGRAPH_CHECK(igraph_is_separator(&graph_copy, igraph_vss_vector(&X),
                                      &issepX));
     if (issepX) {
-        igraph_vector_t *v = igraph_Calloc(1, igraph_vector_t);
+        igraph_vector_t *v = IGRAPH_CALLOC(1, igraph_vector_t);
         if (!v) {
             IGRAPH_ERROR("Cannot find minimal size separators", IGRAPH_ENOMEM);
         }

--- a/src/constructors/regular.c
+++ b/src/constructors/regular.c
@@ -193,12 +193,12 @@ int igraph_lattice(igraph_t *graph, const igraph_vector_t *dimvector,
 
     /* init coords & weights */
 
-    coords = igraph_Calloc(dims, long int);
+    coords = IGRAPH_CALLOC(dims, long int);
     if (coords == 0) {
         IGRAPH_ERROR("Lattice creation failed", IGRAPH_ENOMEM);
     }
     IGRAPH_FINALLY(igraph_free, coords);
-    weights = igraph_Calloc(dims, long int);
+    weights = IGRAPH_CALLOC(dims, long int);
     if (weights == 0) {
         IGRAPH_ERROR("Lattice creation failed", IGRAPH_ENOMEM);
     }
@@ -268,8 +268,8 @@ int igraph_lattice(igraph_t *graph, const igraph_vector_t *dimvector,
     }
 
     /* clean up */
-    igraph_Free(coords);
-    igraph_Free(weights);
+    IGRAPH_FREE(coords);
+    IGRAPH_FREE(weights);
     igraph_vector_destroy(&edges);
     IGRAPH_FINALLY_CLEAN(3);
 

--- a/src/core/dqueue.pmt
+++ b/src/core/dqueue.pmt
@@ -59,7 +59,7 @@ int FUNCTION(igraph_dqueue, init) (TYPE(igraph_dqueue)* q, long int size) {
     if (size <= 0 ) {
         size = 1;
     }
-    q->stor_begin = igraph_Calloc(size, BASE);
+    q->stor_begin = IGRAPH_CALLOC(size, BASE);
     if (q->stor_begin == 0) {
         IGRAPH_ERROR("dqueue init failed", IGRAPH_ENOMEM);
     }
@@ -83,7 +83,7 @@ int FUNCTION(igraph_dqueue, init) (TYPE(igraph_dqueue)* q, long int size) {
 void FUNCTION(igraph_dqueue, destroy) (TYPE(igraph_dqueue)* q) {
     IGRAPH_ASSERT(q != 0);
     if (q->stor_begin != 0) {
-        igraph_Free(q->stor_begin);
+        IGRAPH_FREE(q->stor_begin);
         q->stor_begin = 0;
     }
 }
@@ -298,7 +298,7 @@ int FUNCTION(igraph_dqueue, push) (TYPE(igraph_dqueue)* q, BASE elem) {
 
         BASE *bigger = NULL, *old = q->stor_begin;
 
-        bigger = igraph_Calloc( 2 * (q->stor_end - q->stor_begin) + 1, BASE );
+        bigger = IGRAPH_CALLOC( 2 * (q->stor_end - q->stor_begin) + 1, BASE );
         if (bigger == 0) {
             IGRAPH_ERROR("dqueue push failed", IGRAPH_ENOMEM);
         }
@@ -323,7 +323,7 @@ int FUNCTION(igraph_dqueue, push) (TYPE(igraph_dqueue)* q, BASE elem) {
             q->end = q->stor_begin;
         }
 
-        igraph_Free(old);
+        IGRAPH_FREE(old);
     }
 
     return 0;

--- a/src/core/fixed_vectorlist.c
+++ b/src/core/fixed_vectorlist.c
@@ -44,7 +44,7 @@ int igraph_fixed_vectorlist_convert(igraph_fixed_vectorlist_t *l,
     igraph_vector_t sizes;
     long int i, no = igraph_vector_size(from);
 
-    l->vecs = igraph_Calloc(size, igraph_vector_t);
+    l->vecs = IGRAPH_CALLOC(size, igraph_vector_t);
     if (!l->vecs) {
         IGRAPH_ERROR("Cannot merge attributes for simplify",
                      IGRAPH_ENOMEM);

--- a/src/core/hashtable.c
+++ b/src/core/hashtable.c
@@ -84,7 +84,7 @@ int igraph_hashtable_addset2(igraph_hashtable_t *ht,
 
     IGRAPH_CHECK(igraph_trie_get(&ht->keys, key, &newid));
 
-    tmp = igraph_Calloc(elemlen + 1, char);
+    tmp = IGRAPH_CALLOC(elemlen + 1, char);
     if (tmp == 0) {
         IGRAPH_ERROR("cannot add element to hash table", IGRAPH_ENOMEM);
     }
@@ -101,7 +101,7 @@ int igraph_hashtable_addset2(igraph_hashtable_t *ht,
         IGRAPH_CHECK(igraph_strvector_set(&ht->elements, newid, tmp));
     }
 
-    igraph_Free(tmp);
+    IGRAPH_FREE(tmp);
     IGRAPH_FINALLY_CLEAN(1);
 
     return 0;

--- a/src/core/heap.pmt
+++ b/src/core/heap.pmt
@@ -56,7 +56,7 @@ int FUNCTION(igraph_heap, init)(TYPE(igraph_heap)* h, long int alloc_size) {
     if (alloc_size <= 0 ) {
         alloc_size = 1;
     }
-    h->stor_begin = igraph_Calloc(alloc_size, BASE);
+    h->stor_begin = IGRAPH_CALLOC(alloc_size, BASE);
     if (h->stor_begin == 0) {
         IGRAPH_ERROR("heap init failed", IGRAPH_ENOMEM);
     }
@@ -83,7 +83,7 @@ int FUNCTION(igraph_heap, init)(TYPE(igraph_heap)* h, long int alloc_size) {
  */
 
 int FUNCTION(igraph_heap, init_array)(TYPE(igraph_heap) *h, BASE* data, long int len) {
-    h->stor_begin = igraph_Calloc(len, BASE);
+    h->stor_begin = IGRAPH_CALLOC(len, BASE);
     if (h->stor_begin == 0) {
         IGRAPH_ERROR("heap init from array failed", IGRAPH_ENOMEM);
     }
@@ -111,7 +111,7 @@ int FUNCTION(igraph_heap, init_array)(TYPE(igraph_heap) *h, BASE* data, long int
 void FUNCTION(igraph_heap, destroy)(TYPE(igraph_heap)* h) {
     if (h->destroy) {
         if (h->stor_begin != 0) {
-            igraph_Free(h->stor_begin);
+            IGRAPH_FREE(h->stor_begin);
             h->stor_begin = 0;
         }
     }
@@ -265,7 +265,7 @@ int FUNCTION(igraph_heap, reserve)(TYPE(igraph_heap)* h, long int size) {
         return 0;
     }
 
-    tmp = igraph_Realloc(h->stor_begin, (size_t) size, BASE);
+    tmp = IGRAPH_REALLOC(h->stor_begin, (size_t) size, BASE);
     if (tmp == 0) {
         IGRAPH_ERROR("heap reserve failed", IGRAPH_ENOMEM);
     }

--- a/src/core/indheap.c
+++ b/src/core/indheap.c
@@ -54,14 +54,14 @@ int igraph_indheap_init(igraph_indheap_t* h, long int alloc_size) {
     if (alloc_size <= 0 ) {
         alloc_size = 1;
     }
-    h->stor_begin = igraph_Calloc(alloc_size, igraph_real_t);
+    h->stor_begin = IGRAPH_CALLOC(alloc_size, igraph_real_t);
     if (h->stor_begin == 0) {
         h->index_begin = 0;
         IGRAPH_ERROR("indheap init failed", IGRAPH_ENOMEM);
     }
-    h->index_begin = igraph_Calloc(alloc_size, long int);
+    h->index_begin = IGRAPH_CALLOC(alloc_size, long int);
     if (h->index_begin == 0) {
-        igraph_Free(h->stor_begin);
+        IGRAPH_FREE(h->stor_begin);
         h->stor_begin = 0;
         IGRAPH_ERROR("indheap init failed", IGRAPH_ENOMEM);
     }
@@ -89,14 +89,14 @@ int igraph_indheap_clear(igraph_indheap_t *h) {
 int igraph_indheap_init_array     (igraph_indheap_t *h, igraph_real_t* data, long int len) {
     long int i;
 
-    h->stor_begin = igraph_Calloc(len, igraph_real_t);
+    h->stor_begin = IGRAPH_CALLOC(len, igraph_real_t);
     if (h->stor_begin == 0) {
         h->index_begin = 0;
         IGRAPH_ERROR("indheap init from array failed", IGRAPH_ENOMEM);
     }
-    h->index_begin = igraph_Calloc(len, long int);
+    h->index_begin = IGRAPH_CALLOC(len, long int);
     if (h->index_begin == 0) {
-        igraph_Free(h->stor_begin);
+        IGRAPH_FREE(h->stor_begin);
         h->stor_begin = 0;
         IGRAPH_ERROR("indheap init from array failed", IGRAPH_ENOMEM);
     }
@@ -123,11 +123,11 @@ void igraph_indheap_destroy        (igraph_indheap_t* h) {
     IGRAPH_ASSERT(h != 0);
     if (h->destroy) {
         if (h->stor_begin != 0) {
-            igraph_Free(h->stor_begin);
+            IGRAPH_FREE(h->stor_begin);
             h->stor_begin = 0;
         }
         if (h->index_begin != 0) {
-            igraph_Free(h->index_begin);
+            IGRAPH_FREE(h->index_begin);
             h->index_begin = 0;
         }
     }
@@ -290,20 +290,20 @@ int igraph_indheap_reserve        (igraph_indheap_t* h, long int size) {
         return 0;
     }
 
-    tmp1 = igraph_Calloc(size, igraph_real_t);
+    tmp1 = IGRAPH_CALLOC(size, igraph_real_t);
     if (tmp1 == 0) {
         IGRAPH_ERROR("indheap reserve failed", IGRAPH_ENOMEM);
     }
     IGRAPH_FINALLY(igraph_free, tmp1);
-    tmp2 = igraph_Calloc(size, long int);
+    tmp2 = IGRAPH_CALLOC(size, long int);
     if (tmp2 == 0) {
         IGRAPH_ERROR("indheap reserve failed", IGRAPH_ENOMEM);
     }
     IGRAPH_FINALLY(igraph_free, tmp2);
     memcpy(tmp1, h->stor_begin, (size_t) actual_size * sizeof(igraph_real_t));
     memcpy(tmp2, h->index_begin, (size_t) actual_size * sizeof(long int));
-    igraph_Free(h->stor_begin);
-    igraph_Free(h->index_begin);
+    IGRAPH_FREE(h->stor_begin);
+    IGRAPH_FREE(h->index_begin);
 
     h->stor_begin = tmp1;
     h->index_begin = tmp2;
@@ -432,7 +432,7 @@ int igraph_d_indheap_init           (igraph_d_indheap_t* h, long int alloc_size)
     if (alloc_size <= 0 ) {
         alloc_size = 1;
     }
-    h->stor_begin = igraph_Calloc(alloc_size, igraph_real_t);
+    h->stor_begin = IGRAPH_CALLOC(alloc_size, igraph_real_t);
     if (h->stor_begin == 0) {
         h->index_begin = 0;
         h->index2_begin = 0;
@@ -441,17 +441,17 @@ int igraph_d_indheap_init           (igraph_d_indheap_t* h, long int alloc_size)
     h->stor_end = h->stor_begin + alloc_size;
     h->end = h->stor_begin;
     h->destroy = 1;
-    h->index_begin = igraph_Calloc(alloc_size, long int);
+    h->index_begin = IGRAPH_CALLOC(alloc_size, long int);
     if (h->index_begin == 0) {
-        igraph_Free(h->stor_begin);
+        IGRAPH_FREE(h->stor_begin);
         h->stor_begin = 0;
         h->index2_begin = 0;
         IGRAPH_ERROR("d_indheap init failed", IGRAPH_ENOMEM);
     }
-    h->index2_begin = igraph_Calloc(alloc_size, long int);
+    h->index2_begin = IGRAPH_CALLOC(alloc_size, long int);
     if (h->index2_begin == 0) {
-        igraph_Free(h->stor_begin);
-        igraph_Free(h->index_begin);
+        IGRAPH_FREE(h->stor_begin);
+        IGRAPH_FREE(h->index_begin);
         h->stor_begin = 0;
         h->index_begin = 0;
         IGRAPH_ERROR("d_indheap init failed", IGRAPH_ENOMEM);
@@ -469,15 +469,15 @@ void igraph_d_indheap_destroy        (igraph_d_indheap_t* h) {
     IGRAPH_ASSERT(h != 0);
     if (h->destroy) {
         if (h->stor_begin != 0) {
-            igraph_Free(h->stor_begin);
+            IGRAPH_FREE(h->stor_begin);
             h->stor_begin = 0;
         }
         if (h->index_begin != 0) {
-            igraph_Free(h->index_begin);
+            IGRAPH_FREE(h->index_begin);
             h->index_begin = 0;
         }
         if (h->index2_begin != 0) {
-            igraph_Free(h->index2_begin);
+            IGRAPH_FREE(h->index2_begin);
             h->index2_begin = 0;
         }
     }
@@ -586,17 +586,17 @@ int igraph_d_indheap_reserve        (igraph_d_indheap_t* h, long int size) {
         return 0;
     }
 
-    tmp1 = igraph_Calloc(size, igraph_real_t);
+    tmp1 = IGRAPH_CALLOC(size, igraph_real_t);
     if (tmp1 == 0) {
         IGRAPH_ERROR("d_indheap reserve failed", IGRAPH_ENOMEM);
     }
     IGRAPH_FINALLY(igraph_free, tmp1);
-    tmp2 = igraph_Calloc(size, long int);
+    tmp2 = IGRAPH_CALLOC(size, long int);
     if (tmp2 == 0) {
         IGRAPH_ERROR("d_indheap reserve failed", IGRAPH_ENOMEM);
     }
     IGRAPH_FINALLY(igraph_free, tmp2);
-    tmp3 = igraph_Calloc(size, long int);
+    tmp3 = IGRAPH_CALLOC(size, long int);
     if (tmp3 == 0) {
         IGRAPH_ERROR("d_indheap reserve failed", IGRAPH_ENOMEM);
     }
@@ -605,9 +605,9 @@ int igraph_d_indheap_reserve        (igraph_d_indheap_t* h, long int size) {
     memcpy(tmp1, h->stor_begin, (size_t) actual_size * sizeof(igraph_real_t));
     memcpy(tmp2, h->index_begin, (size_t) actual_size * sizeof(long int));
     memcpy(tmp3, h->index2_begin, (size_t) actual_size * sizeof(long int));
-    igraph_Free(h->stor_begin);
-    igraph_Free(h->index_begin);
-    igraph_Free(h->index2_begin);
+    IGRAPH_FREE(h->stor_begin);
+    IGRAPH_FREE(h->index_begin);
+    IGRAPH_FREE(h->index2_begin);
 
     h->stor_begin = tmp1;
     h->stor_end = h->stor_begin + size;

--- a/src/core/memory.c
+++ b/src/core/memory.c
@@ -47,7 +47,7 @@
  */
 
 void igraph_free(void *p) {
-    igraph_Free(p);
+    IGRAPH_FREE(p);
 }
 
 

--- a/src/core/memory.c
+++ b/src/core/memory.c
@@ -69,5 +69,5 @@ void igraph_free(void *p) {
  */
 
 void *igraph_malloc(size_t n) {
-    return malloc(n);
+    return malloc(n + 1);
 }

--- a/src/core/memory.c
+++ b/src/core/memory.c
@@ -69,5 +69,5 @@ void igraph_free(void *p) {
  */
 
 void *igraph_malloc(size_t n) {
-    return malloc(n + 1);
+    return malloc(n);
 }

--- a/src/core/set.c
+++ b/src/core/set.c
@@ -52,7 +52,7 @@ int igraph_set_init(igraph_set_t *set, int long size) {
         size = 0;
     }
     alloc_size = size > 0 ? size : 1;
-    set->stor_begin = igraph_Calloc(alloc_size, igraph_integer_t);
+    set->stor_begin = IGRAPH_CALLOC(alloc_size, igraph_integer_t);
     set->stor_end = set->stor_begin + alloc_size;
     set->end = set->stor_begin;
 
@@ -71,7 +71,7 @@ int igraph_set_init(igraph_set_t *set, int long size) {
 void igraph_set_destroy(igraph_set_t* set) {
     IGRAPH_ASSERT(set != 0);
     if (set->stor_begin != 0) {
-        igraph_Free(set->stor_begin);
+        IGRAPH_FREE(set->stor_begin);
         set->stor_begin = NULL;
     }
 }
@@ -84,7 +84,7 @@ void igraph_set_destroy(igraph_set_t* set) {
  * This function checks whether the internal storage for the members of the
  * set has been allocated or not, and it assumes that the pointer for the
  * internal storage area contains \c NULL if the area is not initialized yet.
- * This only applies if you have allocated an array of sets with \c igraph_Calloc or
+ * This only applies if you have allocated an array of sets with \c IGRAPH_CALLOC or
  * if you used the \c IGRAPH_SET_NULL constant to initialize the set.
  *
  * \param set The set object.
@@ -115,7 +115,7 @@ int igraph_set_reserve(igraph_set_t* set, long int size) {
         return 0;
     }
 
-    tmp = igraph_Realloc(set->stor_begin, (size_t) size, igraph_integer_t);
+    tmp = IGRAPH_REALLOC(set->stor_begin, (size_t) size, igraph_integer_t);
     if (tmp == 0) {
         IGRAPH_ERROR("cannot reserve space for set", IGRAPH_ENOMEM);
     }

--- a/src/core/sparsemat.c
+++ b/src/core/sparsemat.c
@@ -1828,7 +1828,7 @@ int igraph_sparsemat_luresol(const igraph_sparsemat_symbolic_t *dis,
         IGRAPH_CHECK(igraph_vector_update(res, b));
     }
 
-    workspace = igraph_Calloc(n, igraph_real_t);
+    workspace = IGRAPH_CALLOC(n, igraph_real_t);
     if (!workspace) {
         IGRAPH_ERROR("Cannot LU (re)solve sparse matrix", IGRAPH_ENOMEM);
     }
@@ -1847,7 +1847,7 @@ int igraph_sparsemat_luresol(const igraph_sparsemat_symbolic_t *dis,
         IGRAPH_ERROR("Cannot LU (re)solve sparse matrix", IGRAPH_FAILURE);
     }
 
-    igraph_Free(workspace);
+    IGRAPH_FREE(workspace);
     IGRAPH_FINALLY_CLEAN(1);
 
     return 0;
@@ -1884,7 +1884,7 @@ int igraph_sparsemat_qrresol(const igraph_sparsemat_symbolic_t *dis,
         IGRAPH_CHECK(igraph_vector_update(res, b));
     }
 
-    workspace = igraph_Calloc(dis->symbolic ? dis->symbolic->m2 : 1,
+    workspace = IGRAPH_CALLOC(dis->symbolic ? dis->symbolic->m2 : 1,
                               igraph_real_t);
     if (!workspace) {
         IGRAPH_ERROR("Cannot QR (re)solve sparse matrix", IGRAPH_FAILURE);
@@ -1906,7 +1906,7 @@ int igraph_sparsemat_qrresol(const igraph_sparsemat_symbolic_t *dis,
         IGRAPH_ERROR("Cannot QR (re)solve sparse matrix", IGRAPH_FAILURE);
     }
 
-    igraph_Free(workspace);
+    IGRAPH_FREE(workspace);
     IGRAPH_FINALLY_CLEAN(1);
 
     return 0;
@@ -3034,7 +3034,7 @@ int igraph_sparsemat_dense_multiply(const igraph_matrix_t *A,
 int igraph_sparsemat_view(igraph_sparsemat_t *A, int nzmax, int m, int n,
                           int *p, int *i, double *x, int nz) {
 
-    A->cs = igraph_Calloc(1, cs_di);
+    A->cs = IGRAPH_CALLOC(1, cs_di);
     A->cs->nzmax = nzmax;
     A->cs->m = m;
     A->cs->n = n;

--- a/src/core/stack.c
+++ b/src/core/stack.c
@@ -71,7 +71,7 @@ void igraph_stack_ptr_free_all(igraph_stack_ptr_t* v) {
     IGRAPH_ASSERT(v != 0);
     IGRAPH_ASSERT(v->stor_begin != 0);
     for (ptr = v->stor_begin; ptr < v->end; ptr++) {
-        igraph_Free(*ptr);
+        IGRAPH_FREE(*ptr);
     }
 }
 

--- a/src/core/stack.pmt
+++ b/src/core/stack.pmt
@@ -192,7 +192,7 @@ int FUNCTION(igraph_stack, push)(TYPE(igraph_stack)* s, BASE elem) {
 
         BASE *bigger = NULL, *old = s->stor_begin;
 
-        bigger = IGRAPH_CALLOC(2 * FUNCTION(igraph_stack, size)(s) + 1, BASE);
+        bigger = IGRAPH_CALLOC(2 * FUNCTION(igraph_stack, size)(s), BASE);
         if (bigger == 0) {
             IGRAPH_ERROR("stack push failed", IGRAPH_ENOMEM);
         }

--- a/src/core/stack.pmt
+++ b/src/core/stack.pmt
@@ -200,7 +200,7 @@ int FUNCTION(igraph_stack, push)(TYPE(igraph_stack)* s, BASE elem) {
                (size_t) FUNCTION(igraph_stack, size)(s)*sizeof(BASE));
 
         s->end        = bigger + (s->stor_end - s->stor_begin);
-        s->stor_end   = bigger + 2 * (s->stor_end - s->stor_begin) + 1;
+        s->stor_end   = bigger + 2 * (s->stor_end - s->stor_begin);
         s->stor_begin = bigger;
 
         *(s->end) = elem;

--- a/src/core/stack.pmt
+++ b/src/core/stack.pmt
@@ -49,7 +49,7 @@ int FUNCTION(igraph_stack, init)       (TYPE(igraph_stack)* s, long int size) {
         size = 0;
     }
     alloc_size = size > 0 ? size : 1;
-    s->stor_begin = igraph_Calloc(alloc_size, BASE);
+    s->stor_begin = IGRAPH_CALLOC(alloc_size, BASE);
     if (s->stor_begin == 0) {
         IGRAPH_ERROR("stack init failed", IGRAPH_ENOMEM);
     }
@@ -75,7 +75,7 @@ int FUNCTION(igraph_stack, init)       (TYPE(igraph_stack)* s, long int size) {
 void FUNCTION(igraph_stack, destroy)    (TYPE(igraph_stack)* s) {
     IGRAPH_ASSERT(s != NULL);
     if (s->stor_begin != 0) {
-        igraph_Free(s->stor_begin);
+        IGRAPH_FREE(s->stor_begin);
         s->stor_begin = NULL;
     }
 }
@@ -106,7 +106,7 @@ int FUNCTION(igraph_stack, reserve)    (TYPE(igraph_stack)* s, long int size) {
         return 0;
     }
 
-    tmp = igraph_Realloc(s->stor_begin, (size_t) size, BASE);
+    tmp = IGRAPH_REALLOC(s->stor_begin, (size_t) size, BASE);
     if (tmp == 0) {
         IGRAPH_ERROR("stack reserve failed", IGRAPH_ENOMEM);
     }
@@ -192,7 +192,7 @@ int FUNCTION(igraph_stack, push)(TYPE(igraph_stack)* s, BASE elem) {
 
         BASE *bigger = NULL, *old = s->stor_begin;
 
-        bigger = igraph_Calloc(2 * FUNCTION(igraph_stack, size)(s) + 1, BASE);
+        bigger = IGRAPH_CALLOC(2 * FUNCTION(igraph_stack, size)(s) + 1, BASE);
         if (bigger == 0) {
             IGRAPH_ERROR("stack push failed", IGRAPH_ENOMEM);
         }
@@ -206,7 +206,7 @@ int FUNCTION(igraph_stack, push)(TYPE(igraph_stack)* s, BASE elem) {
         *(s->end) = elem;
         (s->end) += 1;
 
-        igraph_Free(old);
+        IGRAPH_FREE(old);
     } else {
         *(s->end) = elem;
         (s->end) += 1;

--- a/src/core/strvector.c
+++ b/src/core/strvector.c
@@ -60,12 +60,12 @@
 
 int igraph_strvector_init(igraph_strvector_t *sv, long int len) {
     long int i;
-    sv->data = igraph_Calloc(len, char*);
+    sv->data = IGRAPH_CALLOC(len, char*);
     if (sv->data == 0) {
         IGRAPH_ERROR("strvector init failed", IGRAPH_ENOMEM);
     }
     for (i = 0; i < len; i++) {
-        sv->data[i] = igraph_Calloc(1, char);
+        sv->data[i] = IGRAPH_CALLOC(1, char);
         if (sv->data[i] == 0) {
             igraph_strvector_destroy(sv);
             IGRAPH_ERROR("strvector init failed", IGRAPH_ENOMEM);
@@ -96,10 +96,10 @@ void igraph_strvector_destroy(igraph_strvector_t *sv) {
     if (sv->data != 0) {
         for (i = 0; i < sv->len; i++) {
             if (sv->data[i] != 0) {
-                igraph_Free(sv->data[i]);
+                IGRAPH_FREE(sv->data[i]);
             }
         }
-        igraph_Free(sv->data);
+        IGRAPH_FREE(sv->data);
     }
 }
 
@@ -151,12 +151,12 @@ int igraph_strvector_set(igraph_strvector_t *sv, long int idx,
 
     value_len = strlen(value);
     if (sv->data[idx] == 0) {        
-        sv->data[idx] = igraph_Calloc(value_len + 1, char);
+        sv->data[idx] = igraph_CALLOC(value_len + 1, char);
         if (sv->data[idx] == 0) {
             IGRAPH_ERROR("strvector set failed", IGRAPH_ENOMEM);
         }
     } else {
-        char *tmp = igraph_Realloc(sv->data[idx], value_len + 1, char);
+        char *tmp = igraph_REALLOC(sv->data[idx], value_len + 1, char);
         if (tmp == 0) {
             IGRAPH_ERROR("strvector set failed", IGRAPH_ENOMEM);
         }
@@ -191,12 +191,12 @@ int igraph_strvector_set2(igraph_strvector_t *sv, long int idx,
     IGRAPH_ASSERT(sv != 0);
     IGRAPH_ASSERT(sv->data != 0);
     if (sv->data[idx] == 0) {
-        sv->data[idx] = igraph_Calloc(len + 1, char);
+        sv->data[idx] = IGRAPH_CALLOC(len + 1, char);
         if (sv->data[idx] == 0) {
             IGRAPH_ERROR("strvector set failed", IGRAPH_ENOMEM);
         }
     } else {
-        char *tmp = igraph_Realloc(sv->data[idx], (size_t) len + 1, char);
+        char *tmp = IGRAPH_REALLOC(sv->data[idx], (size_t) len + 1, char);
         if (tmp == 0) {
             IGRAPH_ERROR("strvector set failed", IGRAPH_ENOMEM);
         }
@@ -225,7 +225,7 @@ void igraph_strvector_remove_section(igraph_strvector_t *v, long int from,
 
     for (i = from; i < to; i++) {
         if (v->data[i] != 0) {
-            igraph_Free(v->data[i]);
+            IGRAPH_FREE(v->data[i]);
         }
     }
     for (i = 0; i < v->len - to; i++) {
@@ -235,7 +235,7 @@ void igraph_strvector_remove_section(igraph_strvector_t *v, long int from,
     v->len -= (to - from);
 
     /* try to make it smaller */
-    /*   tmp=igraph_Realloc(v->data, v->len, char*); */
+    /*   tmp=IGRAPH_REALLOC(v->data, v->len, char*); */
     /*   if (tmp!=0) { */
     /*     v->data=tmp; */
     /*   } */
@@ -272,13 +272,13 @@ void igraph_strvector_move_interval(igraph_strvector_t *v, long int begin,
     IGRAPH_ASSERT(v->data != 0);
     for (i = to; i < to + end - begin; i++) {
         if (v->data[i] != 0) {
-            igraph_Free(v->data[i]);
+            IGRAPH_FREE(v->data[i]);
         }
     }
     for (i = 0; i < end - begin; i++) {
         if (v->data[begin + i] != 0) {
             size_t len = strlen(v->data[begin + i]) + 1;
-            v->data[to + i] = igraph_Calloc(len, char);
+            v->data[to + i] = IGRAPH_CALLOC(len, char);
             memcpy(v->data[to + i], v->data[begin + i], sizeof(char)*len);
         }
     }
@@ -303,7 +303,7 @@ int igraph_strvector_copy(igraph_strvector_t *to,
     char *str;
     IGRAPH_ASSERT(from != 0);
     /*   IGRAPH_ASSERT(from->data != 0); */
-    to->data = igraph_Calloc(from->len, char*);
+    to->data = IGRAPH_CALLOC(from->len, char*);
     if (to->data == 0) {
         IGRAPH_ERROR("Cannot copy string vector", IGRAPH_ENOMEM);
     }
@@ -343,7 +343,7 @@ int igraph_strvector_append(igraph_strvector_t *to,
     IGRAPH_CHECK(igraph_strvector_resize(to, len1 + len2));
     for (i = 0; i < len2; i++) {
         if (from->data[i][0] != '\0') {
-            igraph_Free(to->data[len1 + i]);
+            IGRAPH_FREE(to->data[len1 + i]);
             to->data[len1 + i] = strdup(from->data[i]);
             if (!to->data[len1 + i]) {
                 error = 1;
@@ -374,11 +374,11 @@ void igraph_strvector_clear(igraph_strvector_t *sv) {
     char **tmp;
 
     for (i = 0; i < n; i++) {
-        igraph_Free(sv->data[i]);
+        IGRAPH_FREE(sv->data[i]);
     }
     sv->len = 0;
     /* try to give back some memory */
-    tmp = igraph_Realloc(sv->data, 1, char*);
+    tmp = IGRAPH_REALLOC(sv->data, 1, char*);
     if (tmp != 0) {
         sv->data = tmp;
     }
@@ -413,24 +413,24 @@ int igraph_strvector_resize(igraph_strvector_t* v, long int newsize) {
     /*   printf("resize %li to %li\n", v->len, newsize); */
     if (newsize < v->len) {
         for (i = newsize; i < v->len; i++) {
-            igraph_Free(v->data[i]);
+            IGRAPH_FREE(v->data[i]);
         }
         /* try to give back some space */
-        tmp = igraph_Realloc(v->data, (size_t) reallocsize, char*);
+        tmp = IGRAPH_REALLOC(v->data, (size_t) reallocsize, char*);
         /*     printf("resize %li to %li, %p\n", v->len, newsize, tmp); */
         if (tmp != 0) {
             v->data = tmp;
         }
     } else if (newsize > v->len) {
         igraph_bool_t error = 0;
-        tmp = igraph_Realloc(v->data, (size_t) reallocsize, char*);
+        tmp = IGRAPH_REALLOC(v->data, (size_t) reallocsize, char*);
         if (tmp == 0) {
             IGRAPH_ERROR("cannot resize string vector", IGRAPH_ENOMEM);
         }
         v->data = tmp;
 
         for (i = 0; i < toadd; i++) {
-            v->data[v->len + i] = igraph_Calloc(1, char);
+            v->data[v->len + i] = IGRAPH_CALLOC(1, char);
             if (v->data[v->len + i] == 0) {
                 error = 1;
                 break;
@@ -441,11 +441,11 @@ int igraph_strvector_resize(igraph_strvector_t* v, long int newsize) {
             /* There was an error, free everything we've allocated so far */
             for (j = 0; j < i; j++) {
                 if (v->data[v->len + i] != 0) {
-                    igraph_Free(v->data[v->len + i]);
+                    IGRAPH_FREE(v->data[v->len + i]);
                 }
             }
             /* Try to give back space */
-            tmp = igraph_Realloc(v->data, (size_t) (v->len), char*);
+            tmp = IGRAPH_REALLOC(v->data, (size_t) (v->len), char*);
             if (tmp != 0) {
                 v->data = tmp;
             }
@@ -493,12 +493,16 @@ int igraph_strvector_add(igraph_strvector_t *v, const char *value) {
     char **tmp;
     IGRAPH_ASSERT(v != 0);
     IGRAPH_ASSERT(v->data != 0);
-    tmp = igraph_Realloc(v->data, (size_t) s + 1, char*);
+    tmp = IGRAPH_REALLOC(v->data, (size_t) s + 1, char*);
     if (tmp == 0) {
         IGRAPH_ERROR("cannot add string to string vector", IGRAPH_ENOMEM);
     }
     v->data = tmp;
+<<<<<<< HEAD
     v->data[s] = igraph_Calloc(value_len + 1, char);
+=======
+    v->data[s] = IGRAPH_CALLOC(strlen(value) + 1, char);
+>>>>>>> Change alloc macro case, use ? for macros
     if (v->data[s] == 0) {
         IGRAPH_ERROR("cannot add string to string vector", IGRAPH_ENOMEM);
     }
@@ -525,11 +529,11 @@ void igraph_strvector_permdelete(igraph_strvector_t *v, const igraph_vector_t *i
         if (VECTOR(*index)[i] != 0) {
             v->data[ (long int) VECTOR(*index)[i] - 1 ] = v->data[i];
         } else {
-            igraph_Free(v->data[i]);
+            IGRAPH_FREE(v->data[i]);
         }
     }
     /* Try to make it shorter */
-    tmp = igraph_Realloc(v->data, v->len - nremove ?
+    tmp = IGRAPH_REALLOC(v->data, v->len - nremove ?
                          (size_t) (v->len - nremove) : 1, char*);
     if (tmp != 0) {
         v->data = tmp;
@@ -553,11 +557,11 @@ void igraph_strvector_remove_negidx(igraph_strvector_t *v, const igraph_vector_t
         if (VECTOR(*neg)[i] >= 0) {
             v->data[idx++] = v->data[i];
         } else {
-            igraph_Free(v->data[i]);
+            IGRAPH_FREE(v->data[i]);
         }
     }
     /* Try to give back some memory */
-    tmp = igraph_Realloc(v->data, v->len - nremove ?
+    tmp = IGRAPH_REALLOC(v->data, v->len - nremove ?
                          (size_t) (v->len - nremove) : 1, char*);
     if (tmp != 0) {
         v->data = tmp;

--- a/src/core/strvector.c
+++ b/src/core/strvector.c
@@ -404,9 +404,6 @@ int igraph_strvector_resize(igraph_strvector_t* v, long int newsize) {
     long int toadd = newsize - v->len, i, j;
     char **tmp;
     long int reallocsize = newsize;
-    if (reallocsize == 0) {
-        reallocsize = 1;
-    }
 
     IGRAPH_ASSERT(v != 0);
     IGRAPH_ASSERT(v->data != 0);

--- a/src/core/strvector.c
+++ b/src/core/strvector.c
@@ -151,12 +151,12 @@ int igraph_strvector_set(igraph_strvector_t *sv, long int idx,
 
     value_len = strlen(value);
     if (sv->data[idx] == 0) {        
-        sv->data[idx] = igraph_CALLOC(value_len + 1, char);
+        sv->data[idx] = IGRAPH_CALLOC(value_len + 1, char);
         if (sv->data[idx] == 0) {
             IGRAPH_ERROR("strvector set failed", IGRAPH_ENOMEM);
         }
     } else {
-        char *tmp = igraph_REALLOC(sv->data[idx], value_len + 1, char);
+        char *tmp = IGRAPH_REALLOC(sv->data[idx], value_len + 1, char);
         if (tmp == 0) {
             IGRAPH_ERROR("strvector set failed", IGRAPH_ENOMEM);
         }
@@ -495,11 +495,7 @@ int igraph_strvector_add(igraph_strvector_t *v, const char *value) {
         IGRAPH_ERROR("cannot add string to string vector", IGRAPH_ENOMEM);
     }
     v->data = tmp;
-<<<<<<< HEAD
-    v->data[s] = igraph_Calloc(value_len + 1, char);
-=======
-    v->data[s] = IGRAPH_CALLOC(strlen(value) + 1, char);
->>>>>>> Change alloc macro case, use ? for macros
+    v->data[s] = IGRAPH_CALLOC(value_len + 1, char);
     if (v->data[s] == 0) {
         IGRAPH_ERROR("cannot add string to string vector", IGRAPH_ENOMEM);
     }

--- a/src/core/trie.c
+++ b/src/core/trie.c
@@ -86,7 +86,7 @@ static void igraph_i_trie_destroy_node_helper(igraph_trie_node_t *t, igraph_bool
     igraph_vector_ptr_destroy(&t->children);
     igraph_vector_destroy(&t->values);
     if (sfree) {
-        igraph_Free(t);
+        IGRAPH_FREE(t);
     }
 }
 
@@ -170,7 +170,7 @@ int igraph_trie_get_node(igraph_trie_node_t *t, const char *key,
             if (node != 0) {
                 return igraph_trie_get_node(node, key + diff, newvalue, id);
             } else if (add) {
-                igraph_trie_node_t *node = igraph_Calloc(1, igraph_trie_node_t);
+                igraph_trie_node_t *node = IGRAPH_CALLOC(1, igraph_trie_node_t);
                 if (node == 0) {
                     IGRAPH_ERROR("cannot add to trie", IGRAPH_ENOMEM);
                 }
@@ -197,7 +197,7 @@ int igraph_trie_get_node(igraph_trie_node_t *t, const char *key,
             /* key is prefix of str, the node has to be cut */
             char *str2;
 
-            igraph_trie_node_t *node = igraph_Calloc(1, igraph_trie_node_t);
+            igraph_trie_node_t *node = IGRAPH_CALLOC(1, igraph_trie_node_t);
             if (node == 0) {
                 IGRAPH_ERROR("cannot add to trie", IGRAPH_ENOMEM);
             }
@@ -216,7 +216,7 @@ int igraph_trie_get_node(igraph_trie_node_t *t, const char *key,
             str2[diff] = '\0';
             IGRAPH_FINALLY(igraph_free, str2);
             IGRAPH_CHECK(igraph_strvector_set(&t->strs, i, str2));
-            igraph_Free(str2);
+            IGRAPH_FREE(str2);
             IGRAPH_FINALLY_CLEAN(4);
 
             VECTOR(t->values)[i] = newvalue;
@@ -231,7 +231,7 @@ int igraph_trie_get_node(igraph_trie_node_t *t, const char *key,
             /* the first diff characters match */
             char *str2;
 
-            igraph_trie_node_t *node = igraph_Calloc(1, igraph_trie_node_t);
+            igraph_trie_node_t *node = IGRAPH_CALLOC(1, igraph_trie_node_t);
             if (node == 0) {
                 IGRAPH_ERROR("cannot add to trie", IGRAPH_ENOMEM);
             }
@@ -252,7 +252,7 @@ int igraph_trie_get_node(igraph_trie_node_t *t, const char *key,
             str2[diff] = '\0';
             IGRAPH_FINALLY(igraph_free, str2);
             IGRAPH_CHECK(igraph_strvector_set(&t->strs, i, str2));
-            igraph_Free(str2);
+            IGRAPH_FREE(str2);
             IGRAPH_FINALLY_CLEAN(4);
 
             VECTOR(t->values)[i] = -1;
@@ -341,7 +341,7 @@ int igraph_trie_get(igraph_trie_t *t, const char *key, long int *id) {
 
 int igraph_trie_get2(igraph_trie_t *t, const char *key, long int length,
                      long int *id) {
-    char *tmp = igraph_Calloc(length + 1, char);
+    char *tmp = IGRAPH_CALLOC(length + 1, char);
 
     if (tmp == 0) {
         IGRAPH_ERROR("Cannot get from trie", IGRAPH_ENOMEM);
@@ -351,7 +351,7 @@ int igraph_trie_get2(igraph_trie_t *t, const char *key, long int length,
     tmp[length] = '\0';
     IGRAPH_FINALLY(igraph_free, tmp);
     IGRAPH_CHECK(igraph_trie_get(t, tmp, id));
-    igraph_Free(tmp);
+    IGRAPH_FREE(tmp);
     IGRAPH_FINALLY_CLEAN(1);
     return 0;
 }

--- a/src/core/vector.pmt
+++ b/src/core/vector.pmt
@@ -1317,7 +1317,7 @@ int FUNCTION(igraph_vector, copy)(TYPE(igraph_vector) *to,
     IGRAPH_ASSERT(from->stor_begin != NULL);
 
     from_size = FUNCTION(igraph_vector, size)(from);
-    to->stor_begin = igraph_CALLOC(from_size, BASE);
+    to->stor_begin = IGRAPH_CALLOC(from_size, BASE);
     if (to->stor_begin == 0) {
         IGRAPH_ERROR("cannot copy vector", IGRAPH_ENOMEM);
     }

--- a/src/core/vector.pmt
+++ b/src/core/vector.pmt
@@ -126,7 +126,7 @@ int FUNCTION(igraph_vector, init)      (TYPE(igraph_vector)* v, int long size) {
     if (size < 0) {
         size = 0;
     }
-    v->stor_begin = igraph_Calloc(alloc_size, BASE);
+    v->stor_begin = IGRAPH_CALLOC(alloc_size, BASE);
     if (v->stor_begin == 0) {
         IGRAPH_ERROR("cannot init vector", IGRAPH_ENOMEM);
     }
@@ -377,7 +377,7 @@ int FUNCTION(igraph_vector_init, int_end)(TYPE(igraph_vector) *v, int endmark, .
 void FUNCTION(igraph_vector, destroy)   (TYPE(igraph_vector)* v) {
     IGRAPH_ASSERT(v != 0);
     if (v->stor_begin != 0) {
-        igraph_Free(v->stor_begin);
+        IGRAPH_FREE(v->stor_begin);
         v->stor_begin = NULL;
     }
 }
@@ -440,7 +440,7 @@ int FUNCTION(igraph_vector, reserve)   (TYPE(igraph_vector)* v, long int size) {
         return 0;
     }
 
-    tmp = igraph_Realloc(v->stor_begin, (size_t) size, BASE);
+    tmp = IGRAPH_REALLOC(v->stor_begin, (size_t) size, BASE);
     if (tmp == 0) {
         IGRAPH_ERROR("cannot reserve space for vector", IGRAPH_ENOMEM);
     }
@@ -878,7 +878,7 @@ long int FUNCTION(igraph_vector, qsort_ind)(TYPE(igraph_vector) *v,
     if (n == 0) {
         return 0;
     }
-    vind = igraph_Calloc(n, BASE*);
+    vind = IGRAPH_CALLOC(n, BASE*);
     if (vind == 0) {
         IGRAPH_ERROR("igraph_vector_qsort_ind failed", IGRAPH_ENOMEM);
     }
@@ -894,7 +894,7 @@ long int FUNCTION(igraph_vector, qsort_ind)(TYPE(igraph_vector) *v,
     for (i = 0; i < n; i++) {
         VECTOR(*inds)[i] = vind[i] - first;
     }
-    igraph_Free(vind);
+    IGRAPH_FREE(vind);
     return 0;
 }
 
@@ -1053,7 +1053,7 @@ int FUNCTION(igraph_vector, resize_min)(TYPE(igraph_vector)*v) {
     }
 
     size = (size_t) (v->end - v->stor_begin);
-    tmp = igraph_Realloc(v->stor_begin, size, BASE);
+    tmp = IGRAPH_REALLOC(v->stor_begin, size, BASE);
     if (tmp == 0) {
         IGRAPH_ERROR("cannot resize vector", IGRAPH_ENOMEM);
     } else {
@@ -1257,7 +1257,7 @@ long int FUNCTION(igraph_vector, which_min)(const TYPE(igraph_vector)* v) {
 
 int FUNCTION(igraph_vector, init_copy)(TYPE(igraph_vector) *v,
                                        const BASE *data, long int length) {
-    v->stor_begin = igraph_Calloc(length, BASE);
+    v->stor_begin = IGRAPH_CALLOC(length, BASE);
     if (v->stor_begin == 0) {
         IGRAPH_ERROR("cannot init vector from array", IGRAPH_ENOMEM);
     }
@@ -1317,7 +1317,7 @@ int FUNCTION(igraph_vector, copy)(TYPE(igraph_vector) *to,
     IGRAPH_ASSERT(from->stor_begin != NULL);
 
     from_size = FUNCTION(igraph_vector, size)(from);
-    to->stor_begin = igraph_Calloc(from_size, BASE);
+    to->stor_begin = igraph_CALLOC(from_size, BASE);
     if (to->stor_begin == 0) {
         IGRAPH_ERROR("cannot copy vector", IGRAPH_ENOMEM);
     }
@@ -2934,7 +2934,7 @@ int FUNCTION(igraph_vector, index_int)(TYPE(igraph_vector) *v,
     BASE *tmp;
     int i, n = igraph_vector_int_size(idx);
 
-    tmp = igraph_Calloc(n, BASE);
+    tmp = IGRAPH_CALLOC(n, BASE);
     if (!tmp) {
         IGRAPH_ERROR("Cannot index vector", IGRAPH_ENOMEM);
     }
@@ -2943,7 +2943,7 @@ int FUNCTION(igraph_vector, index_int)(TYPE(igraph_vector) *v,
         tmp[i] = VECTOR(*v)[ VECTOR(*idx)[i] ];
     }
 
-    igraph_Free(v->stor_begin);
+    IGRAPH_FREE(v->stor_begin);
     v->stor_begin = tmp;
     v->stor_end = v->end = tmp + n;
 

--- a/src/core/vector_ptr.c
+++ b/src/core/vector_ptr.c
@@ -505,7 +505,7 @@ int igraph_vector_ptr_copy(igraph_vector_ptr_t *to, const igraph_vector_ptr_t *f
 
     from_size = igraph_vector_ptr_size(from);
 
-    to->stor_begin = igraph_CALLOC(from_size, void*);
+    to->stor_begin = IGRAPH_CALLOC(from_size, void*);
     if (to->stor_begin == 0) {
         IGRAPH_ERROR("cannot copy ptr vector", IGRAPH_ENOMEM);
     }

--- a/src/core/vector_ptr.c
+++ b/src/core/vector_ptr.c
@@ -92,7 +92,7 @@ int igraph_vector_ptr_init(igraph_vector_ptr_t* v, int long size) {
     if (size < 0) {
         size = 0;
     }
-    v->stor_begin = igraph_Calloc(alloc_size, void*);
+    v->stor_begin = IGRAPH_CALLOC(alloc_size, void*);
     if (v->stor_begin == 0) {
         IGRAPH_ERROR("vector ptr init failed", IGRAPH_ENOMEM);
     }
@@ -134,7 +134,7 @@ const igraph_vector_ptr_t *igraph_vector_ptr_view(const igraph_vector_ptr_t *v, 
 void igraph_vector_ptr_destroy(igraph_vector_ptr_t* v) {
     IGRAPH_ASSERT(v != 0);
     if (v->stor_begin != 0) {
-        igraph_Free(v->stor_begin);
+        IGRAPH_FREE(v->stor_begin);
         v->stor_begin = NULL;
     }
 }
@@ -176,7 +176,7 @@ void igraph_vector_ptr_free_all(igraph_vector_ptr_t* v) {
 
     igraph_i_vector_ptr_call_item_destructor_all(v);
     for (ptr = v->stor_begin; ptr < v->end; ptr++) {
-        igraph_Free(*ptr);
+        IGRAPH_FREE(*ptr);
     }
 }
 
@@ -224,7 +224,7 @@ int igraph_vector_ptr_reserve(igraph_vector_ptr_t* v, long int size) {
         return 0;
     }
 
-    tmp = igraph_Realloc(v->stor_begin, (size_t) size, void*);
+    tmp = IGRAPH_REALLOC(v->stor_begin, (size_t) size, void*);
     if (tmp == 0) {
         IGRAPH_ERROR("vector ptr reserve failed", IGRAPH_ENOMEM);
     }
@@ -445,7 +445,7 @@ int igraph_vector_ptr_resize(igraph_vector_ptr_t* v, long int newsize) {
  */
 
 int igraph_vector_ptr_init_copy(igraph_vector_ptr_t *v, void * *data, long int length) {
-    v->stor_begin = igraph_Calloc(length, void*);
+    v->stor_begin = IGRAPH_CALLOC(length, void*);
     if (v->stor_begin == 0) {
         IGRAPH_ERROR("cannot init ptr vector from array", IGRAPH_ENOMEM);
     }
@@ -505,7 +505,7 @@ int igraph_vector_ptr_copy(igraph_vector_ptr_t *to, const igraph_vector_ptr_t *f
 
     from_size = igraph_vector_ptr_size(from);
 
-    to->stor_begin = igraph_Calloc(from_size, void*);
+    to->stor_begin = igraph_CALLOC(from_size, void*);
     if (to->stor_begin == 0) {
         IGRAPH_ERROR("cannot copy ptr vector", IGRAPH_ENOMEM);
     }
@@ -557,7 +557,7 @@ int igraph_vector_ptr_index_int(igraph_vector_ptr_t *v,
     void **tmp;
     int i, n = igraph_vector_int_size(idx);
 
-    tmp = igraph_Calloc(n, void*);
+    tmp = IGRAPH_CALLOC(n, void*);
     if (!tmp) {
         IGRAPH_ERROR("Cannot index pointer vector", IGRAPH_ENOMEM);
     }
@@ -566,7 +566,7 @@ int igraph_vector_ptr_index_int(igraph_vector_ptr_t *v,
         tmp[i] = VECTOR(*v)[ VECTOR(*idx)[i] ];
     }
 
-    igraph_Free(v->stor_begin);
+    IGRAPH_FREE(v->stor_begin);
     v->stor_begin = tmp;
     v->stor_end = v->end = tmp + n;
 

--- a/src/flow/flow.c
+++ b/src/flow/flow.c
@@ -1425,7 +1425,7 @@ static int igraph_i_mincut_undirected(const igraph_t *graph,
         long int i, idx;
         long int size = 1;
         char *mark;
-        mark = igraph_Calloc(no_of_nodes, char);
+        mark = IGRAPH_CALLOC(no_of_nodes, char);
         if (!mark) {
             IGRAPH_ERROR("Not enough memory for minimum cut", IGRAPH_ENOMEM);
         }

--- a/src/flow/st-cuts.c
+++ b/src/flow/st-cuts.c
@@ -951,7 +951,7 @@ int igraph_provan_shier_list(const igraph_t *graph,
     if (igraph_vector_size(&Isv) == 0) {
         if (igraph_marked_queue_size(S) != 0 &&
             igraph_marked_queue_size(S) != no_of_nodes) {
-            igraph_vector_t *vec = igraph_Calloc(1, igraph_vector_t);
+            igraph_vector_t *vec = IGRAPH_CALLOC(1, igraph_vector_t);
             igraph_vector_init(vec, igraph_marked_queue_size(S));
             igraph_marked_queue_as_vector(S, vec);
             IGRAPH_CHECK(igraph_vector_ptr_push_back(result, vec));
@@ -1100,7 +1100,7 @@ int igraph_all_st_cuts(const igraph_t *graph,
                 }
             }
             /* Add the edges */
-            cut = igraph_Calloc(1, igraph_vector_t);
+            cut = IGRAPH_CALLOC(1, igraph_vector_t);
             if (!cut) {
                 IGRAPH_ERROR("Cannot calculate s-t cuts", IGRAPH_ENOMEM);
             }
@@ -1509,7 +1509,7 @@ int igraph_all_st_mincuts(const igraph_t *graph, igraph_real_t *value,
     for (i = 0; i < nocuts; i++) {
         igraph_vector_t *supercut = VECTOR(closedsets)[i];
         long int j, supercutsize = igraph_vector_size(supercut);
-        igraph_vector_t *cut = igraph_Calloc(1, igraph_vector_t);
+        igraph_vector_t *cut = IGRAPH_CALLOC(1, igraph_vector_t);
         IGRAPH_VECTOR_INIT_FINALLY(cut, 0); /* TODO: better allocation */
         for (j = 0; j < supercutsize; j++) {
             long int vtx = (long int) VECTOR(*supercut)[j];
@@ -1543,7 +1543,7 @@ int igraph_all_st_mincuts(const igraph_t *graph, igraph_real_t *value,
             igraph_vector_t *part = VECTOR(*mypartition1s)[i];
             long int j, n = igraph_vector_size(part);
             igraph_vector_t *v;
-            v = igraph_Calloc(1, igraph_vector_t);
+            v = IGRAPH_CALLOC(1, igraph_vector_t);
             if (!v) {
                 IGRAPH_ERROR("Cannot list minimum s-t cuts", IGRAPH_ENOMEM);
             }

--- a/src/games/barabasi.c
+++ b/src/games/barabasi.c
@@ -96,7 +96,7 @@ static int igraph_i_barabasi_game_bag(igraph_t *graph, igraph_integer_t n,
 
     IGRAPH_VECTOR_INIT_FINALLY(&edges, no_of_edges * 2);
 
-    bag = igraph_Calloc(bagsize, long int);
+    bag = IGRAPH_CALLOC(bagsize, long int);
     if (bag == 0) {
         IGRAPH_ERROR("barabasi_game failed", IGRAPH_ENOMEM);
     }
@@ -160,7 +160,7 @@ static int igraph_i_barabasi_game_bag(igraph_t *graph, igraph_integer_t n,
 
     RNG_END();
 
-    igraph_Free(bag);
+    IGRAPH_FREE(bag);
     IGRAPH_CHECK(igraph_create(graph, &edges, (igraph_integer_t) no_of_nodes,
                                directed));
     igraph_vector_destroy(&edges);

--- a/src/games/callaway_traits.c
+++ b/src/games/callaway_traits.c
@@ -152,7 +152,7 @@ int igraph_callaway_traits_game(igraph_t *graph, igraph_integer_t nodes,
         nodetypes = node_type_vec;
         IGRAPH_CHECK(igraph_vector_resize(nodetypes, nodes));
     } else {
-        nodetypes = igraph_Calloc(1, igraph_vector_t);
+        nodetypes = IGRAPH_CALLOC(1, igraph_vector_t);
         if (! nodetypes) {
             IGRAPH_ERROR("Insufficient memory for callaway_traits_game.", IGRAPH_ENOMEM);
         }
@@ -187,7 +187,7 @@ int igraph_callaway_traits_game(igraph_t *graph, igraph_integer_t nodes,
 
     if (! node_type_vec) {
         igraph_vector_destroy(nodetypes);
-        igraph_Free(nodetypes);
+        IGRAPH_FREE(nodetypes);
         IGRAPH_FINALLY_CLEAN(2);
     }
     igraph_vector_destroy(&cumdist);

--- a/src/games/citations.c
+++ b/src/games/citations.c
@@ -134,13 +134,13 @@ int igraph_lastcit_game(igraph_t *graph,
     binwidth = no_of_nodes / agebins + 1;
     IGRAPH_VECTOR_INIT_FINALLY(&edges, 0);
 
-    lastcit = igraph_Calloc(no_of_nodes, long int);
+    lastcit = IGRAPH_CALLOC(no_of_nodes, long int);
     if (!lastcit) {
         IGRAPH_ERROR("lastcit game failed", IGRAPH_ENOMEM);
     }
     IGRAPH_FINALLY(igraph_free, lastcit);
 
-    index = igraph_Calloc(no_of_nodes + 1, long int);
+    index = IGRAPH_CALLOC(no_of_nodes + 1, long int);
     if (!index) {
         IGRAPH_ERROR("lastcit game failed", IGRAPH_ENOMEM);
     }
@@ -421,7 +421,7 @@ int igraph_citing_cited_type_game(igraph_t *graph, igraph_integer_t nodes,
 
     IGRAPH_VECTOR_INIT_FINALLY(&edges, 0);
 
-    str.sumtrees = sumtrees = igraph_Calloc(no_of_types, igraph_psumtree_t);
+    str.sumtrees = sumtrees = IGRAPH_CALLOC(no_of_types, igraph_psumtree_t);
     if (!sumtrees) {
         IGRAPH_ERROR("Citing-cited type game failed.", IGRAPH_ENOMEM);
     }

--- a/src/games/degree_sequence.c
+++ b/src/games/degree_sequence.c
@@ -61,7 +61,7 @@ static int igraph_i_degree_sequence_game_simple(igraph_t *graph,
     no_of_nodes = igraph_vector_size(out_seq);
     no_of_edges = directed ? outsum : outsum / 2;
 
-    bag1 = igraph_Calloc(outsum, long int);
+    bag1 = IGRAPH_CALLOC(outsum, long int);
     if (bag1 == 0) {
         IGRAPH_ERROR("degree sequence game (simple)", IGRAPH_ENOMEM);
     }
@@ -73,7 +73,7 @@ static int igraph_i_degree_sequence_game_simple(igraph_t *graph,
         }
     }
     if (directed) {
-        bag2 = igraph_Calloc(insum, long int);
+        bag2 = IGRAPH_CALLOC(insum, long int);
         if (bag2 == 0) {
             IGRAPH_ERROR("degree sequence game (simple)", IGRAPH_ENOMEM);
         }
@@ -116,10 +116,10 @@ static int igraph_i_degree_sequence_game_simple(igraph_t *graph,
 
     RNG_END();
 
-    igraph_Free(bag1);
+    IGRAPH_FREE(bag1);
     IGRAPH_FINALLY_CLEAN(1);
     if (directed) {
-        igraph_Free(bag2);
+        IGRAPH_FREE(bag2);
         IGRAPH_FINALLY_CLEAN(1);
     }
 

--- a/src/games/degree_sequence.c
+++ b/src/games/degree_sequence.c
@@ -463,7 +463,7 @@ static int igraph_i_degree_sequence_game_no_multiple_undirected_uniform(igraph_t
     IGRAPH_VECTOR_PTR_SET_ITEM_DESTRUCTOR(&adjlist, igraph_set_destroy);
     IGRAPH_FINALLY(igraph_vector_ptr_destroy_all, &adjlist);
     for (i = 0; i < vcount; ++i) {
-        igraph_set_t *set = igraph_malloc(sizeof(igraph_set_t));
+        igraph_set_t *set = IGRAPH_CALLOC(1, igraph_set_t);
         if (! set) {
             IGRAPH_ERROR("Out of memory", IGRAPH_ENOMEM);
         }
@@ -582,7 +582,7 @@ static int igraph_i_degree_sequence_game_no_multiple_directed_uniform(
     IGRAPH_VECTOR_PTR_SET_ITEM_DESTRUCTOR(&adjlist, igraph_set_destroy);
     IGRAPH_FINALLY(igraph_vector_ptr_destroy_all, &adjlist);
     for (i = 0; i < vcount; ++i) {
-        igraph_set_t *set = igraph_malloc(sizeof(igraph_set_t));
+        igraph_set_t *set = IGRAPH_CALLOC(1, igraph_set_t);
         if (! set) {
             IGRAPH_ERROR("Out of memory", IGRAPH_ENOMEM);
         }

--- a/src/games/establishment.c
+++ b/src/games/establishment.c
@@ -139,7 +139,7 @@ int igraph_establishment_game(igraph_t *graph, igraph_integer_t nodes,
         nodetypes = node_type_vec;
         IGRAPH_CHECK(igraph_vector_resize(nodetypes, nodes));
     } else {
-        nodetypes = igraph_Calloc(1, igraph_vector_t);
+        nodetypes = IGRAPH_CALLOC(1, igraph_vector_t);
         if (! nodetypes) {
             IGRAPH_ERROR("Insufficient memory for establishment_game.", IGRAPH_ENOMEM);
         }
@@ -172,7 +172,7 @@ int igraph_establishment_game(igraph_t *graph, igraph_integer_t nodes,
 
     if (! node_type_vec) {
         igraph_vector_destroy(nodetypes);
-        igraph_Free(nodetypes);
+        IGRAPH_FREE(nodetypes);
         IGRAPH_FINALLY_CLEAN(2);
     }
     igraph_vector_destroy(&potneis);

--- a/src/games/forestfire.c
+++ b/src/games/forestfire.c
@@ -137,12 +137,12 @@ int igraph_forest_fire_game(igraph_t *graph, igraph_integer_t nodes,
 
     IGRAPH_VECTOR_INIT_FINALLY(&edges, 0);
 
-    inneis = igraph_Calloc(no_of_nodes, igraph_vector_t);
+    inneis = IGRAPH_CALLOC(no_of_nodes, igraph_vector_t);
     if (!inneis) {
         IGRAPH_ERROR("Cannot run forest fire model.", IGRAPH_ENOMEM);
     }
     IGRAPH_FINALLY(igraph_free, inneis);
-    outneis = igraph_Calloc(no_of_nodes, igraph_vector_t);
+    outneis = IGRAPH_CALLOC(no_of_nodes, igraph_vector_t);
     if (!outneis) {
         IGRAPH_ERROR("Cannot run forest fire model.", IGRAPH_ENOMEM);
     }

--- a/src/games/preference.c
+++ b/src/games/preference.c
@@ -162,7 +162,7 @@ int igraph_preference_game(igraph_t *graph, igraph_integer_t nodes,
         IGRAPH_CHECK(igraph_vector_resize(node_type_vec, nodes));
         nodetypes = node_type_vec;
     } else {
-        nodetypes = igraph_Calloc(1, igraph_vector_t);
+        nodetypes = IGRAPH_CALLOC(1, igraph_vector_t);
         if (nodetypes == 0) {
             IGRAPH_ERROR("Insufficient memory for preference_game.", IGRAPH_ENOMEM);
         }
@@ -173,7 +173,7 @@ int igraph_preference_game(igraph_t *graph, igraph_integer_t nodes,
     IGRAPH_CHECK(igraph_vector_ptr_init(&vids_by_type, types));
     IGRAPH_FINALLY(igraph_vector_ptr_destroy_all, &vids_by_type);
     for (i = 0; i < types; i++) {
-        VECTOR(vids_by_type)[i] = igraph_Calloc(1, igraph_vector_t);
+        VECTOR(vids_by_type)[i] = IGRAPH_CALLOC(1, igraph_vector_t);
         if (VECTOR(vids_by_type)[i] == 0) {
             IGRAPH_ERROR("Insufficient memory for preference_game.", IGRAPH_ENOMEM);
         }
@@ -342,7 +342,7 @@ int igraph_preference_game(igraph_t *graph, igraph_integer_t nodes,
 
     if (node_type_vec == 0) {
         igraph_vector_destroy(nodetypes);
-        igraph_Free(nodetypes);
+        IGRAPH_FREE(nodetypes);
         IGRAPH_FINALLY_CLEAN(2);
     }
 
@@ -459,7 +459,7 @@ int igraph_asymmetric_preference_game(igraph_t *graph, igraph_integer_t nodes,
         nodetypes_in = node_type_in_vec;
         IGRAPH_CHECK(igraph_vector_resize(nodetypes_in, nodes));
     } else {
-        nodetypes_in = igraph_Calloc(1, igraph_vector_t);
+        nodetypes_in = IGRAPH_CALLOC(1, igraph_vector_t);
         if (nodetypes_in == 0) {
             IGRAPH_ERROR("Insufficient memory for asymmetric_preference_game.", IGRAPH_ENOMEM);
         }
@@ -470,7 +470,7 @@ int igraph_asymmetric_preference_game(igraph_t *graph, igraph_integer_t nodes,
         nodetypes_out = node_type_out_vec;
         IGRAPH_CHECK(igraph_vector_resize(nodetypes_out, nodes));
     } else {
-        nodetypes_out = igraph_Calloc(1, igraph_vector_t);
+        nodetypes_out = IGRAPH_CALLOC(1, igraph_vector_t);
         if (nodetypes_out == 0) {
             IGRAPH_ERROR("Insufficient memory for asymmetric_preference_game.", IGRAPH_ENOMEM);
         }
@@ -482,14 +482,14 @@ int igraph_asymmetric_preference_game(igraph_t *graph, igraph_integer_t nodes,
     IGRAPH_CHECK(igraph_vector_ptr_init(&vids_by_outtype, out_types));
     IGRAPH_FINALLY(igraph_vector_ptr_destroy_all, &vids_by_outtype);
     for (i = 0; i < in_types; i++) {
-        VECTOR(vids_by_intype)[i] = igraph_Calloc(1, igraph_vector_t);
+        VECTOR(vids_by_intype)[i] = IGRAPH_CALLOC(1, igraph_vector_t);
         if (! VECTOR(vids_by_intype)[i]) {
             IGRAPH_ERROR("Insufficient memory for asymmetric_preference_game.", IGRAPH_ENOMEM);
         }
         IGRAPH_CHECK(igraph_vector_init(VECTOR(vids_by_intype)[i], 0));
     }
     for (i = 0; i < out_types; i++) {
-        VECTOR(vids_by_outtype)[i] = igraph_Calloc(1, igraph_vector_t);
+        VECTOR(vids_by_outtype)[i] = IGRAPH_CALLOC(1, igraph_vector_t);
         if (! VECTOR(vids_by_outtype)[i]) {
             IGRAPH_ERROR("Insufficient memory for asymmetric_preference_game.", IGRAPH_ENOMEM);
         }
@@ -613,13 +613,13 @@ int igraph_asymmetric_preference_game(igraph_t *graph, igraph_integer_t nodes,
 
     if (node_type_out_vec == 0) {
         igraph_vector_destroy(nodetypes_out);
-        igraph_Free(nodetypes_out);
+        IGRAPH_FREE(nodetypes_out);
         IGRAPH_FINALLY_CLEAN(1);
     }
 
     if (node_type_in_vec == 0) {
         igraph_vector_destroy(nodetypes_in);
-        igraph_Free(nodetypes_in);
+        IGRAPH_FREE(nodetypes_in);
         IGRAPH_FINALLY_CLEAN(1);
     }
 

--- a/src/graph/adjlist.c
+++ b/src/graph/adjlist.c
@@ -141,7 +141,7 @@ int igraph_adjlist_init(const igraph_t *graph, igraph_adjlist_t *al,
     }
 
     al->length = igraph_vcount(graph);
-    al->adjs = igraph_Calloc(al->length, igraph_vector_int_t);
+    al->adjs = IGRAPH_CALLOC(al->length, igraph_vector_int_t);
     if (al->adjs == 0) {
         IGRAPH_ERROR("Cannot create adjacency list view", IGRAPH_ENOMEM);
     }
@@ -187,7 +187,7 @@ int igraph_adjlist_init_empty(igraph_adjlist_t *al, igraph_integer_t no_of_nodes
     long int i;
 
     al->length = no_of_nodes;
-    al->adjs = igraph_Calloc(al->length, igraph_vector_int_t);
+    al->adjs = IGRAPH_CALLOC(al->length, igraph_vector_int_t);
     if (al->adjs == 0) {
         IGRAPH_ERROR("Cannot create adjlist view", IGRAPH_ENOMEM);
     }
@@ -238,7 +238,7 @@ int igraph_adjlist_init_complementer(const igraph_t *graph,
     }
 
     al->length = igraph_vcount(graph);
-    al->adjs = igraph_Calloc(al->length, igraph_vector_int_t);
+    al->adjs = IGRAPH_CALLOC(al->length, igraph_vector_int_t);
     if (al->adjs == 0) {
         IGRAPH_ERROR("Cannot create complementer adjlist view", IGRAPH_ENOMEM);
     }
@@ -246,7 +246,7 @@ int igraph_adjlist_init_complementer(const igraph_t *graph,
     IGRAPH_FINALLY(igraph_adjlist_destroy, al);
 
     n = al->length;
-    seen = igraph_Calloc(n, igraph_bool_t);
+    seen = IGRAPH_CALLOC(n, igraph_bool_t);
     if (seen == 0) {
         IGRAPH_ERROR("Cannot create complementer adjlist view", IGRAPH_ENOMEM);
     }
@@ -277,7 +277,7 @@ int igraph_adjlist_init_complementer(const igraph_t *graph,
         }
     }
 
-    igraph_Free(seen);
+    IGRAPH_FREE(seen);
     igraph_vector_destroy(&vec);
     IGRAPH_FINALLY_CLEAN(3);
     return 0;
@@ -299,7 +299,7 @@ void igraph_adjlist_destroy(igraph_adjlist_t *al) {
             igraph_vector_int_destroy(&al->adjs[i]);
         }
     }
-    igraph_Free(al->adjs);
+    IGRAPH_FREE(al->adjs);
 }
 
 /**
@@ -526,7 +526,7 @@ static int igraph_i_remove_loops_from_incidence_vector_in_place(
 
     if (loops == IGRAPH_LOOPS_ONCE) {
         /* We need a helper vector */
-        seen_loops = igraph_Calloc(1, igraph_vector_int_t);
+        seen_loops = IGRAPH_CALLOC(1, igraph_vector_int_t);
         IGRAPH_FINALLY(igraph_free, seen_loops);
         IGRAPH_CHECK(igraph_vector_int_init(seen_loops, 0));
         IGRAPH_FINALLY(igraph_vector_int_destroy, seen_loops);
@@ -554,7 +554,7 @@ static int igraph_i_remove_loops_from_incidence_vector_in_place(
     /* Destroy the helper vector */
     if (seen_loops) {
         igraph_vector_int_destroy(seen_loops);
-        igraph_Free(seen_loops);
+        IGRAPH_FREE(seen_loops);
         IGRAPH_FINALLY_CLEAN(2);
     }
     
@@ -660,7 +660,7 @@ int igraph_inclist_init(const igraph_t *graph,
     }
 
     il->length = igraph_vcount(graph);
-    il->incs = igraph_Calloc(il->length, igraph_vector_int_t);
+    il->incs = IGRAPH_CALLOC(il->length, igraph_vector_int_t);
     if (il->incs == 0) {
         IGRAPH_ERROR("Cannot create incidence list view", IGRAPH_ENOMEM);
     }
@@ -711,7 +711,7 @@ int igraph_inclist_init_empty(igraph_inclist_t *il, igraph_integer_t n) {
     long int i;
 
     il->length = n;
-    il->incs = igraph_Calloc(il->length, igraph_vector_int_t);
+    il->incs = IGRAPH_CALLOC(il->length, igraph_vector_int_t);
     if (il->incs == 0) {
         IGRAPH_ERROR("Cannot create incidence list view", IGRAPH_ENOMEM);
     }
@@ -741,7 +741,7 @@ void igraph_inclist_destroy(igraph_inclist_t *il) {
            because igraph_vector_destroy can handle this. */
         igraph_vector_int_destroy(&il->incs[i]);
     }
-    igraph_Free(il->incs);
+    IGRAPH_FREE(il->incs);
 }
 
 /**
@@ -921,7 +921,7 @@ int igraph_lazy_adjlist_init(const igraph_t *graph,
     al->graph = graph;
 
     al->length = igraph_vcount(graph);
-    al->adjs = igraph_Calloc(al->length, igraph_vector_int_t*);
+    al->adjs = IGRAPH_CALLOC(al->length, igraph_vector_int_t*);
 
     if (al->adjs == 0) {
         IGRAPH_ERROR("Cannot create lazy adjacency list view", IGRAPH_ENOMEM);
@@ -948,7 +948,7 @@ int igraph_lazy_adjlist_init(const igraph_t *graph,
 void igraph_lazy_adjlist_destroy(igraph_lazy_adjlist_t *al) {
     igraph_lazy_adjlist_clear(al);
     igraph_vector_destroy(&al->dummy);
-    igraph_Free(al->adjs);
+    IGRAPH_FREE(al->adjs);
 }
 
 /**
@@ -964,7 +964,7 @@ void igraph_lazy_adjlist_clear(igraph_lazy_adjlist_t *al) {
     for (i = 0; i < n; i++) {
         if (al->adjs[i] != 0) {
             igraph_vector_int_destroy(al->adjs[i]);
-            igraph_Free(al->adjs[i]);
+            IGRAPH_FREE(al->adjs[i]);
         }
     }
 }
@@ -995,7 +995,7 @@ igraph_vector_int_t *igraph_i_lazy_adjlist_get_real(igraph_lazy_adjlist_t *al,
             return 0;
         }
 
-        al->adjs[no] = igraph_Calloc(1, igraph_vector_int_t);
+        al->adjs[no] = IGRAPH_CALLOC(1, igraph_vector_int_t);
         if (al->adjs[no] == 0) {
             igraph_error("Lazy adjlist failed", IGRAPH_FILE_BASENAME, __LINE__,
                          IGRAPH_ENOMEM);
@@ -1005,7 +1005,7 @@ igraph_vector_int_t *igraph_i_lazy_adjlist_get_real(igraph_lazy_adjlist_t *al,
         n = igraph_vector_size(&al->dummy);
         ret = igraph_vector_int_init(al->adjs[no], n);
         if (ret != 0) {
-            igraph_Free(al->adjs[no]);
+            IGRAPH_FREE(al->adjs[no]);
             igraph_error("", IGRAPH_FILE_BASENAME, __LINE__, ret);
             return 0;
         }
@@ -1019,7 +1019,7 @@ igraph_vector_int_t *igraph_i_lazy_adjlist_get_real(igraph_lazy_adjlist_t *al,
         );
         if (ret != 0) {
             igraph_vector_int_destroy(al->adjs[no]);
-            igraph_Free(al->adjs[no]);
+            IGRAPH_FREE(al->adjs[no]);
             igraph_error("", IGRAPH_FILE_BASENAME, __LINE__, ret);
             return 0;
         }
@@ -1082,7 +1082,7 @@ int igraph_lazy_inclist_init(const igraph_t *graph,
     il->mode = mode;
 
     il->length = igraph_vcount(graph);
-    il->incs = igraph_Calloc(il->length, igraph_vector_int_t*);
+    il->incs = IGRAPH_CALLOC(il->length, igraph_vector_int_t*);
     if (il->incs == 0) {
      
         IGRAPH_ERROR("Cannot create lazy incidence list view", IGRAPH_ENOMEM);
@@ -1109,7 +1109,7 @@ int igraph_lazy_inclist_init(const igraph_t *graph,
 void igraph_lazy_inclist_destroy(igraph_lazy_inclist_t *il) {
     igraph_lazy_inclist_clear(il);
     igraph_vector_destroy(&il->dummy);
-    igraph_Free(il->incs);
+    IGRAPH_FREE(il->incs);
 }
 
 /**
@@ -1126,7 +1126,7 @@ void igraph_lazy_inclist_clear(igraph_lazy_inclist_t *il) {
     for (i = 0; i < n; i++) {
         if (il->incs[i] != 0) {
             igraph_vector_int_destroy(il->incs[i]);
-            igraph_Free(il->incs[i]);
+            IGRAPH_FREE(il->incs[i]);
         }
     }
 }
@@ -1157,7 +1157,7 @@ igraph_vector_int_t *igraph_i_lazy_inclist_get_real(igraph_lazy_inclist_t *il,
             return 0;
         }
 
-        il->incs[no] = igraph_Calloc(1, igraph_vector_int_t);
+        il->incs[no] = IGRAPH_CALLOC(1, igraph_vector_int_t);
         if (il->incs[no] == 0) {
             igraph_error("Lazy incidence list query failed", IGRAPH_FILE_BASENAME, __LINE__,
                          IGRAPH_ENOMEM);
@@ -1167,7 +1167,7 @@ igraph_vector_int_t *igraph_i_lazy_inclist_get_real(igraph_lazy_inclist_t *il,
         n = igraph_vector_size(&il->dummy);
         ret = igraph_vector_int_init(il->incs[no], n);
         if (ret != 0) {
-            igraph_Free(il->incs[no]);
+            IGRAPH_FREE(il->incs[no]);
             igraph_error("", IGRAPH_FILE_BASENAME, __LINE__, ret);
             return 0;
         }
@@ -1180,7 +1180,7 @@ igraph_vector_int_t *igraph_i_lazy_inclist_get_real(igraph_lazy_inclist_t *il,
             ret = igraph_i_remove_loops_from_incidence_vector_in_place(il->incs[no], il->graph, il->loops);
             if (ret != 0) {
                 igraph_vector_int_destroy(il->incs[no]);
-                igraph_Free(il->incs[no]);
+                IGRAPH_FREE(il->incs[no]);
                 return 0;
             }
         }

--- a/src/graph/attributes.c
+++ b/src/graph/attributes.c
@@ -301,9 +301,9 @@ void igraph_attribute_combination_destroy(igraph_attribute_combination_t *comb) 
     for (i = 0; i < n; i++) {
         igraph_attribute_combination_record_t *rec = VECTOR(comb->list)[i];
         if (rec->name) {
-            igraph_Free(rec->name);
+            IGRAPH_FREE(rec->name);
         }
-        igraph_Free(rec);
+        IGRAPH_FREE(rec);
     }
     igraph_vector_ptr_destroy(&comb->list);
 }
@@ -329,7 +329,7 @@ int igraph_attribute_combination_add(igraph_attribute_combination_t *comb,
     if (i == n) {
         /* This is a new attribute name */
         igraph_attribute_combination_record_t *rec =
-            igraph_Calloc(1, igraph_attribute_combination_record_t);
+            IGRAPH_CALLOC(1, igraph_attribute_combination_record_t);
 
         if (!rec) {
             IGRAPH_ERROR("Cannot create attribute combination data",
@@ -367,9 +367,9 @@ int igraph_attribute_combination_remove(igraph_attribute_combination_t *comb,
     if (i != n) {
         igraph_attribute_combination_record_t *r = VECTOR(comb->list)[i];
         if (r->name) {
-            igraph_Free(r->name);
+            IGRAPH_FREE(r->name);
         }
-        igraph_Free(r);
+        IGRAPH_FREE(r);
         igraph_vector_ptr_remove(&comb->list, i);
     } else {
         /* It is not there, we don't do anything */

--- a/src/graph/cattributes.c
+++ b/src/graph/cattributes.c
@@ -62,7 +62,7 @@ static int igraph_i_cattributes_copy_attribute_record(igraph_attribute_record_t 
     igraph_vector_t *num, *newnum;
     igraph_strvector_t *str, *newstr;
 
-    *newrec = igraph_Calloc(1, igraph_attribute_record_t);
+    *newrec = IGRAPH_CALLOC(1, igraph_attribute_record_t);
     if (!(*newrec)) {
         IGRAPH_ERROR("Cannot copy attributes", IGRAPH_ENOMEM);
     }
@@ -75,7 +75,7 @@ static int igraph_i_cattributes_copy_attribute_record(igraph_attribute_record_t 
     IGRAPH_FINALLY(igraph_free, (void*)(*newrec)->name);
     if (rec->type == IGRAPH_ATTRIBUTE_NUMERIC) {
         num = (igraph_vector_t *)rec->value;
-        newnum = igraph_Calloc(1, igraph_vector_t);
+        newnum = IGRAPH_CALLOC(1, igraph_vector_t);
         if (!newnum) {
             IGRAPH_ERROR("Cannot copy attributes", IGRAPH_ENOMEM);
         }
@@ -85,7 +85,7 @@ static int igraph_i_cattributes_copy_attribute_record(igraph_attribute_record_t 
         (*newrec)->value = newnum;
     } else if (rec->type == IGRAPH_ATTRIBUTE_STRING) {
         str = (igraph_strvector_t*)rec->value;
-        newstr = igraph_Calloc(1, igraph_strvector_t);
+        newstr = IGRAPH_CALLOC(1, igraph_strvector_t);
         if (!newstr) {
             IGRAPH_ERROR("Cannot copy attributes", IGRAPH_ENOMEM);
         }
@@ -95,7 +95,7 @@ static int igraph_i_cattributes_copy_attribute_record(igraph_attribute_record_t 
         (*newrec)->value = newstr;
     } else if (rec->type == IGRAPH_ATTRIBUTE_BOOLEAN) {
         igraph_vector_bool_t *log = (igraph_vector_bool_t*) rec->value;
-        igraph_vector_bool_t *newlog = igraph_Calloc(1, igraph_vector_bool_t);
+        igraph_vector_bool_t *newlog = IGRAPH_CALLOC(1, igraph_vector_bool_t);
         if (!newlog) {
             IGRAPH_ERROR("Cannot copy attributes", IGRAPH_ENOMEM);
         }
@@ -117,7 +117,7 @@ static int igraph_i_cattribute_init(igraph_t *graph, igraph_vector_ptr_t *attr) 
 
     n = attr ? igraph_vector_ptr_size(attr) : 0;
 
-    nattr = igraph_Calloc(1, igraph_i_cattributes_t);
+    nattr = IGRAPH_CALLOC(1, igraph_i_cattributes_t);
     if (!nattr) {
         IGRAPH_ERROR("Can't init attributes", IGRAPH_ENOMEM);
     }
@@ -225,7 +225,7 @@ static int igraph_i_cattribute_copy(igraph_t *to, const igraph_t *from,
                                                };
     long int i, n, a;
     igraph_bool_t copy[3] = { ga, va, ea };
-    to->attr = attrto = igraph_Calloc(1, igraph_i_cattributes_t);
+    to->attr = attrto = IGRAPH_CALLOC(1, igraph_i_cattributes_t);
     if (!attrto) {
         IGRAPH_ERROR("Cannot copy attributes", IGRAPH_ENOMEM);
     }
@@ -290,7 +290,7 @@ static int igraph_i_cattribute_add_vertices(igraph_t *graph, long int nv,
     if (newattrs != 0) {
         for (i = 0; i < newattrs; i++) {
             igraph_attribute_record_t *tmp = VECTOR(*nattr)[(long int)VECTOR(news)[i]];
-            igraph_attribute_record_t *newrec = igraph_Calloc(1, igraph_attribute_record_t);
+            igraph_attribute_record_t *newrec = IGRAPH_CALLOC(1, igraph_attribute_record_t);
             igraph_attribute_type_t type = tmp->type;
             if (!newrec) {
                 IGRAPH_ERROR("Cannot add attributes", IGRAPH_ENOMEM);
@@ -303,7 +303,7 @@ static int igraph_i_cattribute_add_vertices(igraph_t *graph, long int nv,
             }
             IGRAPH_FINALLY(igraph_free, (char*)newrec->name);
             if (type == IGRAPH_ATTRIBUTE_NUMERIC) {
-                igraph_vector_t *newnum = igraph_Calloc(1, igraph_vector_t);
+                igraph_vector_t *newnum = IGRAPH_CALLOC(1, igraph_vector_t);
                 if (!newnum) {
                     IGRAPH_ERROR("Cannot add attributes", IGRAPH_ENOMEM);
                 }
@@ -312,7 +312,7 @@ static int igraph_i_cattribute_add_vertices(igraph_t *graph, long int nv,
                 newrec->value = newnum;
                 igraph_vector_fill(newnum, IGRAPH_NAN);
             } else if (type == IGRAPH_ATTRIBUTE_STRING) {
-                igraph_strvector_t *newstr = igraph_Calloc(1, igraph_strvector_t);
+                igraph_strvector_t *newstr = IGRAPH_CALLOC(1, igraph_strvector_t);
                 if (!newstr) {
                     IGRAPH_ERROR("Cannot add attributes", IGRAPH_ENOMEM);
                 }
@@ -320,7 +320,7 @@ static int igraph_i_cattribute_add_vertices(igraph_t *graph, long int nv,
                 IGRAPH_STRVECTOR_INIT_FINALLY(newstr, origlen);
                 newrec->value = newstr;
             } else if (type == IGRAPH_ATTRIBUTE_BOOLEAN) {
-                igraph_vector_bool_t *newbool = igraph_Calloc(1, igraph_vector_bool_t);
+                igraph_vector_bool_t *newbool = IGRAPH_CALLOC(1, igraph_vector_bool_t);
                 if (!newbool) {
                     IGRAPH_ERROR("Cannot add attributes", IGRAPH_ENOMEM);
                 }
@@ -422,21 +422,21 @@ static void igraph_i_cattribute_permute_free(igraph_vector_ptr_t *v) {
     long int i, n = igraph_vector_ptr_size(v);
     for (i = 0; i < n; i++) {
         igraph_attribute_record_t *rec = VECTOR(*v)[i];
-        igraph_Free(rec->name);
+        IGRAPH_FREE(rec->name);
         if (rec->type == IGRAPH_ATTRIBUTE_NUMERIC) {
             igraph_vector_t *numv = (igraph_vector_t*) rec->value;
             igraph_vector_destroy(numv);
-            igraph_Free(numv);
+            IGRAPH_FREE(numv);
         } else if (rec->type == IGRAPH_ATTRIBUTE_STRING) {
             igraph_strvector_t *strv = (igraph_strvector_t*) rec->value;
             igraph_strvector_destroy(strv);
-            igraph_Free(strv);
+            IGRAPH_FREE(strv);
         } else if (rec->type == IGRAPH_ATTRIBUTE_BOOLEAN) {
             igraph_vector_bool_t *boolv = (igraph_vector_bool_t*) rec->value;
             igraph_vector_bool_destroy(boolv);
-            igraph_Free(boolv);
+            IGRAPH_FREE(boolv);
         }
-        igraph_Free(rec);
+        IGRAPH_FREE(rec);
     }
     igraph_vector_ptr_clear(v);
 }
@@ -461,7 +461,7 @@ static int igraph_i_cattribute_permute_vertices(const igraph_t *graph,
             switch (type) {
             case IGRAPH_ATTRIBUTE_NUMERIC:
                 num = (igraph_vector_t*) oldrec->value;
-                newnum = igraph_Calloc(1, igraph_vector_t);
+                newnum = IGRAPH_CALLOC(1, igraph_vector_t);
                 if (!newnum) {
                     IGRAPH_ERROR("Cannot permute vertex attributes", IGRAPH_ENOMEM);
                 }
@@ -469,12 +469,12 @@ static int igraph_i_cattribute_permute_vertices(const igraph_t *graph,
                 igraph_vector_index(num, newnum, idx);
                 oldrec->value = newnum;
                 igraph_vector_destroy(num);
-                igraph_Free(num);
+                IGRAPH_FREE(num);
                 IGRAPH_FINALLY_CLEAN(1);
                 break;
             case IGRAPH_ATTRIBUTE_BOOLEAN:
                 oldbool = (igraph_vector_bool_t*) oldrec->value;
-                newbool = igraph_Calloc(1, igraph_vector_bool_t);
+                newbool = IGRAPH_CALLOC(1, igraph_vector_bool_t);
                 if (!newbool) {
                     IGRAPH_ERROR("Cannot permute vertex attributes", IGRAPH_ENOMEM);
                 }
@@ -483,12 +483,12 @@ static int igraph_i_cattribute_permute_vertices(const igraph_t *graph,
                 igraph_vector_bool_index(oldbool, newbool, idx);
                 oldrec->value = newbool;
                 igraph_vector_bool_destroy(oldbool);
-                igraph_Free(oldbool);
+                IGRAPH_FREE(oldbool);
                 IGRAPH_FINALLY_CLEAN(1);
                 break;
             case IGRAPH_ATTRIBUTE_STRING:
                 str = (igraph_strvector_t*)oldrec->value;
-                newstr = igraph_Calloc(1, igraph_strvector_t);
+                newstr = IGRAPH_CALLOC(1, igraph_strvector_t);
                 if (!newstr) {
                     IGRAPH_ERROR("Cannot permute vertex attributes", IGRAPH_ENOMEM);
                 }
@@ -497,7 +497,7 @@ static int igraph_i_cattribute_permute_vertices(const igraph_t *graph,
                 igraph_strvector_index(str, newstr, idx);
                 oldrec->value = newstr;
                 igraph_strvector_destroy(str);
-                igraph_Free(str);
+                IGRAPH_FREE(str);
                 IGRAPH_FINALLY_CLEAN(1);
                 break;
             default:
@@ -531,7 +531,7 @@ static int igraph_i_cattribute_permute_vertices(const igraph_t *graph,
 
             /* The record itself */
             igraph_attribute_record_t *new_rec =
-                igraph_Calloc(1, igraph_attribute_record_t);
+                IGRAPH_CALLOC(1, igraph_attribute_record_t);
             if (!new_rec) {
                 IGRAPH_ERROR("Cannot create vertex attributes", IGRAPH_ENOMEM);
             }
@@ -543,7 +543,7 @@ static int igraph_i_cattribute_permute_vertices(const igraph_t *graph,
             switch (type) {
             case IGRAPH_ATTRIBUTE_NUMERIC:
                 num = (igraph_vector_t*)oldrec->value;
-                newnum = igraph_Calloc(1, igraph_vector_t);
+                newnum = IGRAPH_CALLOC(1, igraph_vector_t);
                 if (!newnum) {
                     IGRAPH_ERROR("Cannot permute vertex attributes", IGRAPH_ENOMEM);
                 }
@@ -554,7 +554,7 @@ static int igraph_i_cattribute_permute_vertices(const igraph_t *graph,
                 break;
             case IGRAPH_ATTRIBUTE_BOOLEAN:
                 oldbool = (igraph_vector_bool_t*)oldrec->value;
-                newbool = igraph_Calloc(1, igraph_vector_bool_t);
+                newbool = IGRAPH_CALLOC(1, igraph_vector_bool_t);
                 if (!newbool) {
                     IGRAPH_ERROR("Cannot permute vertex attributes", IGRAPH_ENOMEM);
                 }
@@ -566,7 +566,7 @@ static int igraph_i_cattribute_permute_vertices(const igraph_t *graph,
                 break;
             case IGRAPH_ATTRIBUTE_STRING:
                 str = (igraph_strvector_t*)oldrec->value;
-                newstr = igraph_Calloc(1, igraph_strvector_t);
+                newstr = IGRAPH_CALLOC(1, igraph_strvector_t);
                 if (!newstr) {
                     IGRAPH_ERROR("Cannot permute vertex attributes", IGRAPH_ENOMEM);
                 }
@@ -599,7 +599,7 @@ static int igraph_i_cattributes_cn_sum(const igraph_attribute_record_t *oldrec,
                                        igraph_attribute_record_t * newrec,
                                        const igraph_vector_ptr_t *merges) {
     const igraph_vector_t *oldv = oldrec->value;
-    igraph_vector_t *newv = igraph_Calloc(1, igraph_vector_t);
+    igraph_vector_t *newv = IGRAPH_CALLOC(1, igraph_vector_t);
     long int newlen = igraph_vector_ptr_size(merges);
     long int i;
 
@@ -630,7 +630,7 @@ static int igraph_i_cattributes_cn_prod(const igraph_attribute_record_t *oldrec,
                                         igraph_attribute_record_t * newrec,
                                         const igraph_vector_ptr_t *merges) {
     const igraph_vector_t *oldv = oldrec->value;
-    igraph_vector_t *newv = igraph_Calloc(1, igraph_vector_t);
+    igraph_vector_t *newv = IGRAPH_CALLOC(1, igraph_vector_t);
     long int newlen = igraph_vector_ptr_size(merges);
     long int i;
 
@@ -661,7 +661,7 @@ static int igraph_i_cattributes_cn_min(const igraph_attribute_record_t *oldrec,
                                        igraph_attribute_record_t * newrec,
                                        const igraph_vector_ptr_t *merges) {
     const igraph_vector_t *oldv = oldrec->value;
-    igraph_vector_t *newv = igraph_Calloc(1, igraph_vector_t);
+    igraph_vector_t *newv = IGRAPH_CALLOC(1, igraph_vector_t);
     long int newlen = igraph_vector_ptr_size(merges);
     long int i;
     igraph_real_t nan = IGRAPH_NAN;
@@ -696,7 +696,7 @@ static int igraph_i_cattributes_cn_max(const igraph_attribute_record_t *oldrec,
                                        igraph_attribute_record_t * newrec,
                                        const igraph_vector_ptr_t *merges) {
     const igraph_vector_t *oldv = oldrec->value;
-    igraph_vector_t *newv = igraph_Calloc(1, igraph_vector_t);
+    igraph_vector_t *newv = IGRAPH_CALLOC(1, igraph_vector_t);
     long int newlen = igraph_vector_ptr_size(merges);
     long int i;
     igraph_real_t nan = IGRAPH_NAN;
@@ -732,7 +732,7 @@ static int igraph_i_cattributes_cn_random(const igraph_attribute_record_t *oldre
                                           const igraph_vector_ptr_t *merges) {
 
     const igraph_vector_t *oldv = oldrec->value;
-    igraph_vector_t *newv = igraph_Calloc(1, igraph_vector_t);
+    igraph_vector_t *newv = IGRAPH_CALLOC(1, igraph_vector_t);
     long int newlen = igraph_vector_ptr_size(merges);
     long int i;
     igraph_real_t nan = IGRAPH_NAN;
@@ -771,7 +771,7 @@ static int igraph_i_cattributes_cn_first(const igraph_attribute_record_t *oldrec
                                          const igraph_vector_ptr_t *merges) {
 
     const igraph_vector_t *oldv = oldrec->value;
-    igraph_vector_t *newv = igraph_Calloc(1, igraph_vector_t);
+    igraph_vector_t *newv = IGRAPH_CALLOC(1, igraph_vector_t);
     long int newlen = igraph_vector_ptr_size(merges);
     long int i;
     igraph_real_t nan = IGRAPH_NAN;
@@ -803,7 +803,7 @@ static int igraph_i_cattributes_cn_last(const igraph_attribute_record_t *oldrec,
                                         const igraph_vector_ptr_t *merges) {
 
     const igraph_vector_t *oldv = oldrec->value;
-    igraph_vector_t *newv = igraph_Calloc(1, igraph_vector_t);
+    igraph_vector_t *newv = IGRAPH_CALLOC(1, igraph_vector_t);
     long int newlen = igraph_vector_ptr_size(merges);
     long int i;
     igraph_real_t nan = IGRAPH_NAN;
@@ -834,7 +834,7 @@ static int igraph_i_cattributes_cn_mean(const igraph_attribute_record_t *oldrec,
                                         igraph_attribute_record_t * newrec,
                                         const igraph_vector_ptr_t *merges) {
     const igraph_vector_t *oldv = oldrec->value;
-    igraph_vector_t *newv = igraph_Calloc(1, igraph_vector_t);
+    igraph_vector_t *newv = IGRAPH_CALLOC(1, igraph_vector_t);
     long int newlen = igraph_vector_ptr_size(merges);
     long int i;
     igraph_real_t nan = IGRAPH_NAN;
@@ -873,7 +873,7 @@ static int igraph_i_cattributes_cn_func(const igraph_attribute_record_t *oldrec,
     const igraph_vector_t *oldv = oldrec->value;
     long int newlen = igraph_vector_ptr_size(merges);
     long int i;
-    igraph_vector_t *newv = igraph_Calloc(1, igraph_vector_t);
+    igraph_vector_t *newv = IGRAPH_CALLOC(1, igraph_vector_t);
     igraph_vector_t values;
 
     if (!newv) {
@@ -909,7 +909,7 @@ static int igraph_i_cattributes_cb_random(const igraph_attribute_record_t *oldre
                                           const igraph_vector_ptr_t *merges) {
 
     const igraph_vector_bool_t *oldv = oldrec->value;
-    igraph_vector_bool_t *newv = igraph_Calloc(1, igraph_vector_bool_t);
+    igraph_vector_bool_t *newv = IGRAPH_CALLOC(1, igraph_vector_bool_t);
     long int newlen = igraph_vector_ptr_size(merges);
     long int i;
 
@@ -948,7 +948,7 @@ static int igraph_i_cattributes_cb_first(const igraph_attribute_record_t *oldrec
                                          const igraph_vector_ptr_t *merges) {
 
     const igraph_vector_bool_t *oldv = oldrec->value;
-    igraph_vector_bool_t *newv = igraph_Calloc(1, igraph_vector_bool_t);
+    igraph_vector_bool_t *newv = IGRAPH_CALLOC(1, igraph_vector_bool_t);
     long int newlen = igraph_vector_ptr_size(merges);
     long int i;
 
@@ -980,7 +980,7 @@ static int igraph_i_cattributes_cb_last(const igraph_attribute_record_t *oldrec,
                                         const igraph_vector_ptr_t *merges) {
 
     const igraph_vector_bool_t *oldv = oldrec->value;
-    igraph_vector_bool_t *newv = igraph_Calloc(1, igraph_vector_bool_t);
+    igraph_vector_bool_t *newv = IGRAPH_CALLOC(1, igraph_vector_bool_t);
     long int newlen = igraph_vector_ptr_size(merges);
     long int i;
 
@@ -1012,7 +1012,7 @@ static int igraph_i_cattributes_cb_all_is_true(const igraph_attribute_record_t *
                                                const igraph_vector_ptr_t *merges) {
 
     const igraph_vector_bool_t *oldv = oldrec->value;
-    igraph_vector_bool_t *newv = igraph_Calloc(1, igraph_vector_bool_t);
+    igraph_vector_bool_t *newv = IGRAPH_CALLOC(1, igraph_vector_bool_t);
     long int newlen = igraph_vector_ptr_size(merges);
     long int i, j, n, x;
 
@@ -1047,7 +1047,7 @@ static int igraph_i_cattributes_cb_any_is_true(const igraph_attribute_record_t *
                                                const igraph_vector_ptr_t *merges) {
 
     const igraph_vector_bool_t *oldv = oldrec->value;
-    igraph_vector_bool_t *newv = igraph_Calloc(1, igraph_vector_bool_t);
+    igraph_vector_bool_t *newv = IGRAPH_CALLOC(1, igraph_vector_bool_t);
     long int newlen = igraph_vector_ptr_size(merges);
     long int i, j, n, x;
 
@@ -1082,7 +1082,7 @@ static int igraph_i_cattributes_cb_majority(const igraph_attribute_record_t *old
                                             const igraph_vector_ptr_t *merges) {
 
     const igraph_vector_bool_t *oldv = oldrec->value;
-    igraph_vector_bool_t *newv = igraph_Calloc(1, igraph_vector_bool_t);
+    igraph_vector_bool_t *newv = IGRAPH_CALLOC(1, igraph_vector_bool_t);
     long int newlen = igraph_vector_ptr_size(merges);
     long int i, j, n, x, num_trues;
 
@@ -1135,7 +1135,7 @@ static int igraph_i_cattributes_cb_func(const igraph_attribute_record_t *oldrec,
     const igraph_vector_bool_t *oldv = oldrec->value;
     long int newlen = igraph_vector_ptr_size(merges);
     long int i;
-    igraph_vector_bool_t *newv = igraph_Calloc(1, igraph_vector_bool_t);
+    igraph_vector_bool_t *newv = IGRAPH_CALLOC(1, igraph_vector_bool_t);
     igraph_vector_bool_t values;
 
     if (!newv) {
@@ -1177,7 +1177,7 @@ static int igraph_i_cattributes_sn_random(const igraph_attribute_record_t *oldre
     const igraph_strvector_t *oldv = oldrec->value;
     long int newlen = igraph_vector_ptr_size(merges);
     long int i;
-    igraph_strvector_t *newv = igraph_Calloc(1, igraph_strvector_t);
+    igraph_strvector_t *newv = IGRAPH_CALLOC(1, igraph_strvector_t);
 
     if (!newv) {
         IGRAPH_ERROR("Cannot combine attributes", IGRAPH_ENOMEM);
@@ -1218,7 +1218,7 @@ static int igraph_i_cattributes_sn_first(const igraph_attribute_record_t *oldrec
 
     const igraph_strvector_t *oldv = oldrec->value;
     long int i, newlen = igraph_vector_ptr_size(merges);
-    igraph_strvector_t *newv = igraph_Calloc(1, igraph_strvector_t);
+    igraph_strvector_t *newv = IGRAPH_CALLOC(1, igraph_strvector_t);
 
     if (!newv) {
         IGRAPH_ERROR("Cannot combine attributes", IGRAPH_ENOMEM);
@@ -1251,7 +1251,7 @@ static int igraph_i_cattributes_sn_last(const igraph_attribute_record_t *oldrec,
 
     const igraph_strvector_t *oldv = oldrec->value;
     long int i, newlen = igraph_vector_ptr_size(merges);
-    igraph_strvector_t *newv = igraph_Calloc(1, igraph_strvector_t);
+    igraph_strvector_t *newv = IGRAPH_CALLOC(1, igraph_strvector_t);
 
     if (!newv) {
         IGRAPH_ERROR("Cannot combine attributes", IGRAPH_ENOMEM);
@@ -1284,7 +1284,7 @@ static int igraph_i_cattributes_sn_concat(const igraph_attribute_record_t *oldre
 
     const igraph_strvector_t *oldv = oldrec->value;
     long int i, newlen = igraph_vector_ptr_size(merges);
-    igraph_strvector_t *newv = igraph_Calloc(1, igraph_strvector_t);
+    igraph_strvector_t *newv = IGRAPH_CALLOC(1, igraph_strvector_t);
 
     if (!newv) {
         IGRAPH_ERROR("Cannot combine attributes", IGRAPH_ENOMEM);
@@ -1302,7 +1302,7 @@ static int igraph_i_cattributes_sn_concat(const igraph_attribute_record_t *oldre
             igraph_strvector_get(oldv, j, &tmp);
             len += strlen(tmp);
         }
-        tmp2 = igraph_Calloc(len + 1, char);
+        tmp2 = IGRAPH_CALLOC(len + 1, char);
         if (!tmp2) {
             IGRAPH_ERROR("Cannot combine attributes", IGRAPH_ENOMEM);
         }
@@ -1315,7 +1315,7 @@ static int igraph_i_cattributes_sn_concat(const igraph_attribute_record_t *oldre
         }
 
         IGRAPH_CHECK(igraph_strvector_set(newv, i, tmp2));
-        igraph_Free(tmp2);
+        IGRAPH_FREE(tmp2);
         IGRAPH_FINALLY_CLEAN(1);
     }
 
@@ -1333,7 +1333,7 @@ static int igraph_i_cattributes_sn_func(const igraph_attribute_record_t *oldrec,
     const igraph_strvector_t *oldv = oldrec->value;
     long int newlen = igraph_vector_ptr_size(merges);
     long int i;
-    igraph_strvector_t *newv = igraph_Calloc(1, igraph_strvector_t);
+    igraph_strvector_t *newv = IGRAPH_CALLOC(1, igraph_strvector_t);
     igraph_strvector_t values;
 
     if (!newv) {
@@ -1361,7 +1361,7 @@ static int igraph_i_cattributes_sn_func(const igraph_attribute_record_t *oldrec,
         IGRAPH_FINALLY(igraph_free, res);
         IGRAPH_CHECK(igraph_strvector_set(newv, i, res));
         IGRAPH_FINALLY_CLEAN(1);
-        igraph_Free(res);
+        IGRAPH_FREE(res);
     }
 
     igraph_strvector_destroy(&values);
@@ -1386,13 +1386,13 @@ static int igraph_i_cattribute_combine_vertices(const igraph_t *graph,
     int *TODO;
     igraph_function_pointer_t *funcs;
 
-    TODO = igraph_Calloc(valno, int);
+    TODO = IGRAPH_CALLOC(valno, int);
     if (!TODO) {
         IGRAPH_ERROR("Cannot combine vertex attributes",
                      IGRAPH_ENOMEM);
     }
     IGRAPH_FINALLY(igraph_free, TODO);
-    funcs = igraph_Calloc(valno, igraph_function_pointer_t);
+    funcs = IGRAPH_CALLOC(valno, igraph_function_pointer_t);
     if (!funcs) {
         IGRAPH_ERROR("Cannot combine vertex attributes",
                      IGRAPH_ENOMEM);
@@ -1433,7 +1433,7 @@ static int igraph_i_cattribute_combine_vertices(const igraph_t *graph,
             continue;
         }
 
-        newrec = igraph_Calloc(1, igraph_attribute_record_t);
+        newrec = IGRAPH_CALLOC(1, igraph_attribute_record_t);
         if (!newrec) {
             IGRAPH_ERROR("Cannot combine vertex attributes",
                          IGRAPH_ENOMEM);
@@ -1681,7 +1681,7 @@ static int igraph_i_cattribute_add_edges(igraph_t *graph, const igraph_vector_t 
     if (newattrs != 0) {
         for (i = 0; i < newattrs; i++) {
             igraph_attribute_record_t *tmp = VECTOR(*nattr)[(long int)VECTOR(news)[i]];
-            igraph_attribute_record_t *newrec = igraph_Calloc(1, igraph_attribute_record_t);
+            igraph_attribute_record_t *newrec = IGRAPH_CALLOC(1, igraph_attribute_record_t);
             igraph_attribute_type_t type = tmp->type;
             if (!newrec) {
                 IGRAPH_ERROR("Cannot add attributes", IGRAPH_ENOMEM);
@@ -1694,7 +1694,7 @@ static int igraph_i_cattribute_add_edges(igraph_t *graph, const igraph_vector_t 
             }
             IGRAPH_FINALLY(igraph_free, (char*)newrec->name);
             if (type == IGRAPH_ATTRIBUTE_NUMERIC) {
-                igraph_vector_t *newnum = igraph_Calloc(1, igraph_vector_t);
+                igraph_vector_t *newnum = IGRAPH_CALLOC(1, igraph_vector_t);
                 if (!newnum) {
                     IGRAPH_ERROR("Cannot add attributes", IGRAPH_ENOMEM);
                 }
@@ -1703,7 +1703,7 @@ static int igraph_i_cattribute_add_edges(igraph_t *graph, const igraph_vector_t 
                 newrec->value = newnum;
                 igraph_vector_fill(newnum, IGRAPH_NAN);
             } else if (type == IGRAPH_ATTRIBUTE_BOOLEAN) {
-                igraph_vector_bool_t *newbool = igraph_Calloc(1, igraph_vector_bool_t);
+                igraph_vector_bool_t *newbool = IGRAPH_CALLOC(1, igraph_vector_bool_t);
                 if (!newbool) {
                     IGRAPH_ERROR("Cannot add attributes", IGRAPH_ENOMEM);
                 }
@@ -1713,7 +1713,7 @@ static int igraph_i_cattribute_add_edges(igraph_t *graph, const igraph_vector_t 
                 newrec->value = newbool;
                 igraph_vector_bool_fill(newbool, 0);
             } else if (type == IGRAPH_ATTRIBUTE_STRING) {
-                igraph_strvector_t *newstr = igraph_Calloc(1, igraph_strvector_t);
+                igraph_strvector_t *newstr = IGRAPH_CALLOC(1, igraph_strvector_t);
                 if (!newstr) {
                     IGRAPH_ERROR("Cannot add attributes", IGRAPH_ENOMEM);
                 }
@@ -1862,7 +1862,7 @@ static int igraph_i_cattribute_permute_edges(const igraph_t *graph,
             switch (type) {
             case IGRAPH_ATTRIBUTE_NUMERIC:
                 num = (igraph_vector_t*) oldrec->value;
-                newnum = igraph_Calloc(1, igraph_vector_t);
+                newnum = IGRAPH_CALLOC(1, igraph_vector_t);
                 if (!newnum) {
                     IGRAPH_ERROR("Cannot permute edge attributes", IGRAPH_ENOMEM);
                 }
@@ -1870,12 +1870,12 @@ static int igraph_i_cattribute_permute_edges(const igraph_t *graph,
                 igraph_vector_index(num, newnum, idx);
                 oldrec->value = newnum;
                 igraph_vector_destroy(num);
-                igraph_Free(num);
+                IGRAPH_FREE(num);
                 IGRAPH_FINALLY_CLEAN(1);
                 break;
             case IGRAPH_ATTRIBUTE_BOOLEAN:
                 oldbool = (igraph_vector_bool_t*) oldrec->value;
-                newbool = igraph_Calloc(1, igraph_vector_bool_t);
+                newbool = IGRAPH_CALLOC(1, igraph_vector_bool_t);
                 if (!newbool) {
                     IGRAPH_ERROR("Cannot permute edge attributes", IGRAPH_ENOMEM);
                 }
@@ -1884,12 +1884,12 @@ static int igraph_i_cattribute_permute_edges(const igraph_t *graph,
                 igraph_vector_bool_index(oldbool, newbool, idx);
                 oldrec->value = newbool;
                 igraph_vector_bool_destroy(oldbool);
-                igraph_Free(oldbool);
+                IGRAPH_FREE(oldbool);
                 IGRAPH_FINALLY_CLEAN(1);
                 break;
             case IGRAPH_ATTRIBUTE_STRING:
                 str = (igraph_strvector_t*)oldrec->value;
-                newstr = igraph_Calloc(1, igraph_strvector_t);
+                newstr = IGRAPH_CALLOC(1, igraph_strvector_t);
                 if (!newstr) {
                     IGRAPH_ERROR("Cannot permute edge attributes", IGRAPH_ENOMEM);
                 }
@@ -1898,7 +1898,7 @@ static int igraph_i_cattribute_permute_edges(const igraph_t *graph,
                 igraph_strvector_index(str, newstr, idx);
                 oldrec->value = newstr;
                 igraph_strvector_destroy(str);
-                igraph_Free(str);
+                IGRAPH_FREE(str);
                 IGRAPH_FINALLY_CLEAN(1);
                 break;
             default:
@@ -1929,7 +1929,7 @@ static int igraph_i_cattribute_permute_edges(const igraph_t *graph,
 
             /* The record itself */
             igraph_attribute_record_t *new_rec =
-                igraph_Calloc(1, igraph_attribute_record_t);
+                IGRAPH_CALLOC(1, igraph_attribute_record_t);
             if (!new_rec) {
                 IGRAPH_ERROR("Cannot create edge attributes", IGRAPH_ENOMEM);
             }
@@ -1940,7 +1940,7 @@ static int igraph_i_cattribute_permute_edges(const igraph_t *graph,
             switch (type) {
             case IGRAPH_ATTRIBUTE_NUMERIC:
                 num = (igraph_vector_t*) oldrec->value;
-                newnum = igraph_Calloc(1, igraph_vector_t);
+                newnum = IGRAPH_CALLOC(1, igraph_vector_t);
                 if (!newnum) {
                     IGRAPH_ERROR("Cannot permute edge attributes", IGRAPH_ENOMEM);
                 }
@@ -1951,7 +1951,7 @@ static int igraph_i_cattribute_permute_edges(const igraph_t *graph,
                 break;
             case IGRAPH_ATTRIBUTE_STRING:
                 str = (igraph_strvector_t*)oldrec->value;
-                newstr = igraph_Calloc(1, igraph_strvector_t);
+                newstr = IGRAPH_CALLOC(1, igraph_strvector_t);
                 if (!newstr) {
                     IGRAPH_ERROR("Cannot permute edge attributes", IGRAPH_ENOMEM);
                 }
@@ -1963,7 +1963,7 @@ static int igraph_i_cattribute_permute_edges(const igraph_t *graph,
                 break;
             case IGRAPH_ATTRIBUTE_BOOLEAN:
                 oldbool = (igraph_vector_bool_t*) oldrec->value;
-                newbool = igraph_Calloc(1, igraph_vector_bool_t);
+                newbool = IGRAPH_CALLOC(1, igraph_vector_bool_t);
                 if (!newbool) {
                     IGRAPH_ERROR("Cannot permute edge attributes", IGRAPH_ENOMEM);
                 }
@@ -1997,13 +1997,13 @@ static int igraph_i_cattribute_combine_edges(const igraph_t *graph,
     int *TODO;
     igraph_function_pointer_t *funcs;
 
-    TODO = igraph_Calloc(ealno, int);
+    TODO = IGRAPH_CALLOC(ealno, int);
     if (!TODO) {
         IGRAPH_ERROR("Cannot combine edge attributes",
                      IGRAPH_ENOMEM);
     }
     IGRAPH_FINALLY(igraph_free, TODO);
-    funcs = igraph_Calloc(ealno, igraph_function_pointer_t);
+    funcs = IGRAPH_CALLOC(ealno, igraph_function_pointer_t);
     if (!funcs) {
         IGRAPH_ERROR("Cannot combine edge attributes",
                      IGRAPH_ENOMEM);
@@ -2044,7 +2044,7 @@ static int igraph_i_cattribute_combine_edges(const igraph_t *graph,
             continue;
         }
 
-        newrec = igraph_Calloc(1, igraph_attribute_record_t);
+        newrec = IGRAPH_CALLOC(1, igraph_attribute_record_t);
         if (!newrec) {
             IGRAPH_ERROR("Cannot combine edge attributes",
                          IGRAPH_ENOMEM);
@@ -3156,7 +3156,7 @@ int igraph_cattribute_GAN_set(igraph_t *graph, const char *name,
             VECTOR(*num)[0] = value;
         }
     } else {
-        igraph_attribute_record_t *rec = igraph_Calloc(1, igraph_attribute_record_t);
+        igraph_attribute_record_t *rec = IGRAPH_CALLOC(1, igraph_attribute_record_t);
         igraph_vector_t *num;
         if (!rec) {
             IGRAPH_ERROR("Cannot add graph attribute", IGRAPH_ENOMEM);
@@ -3168,7 +3168,7 @@ int igraph_cattribute_GAN_set(igraph_t *graph, const char *name,
         }
         IGRAPH_FINALLY(igraph_free, (char*)rec->name);
         rec->type = IGRAPH_ATTRIBUTE_NUMERIC;
-        num = igraph_Calloc(1, igraph_vector_t);
+        num = IGRAPH_CALLOC(1, igraph_vector_t);
         if (!num) {
             IGRAPH_ERROR("Cannot add graph attribute", IGRAPH_ENOMEM);
         }
@@ -3214,7 +3214,7 @@ int igraph_cattribute_GAB_set(igraph_t *graph, const char *name,
             VECTOR(*log)[0] = value;
         }
     } else {
-        igraph_attribute_record_t *rec = igraph_Calloc(1, igraph_attribute_record_t);
+        igraph_attribute_record_t *rec = IGRAPH_CALLOC(1, igraph_attribute_record_t);
         igraph_vector_bool_t *log;
         if (!rec) {
             IGRAPH_ERROR("Cannot add graph attribute", IGRAPH_ENOMEM);
@@ -3226,7 +3226,7 @@ int igraph_cattribute_GAB_set(igraph_t *graph, const char *name,
         }
         IGRAPH_FINALLY(igraph_free, (char*)rec->name);
         rec->type = IGRAPH_ATTRIBUTE_BOOLEAN;
-        log = igraph_Calloc(1, igraph_vector_bool_t);
+        log = IGRAPH_CALLOC(1, igraph_vector_bool_t);
         if (!log) {
             IGRAPH_ERROR("Cannot add graph attribute", IGRAPH_ENOMEM);
         }
@@ -3274,7 +3274,7 @@ int igraph_cattribute_GAS_set(igraph_t *graph, const char *name,
             IGRAPH_CHECK(igraph_strvector_set(str, 0, value));
         }
     } else {
-        igraph_attribute_record_t *rec = igraph_Calloc(1, igraph_attribute_record_t);
+        igraph_attribute_record_t *rec = IGRAPH_CALLOC(1, igraph_attribute_record_t);
         igraph_strvector_t *str;
         if (!rec) {
             IGRAPH_ERROR("Cannot add graph attribute", IGRAPH_ENOMEM);
@@ -3286,7 +3286,7 @@ int igraph_cattribute_GAS_set(igraph_t *graph, const char *name,
         }
         IGRAPH_FINALLY(igraph_free, (char*)rec->name);
         rec->type = IGRAPH_ATTRIBUTE_STRING;
-        str = igraph_Calloc(1, igraph_strvector_t);
+        str = IGRAPH_CALLOC(1, igraph_strvector_t);
         if (!str) {
             IGRAPH_ERROR("Cannot add graph attribute", IGRAPH_ENOMEM);
         }
@@ -3336,7 +3336,7 @@ int igraph_cattribute_VAN_set(igraph_t *graph, const char *name,
             VECTOR(*num)[(long int)vid] = value;
         }
     } else {
-        igraph_attribute_record_t *rec = igraph_Calloc(1, igraph_attribute_record_t);
+        igraph_attribute_record_t *rec = IGRAPH_CALLOC(1, igraph_attribute_record_t);
         igraph_vector_t *num;
         if (!rec) {
             IGRAPH_ERROR("Cannot add vertex attribute", IGRAPH_ENOMEM);
@@ -3348,7 +3348,7 @@ int igraph_cattribute_VAN_set(igraph_t *graph, const char *name,
         }
         IGRAPH_FINALLY(igraph_free, (char*)rec->name);
         rec->type = IGRAPH_ATTRIBUTE_NUMERIC;
-        num = igraph_Calloc(1, igraph_vector_t);
+        num = IGRAPH_CALLOC(1, igraph_vector_t);
         if (!num) {
             IGRAPH_ERROR("Cannot add vertex attribute", IGRAPH_ENOMEM);
         }
@@ -3399,7 +3399,7 @@ int igraph_cattribute_VAB_set(igraph_t *graph, const char *name,
             VECTOR(*log)[(long int)vid] = value;
         }
     } else {
-        igraph_attribute_record_t *rec = igraph_Calloc(1, igraph_attribute_record_t);
+        igraph_attribute_record_t *rec = IGRAPH_CALLOC(1, igraph_attribute_record_t);
         igraph_vector_bool_t *log;
         if (!rec) {
             IGRAPH_ERROR("Cannot add vertex attribute", IGRAPH_ENOMEM);
@@ -3411,7 +3411,7 @@ int igraph_cattribute_VAB_set(igraph_t *graph, const char *name,
         }
         IGRAPH_FINALLY(igraph_free, (char*)rec->name);
         rec->type = IGRAPH_ATTRIBUTE_BOOLEAN;
-        log = igraph_Calloc(1, igraph_vector_bool_t);
+        log = IGRAPH_CALLOC(1, igraph_vector_bool_t);
         if (!log) {
             IGRAPH_ERROR("Cannot add vertex attribute", IGRAPH_ENOMEM);
         }
@@ -3464,7 +3464,7 @@ int igraph_cattribute_VAS_set(igraph_t *graph, const char *name,
             IGRAPH_CHECK(igraph_strvector_set(str, vid, value));
         }
     } else {
-        igraph_attribute_record_t *rec = igraph_Calloc(1, igraph_attribute_record_t);
+        igraph_attribute_record_t *rec = IGRAPH_CALLOC(1, igraph_attribute_record_t);
         igraph_strvector_t *str;
         if (!rec) {
             IGRAPH_ERROR("Cannot add vertex attribute", IGRAPH_ENOMEM);
@@ -3476,7 +3476,7 @@ int igraph_cattribute_VAS_set(igraph_t *graph, const char *name,
         }
         IGRAPH_FINALLY(igraph_free, (char*)rec->name);
         rec->type = IGRAPH_ATTRIBUTE_STRING;
-        str = igraph_Calloc(1, igraph_strvector_t);
+        str = IGRAPH_CALLOC(1, igraph_strvector_t);
         if (!str) {
             IGRAPH_ERROR("Cannot add vertex attribute", IGRAPH_ENOMEM);
         }
@@ -3526,7 +3526,7 @@ int igraph_cattribute_EAN_set(igraph_t *graph, const char *name,
             VECTOR(*num)[(long int)eid] = value;
         }
     } else {
-        igraph_attribute_record_t *rec = igraph_Calloc(1, igraph_attribute_record_t);
+        igraph_attribute_record_t *rec = IGRAPH_CALLOC(1, igraph_attribute_record_t);
         igraph_vector_t *num;
         if (!rec) {
             IGRAPH_ERROR("Cannot add edge attribute", IGRAPH_ENOMEM);
@@ -3538,7 +3538,7 @@ int igraph_cattribute_EAN_set(igraph_t *graph, const char *name,
         }
         IGRAPH_FINALLY(igraph_free, (char*)rec->name);
         rec->type = IGRAPH_ATTRIBUTE_NUMERIC;
-        num = igraph_Calloc(1, igraph_vector_t);
+        num = IGRAPH_CALLOC(1, igraph_vector_t);
         if (!num) {
             IGRAPH_ERROR("Cannot add edge attribute", IGRAPH_ENOMEM);
         }
@@ -3589,7 +3589,7 @@ int igraph_cattribute_EAB_set(igraph_t *graph, const char *name,
             VECTOR(*log)[(long int)eid] = value;
         }
     } else {
-        igraph_attribute_record_t *rec = igraph_Calloc(1, igraph_attribute_record_t);
+        igraph_attribute_record_t *rec = IGRAPH_CALLOC(1, igraph_attribute_record_t);
         igraph_vector_bool_t *log;
         if (!rec) {
             IGRAPH_ERROR("Cannot add edge attribute", IGRAPH_ENOMEM);
@@ -3601,7 +3601,7 @@ int igraph_cattribute_EAB_set(igraph_t *graph, const char *name,
         }
         IGRAPH_FINALLY(igraph_free, (char*)rec->name);
         rec->type = IGRAPH_ATTRIBUTE_BOOLEAN;
-        log = igraph_Calloc(1, igraph_vector_bool_t);
+        log = IGRAPH_CALLOC(1, igraph_vector_bool_t);
         if (!log) {
             IGRAPH_ERROR("Cannot add edge attribute", IGRAPH_ENOMEM);
         }
@@ -3654,7 +3654,7 @@ int igraph_cattribute_EAS_set(igraph_t *graph, const char *name,
             IGRAPH_CHECK(igraph_strvector_set(str, eid, value));
         }
     } else {
-        igraph_attribute_record_t *rec = igraph_Calloc(1, igraph_attribute_record_t);
+        igraph_attribute_record_t *rec = IGRAPH_CALLOC(1, igraph_attribute_record_t);
         igraph_strvector_t *str;
         if (!rec) {
             IGRAPH_ERROR("Cannot add edge attribute", IGRAPH_ENOMEM);
@@ -3666,7 +3666,7 @@ int igraph_cattribute_EAS_set(igraph_t *graph, const char *name,
         }
         IGRAPH_FINALLY(igraph_free, (char*)rec->name);
         rec->type = IGRAPH_ATTRIBUTE_STRING;
-        str = igraph_Calloc(1, igraph_strvector_t);
+        str = IGRAPH_CALLOC(1, igraph_strvector_t);
         if (!str) {
             IGRAPH_ERROR("Cannot add edge attribute", IGRAPH_ENOMEM);
         }
@@ -3720,7 +3720,7 @@ int igraph_cattribute_VAN_setv(igraph_t *graph, const char *name,
         IGRAPH_CHECK(igraph_vector_append(num, v));
     } else {
         /* Add it */
-        igraph_attribute_record_t *rec = igraph_Calloc(1, igraph_attribute_record_t);
+        igraph_attribute_record_t *rec = IGRAPH_CALLOC(1, igraph_attribute_record_t);
         igraph_vector_t *num;
         if (!rec) {
             IGRAPH_ERROR("Cannot add vertex attribute", IGRAPH_ENOMEM);
@@ -3732,7 +3732,7 @@ int igraph_cattribute_VAN_setv(igraph_t *graph, const char *name,
             IGRAPH_ERROR("Cannot add vertex attribute", IGRAPH_ENOMEM);
         }
         IGRAPH_FINALLY(igraph_free, (char*)rec->name);
-        num = igraph_Calloc(1, igraph_vector_t);
+        num = IGRAPH_CALLOC(1, igraph_vector_t);
         if (!num) {
             IGRAPH_ERROR("Cannot add vertex attribute", IGRAPH_ENOMEM);
         }
@@ -3785,7 +3785,7 @@ int igraph_cattribute_VAB_setv(igraph_t *graph, const char *name,
         IGRAPH_CHECK(igraph_vector_bool_append(log, v));
     } else {
         /* Add it */
-        igraph_attribute_record_t *rec = igraph_Calloc(1, igraph_attribute_record_t);
+        igraph_attribute_record_t *rec = IGRAPH_CALLOC(1, igraph_attribute_record_t);
         igraph_vector_bool_t *log;
         if (!rec) {
             IGRAPH_ERROR("Cannot add vertex attribute", IGRAPH_ENOMEM);
@@ -3797,7 +3797,7 @@ int igraph_cattribute_VAB_setv(igraph_t *graph, const char *name,
             IGRAPH_ERROR("Cannot add vertex attribute", IGRAPH_ENOMEM);
         }
         IGRAPH_FINALLY(igraph_free, (char*)rec->name);
-        log = igraph_Calloc(1, igraph_vector_bool_t);
+        log = IGRAPH_CALLOC(1, igraph_vector_bool_t);
         if (!log) {
             IGRAPH_ERROR("Cannot add vertex attribute", IGRAPH_ENOMEM);
         }
@@ -3852,7 +3852,7 @@ int igraph_cattribute_VAS_setv(igraph_t *graph, const char *name,
         IGRAPH_CHECK(igraph_strvector_append(str, sv));
     } else {
         /* Add it */
-        igraph_attribute_record_t *rec = igraph_Calloc(1, igraph_attribute_record_t);
+        igraph_attribute_record_t *rec = IGRAPH_CALLOC(1, igraph_attribute_record_t);
         igraph_strvector_t *str;
         if (!rec) {
             IGRAPH_ERROR("Cannot add vertex attribute", IGRAPH_ENOMEM);
@@ -3864,7 +3864,7 @@ int igraph_cattribute_VAS_setv(igraph_t *graph, const char *name,
             IGRAPH_ERROR("Cannot add vertex attribute", IGRAPH_ENOMEM);
         }
         IGRAPH_FINALLY(igraph_free, (char*)rec->name);
-        str = igraph_Calloc(1, igraph_strvector_t);
+        str = IGRAPH_CALLOC(1, igraph_strvector_t);
         if (!str) {
             IGRAPH_ERROR("Cannot add vertex attribute", IGRAPH_ENOMEM);
         }
@@ -3918,7 +3918,7 @@ int igraph_cattribute_EAN_setv(igraph_t *graph, const char *name,
         IGRAPH_CHECK(igraph_vector_append(num, v));
     } else {
         /* Add it */
-        igraph_attribute_record_t *rec = igraph_Calloc(1, igraph_attribute_record_t);
+        igraph_attribute_record_t *rec = IGRAPH_CALLOC(1, igraph_attribute_record_t);
         igraph_vector_t *num;
         if (!rec) {
             IGRAPH_ERROR("Cannot add edge attribute", IGRAPH_ENOMEM);
@@ -3930,7 +3930,7 @@ int igraph_cattribute_EAN_setv(igraph_t *graph, const char *name,
             IGRAPH_ERROR("Cannot add edge attribute", IGRAPH_ENOMEM);
         }
         IGRAPH_FINALLY(igraph_free, (char*)rec->name);
-        num = igraph_Calloc(1, igraph_vector_t);
+        num = IGRAPH_CALLOC(1, igraph_vector_t);
         if (!num) {
             IGRAPH_ERROR("Cannot add edge attribute", IGRAPH_ENOMEM);
         }
@@ -3984,7 +3984,7 @@ int igraph_cattribute_EAB_setv(igraph_t *graph, const char *name,
         IGRAPH_CHECK(igraph_vector_bool_append(log, v));
     } else {
         /* Add it */
-        igraph_attribute_record_t *rec = igraph_Calloc(1, igraph_attribute_record_t);
+        igraph_attribute_record_t *rec = IGRAPH_CALLOC(1, igraph_attribute_record_t);
         igraph_vector_bool_t *log;
         if (!rec) {
             IGRAPH_ERROR("Cannot add edge attribute", IGRAPH_ENOMEM);
@@ -3996,7 +3996,7 @@ int igraph_cattribute_EAB_setv(igraph_t *graph, const char *name,
             IGRAPH_ERROR("Cannot add edge attribute", IGRAPH_ENOMEM);
         }
         IGRAPH_FINALLY(igraph_free, (char*)rec->name);
-        log = igraph_Calloc(1, igraph_vector_bool_t);
+        log = IGRAPH_CALLOC(1, igraph_vector_bool_t);
         if (!log) {
             IGRAPH_ERROR("Cannot add edge attribute", IGRAPH_ENOMEM);
         }
@@ -4051,7 +4051,7 @@ int igraph_cattribute_EAS_setv(igraph_t *graph, const char *name,
         IGRAPH_CHECK(igraph_strvector_append(str, sv));
     } else {
         /* Add it */
-        igraph_attribute_record_t *rec = igraph_Calloc(1, igraph_attribute_record_t);
+        igraph_attribute_record_t *rec = IGRAPH_CALLOC(1, igraph_attribute_record_t);
         igraph_strvector_t *str;
         if (!rec) {
             IGRAPH_ERROR("Cannot add vertex attribute", IGRAPH_ENOMEM);
@@ -4063,7 +4063,7 @@ int igraph_cattribute_EAS_setv(igraph_t *graph, const char *name,
             IGRAPH_ERROR("Cannot add vertex attribute", IGRAPH_ENOMEM);
         }
         IGRAPH_FINALLY(igraph_free, (char*)rec->name);
-        str = igraph_Calloc(1, igraph_strvector_t);
+        str = IGRAPH_CALLOC(1, igraph_strvector_t);
         if (!str) {
             IGRAPH_ERROR("Cannot add vertex attribute", IGRAPH_ENOMEM);
         }
@@ -4090,9 +4090,9 @@ static void igraph_i_cattribute_free_rec(igraph_attribute_record_t *rec) {
         igraph_vector_bool_t *boolvec = (igraph_vector_bool_t*)rec->value;
         igraph_vector_bool_destroy(boolvec);
     }
-    igraph_Free(rec->name);
-    igraph_Free(rec->value);
-    igraph_Free(rec);
+    IGRAPH_FREE(rec->name);
+    IGRAPH_FREE(rec->value);
+    IGRAPH_FREE(rec);
 }
 
 /**

--- a/src/graph/iterators.c
+++ b/src/graph/iterators.c
@@ -355,7 +355,7 @@ int igraph_vs_vector_small(igraph_vs_t *vs, ...) {
     va_list ap;
     long int i, n = 0;
     vs->type = IGRAPH_VS_VECTOR;
-    vs->data.vecptr = igraph_Calloc(1, igraph_vector_t);
+    vs->data.vecptr = IGRAPH_CALLOC(1, igraph_vector_t);
     if (vs->data.vecptr == 0) {
         IGRAPH_ERROR("Cannot create vertex selector", IGRAPH_ENOMEM);
     }
@@ -405,7 +405,7 @@ int igraph_vs_vector_small(igraph_vs_t *vs, ...) {
 int igraph_vs_vector_copy(igraph_vs_t *vs,
                           const igraph_vector_t *v) {
     vs->type = IGRAPH_VS_VECTOR;
-    vs->data.vecptr = igraph_Calloc(1, igraph_vector_t);
+    vs->data.vecptr = IGRAPH_CALLOC(1, igraph_vector_t);
     if (vs->data.vecptr == 0) {
         IGRAPH_ERROR("Cannot create vertex selector", IGRAPH_ENOMEM);
     }
@@ -495,7 +495,7 @@ void igraph_vs_destroy(igraph_vs_t *vs) {
         break;
     case IGRAPH_VS_VECTOR:
         igraph_vector_destroy((igraph_vector_t*)vs->data.vecptr);
-        igraph_Free(vs->data.vecptr);
+        IGRAPH_FREE(vs->data.vecptr);
         break;
     default:
         break;
@@ -546,7 +546,7 @@ int igraph_vs_copy(igraph_vs_t* dest, const igraph_vs_t* src) {
     memcpy(dest, src, sizeof(igraph_vs_t));
     switch (dest->type) {
     case IGRAPH_VS_VECTOR:
-        dest->data.vecptr = igraph_Calloc(1, igraph_vector_t);
+        dest->data.vecptr = IGRAPH_CALLOC(1, igraph_vector_t);
         if (!dest->data.vecptr) {
             IGRAPH_ERROR("Cannot copy vertex selector", IGRAPH_ENOMEM);
         }
@@ -611,7 +611,7 @@ int igraph_vs_size(const igraph_t *graph, const igraph_vs_t *vs,
         IGRAPH_VECTOR_INIT_FINALLY(&vec, 0);
         IGRAPH_CHECK(igraph_neighbors(graph, &vec, vs->data.adj.vid, vs->data.adj.mode));
         *result = igraph_vcount(graph);
-        seen = igraph_Calloc(*result, igraph_bool_t);
+        seen = IGRAPH_CALLOC(*result, igraph_bool_t);
         if (seen == 0) {
             IGRAPH_ERROR("Cannot calculate selector length", IGRAPH_ENOMEM);
         }
@@ -688,7 +688,7 @@ int igraph_vit_create(const igraph_t *graph,
         vit->type = IGRAPH_VIT_VECTOR;
         vit->pos = 0;
         vit->start = 0;
-        vit->vec = igraph_Calloc(1, igraph_vector_t);
+        vit->vec = IGRAPH_CALLOC(1, igraph_vector_t);
         if (vit->vec == 0) {
             IGRAPH_ERROR("Cannot create iterator", IGRAPH_ENOMEM);
         }
@@ -703,7 +703,7 @@ int igraph_vit_create(const igraph_t *graph,
         vit->type = IGRAPH_VIT_VECTOR;
         vit->pos = 0;
         vit->start = 0;
-        vit->vec = igraph_Calloc(1, igraph_vector_t);
+        vit->vec = IGRAPH_CALLOC(1, igraph_vector_t);
         if (vit->vec == 0) {
             IGRAPH_ERROR("Cannot create iterator", IGRAPH_ENOMEM);
         }
@@ -713,7 +713,7 @@ int igraph_vit_create(const igraph_t *graph,
         IGRAPH_CHECK(igraph_neighbors(graph, &vec,
                                       vs.data.adj.vid, vs.data.adj.mode));
         n = igraph_vcount(graph);
-        seen = igraph_Calloc(n, igraph_bool_t);
+        seen = IGRAPH_CALLOC(n, igraph_bool_t);
         if (seen == 0) {
             IGRAPH_ERROR("Cannot create iterator", IGRAPH_ENOMEM);
         }
@@ -731,7 +731,7 @@ int igraph_vit_create(const igraph_t *graph,
             }
         }
 
-        igraph_Free(seen);
+        IGRAPH_FREE(seen);
         igraph_vector_destroy(&vec);
         vit->end = n;
         IGRAPH_FINALLY_CLEAN(4);
@@ -1038,7 +1038,7 @@ int igraph_es_vector(igraph_es_t *es,
 
 int igraph_es_vector_copy(igraph_es_t *es, const igraph_vector_t *v) {
     es->type = IGRAPH_ES_VECTOR;
-    es->data.vecptr = igraph_Calloc(1, igraph_vector_t);
+    es->data.vecptr = IGRAPH_CALLOC(1, igraph_vector_t);
     if (es->data.vecptr == 0) {
         IGRAPH_ERROR("Cannot create edge selector", IGRAPH_ENOMEM);
     }
@@ -1169,7 +1169,7 @@ int igraph_es_pairs(igraph_es_t *es, const igraph_vector_t *v,
                     igraph_bool_t directed) {
     es->type = IGRAPH_ES_PAIRS;
     es->data.path.mode = directed;
-    es->data.path.ptr = igraph_Calloc(1, igraph_vector_t);
+    es->data.path.ptr = IGRAPH_CALLOC(1, igraph_vector_t);
     if (es->data.path.ptr == 0) {
         IGRAPH_ERROR("Cannot create edge selector", IGRAPH_ENOMEM);
     }
@@ -1205,7 +1205,7 @@ int igraph_es_pairs_small(igraph_es_t *es, igraph_bool_t directed, ...) {
     long int i, n = 0;
     es->type = IGRAPH_ES_PAIRS;
     es->data.path.mode = directed;
-    es->data.path.ptr = igraph_Calloc(1, igraph_vector_t);
+    es->data.path.ptr = IGRAPH_CALLOC(1, igraph_vector_t);
     if (es->data.path.ptr == 0) {
         IGRAPH_ERROR("Cannot create edge selector", IGRAPH_ENOMEM);
     }
@@ -1237,7 +1237,7 @@ int igraph_es_multipairs(igraph_es_t *es, const igraph_vector_t *v,
                          igraph_bool_t directed) {
     es->type = IGRAPH_ES_MULTIPAIRS;
     es->data.path.mode = directed;
-    es->data.path.ptr = igraph_Calloc(1, igraph_vector_t);
+    es->data.path.ptr = IGRAPH_CALLOC(1, igraph_vector_t);
     if (es->data.path.ptr == 0) {
         IGRAPH_ERROR("Cannot create edge selector", IGRAPH_ENOMEM);
     }
@@ -1271,7 +1271,7 @@ int igraph_es_path(igraph_es_t *es, const igraph_vector_t *v,
                    igraph_bool_t directed) {
     es->type = IGRAPH_ES_PATH;
     es->data.path.mode = directed;
-    es->data.path.ptr = igraph_Calloc(1, igraph_vector_t);
+    es->data.path.ptr = IGRAPH_CALLOC(1, igraph_vector_t);
     if (es->data.path.ptr == 0) {
         IGRAPH_ERROR("Cannot create edge selector", IGRAPH_ENOMEM);
     }
@@ -1288,7 +1288,7 @@ int igraph_es_path_small(igraph_es_t *es, igraph_bool_t directed, ...) {
     long int i, n = 0;
     es->type = IGRAPH_ES_PATH;
     es->data.path.mode = directed;
-    es->data.path.ptr = igraph_Calloc(1, igraph_vector_t);
+    es->data.path.ptr = IGRAPH_CALLOC(1, igraph_vector_t);
     if (es->data.path.ptr == 0) {
         IGRAPH_ERROR("Cannot create edge selector", IGRAPH_ENOMEM);
     }
@@ -1343,13 +1343,13 @@ void igraph_es_destroy(igraph_es_t *es) {
         break;
     case IGRAPH_ES_VECTOR:
         igraph_vector_destroy((igraph_vector_t*)es->data.vecptr);
-        igraph_Free(es->data.vecptr);
+        IGRAPH_FREE(es->data.vecptr);
         break;
     case IGRAPH_ES_PAIRS:
     case IGRAPH_ES_PATH:
     case IGRAPH_ES_MULTIPAIRS:
         igraph_vector_destroy((igraph_vector_t*)es->data.path.ptr);
-        igraph_Free(es->data.path.ptr);
+        IGRAPH_FREE(es->data.path.ptr);
         break;
     default:
         break;
@@ -1382,7 +1382,7 @@ int igraph_es_copy(igraph_es_t* dest, const igraph_es_t* src) {
     memcpy(dest, src, sizeof(igraph_es_t));
     switch (dest->type) {
     case IGRAPH_ES_VECTOR:
-        dest->data.vecptr = igraph_Calloc(1, igraph_vector_t);
+        dest->data.vecptr = IGRAPH_CALLOC(1, igraph_vector_t);
         if (!dest->data.vecptr) {
             IGRAPH_ERROR("Cannot copy edge selector", IGRAPH_ENOMEM);
         }
@@ -1392,7 +1392,7 @@ int igraph_es_copy(igraph_es_t* dest, const igraph_es_t* src) {
     case IGRAPH_ES_PATH:
     case IGRAPH_ES_PAIRS:
     case IGRAPH_ES_MULTIPAIRS:
-        dest->data.path.ptr = igraph_Calloc(1, igraph_vector_t);
+        dest->data.path.ptr = IGRAPH_CALLOC(1, igraph_vector_t);
         if (!dest->data.path.ptr) {
             IGRAPH_ERROR("Cannot copy edge selector", IGRAPH_ENOMEM);
         }
@@ -1602,7 +1602,7 @@ static int igraph_i_eit_create_allfromto(const igraph_t *graph,
     long int no_of_edges = igraph_ecount(graph);
     long int i;
 
-    vec = igraph_Calloc(1, igraph_vector_t);
+    vec = IGRAPH_CALLOC(1, igraph_vector_t);
     if (vec == 0) {
         IGRAPH_ERROR("Cannot create edge iterator", IGRAPH_ENOMEM);
     }
@@ -1626,7 +1626,7 @@ static int igraph_i_eit_create_allfromto(const igraph_t *graph,
         igraph_bool_t *added;
         long int j;
         IGRAPH_VECTOR_INIT_FINALLY(&adj, 0);
-        added = igraph_Calloc(no_of_edges, igraph_bool_t);
+        added = igraph_CALLOC(no_of_edges, igraph_bool_t);
         if (added == 0) {
             IGRAPH_ERROR("Cannot create edge iterator", IGRAPH_ENOMEM);
         }
@@ -1641,7 +1641,7 @@ static int igraph_i_eit_create_allfromto(const igraph_t *graph,
             }
         }
         igraph_vector_destroy(&adj);
-        igraph_Free(added);
+        IGRAPH_FREE(added);
         IGRAPH_FINALLY_CLEAN(2);
     }
 
@@ -1673,7 +1673,7 @@ static int igraph_i_eit_pairs(const igraph_t *graph,
     eit->pos = 0;
     eit->start = 0;
     eit->end = n / 2;
-    eit->vec = igraph_Calloc(1, igraph_vector_t);
+    eit->vec = IGRAPH_CALLOC(1, igraph_vector_t);
     if (eit->vec == 0) {
         IGRAPH_ERROR("Cannot create edge iterator", IGRAPH_ENOMEM);
     }
@@ -1711,7 +1711,7 @@ static int igraph_i_eit_multipairs(const igraph_t *graph,
     eit->pos = 0;
     eit->start = 0;
     eit->end = n / 2;
-    eit->vec = igraph_Calloc(1, igraph_vector_t);
+    eit->vec = IGRAPH_CALLOC(1, igraph_vector_t);
     if (eit->vec == 0) {
         IGRAPH_ERROR("Cannot create edge iterator", IGRAPH_ENOMEM);
     }
@@ -1746,7 +1746,7 @@ static int igraph_i_eit_path(const igraph_t *graph,
     eit->pos = 0;
     eit->start = 0;
     eit->end = len;
-    eit->vec = igraph_Calloc(1, igraph_vector_t);
+    eit->vec = IGRAPH_CALLOC(1, igraph_vector_t);
     if (eit->vec == 0) {
         IGRAPH_ERROR("Cannot create edge iterator.", IGRAPH_ENOMEM);
     }
@@ -1813,7 +1813,7 @@ int igraph_eit_create(const igraph_t *graph,
         eit->type = IGRAPH_EIT_VECTOR;
         eit->pos = 0;
         eit->start = 0;
-        eit->vec = igraph_Calloc(1, igraph_vector_t);
+        eit->vec = IGRAPH_CALLOC(1, igraph_vector_t);
         if (eit->vec == 0) {
             IGRAPH_ERROR("Cannot create iterator.", IGRAPH_ENOMEM);
         }

--- a/src/graph/iterators.c
+++ b/src/graph/iterators.c
@@ -1626,7 +1626,7 @@ static int igraph_i_eit_create_allfromto(const igraph_t *graph,
         igraph_bool_t *added;
         long int j;
         IGRAPH_VECTOR_INIT_FINALLY(&adj, 0);
-        added = igraph_CALLOC(no_of_edges, igraph_bool_t);
+        added = IGRAPH_CALLOC(no_of_edges, igraph_bool_t);
         if (added == 0) {
             IGRAPH_ERROR("Cannot create edge iterator", IGRAPH_ENOMEM);
         }

--- a/src/graph/type_indexededgelist.c
+++ b/src/graph/type_indexededgelist.c
@@ -422,7 +422,7 @@ int igraph_delete_edges(igraph_t *graph, igraph_es_t edges) {
     int *mark;
     long int i, j;
 
-    mark = igraph_Calloc(no_of_edges, int);
+    mark = IGRAPH_CALLOC(no_of_edges, int);
     if (mark == 0) {
         IGRAPH_ERROR("Cannot delete edges", IGRAPH_ENOMEM);
     }
@@ -486,7 +486,7 @@ int igraph_delete_edges(igraph_t *graph, igraph_es_t edges) {
     graph->oi = newoi;
     IGRAPH_FINALLY_CLEAN(3);
 
-    igraph_Free(mark);
+    IGRAPH_FREE(mark);
     IGRAPH_FINALLY_CLEAN(1);
 
     /* Create start vectors, no memory is needed for this */
@@ -1477,7 +1477,7 @@ int igraph_get_eids_multipairs(const igraph_t *graph, igraph_vector_t *eids,
         IGRAPH_ERROR("Cannot get edge ids, invalid vertex id", IGRAPH_EINVVID);
     }
 
-    seen = igraph_Calloc(no_of_edges, igraph_bool_t);
+    seen = IGRAPH_CALLOC(no_of_edges, igraph_bool_t);
     if (seen == 0) {
         IGRAPH_ERROR("Cannot get edge ids", IGRAPH_ENOMEM);
     }
@@ -1518,7 +1518,7 @@ int igraph_get_eids_multipairs(const igraph_t *graph, igraph_vector_t *eids,
         }
     }
 
-    igraph_Free(seen);
+    IGRAPH_FREE(seen);
     IGRAPH_FINALLY_CLEAN(1);
     return 0;
 }
@@ -1538,7 +1538,7 @@ int igraph_get_eids_multipath(const igraph_t *graph, igraph_vector_t *eids,
         IGRAPH_ERROR("Cannot get edge ids, invalid vertex id", IGRAPH_EINVVID);
     }
 
-    seen = igraph_Calloc(no_of_edges, igraph_bool_t);
+    seen = IGRAPH_CALLOC(no_of_edges, igraph_bool_t);
     if (!seen) {
         IGRAPH_ERROR("Cannot get edge ids", IGRAPH_ENOMEM);
     }
@@ -1579,7 +1579,7 @@ int igraph_get_eids_multipath(const igraph_t *graph, igraph_vector_t *eids,
         }
     }
 
-    igraph_Free(seen);
+    IGRAPH_FREE(seen);
     IGRAPH_FINALLY_CLEAN(1);
     return 0;
 }

--- a/src/graph/visitors.c
+++ b/src/graph/visitors.c
@@ -346,7 +346,7 @@ int igraph_bfs_simple(igraph_t *graph, igraph_integer_t vid, igraph_neimode_t mo
     }
 
     /* temporary storage */
-    added = igraph_Calloc(no_of_nodes, char);
+    added = IGRAPH_CALLOC(no_of_nodes, char);
     if (added == 0) {
         IGRAPH_ERROR("Cannot calculate BFS", IGRAPH_ENOMEM);
     }
@@ -413,7 +413,7 @@ int igraph_bfs_simple(igraph_t *graph, igraph_integer_t vid, igraph_neimode_t mo
 
     igraph_vector_destroy(&neis);
     igraph_dqueue_destroy(&q);
-    igraph_Free(added);
+    IGRAPH_FREE(added);
     IGRAPH_FINALLY_CLEAN(3);
 
     return 0;

--- a/src/hrg/hrg.cc
+++ b/src/hrg/hrg.cc
@@ -504,7 +504,7 @@ int igraph_hrg_sample(const igraph_t *input_graph,
         d->makeRandomGraph();
         d->recordGraphStructure(sample);
         if (samples) {
-            igraph_t *G = igraph_Calloc(1, igraph_t);
+            igraph_t *G = IGRAPH_CALLOC(1, igraph_t);
             if (!G) {
                 IGRAPH_ERROR("Cannot sample HRG graphs", IGRAPH_ENOMEM);
             }
@@ -516,7 +516,7 @@ int igraph_hrg_sample(const igraph_t *input_graph,
         // Sample many
         IGRAPH_CHECK(igraph_vector_ptr_resize(samples, no_samples));
         for (i = 0; i < no_samples; i++) {
-            igraph_t *G = igraph_Calloc(1, igraph_t);
+            igraph_t *G = IGRAPH_CALLOC(1, igraph_t);
             if (!G) {
                 IGRAPH_ERROR("Cannot sample HRG graphs", IGRAPH_ENOMEM);
             }

--- a/src/io/dot.c
+++ b/src/io/dot.c
@@ -200,12 +200,8 @@ int igraph_write_graph_dot(const igraph_t *graph, FILE* outstream) {
             } else {
                 IGRAPH_WARNING("A non-numeric, non-string, non-boolean graph attribute ignored");
             }
-<<<<<<< HEAD
-            igraph_Free(newname);
-            IGRAPH_FINALLY_CLEAN(1);
-=======
             IGRAPH_FREE(newname);
->>>>>>> Change alloc macro case, use ? for macros
+            IGRAPH_FINALLY_CLEAN(1);
         }
         CHECK(fprintf(outstream, "  ];\n"));
     }
@@ -243,12 +239,8 @@ int igraph_write_graph_dot(const igraph_t *graph, FILE* outstream) {
                 } else {
                     IGRAPH_WARNING("A non-numeric, non-string, non-boolean vertex attribute was ignored");
                 }
-<<<<<<< HEAD
-                igraph_Free(newname);
-                IGRAPH_FINALLY_CLEAN(1);
-=======
                 IGRAPH_FREE(newname);
->>>>>>> Change alloc macro case, use ? for macros
+                IGRAPH_FINALLY_CLEAN(1);
             }
             CHECK(fprintf(outstream, "  ];\n"));
         }
@@ -280,10 +272,6 @@ int igraph_write_graph_dot(const igraph_t *graph, FILE* outstream) {
                         CHECK(igraph_real_fprintf_precise(outstream, VECTOR(numv)[0]));
                         CHECK(fputc('\n', outstream));
                     }
-<<<<<<< HEAD
-=======
-                    IGRAPH_FREE(newname);
->>>>>>> Change alloc macro case, use ? for macros
                 } else if (VECTOR(etypes)[j] == IGRAPH_ATTRIBUTE_STRING) {
                     char *s, *news;
                     IGRAPH_CHECK(igraph_i_attribute_get_string_edge_attr(graph,
@@ -291,12 +279,7 @@ int igraph_write_graph_dot(const igraph_t *graph, FILE* outstream) {
                     igraph_strvector_get(&strv, 0, &s);
                     IGRAPH_CHECK(igraph_i_dot_escape(s, &news));
                     CHECK(fprintf(outstream, "    %s=%s\n", newname, news));
-<<<<<<< HEAD
-                    igraph_Free(news);
-=======
-                    IGRAPH_FREE(newname);
                     IGRAPH_FREE(news);
->>>>>>> Change alloc macro case, use ? for macros
                 } else if (VECTOR(etypes)[j] == IGRAPH_ATTRIBUTE_BOOLEAN) {
                     IGRAPH_CHECK(igraph_i_attribute_get_bool_edge_attr(graph,
                                  name, igraph_ess_1((igraph_integer_t) i), &boolv));
@@ -305,7 +288,7 @@ int igraph_write_graph_dot(const igraph_t *graph, FILE* outstream) {
                 } else {
                     IGRAPH_WARNING("A non-numeric, non-string graph attribute ignored");
                 }
-                igraph_Free(newname);
+                IGRAPH_FREE(newname);
                 IGRAPH_FINALLY_CLEAN(1);
             }
             CHECK(fprintf(outstream, "  ];\n"));

--- a/src/io/dot.c
+++ b/src/io/dot.c
@@ -86,7 +86,7 @@ static int igraph_i_dot_escape(const char *orig, char **result) {
             IGRAPH_ERROR("Writing DOT format failed.", IGRAPH_ENOMEM);
         }
     } else {
-        *result = igraph_Calloc(newlen + 3, char);
+        *result = IGRAPH_CALLOC(newlen + 3, char);
         if (!*result) {
             IGRAPH_ERROR("Writing DOT format failed.", IGRAPH_ENOMEM);
         }
@@ -192,7 +192,7 @@ int igraph_write_graph_dot(const igraph_t *graph, FILE* outstream) {
                 igraph_strvector_get(&strv, 0, &s);
                 IGRAPH_CHECK(igraph_i_dot_escape(s, &news));
                 CHECK(fprintf(outstream, "    %s=%s\n", newname, news));
-                igraph_Free(news);
+                IGRAPH_FREE(news);
             } else if (VECTOR(gtypes)[i] == IGRAPH_ATTRIBUTE_BOOLEAN) {
                 IGRAPH_CHECK(igraph_i_attribute_get_bool_graph_attr(graph, name, &boolv));
                 CHECK(fprintf(outstream, "    %s=%d\n", newname, VECTOR(boolv)[0] ? 1 : 0));
@@ -200,8 +200,12 @@ int igraph_write_graph_dot(const igraph_t *graph, FILE* outstream) {
             } else {
                 IGRAPH_WARNING("A non-numeric, non-string, non-boolean graph attribute ignored");
             }
+<<<<<<< HEAD
             igraph_Free(newname);
             IGRAPH_FINALLY_CLEAN(1);
+=======
+            IGRAPH_FREE(newname);
+>>>>>>> Change alloc macro case, use ? for macros
         }
         CHECK(fprintf(outstream, "  ];\n"));
     }
@@ -231,7 +235,7 @@ int igraph_write_graph_dot(const igraph_t *graph, FILE* outstream) {
                     igraph_strvector_get(&strv, 0, &s);
                     IGRAPH_CHECK(igraph_i_dot_escape(s, &news));
                     CHECK(fprintf(outstream, "    %s=%s\n", newname, news));
-                    igraph_Free(news);
+                    IGRAPH_FREE(news);
                 } else if (VECTOR(vtypes)[j] == IGRAPH_ATTRIBUTE_BOOLEAN) {
                     IGRAPH_CHECK(igraph_i_attribute_get_bool_vertex_attr(graph, name, igraph_vss_1((igraph_integer_t) i), &boolv));
                     CHECK(fprintf(outstream, "    %s=%d\n", newname, VECTOR(boolv)[0] ? 1 : 0));
@@ -239,8 +243,12 @@ int igraph_write_graph_dot(const igraph_t *graph, FILE* outstream) {
                 } else {
                     IGRAPH_WARNING("A non-numeric, non-string, non-boolean vertex attribute was ignored");
                 }
+<<<<<<< HEAD
                 igraph_Free(newname);
                 IGRAPH_FINALLY_CLEAN(1);
+=======
+                IGRAPH_FREE(newname);
+>>>>>>> Change alloc macro case, use ? for macros
             }
             CHECK(fprintf(outstream, "  ];\n"));
         }
@@ -272,6 +280,10 @@ int igraph_write_graph_dot(const igraph_t *graph, FILE* outstream) {
                         CHECK(igraph_real_fprintf_precise(outstream, VECTOR(numv)[0]));
                         CHECK(fputc('\n', outstream));
                     }
+<<<<<<< HEAD
+=======
+                    IGRAPH_FREE(newname);
+>>>>>>> Change alloc macro case, use ? for macros
                 } else if (VECTOR(etypes)[j] == IGRAPH_ATTRIBUTE_STRING) {
                     char *s, *news;
                     IGRAPH_CHECK(igraph_i_attribute_get_string_edge_attr(graph,
@@ -279,7 +291,12 @@ int igraph_write_graph_dot(const igraph_t *graph, FILE* outstream) {
                     igraph_strvector_get(&strv, 0, &s);
                     IGRAPH_CHECK(igraph_i_dot_escape(s, &news));
                     CHECK(fprintf(outstream, "    %s=%s\n", newname, news));
+<<<<<<< HEAD
                     igraph_Free(news);
+=======
+                    IGRAPH_FREE(newname);
+                    IGRAPH_FREE(news);
+>>>>>>> Change alloc macro case, use ? for macros
                 } else if (VECTOR(etypes)[j] == IGRAPH_ATTRIBUTE_BOOLEAN) {
                     IGRAPH_CHECK(igraph_i_attribute_get_bool_edge_attr(graph,
                                  name, igraph_ess_1((igraph_integer_t) i), &boolv));

--- a/src/io/gml-parser.y
+++ b/src/io/gml-parser.y
@@ -115,7 +115,7 @@ igraph_gml_tree_t *igraph_i_gml_merge(igraph_gml_tree_t *t1, igraph_gml_tree_t* 
 %token EOFF
 %token ERROR
 
-%destructor { igraph_Free($$.s); } string key KEYWORD;
+%destructor { IGRAPH_FREE($$.s); } string key KEYWORD;
 %destructor { igraph_gml_tree_destroy($$); } list keyvalue;
 
 %%
@@ -159,7 +159,7 @@ int igraph_gml_yyerror(YYLTYPE* locp, igraph_i_gml_parsedata_t *context,
 
 void igraph_i_gml_get_keyword(char *s, int len, void *res) {
   struct { char *s; int len; } *p=res;
-  p->s=igraph_Calloc(len+1, char);
+  p->s=IGRAPH_CALLOC(len+1, char);
   if (!p->s) { 
     igraph_error("Cannot read GML file", IGRAPH_FILE_BASENAME, __LINE__, IGRAPH_PARSEERROR);
   }
@@ -170,7 +170,7 @@ void igraph_i_gml_get_keyword(char *s, int len, void *res) {
 
 void igraph_i_gml_get_string(char *s, int len, void *res) {
   struct { char *s; int len; } *p=res;
-  p->s=igraph_Calloc(len-1, char);
+  p->s=IGRAPH_CALLOC(len-1, char);
   if (!p->s) { 
     igraph_error("Cannot read GML file", IGRAPH_FILE_BASENAME, __LINE__, IGRAPH_PARSEERROR);
   }
@@ -189,7 +189,7 @@ double igraph_i_gml_get_real(char *s, int len) {
 } 
 
 igraph_gml_tree_t *igraph_i_gml_make_numeric(char* s, int len, double value) {
-  igraph_gml_tree_t *t = igraph_Calloc(1, igraph_gml_tree_t);
+  igraph_gml_tree_t *t = IGRAPH_CALLOC(1, igraph_gml_tree_t);
 
   if (!t) { 
     igraph_error("Cannot build GML tree", IGRAPH_FILE_BASENAME, __LINE__, IGRAPH_ENOMEM);
@@ -213,7 +213,7 @@ igraph_gml_tree_t *igraph_i_gml_make_numeric(char* s, int len, double value) {
 
 igraph_gml_tree_t *igraph_i_gml_make_numeric2(char* s, int len, 
                                               char* v, int vlen) {
-  igraph_gml_tree_t *t = igraph_Calloc(1, igraph_gml_tree_t);
+  igraph_gml_tree_t *t = IGRAPH_CALLOC(1, igraph_gml_tree_t);
   char tmp = v[vlen];
 
   if (!t) { 
@@ -255,7 +255,7 @@ igraph_gml_tree_t *igraph_i_gml_make_numeric2(char* s, int len,
 
 igraph_gml_tree_t *igraph_i_gml_make_string(char* s, int len, 
                                             char *value, int valuelen) {
-  igraph_gml_tree_t *t = igraph_Calloc(1, igraph_gml_tree_t);
+  igraph_gml_tree_t *t = IGRAPH_CALLOC(1, igraph_gml_tree_t);
 
   if (!t) { 
     igraph_error("Cannot build GML tree", IGRAPH_FILE_BASENAME, __LINE__, IGRAPH_ENOMEM);
@@ -277,7 +277,7 @@ igraph_gml_tree_t *igraph_i_gml_make_string(char* s, int len,
 igraph_gml_tree_t *igraph_i_gml_make_list(char* s, int len, 
                                           igraph_gml_tree_t *list) {
   
-  igraph_gml_tree_t *t=igraph_Calloc(1, igraph_gml_tree_t);
+  igraph_gml_tree_t *t=IGRAPH_CALLOC(1, igraph_gml_tree_t);
 
   if (!t) { 
     igraph_error("Cannot build GML tree", IGRAPH_FILE_BASENAME, __LINE__, IGRAPH_ENOMEM);
@@ -295,7 +295,7 @@ igraph_gml_tree_t *igraph_i_gml_make_list(char* s, int len,
 igraph_gml_tree_t *igraph_i_gml_merge(igraph_gml_tree_t *t1, igraph_gml_tree_t* t2) {
 
   igraph_gml_tree_mergedest(t1, t2);
-  igraph_Free(t2);
+  IGRAPH_FREE(t2);
 
   return t1;
 }

--- a/src/io/gml-tree.c
+++ b/src/io/gml-tree.c
@@ -47,7 +47,7 @@ int igraph_gml_tree_init_integer(igraph_gml_tree_t *t,
     VECTOR(t->types)[0] = IGRAPH_I_GML_TREE_INTEGER;
 
     /* children */
-    p = igraph_Calloc(1, igraph_integer_t);
+    p = IGRAPH_CALLOC(1, igraph_integer_t);
     if (!p) {
         IGRAPH_ERROR("Cannot create integer GML tree node", IGRAPH_ENOMEM);
     }
@@ -78,7 +78,7 @@ int igraph_gml_tree_init_real(igraph_gml_tree_t *t,
     VECTOR(t->types)[0] = IGRAPH_I_GML_TREE_REAL;
 
     /* children */
-    p = igraph_Calloc(1, igraph_real_t);
+    p = IGRAPH_CALLOC(1, igraph_real_t);
     if (!p) {
         IGRAPH_ERROR("Cannot create real GML tree node", IGRAPH_ENOMEM);
     }
@@ -163,19 +163,19 @@ void igraph_gml_tree_destroy(igraph_gml_tree_t *t) {
         switch (type) {
         case IGRAPH_I_GML_TREE_TREE:
             igraph_gml_tree_destroy(VECTOR(t->children)[i]);
-            igraph_Free(VECTOR(t->names)[i]);
+            IGRAPH_FREE(VECTOR(t->names)[i]);
             break;
         case IGRAPH_I_GML_TREE_INTEGER:
-            igraph_Free(VECTOR(t->children)[i]);
-            igraph_Free(VECTOR(t->names)[i]);
+            IGRAPH_FREE(VECTOR(t->children)[i]);
+            IGRAPH_FREE(VECTOR(t->names)[i]);
             break;
         case IGRAPH_I_GML_TREE_REAL:
-            igraph_Free(VECTOR(t->children)[i]);
-            igraph_Free(VECTOR(t->names)[i]);
+            IGRAPH_FREE(VECTOR(t->children)[i]);
+            IGRAPH_FREE(VECTOR(t->names)[i]);
             break;
         case IGRAPH_I_GML_TREE_STRING:
-            igraph_Free(VECTOR(t->children)[i]);
-            igraph_Free(VECTOR(t->names)[i]);
+            IGRAPH_FREE(VECTOR(t->children)[i]);
+            IGRAPH_FREE(VECTOR(t->names)[i]);
             break;
         case IGRAPH_I_GML_TREE_DELETED:
             break;
@@ -184,7 +184,7 @@ void igraph_gml_tree_destroy(igraph_gml_tree_t *t) {
     igraph_vector_ptr_destroy(&t->names);
     igraph_vector_char_destroy(&t->types);
     igraph_vector_ptr_destroy(&t->children);
-    igraph_Free(t);
+    IGRAPH_FREE(t);
 }
 
 long int igraph_gml_tree_length(const igraph_gml_tree_t *t) {
@@ -252,8 +252,8 @@ void igraph_gml_tree_delete(igraph_gml_tree_t *t, long int pos) {
     if (VECTOR(t->types)[pos] == IGRAPH_I_GML_TREE_TREE) {
         igraph_gml_tree_destroy(VECTOR(t->children)[pos]);
     }
-    igraph_Free(VECTOR(t->names)[pos]);
-    igraph_Free(VECTOR(t->children)[pos]);
+    IGRAPH_FREE(VECTOR(t->names)[pos]);
+    IGRAPH_FREE(VECTOR(t->children)[pos]);
     VECTOR(t->children)[pos] = 0;
     VECTOR(t->names)[pos] = 0;
     VECTOR(t->types)[pos] = IGRAPH_I_GML_TREE_DELETED;

--- a/src/io/gml.c
+++ b/src/io/gml.c
@@ -53,17 +53,17 @@ static void igraph_i_gml_destroy_attrs(igraph_vector_ptr_t **ptr) {
                 igraph_vector_t *value = (igraph_vector_t*)atrec->value;
                 if (value != 0) {
                     igraph_vector_destroy(value);
-                    igraph_Free(value);
+                    IGRAPH_FREE(value);
                 }
             } else {
                 igraph_strvector_t *value = (igraph_strvector_t*)atrec->value;
                 if (value != 0) {
                     igraph_strvector_destroy(value);
-                    igraph_Free(value);
+                    IGRAPH_FREE(value);
                 }
             }
-            igraph_Free(atrec->name);
-            igraph_Free(atrec);
+            IGRAPH_FREE(atrec->name);
+            IGRAPH_FREE(atrec);
         }
         igraph_vector_ptr_destroy(vec);
     }
@@ -277,7 +277,7 @@ int igraph_read_graph_gml(igraph_t *graph, FILE *instream) {
                 IGRAPH_CHECK(igraph_trie_get(&vattrnames, name, &trieid));
                 if (trieid == triesize) {
                     /* new attribute */
-                    igraph_attribute_record_t *atrec = igraph_Calloc(1, igraph_attribute_record_t);
+                    igraph_attribute_record_t *atrec = IGRAPH_CALLOC(1, igraph_attribute_record_t);
                     int type = igraph_gml_tree_type(node, j);
                     if (!atrec) {
                         IGRAPH_ERROR("Cannot read GML file.", IGRAPH_ENOMEM);
@@ -341,7 +341,7 @@ int igraph_read_graph_gml(igraph_t *graph, FILE *instream) {
                     IGRAPH_CHECK(igraph_trie_get(&eattrnames, name, &trieid));
                     if (trieid == triesize) {
                         /* new attribute */
-                        igraph_attribute_record_t *atrec = igraph_Calloc(1, igraph_attribute_record_t);
+                        igraph_attribute_record_t *atrec = IGRAPH_CALLOC(1, igraph_attribute_record_t);
                         int type = igraph_gml_tree_type(edge, j);
                         if (!atrec) {
                             IGRAPH_ERROR("Cannot read GML file.", IGRAPH_ENOMEM);
@@ -385,11 +385,11 @@ int igraph_read_graph_gml(igraph_t *graph, FILE *instream) {
         igraph_attribute_record_t *atrec = VECTOR(vattrs)[i];
         int type = atrec->type;
         if (type == IGRAPH_ATTRIBUTE_NUMERIC) {
-            igraph_vector_t *p = igraph_Calloc(1, igraph_vector_t);
+            igraph_vector_t *p = IGRAPH_CALLOC(1, igraph_vector_t);
             atrec->value = p;
             IGRAPH_CHECK(igraph_vector_init(p, no_of_nodes));
         } else if (type == IGRAPH_ATTRIBUTE_STRING) {
-            igraph_strvector_t *p = igraph_Calloc(1, igraph_strvector_t);
+            igraph_strvector_t *p = IGRAPH_CALLOC(1, igraph_strvector_t);
             atrec->value = p;
             IGRAPH_CHECK(igraph_strvector_init(p, no_of_nodes));
         } else {
@@ -401,11 +401,11 @@ int igraph_read_graph_gml(igraph_t *graph, FILE *instream) {
         igraph_attribute_record_t *atrec = VECTOR(eattrs)[i];
         int type = atrec->type;
         if (type == IGRAPH_ATTRIBUTE_NUMERIC) {
-            igraph_vector_t *p = igraph_Calloc(1, igraph_vector_t);
+            igraph_vector_t *p = IGRAPH_CALLOC(1, igraph_vector_t);
             atrec->value = p;
             IGRAPH_CHECK(igraph_vector_init(p, no_of_edges));
         } else if (type == IGRAPH_ATTRIBUTE_STRING) {
-            igraph_strvector_t *p = igraph_Calloc(1, igraph_strvector_t);
+            igraph_strvector_t *p = IGRAPH_CALLOC(1, igraph_strvector_t);
             atrec->value = p;
             IGRAPH_CHECK(igraph_strvector_init(p, no_of_edges));
         } else {
@@ -525,7 +525,7 @@ static int igraph_i_gml_convert_to_key(const char *orig, char **key) {
             newlen++;
         }
     }
-    *key = igraph_Calloc(newlen + 1, char);
+    *key = IGRAPH_CALLOC(newlen + 1, char);
     if (! *key) {
         IGRAPH_ERROR("Writing GML format failed.", IGRAPH_ENOMEM);
     }
@@ -675,7 +675,7 @@ int igraph_write_graph_gml(const igraph_t *graph, FILE *outstream,
         } else {
             IGRAPH_WARNING("A non-numeric, non-string, non-boolean graph attribute ignored");
         }
-        igraph_Free(newname);
+        IGRAPH_FREE(newname);
         IGRAPH_FINALLY_CLEAN(1);
     }
 
@@ -715,8 +715,12 @@ int igraph_write_graph_gml(const igraph_t *graph, FILE *outstream,
             } else {
                 IGRAPH_WARNING("A non-numeric, non-string, non-boolean edge attribute was ignored");
             }
+<<<<<<< HEAD
             igraph_Free(newname);
             IGRAPH_FINALLY_CLEAN(1);
+=======
+            IGRAPH_FREE(newname);
+>>>>>>> Change alloc macro case, use ? for macros
         }
         CHECK(fprintf(outstream, "  ]\n"));
     }
@@ -763,8 +767,12 @@ int igraph_write_graph_gml(const igraph_t *graph, FILE *outstream,
             } else {
                 IGRAPH_WARNING("A non-numeric, non-string, non-boolean edge attribute was ignored");
             }
+<<<<<<< HEAD
             igraph_Free(newname);
             IGRAPH_FINALLY_CLEAN(1);
+=======
+            IGRAPH_FREE(newname);
+>>>>>>> Change alloc macro case, use ? for macros
         }
         CHECK(fprintf(outstream, "  ]\n"));
     }

--- a/src/io/gml.c
+++ b/src/io/gml.c
@@ -715,12 +715,8 @@ int igraph_write_graph_gml(const igraph_t *graph, FILE *outstream,
             } else {
                 IGRAPH_WARNING("A non-numeric, non-string, non-boolean edge attribute was ignored");
             }
-<<<<<<< HEAD
-            igraph_Free(newname);
-            IGRAPH_FINALLY_CLEAN(1);
-=======
             IGRAPH_FREE(newname);
->>>>>>> Change alloc macro case, use ? for macros
+            IGRAPH_FINALLY_CLEAN(1);
         }
         CHECK(fprintf(outstream, "  ]\n"));
     }
@@ -767,12 +763,8 @@ int igraph_write_graph_gml(const igraph_t *graph, FILE *outstream,
             } else {
                 IGRAPH_WARNING("A non-numeric, non-string, non-boolean edge attribute was ignored");
             }
-<<<<<<< HEAD
-            igraph_Free(newname);
-            IGRAPH_FINALLY_CLEAN(1);
-=======
             IGRAPH_FREE(newname);
->>>>>>> Change alloc macro case, use ? for macros
+            IGRAPH_FINALLY_CLEAN(1);
         }
         CHECK(fprintf(outstream, "  ]\n"));
     }

--- a/src/io/graphml.c
+++ b/src/io/graphml.c
@@ -179,27 +179,27 @@ static void igraph_i_graphml_attribute_record_destroy(igraph_i_graphml_attribute
     if (rec->record.type == IGRAPH_ATTRIBUTE_NUMERIC) {
         if (rec->record.value != 0) {
             igraph_vector_destroy((igraph_vector_t*)rec->record.value);
-            igraph_Free(rec->record.value);
+            IGRAPH_FREE(rec->record.value);
         }
     } else if (rec->record.type == IGRAPH_ATTRIBUTE_STRING) {
         if (rec->record.value != 0) {
             igraph_strvector_destroy((igraph_strvector_t*)rec->record.value);
             if (rec->default_value.as_string != 0) {
-                igraph_Free(rec->default_value.as_string);
+                IGRAPH_FREE(rec->default_value.as_string);
             }
-            igraph_Free(rec->record.value);
+            IGRAPH_FREE(rec->record.value);
         }
     } else if (rec->record.type == IGRAPH_ATTRIBUTE_BOOLEAN) {
         if (rec->record.value != 0) {
             igraph_vector_bool_destroy((igraph_vector_bool_t*)rec->record.value);
-            igraph_Free(rec->record.value);
+            IGRAPH_FREE(rec->record.value);
         }
     }
     if (rec->id != 0) {
-        igraph_Free(rec->id);
+        IGRAPH_FREE(rec->id);
     }
     if (rec->record.name != 0) {
-        igraph_Free(rec->record.name);
+        IGRAPH_FREE(rec->record.name);
     }
 }
 
@@ -242,7 +242,7 @@ static void igraph_i_graphml_sax_handler_error(void *state0, const char* msg, ..
     va_start(ap, msg);
 
     if (state->error_message == 0) {
-        state->error_message = igraph_Calloc(4096, char);
+        state->error_message = IGRAPH_CALLOC(4096, char);
     }
 
     state->successful = 0;
@@ -578,7 +578,7 @@ static igraph_i_graphml_attribute_record_t* igraph_i_graphml_add_attribute_key(
         return 0;
     }
 
-    rec = igraph_Calloc(1, igraph_i_graphml_attribute_record_t);
+    rec = IGRAPH_CALLOC(1, igraph_i_graphml_attribute_record_t);
     if (rec == 0) {
         GRAPHML_PARSE_ERROR_WITH_CODE(state, "Cannot parse GraphML file", IGRAPH_ENOMEM);
         return 0;
@@ -720,7 +720,7 @@ static igraph_i_graphml_attribute_record_t* igraph_i_graphml_add_attribute_key(
         igraph_vector_bool_t *boolvec;
         igraph_strvector_t *strvec;
     case IGRAPH_ATTRIBUTE_BOOLEAN:
-        boolvec = igraph_Calloc(1, igraph_vector_bool_t);
+        boolvec = IGRAPH_CALLOC(1, igraph_vector_bool_t);
         if (boolvec == 0) {
             GRAPHML_PARSE_ERROR_WITH_CODE(state, "Cannot parse GraphML file", IGRAPH_ENOMEM);
             return 0;
@@ -729,7 +729,7 @@ static igraph_i_graphml_attribute_record_t* igraph_i_graphml_add_attribute_key(
         igraph_vector_bool_init(boolvec, 0);
         break;
     case IGRAPH_ATTRIBUTE_NUMERIC:
-        vec = igraph_Calloc(1, igraph_vector_t);
+        vec = IGRAPH_CALLOC(1, igraph_vector_t);
         if (vec == 0) {
             GRAPHML_PARSE_ERROR_WITH_CODE(state, "Cannot parse GraphML file", IGRAPH_ENOMEM);
             return 0;
@@ -738,7 +738,7 @@ static igraph_i_graphml_attribute_record_t* igraph_i_graphml_add_attribute_key(
         igraph_vector_init(vec, 0);
         break;
     case IGRAPH_ATTRIBUTE_STRING:
-        strvec = igraph_Calloc(1, igraph_strvector_t);
+        strvec = IGRAPH_CALLOC(1, igraph_strvector_t);
         if (strvec == 0) {
             GRAPHML_PARSE_ERROR_WITH_CODE(state, "Cannot parse GraphML file", IGRAPH_ENOMEM);
             return 0;
@@ -795,10 +795,10 @@ static void igraph_i_graphml_append_to_data_char(struct igraph_i_graphml_parser_
 
     if (state->data_char) {
         data_char_new_start = (long int) strlen(state->data_char);
-        state->data_char = igraph_Realloc(state->data_char,
+        state->data_char = IGRAPH_REALLOC(state->data_char,
                                           (size_t)(data_char_new_start + len + 1), char);
     } else {
-        state->data_char = igraph_Calloc((size_t) len + 1, char);
+        state->data_char = IGRAPH_CALLOC((size_t) len + 1, char);
     }
     if (state->data_char == 0) {
         RETURN_GRAPHML_PARSE_ERROR_WITH_CODE(state, "Cannot parse GraphML file", IGRAPH_ENOMEM);
@@ -846,7 +846,7 @@ static void igraph_i_graphml_attribute_data_finish(struct igraph_i_graphml_parse
             IGRAPH_FILE_BASENAME, __LINE__, 0,
             key
         );
-        igraph_Free(state->data_char);
+        IGRAPH_FREE(state->data_char);
         return;
     }
 
@@ -858,7 +858,7 @@ static void igraph_i_graphml_attribute_data_finish(struct igraph_i_graphml_parse
             IGRAPH_FILE_BASENAME, __LINE__, 0,
             key
         );
-        igraph_Free(state->data_char);
+        IGRAPH_FREE(state->data_char);
         return;
     }
 
@@ -929,7 +929,7 @@ static void igraph_i_graphml_attribute_data_finish(struct igraph_i_graphml_parse
     }
 
     if (state->data_char) {
-        igraph_Free(state->data_char);
+        IGRAPH_FREE(state->data_char);
     }
 }
 
@@ -970,7 +970,7 @@ static void igraph_i_graphml_attribute_default_value_finish(
     }
 
     if (state->data_char) {
-        igraph_Free(state->data_char);
+        IGRAPH_FREE(state->data_char);
     }
 }
 
@@ -1327,7 +1327,7 @@ static int igraph_i_xml_escape(char* src, char** dest) {
             IGRAPH_ERROR(msg, IGRAPH_EINVAL);
         }
     }
-    *dest = igraph_Calloc(destlen + 1, char);
+    *dest = IGRAPH_CALLOC(destlen + 1, char);
     if (!*dest) {
         IGRAPH_ERROR("Not enough memory", IGRAPH_ENOMEM);
     }
@@ -1571,7 +1571,7 @@ int igraph_write_graph_graphml(const igraph_t *graph, FILE *outstream,
                 IGRAPH_ERROR("Write failed", IGRAPH_EFILE);
             }
         }
-        igraph_Free(name_escaped);
+        IGRAPH_FREE(name_escaped);
     }
 
     /* vertex attributes */
@@ -1595,7 +1595,7 @@ int igraph_write_graph_graphml(const igraph_t *graph, FILE *outstream,
                 IGRAPH_ERROR("Write failed", IGRAPH_EFILE);
             }
         }
-        igraph_Free(name_escaped);
+        IGRAPH_FREE(name_escaped);
     }
 
     /* edge attributes */
@@ -1619,7 +1619,7 @@ int igraph_write_graph_graphml(const igraph_t *graph, FILE *outstream,
                 IGRAPH_ERROR("Write failed", IGRAPH_EFILE);
             }
         }
-        igraph_Free(name_escaped);
+        IGRAPH_FREE(name_escaped);
     }
 
     ret = fprintf(outstream, "  <graph id=\"G\" edgedefault=\"%s\">\n", (igraph_is_directed(graph) ? "directed" : "undirected"));
@@ -1637,7 +1637,7 @@ int igraph_write_graph_graphml(const igraph_t *graph, FILE *outstream,
             if (!isnan(VECTOR(numv)[0])) {
                 IGRAPH_CHECK(igraph_i_xml_escape(name, &name_escaped));
                 ret = fprintf(outstream, "    <data key=\"%s%s\">", gprefix, name_escaped);
-                igraph_Free(name_escaped);
+                IGRAPH_FREE(name_escaped);
                 if (ret < 0) {
                     IGRAPH_ERROR("Write failed", IGRAPH_EFILE);
                 }
@@ -1656,12 +1656,12 @@ int igraph_write_graph_graphml(const igraph_t *graph, FILE *outstream,
             IGRAPH_CHECK(igraph_i_xml_escape(name, &name_escaped));
             ret = fprintf(outstream, "    <data key=\"%s%s\">", gprefix,
                           name_escaped);
-            igraph_Free(name_escaped);
+            IGRAPH_FREE(name_escaped);
             IGRAPH_CHECK(igraph_i_attribute_get_string_graph_attr(graph, name, &strv));
             igraph_strvector_get(&strv, 0, &s);
             IGRAPH_CHECK(igraph_i_xml_escape(s, &s_escaped));
             ret = fprintf(outstream, "%s", s_escaped);
-            igraph_Free(s_escaped);
+            IGRAPH_FREE(s_escaped);
             if (ret < 0) {
                 IGRAPH_ERROR("Write failed", IGRAPH_EFILE);
             }
@@ -1675,7 +1675,7 @@ int igraph_write_graph_graphml(const igraph_t *graph, FILE *outstream,
             IGRAPH_CHECK(igraph_i_xml_escape(name, &name_escaped));
             ret = fprintf(outstream, "    <data key=\"%s%s\">%s</data>\n",
                           gprefix, name_escaped, VECTOR(boolv)[0] ? "true" : "false");
-            igraph_Free(name_escaped);
+            IGRAPH_FREE(name_escaped);
             if (ret < 0) {
                 IGRAPH_ERROR("Write failed", IGRAPH_EFILE);
             }
@@ -1700,7 +1700,7 @@ int igraph_write_graph_graphml(const igraph_t *graph, FILE *outstream,
                 if (!isnan(VECTOR(numv)[0])) {
                     IGRAPH_CHECK(igraph_i_xml_escape(name, &name_escaped));
                     ret = fprintf(outstream, "      <data key=\"%s%s\">", vprefix, name_escaped);
-                    igraph_Free(name_escaped);
+                    IGRAPH_FREE(name_escaped);
                     if (ret < 0) {
                         IGRAPH_ERROR("Write failed", IGRAPH_EFILE);
                     }
@@ -1719,13 +1719,13 @@ int igraph_write_graph_graphml(const igraph_t *graph, FILE *outstream,
                 IGRAPH_CHECK(igraph_i_xml_escape(name, &name_escaped));
                 ret = fprintf(outstream, "      <data key=\"%s%s\">", vprefix,
                               name_escaped);
-                igraph_Free(name_escaped);
+                IGRAPH_FREE(name_escaped);
                 IGRAPH_CHECK(igraph_i_attribute_get_string_vertex_attr(graph, name,
                              igraph_vss_1(l), &strv));
                 igraph_strvector_get(&strv, 0, &s);
                 IGRAPH_CHECK(igraph_i_xml_escape(s, &s_escaped));
                 ret = fprintf(outstream, "%s", s_escaped);
-                igraph_Free(s_escaped);
+                IGRAPH_FREE(s_escaped);
                 if (ret < 0) {
                     IGRAPH_ERROR("Write failed", IGRAPH_EFILE);
                 }
@@ -1740,7 +1740,7 @@ int igraph_write_graph_graphml(const igraph_t *graph, FILE *outstream,
                 IGRAPH_CHECK(igraph_i_xml_escape(name, &name_escaped));
                 ret = fprintf(outstream, "      <data key=\"%s%s\">%s</data>\n",
                               vprefix, name_escaped, VECTOR(boolv)[0] ? "true" : "false");
-                igraph_Free(name_escaped);
+                IGRAPH_FREE(name_escaped);
                 if (ret < 0) {
                     IGRAPH_ERROR("Write failed", IGRAPH_EFILE);
                 }
@@ -1775,7 +1775,7 @@ int igraph_write_graph_graphml(const igraph_t *graph, FILE *outstream,
                 if (!isnan(VECTOR(numv)[0])) {
                     IGRAPH_CHECK(igraph_i_xml_escape(name, &name_escaped));
                     ret = fprintf(outstream, "      <data key=\"%s%s\">", eprefix, name_escaped);
-                    igraph_Free(name_escaped);
+                    IGRAPH_FREE(name_escaped);
                     if (ret < 0) {
                         IGRAPH_ERROR("Write failed", IGRAPH_EFILE);
                     }
@@ -1794,13 +1794,13 @@ int igraph_write_graph_graphml(const igraph_t *graph, FILE *outstream,
                 IGRAPH_CHECK(igraph_i_xml_escape(name, &name_escaped));
                 ret = fprintf(outstream, "      <data key=\"%s%s\">", eprefix,
                               name_escaped);
-                igraph_Free(name_escaped);
+                IGRAPH_FREE(name_escaped);
                 IGRAPH_CHECK(igraph_i_attribute_get_string_edge_attr(graph, name,
                              igraph_ess_1((igraph_integer_t) edge), &strv));
                 igraph_strvector_get(&strv, 0, &s);
                 IGRAPH_CHECK(igraph_i_xml_escape(s, &s_escaped));
                 ret = fprintf(outstream, "%s", s_escaped);
-                igraph_Free(s_escaped);
+                IGRAPH_FREE(s_escaped);
                 if (ret < 0) {
                     IGRAPH_ERROR("Write failed", IGRAPH_EFILE);
                 }
@@ -1815,7 +1815,7 @@ int igraph_write_graph_graphml(const igraph_t *graph, FILE *outstream,
                 IGRAPH_CHECK(igraph_i_xml_escape(name, &name_escaped));
                 ret = fprintf(outstream, "      <data key=\"%s%s\">%s</data>\n",
                               eprefix, name_escaped, VECTOR(boolv)[0] ? "true" : "false");
-                igraph_Free(name_escaped);
+                IGRAPH_FREE(name_escaped);
                 if (ret < 0) {
                     IGRAPH_ERROR("Write failed", IGRAPH_EFILE);
                 }

--- a/src/io/lgl-parser.y
+++ b/src/io/lgl-parser.y
@@ -140,11 +140,11 @@ int igraph_lgl_yyerror(YYLTYPE* locp, igraph_i_lgl_parsedata_t *context,
 
 igraph_real_t igraph_lgl_get_number(const char *str, long int length) {
   igraph_real_t num;
-  char *tmp=igraph_Calloc(length+1, char);
+  char *tmp=IGRAPH_CALLOC(length+1, char);
   
   strncpy(tmp, str, length);
   tmp[length]='\0';
   sscanf(tmp, "%lf", &num);
-  igraph_Free(tmp);
+  IGRAPH_FREE(tmp);
   return num;
 } 

--- a/src/io/ncol-parser.y
+++ b/src/io/ncol-parser.y
@@ -134,11 +134,11 @@ int igraph_ncol_yyerror(YYLTYPE* locp,
 
 igraph_real_t igraph_ncol_get_number(const char *str, long int length) {
   igraph_real_t num;
-  char *tmp=igraph_Calloc(length+1, char);
+  char *tmp=IGRAPH_CALLOC(length+1, char);
   
   strncpy(tmp, str, length);
   tmp[length]='\0';
   sscanf(tmp, "%lf", &num);
-  igraph_Free(tmp);
+  IGRAPH_FREE(tmp);
   return num;
 } 

--- a/src/io/pajek-parser.y
+++ b/src/io/pajek-parser.y
@@ -529,12 +529,12 @@ int igraph_pajek_yyerror(YYLTYPE* locp,
 
 igraph_real_t igraph_pajek_get_number(const char *str, long int length) {
   igraph_real_t num;
-  char *tmp=igraph_Calloc(length+1, char);
+  char *tmp=IGRAPH_CALLOC(length+1, char);
   
   strncpy(tmp, str, length);
   tmp[length]='\0';
   sscanf(tmp, "%lf", &num);
-  igraph_Free(tmp);
+  IGRAPH_FREE(tmp);
   return num;
 } 
 
@@ -554,8 +554,8 @@ int igraph_i_pajek_add_numeric_attribute(igraph_trie_t *names,
   igraph_trie_get(names, attrname, &id);
   if (id == attrsize) {
     /* add a new attribute */
-    rec=igraph_Calloc(1, igraph_attribute_record_t);
-    na=igraph_Calloc(1, igraph_vector_t);
+    rec=IGRAPH_CALLOC(1, igraph_attribute_record_t);
+    na=IGRAPH_CALLOC(1, igraph_vector_t);
     igraph_vector_init(na, count);
     rec->name=strdup(attrname);
     rec->type=IGRAPH_ATTRIBUTE_NUMERIC;
@@ -597,8 +597,8 @@ int igraph_i_pajek_add_string_attribute(igraph_trie_t *names,
   igraph_trie_get(names, attrname, &id);
   if (id == attrsize) {
     /* add a new attribute */
-    rec=igraph_Calloc(1, igraph_attribute_record_t);
-    na=igraph_Calloc(1, igraph_strvector_t);
+    rec=IGRAPH_CALLOC(1, igraph_attribute_record_t);
+    na=IGRAPH_CALLOC(1, igraph_strvector_t);
     igraph_strvector_init(na, count);
     for (i=0; i<count; i++) {
       igraph_strvector_set(na, i, "");
@@ -629,7 +629,7 @@ int igraph_i_pajek_add_string_vertex_attribute(const char *name,
   char *tmp;
   int ret;
 
-  tmp=igraph_Calloc(len+1, char);
+  tmp=IGRAPH_CALLOC(len+1, char);
   if (tmp==0) {
     IGRAPH_ERROR("cannot add element to hash table", IGRAPH_ENOMEM);
   }
@@ -643,7 +643,7 @@ int igraph_i_pajek_add_string_vertex_attribute(const char *name,
 					  name, context->actvertex-1,
 					  tmp);
   
-  igraph_Free(tmp);
+  IGRAPH_FREE(tmp);
   IGRAPH_FINALLY_CLEAN(1);
   
   return ret;
@@ -656,7 +656,7 @@ int igraph_i_pajek_add_string_edge_attribute(const char *name,
   char *tmp;
   int ret;
 
-  tmp=igraph_Calloc(len+1, char);
+  tmp=IGRAPH_CALLOC(len+1, char);
   if (tmp==0) {
     IGRAPH_ERROR("cannot add element to hash table", IGRAPH_ENOMEM);
   }
@@ -670,7 +670,7 @@ int igraph_i_pajek_add_string_edge_attribute(const char *name,
 					  name, context->actedge-1,
 					  tmp);
 
-  igraph_Free(tmp);
+  IGRAPH_FREE(tmp);
   IGRAPH_FINALLY_CLEAN(1);
   
   return ret;
@@ -722,8 +722,8 @@ int igraph_i_pajek_add_bipartite_type(igraph_i_pajek_parsedata_t *context) {
   }
   
   /* add a new attribute */
-  rec=igraph_Calloc(1, igraph_attribute_record_t);
-  na=igraph_Calloc(1, igraph_vector_t);
+  rec=IGRAPH_CALLOC(1, igraph_attribute_record_t);
+  na=IGRAPH_CALLOC(1, igraph_vector_t);
   igraph_vector_init(na, n);
   rec->name=strdup(attrname);
   rec->type=IGRAPH_ATTRIBUTE_NUMERIC;

--- a/src/io/pajek.c
+++ b/src/io/pajek.c
@@ -207,14 +207,14 @@ int igraph_read_graph_pajek(igraph_t *graph, FILE *instream) {
         if (rec->type == IGRAPH_ATTRIBUTE_NUMERIC) {
             igraph_vector_t *vec = (igraph_vector_t*) rec->value;
             igraph_vector_destroy(vec);
-            igraph_Free(vec);
+            IGRAPH_FREE(vec);
         } else if (rec->type == IGRAPH_ATTRIBUTE_STRING) {
             igraph_strvector_t *strvec = (igraph_strvector_t *)rec->value;
             igraph_strvector_destroy(strvec);
-            igraph_Free(strvec);
+            IGRAPH_FREE(strvec);
         }
         igraph_free( (char*)(rec->name));
-        igraph_Free(rec);
+        IGRAPH_FREE(rec);
     }
 
     for (i = 0; i < igraph_vector_ptr_size(&eattrs); i++) {
@@ -222,14 +222,14 @@ int igraph_read_graph_pajek(igraph_t *graph, FILE *instream) {
         if (rec->type == IGRAPH_ATTRIBUTE_NUMERIC) {
             igraph_vector_t *vec = (igraph_vector_t*) rec->value;
             igraph_vector_destroy(vec);
-            igraph_Free(vec);
+            IGRAPH_FREE(vec);
         } else if (rec->type == IGRAPH_ATTRIBUTE_STRING) {
             igraph_strvector_t *strvec = (igraph_strvector_t *)rec->value;
             igraph_strvector_destroy(strvec);
-            igraph_Free(strvec);
+            IGRAPH_FREE(strvec);
         }
         igraph_free( (char*)(rec->name));
-        igraph_Free(rec);
+        IGRAPH_FREE(rec);
     }
 
     igraph_vector_destroy(&edges);
@@ -326,7 +326,7 @@ static int igraph_i_pajek_escape(char* src, char** dest) {
          * reserved words in its format (like 'c' standing for color) and they
          * have to be quoted as well.
          */
-        *dest = igraph_Calloc(destlen + 3, char);
+        *dest = IGRAPH_CALLOC(destlen + 3, char);
         if (!*dest) {
             IGRAPH_ERROR("Not enough memory", IGRAPH_ENOMEM);
         }
@@ -338,7 +338,7 @@ static int igraph_i_pajek_escape(char* src, char** dest) {
         return IGRAPH_SUCCESS;
     }
 
-    *dest = igraph_Calloc(destlen + 3, char);
+    *dest = IGRAPH_CALLOC(destlen + 3, char);
     if (!*dest) {
         IGRAPH_ERROR("Not enough memory", IGRAPH_ENOMEM);
     }
@@ -604,7 +604,7 @@ int igraph_write_graph_pajek(const igraph_t *graph, FILE *outstream) {
                 igraph_strvector_get(&strv, 0, &s);
                 IGRAPH_CHECK(igraph_i_pajek_escape(s, &escaped));
                 fprintf(outstream, " %s", escaped);
-                igraph_Free(escaped);
+                IGRAPH_FREE(escaped);
             } else {
                 fprintf(outstream, " \"%li\"", id + 1);
             }
@@ -635,7 +635,7 @@ int igraph_write_graph_pajek(const igraph_t *graph, FILE *outstream) {
                 igraph_strvector_get(&strv, 0, &s);
                 IGRAPH_CHECK(igraph_i_pajek_escape(s, &escaped));
                 fprintf(outstream, " %s", escaped);
-                igraph_Free(escaped);
+                IGRAPH_FREE(escaped);
             }
 
             /* numeric parameters */
@@ -655,7 +655,7 @@ int igraph_write_graph_pajek(const igraph_t *graph, FILE *outstream) {
                 igraph_strvector_get(&strv, 0, &s);
                 IGRAPH_CHECK(igraph_i_pajek_escape(s, &escaped));
                 fprintf(outstream, " %s %s", vstrnames2[idx], escaped);
-                igraph_Free(escaped);
+                IGRAPH_FREE(escaped);
             }
 
             /* trailing newline */
@@ -743,7 +743,7 @@ int igraph_write_graph_pajek(const igraph_t *graph, FILE *outstream) {
             igraph_strvector_get(&strv, 0, &s);
             IGRAPH_CHECK(igraph_i_pajek_escape(s, &escaped));
             fprintf(outstream, " %s %s", estrnames2[idx], escaped);
-            igraph_Free(escaped);
+            IGRAPH_FREE(escaped);
         }
 
         /* trailing newline */

--- a/src/isomorphism/bliss.cc
+++ b/src/isomorphism/bliss.cc
@@ -160,7 +160,7 @@ inline int bliss_info_to_igraph(igraph_bliss_info_t *info, const Stats &stats) {
         mpz_init(group_size);
         stats.get_group_size().get(group_size);
         group_size_strlen = mpz_sizeinbase(group_size, /* base */ 10) + 2;
-        info->group_size = igraph_Calloc(group_size_strlen, char);
+        info->group_size = IGRAPH_CALLOC(group_size_strlen, char);
         if (! info->group_size) {
             IGRAPH_ERROR("Insufficient memory to retrieve automotphism group size.", IGRAPH_ENOMEM);
         }
@@ -197,7 +197,7 @@ public:
 
     void operator ()(unsigned int n, const unsigned int *aut) {
         int err;
-        igraph_vector_t *newvector = igraph_Calloc(1, igraph_vector_t);
+        igraph_vector_t *newvector = IGRAPH_CALLOC(1, igraph_vector_t);
         if (! newvector) {
             throw bad_alloc();
         }

--- a/src/isomorphism/lad.c
+++ b/src/isomorphism/lad.c
@@ -71,7 +71,7 @@
 /* helper to allocate an array of given size and free it using IGRAPH_FINALLY
  * when needed */
 #define ALLOC_ARRAY(VAR, SIZE, TYPE) { \
-        VAR = igraph_Calloc(SIZE, TYPE);   \
+        VAR = IGRAPH_CALLOC(SIZE, TYPE);   \
         if (VAR == 0) {                    \
             IGRAPH_ERROR("cannot allocate '" #VAR "' array in LAD isomorphism search", IGRAPH_ENOMEM); \
         }  \
@@ -81,7 +81,7 @@
 /* helper to allocate an array of given size and store its address in a
  * pointer array */
 #define ALLOC_ARRAY_IN_HISTORY(VAR, SIZE, TYPE, HISTORY) { \
-        VAR = igraph_Calloc(SIZE, TYPE);   \
+        VAR = IGRAPH_CALLOC(SIZE, TYPE);   \
         if (VAR == 0) {                    \
             IGRAPH_ERROR("cannot allocate '" #VAR "' array in LAD isomorphism search", IGRAPH_ENOMEM); \
         }  \
@@ -565,12 +565,12 @@ static int igraph_i_lad_initDomains(bool initialDomains,
                 MATRIX(D->firstMatch, u, v) = matchingSize;
                 matchingSize += VECTOR(Gp->nbSucc)[u];
                 if (VECTOR(Gp->nbSucc)[u] <= VECTOR(Gt->nbSucc)[v]) {
-                    mu = igraph_Calloc((long int) VECTOR(Gp->nbSucc)[u], int);
+                    mu = IGRAPH_CALLOC((long int) VECTOR(Gp->nbSucc)[u], int);
                     if (mu == 0) {
                         igraph_free(val); igraph_free(dom);
                         IGRAPH_ERROR("cannot allocate 'mu' array in igraph_i_lad_initDomains", IGRAPH_ENOMEM);
                     }
-                    mv = igraph_Calloc((long int) VECTOR(Gt->nbSucc)[v], int);
+                    mv = IGRAPH_CALLOC((long int) VECTOR(Gt->nbSucc)[v], int);
                     if (mv == 0) {
                         igraph_free(mu); igraph_free(val); igraph_free(dom);
                         IGRAPH_ERROR("cannot allocate 'mv' array in igraph_i_lad_initDomains", IGRAPH_ENOMEM);
@@ -1413,7 +1413,7 @@ static int igraph_i_lad_solve(int timeLimit, bool firstSol, bool induced,
             }
         }
         if (maps) {
-            vec = igraph_Calloc(1, igraph_vector_t);
+            vec = IGRAPH_CALLOC(1, igraph_vector_t);
             if (!vec) {
                 IGRAPH_ERROR("LAD failed", IGRAPH_ENOMEM);
             }

--- a/src/isomorphism/vf2.c
+++ b/src/isomorphism/vf2.c
@@ -864,7 +864,7 @@ static igraph_bool_t igraph_i_get_isomorphisms_vf2(
 
     igraph_i_iso_cb_data_t *data = arg;
     igraph_vector_ptr_t *ptrvector = data->arg;
-    igraph_vector_t *newvector = igraph_Calloc(1, igraph_vector_t);
+    igraph_vector_t *newvector = IGRAPH_CALLOC(1, igraph_vector_t);
     IGRAPH_UNUSED(map12);
     if (!newvector) {
         igraph_error("Out of memory", IGRAPH_FILE_BASENAME, __LINE__, IGRAPH_ENOMEM);
@@ -1658,7 +1658,7 @@ static igraph_bool_t igraph_i_get_subisomorphisms_vf2(
 
     igraph_i_iso_cb_data_t *data = arg;
     igraph_vector_ptr_t *vector = data->arg;
-    igraph_vector_t *newvector = igraph_Calloc(1, igraph_vector_t);
+    igraph_vector_t *newvector = IGRAPH_CALLOC(1, igraph_vector_t);
     IGRAPH_UNUSED(map12);
     if (!newvector) {
         igraph_error("Out of memory", IGRAPH_FILE_BASENAME, __LINE__, IGRAPH_ENOMEM);

--- a/src/layout/mds.c
+++ b/src/layout/mds.c
@@ -240,7 +240,7 @@ int igraph_layout_mds(const igraph_t* graph, igraph_matrix_t *res,
         IGRAPH_CHECK(igraph_matrix_init(&dist_submatrix, 0, 0));
         IGRAPH_FINALLY(igraph_matrix_destroy, &dist_submatrix);
 
-        seen_vertices = igraph_Calloc(no_of_nodes, igraph_bool_t);
+        seen_vertices = IGRAPH_CALLOC(no_of_nodes, igraph_bool_t);
         if (seen_vertices == 0) {
             IGRAPH_ERROR("cannot calculate MDS layout", IGRAPH_ENOMEM);
         }
@@ -261,7 +261,7 @@ int igraph_layout_mds(const igraph_t* graph, igraph_matrix_t *res,
             IGRAPH_CHECK(igraph_matrix_select_rows_cols(&m, &dist_submatrix,
                          &comp, &comp));
             /* Allocate a new matrix for storing the layout */
-            layout = igraph_Calloc(1, igraph_matrix_t);
+            layout = IGRAPH_CALLOC(1, igraph_matrix_t);
             if (layout == 0) {
                 IGRAPH_ERROR("cannot calculate MDS layout", IGRAPH_ENOMEM);
             }

--- a/src/layout/merge_grid.c
+++ b/src/layout/merge_grid.c
@@ -58,7 +58,7 @@ int igraph_i_layout_mergegrid_init(igraph_i_layout_mergegrid_t *grid,
     grid->stepsy = stepsy;
     grid->deltay = (maxy - miny) / stepsy;
 
-    grid->data = igraph_Calloc(stepsx * stepsy, long int);
+    grid->data = IGRAPH_CALLOC(stepsx * stepsy, long int);
     if (grid->data == 0) {
         IGRAPH_ERROR("Cannot create grid", IGRAPH_ENOMEM);
     }
@@ -66,7 +66,7 @@ int igraph_i_layout_mergegrid_init(igraph_i_layout_mergegrid_t *grid,
 }
 
 void igraph_i_layout_mergegrid_destroy(igraph_i_layout_mergegrid_t *grid) {
-    igraph_Free(grid->data);
+    IGRAPH_FREE(grid->data);
 }
 
 #define MAT(i,j) (grid->data[(grid->stepsy)*(j)+(i)])

--- a/src/layout/reingold_tilford.c
+++ b/src/layout/reingold_tilford.c
@@ -148,7 +148,7 @@ static int igraph_i_layout_reingold_tilford(const igraph_t *graph,
     IGRAPH_CHECK(igraph_adjlist_init(graph, &allneis, mode, IGRAPH_NO_LOOPS, IGRAPH_NO_MULTIPLE));
     IGRAPH_FINALLY(igraph_adjlist_destroy, &allneis);
 
-    vdata = igraph_Calloc(no_of_nodes, struct igraph_i_reingold_tilford_vertex);
+    vdata = IGRAPH_CALLOC(no_of_nodes, struct igraph_i_reingold_tilford_vertex);
     if (vdata == 0) {
         IGRAPH_ERROR("igraph_layout_reingold_tilford failed", IGRAPH_ENOMEM);
     }

--- a/src/layout/sugiyama.c
+++ b/src/layout/sugiyama.c
@@ -175,7 +175,7 @@ static int igraph_i_layering_init(igraph_i_layering_t* layering,
     IGRAPH_FINALLY(igraph_vector_ptr_destroy_all, &layering->layers);
 
     for (i = 0; i < num_layers; i++) {
-        igraph_vector_t* vec = igraph_Calloc(1, igraph_vector_t);
+        igraph_vector_t* vec = IGRAPH_CALLOC(1, igraph_vector_t);
         IGRAPH_VECTOR_INIT_FINALLY(vec, 0);
         VECTOR(layering->layers)[i] = vec;
         IGRAPH_FINALLY_CLEAN(1);
@@ -762,7 +762,7 @@ static int igraph_i_layout_sugiyama_order_nodes_horizontally(const igraph_t* gra
     /* The first column of the matrix will serve as the ordering */
     /* Start with a first-seen ordering within each layer */
     {
-        long int *xs = igraph_Calloc(no_of_layers, long int);
+        long int *xs = IGRAPH_CALLOC(no_of_layers, long int);
         if (xs == 0) {
             IGRAPH_ERROR("cannot order nodes horizontally", IGRAPH_ENOMEM);
         }

--- a/src/linalg/arpack.c
+++ b/src/linalg/arpack.c
@@ -203,21 +203,21 @@ int igraph_arpack_storage_init(igraph_arpack_storage_t *s, long int maxn,
     } \
     IGRAPH_FINALLY(igraph_free, x);
 
-    s->v = igraph_Calloc(maxldv * maxncv, igraph_real_t); CHECKMEM(s->v);
-    s->workd = igraph_Calloc(3 * maxn, igraph_real_t); CHECKMEM(s->workd);
-    s->d = igraph_Calloc(2 * maxncv, igraph_real_t); CHECKMEM(s->d);
-    s->resid = igraph_Calloc(maxn, igraph_real_t); CHECKMEM(s->resid);
-    s->ax = igraph_Calloc(maxn, igraph_real_t); CHECKMEM(s->ax);
-    s->select = igraph_Calloc(maxncv, int); CHECKMEM(s->select);
+    s->v = IGRAPH_CALLOC(maxldv * maxncv, igraph_real_t); CHECKMEM(s->v);
+    s->workd = IGRAPH_CALLOC(3 * maxn, igraph_real_t); CHECKMEM(s->workd);
+    s->d = IGRAPH_CALLOC(2 * maxncv, igraph_real_t); CHECKMEM(s->d);
+    s->resid = IGRAPH_CALLOC(maxn, igraph_real_t); CHECKMEM(s->resid);
+    s->ax = IGRAPH_CALLOC(maxn, igraph_real_t); CHECKMEM(s->ax);
+    s->select = IGRAPH_CALLOC(maxncv, int); CHECKMEM(s->select);
 
     if (symm) {
-        s->workl = igraph_Calloc(maxncv * (maxncv + 8), igraph_real_t); CHECKMEM(s->workl);
+        s->workl = IGRAPH_CALLOC(maxncv * (maxncv + 8), igraph_real_t); CHECKMEM(s->workl);
         s->di = 0;
         s->workev = 0;
     } else {
-        s->workl = igraph_Calloc(3 * maxncv * (maxncv + 2), igraph_real_t); CHECKMEM(s->workl);
-        s->di = igraph_Calloc(2 * maxncv, igraph_real_t); CHECKMEM(s->di);
-        s->workev = igraph_Calloc(3 * maxncv, igraph_real_t); CHECKMEM(s->workev);
+        s->workl = IGRAPH_CALLOC(3 * maxncv * (maxncv + 2), igraph_real_t); CHECKMEM(s->workl);
+        s->di = IGRAPH_CALLOC(2 * maxncv, igraph_real_t); CHECKMEM(s->di);
+        s->workev = IGRAPH_CALLOC(3 * maxncv, igraph_real_t); CHECKMEM(s->workev);
         IGRAPH_FINALLY_CLEAN(2);
     }
 
@@ -240,19 +240,19 @@ int igraph_arpack_storage_init(igraph_arpack_storage_t *s, long int maxn,
 void igraph_arpack_storage_destroy(igraph_arpack_storage_t *s) {
 
     if (s->di) {
-        igraph_Free(s->di);
+        IGRAPH_FREE(s->di);
     }
     if (s->workev) {
-        igraph_Free(s->workev);
+        IGRAPH_FREE(s->workev);
     }
 
-    igraph_Free(s->workl);
-    igraph_Free(s->select);
-    igraph_Free(s->ax);
-    igraph_Free(s->resid);
-    igraph_Free(s->d);
-    igraph_Free(s->workd);
-    igraph_Free(s->v);
+    IGRAPH_FREE(s->workl);
+    IGRAPH_FREE(s->select);
+    IGRAPH_FREE(s->ax);
+    IGRAPH_FREE(s->resid);
+    IGRAPH_FREE(s->d);
+    IGRAPH_FREE(s->workd);
+    IGRAPH_FREE(s->v);
 }
 
 /**
@@ -928,13 +928,13 @@ int igraph_arpack_rssolve(igraph_arpack_function_t *fun, void *extra,
     } \
     IGRAPH_FINALLY(igraph_free, x);
 
-        v = igraph_Calloc(options->ldv * options->ncv, igraph_real_t); CHECKMEM(v);
-        workl = igraph_Calloc(options->lworkl, igraph_real_t); CHECKMEM(workl);
-        workd = igraph_Calloc(3 * options->n, igraph_real_t); CHECKMEM(workd);
-        d = igraph_Calloc(2 * options->ncv, igraph_real_t); CHECKMEM(d);
-        resid = igraph_Calloc(options->n, igraph_real_t); CHECKMEM(resid);
-        ax = igraph_Calloc(options->n, igraph_real_t); CHECKMEM(ax);
-        select = igraph_Calloc(options->ncv, int); CHECKMEM(select);
+        v = IGRAPH_CALLOC(options->ldv * options->ncv, igraph_real_t); CHECKMEM(v);
+        workl = IGRAPH_CALLOC(options->lworkl, igraph_real_t); CHECKMEM(workl);
+        workd = IGRAPH_CALLOC(3 * options->n, igraph_real_t); CHECKMEM(workd);
+        d = IGRAPH_CALLOC(2 * options->ncv, igraph_real_t); CHECKMEM(d);
+        resid = IGRAPH_CALLOC(options->n, igraph_real_t); CHECKMEM(resid);
+        ax = IGRAPH_CALLOC(options->n, igraph_real_t); CHECKMEM(ax);
+        select = IGRAPH_CALLOC(options->ncv, int); CHECKMEM(select);
 
 #undef CHECKMEM
 
@@ -1054,13 +1054,13 @@ int igraph_arpack_rssolve(igraph_arpack_function_t *fun, void *extra,
 
     /* Clean up if needed */
     if (free_them) {
-        igraph_Free(select);
-        igraph_Free(ax);
-        igraph_Free(resid);
-        igraph_Free(d);
-        igraph_Free(workd);
-        igraph_Free(workl);
-        igraph_Free(v);
+        IGRAPH_FREE(select);
+        IGRAPH_FREE(ax);
+        IGRAPH_FREE(resid);
+        IGRAPH_FREE(d);
+        IGRAPH_FREE(workd);
+        IGRAPH_FREE(workl);
+        IGRAPH_FREE(v);
         IGRAPH_FINALLY_CLEAN(7);
     }
     return 0;
@@ -1189,15 +1189,15 @@ int igraph_arpack_rnsolve(igraph_arpack_function_t *fun, void *extra,
     } \
     IGRAPH_FINALLY(igraph_free, x);
 
-        v = igraph_Calloc(options->n * options->ncv, igraph_real_t); CHECKMEM(v);
-        workl = igraph_Calloc(options->lworkl, igraph_real_t); CHECKMEM(workl);
-        workd = igraph_Calloc(3 * options->n, igraph_real_t); CHECKMEM(workd);
+        v = IGRAPH_CALLOC(options->n * options->ncv, igraph_real_t); CHECKMEM(v);
+        workl = IGRAPH_CALLOC(options->lworkl, igraph_real_t); CHECKMEM(workl);
+        workd = IGRAPH_CALLOC(3 * options->n, igraph_real_t); CHECKMEM(workd);
         d_size = 2 * options->nev + 1 > options->ncv ? 2 * options->nev + 1 : options->ncv;
-        dr = igraph_Calloc(d_size, igraph_real_t); CHECKMEM(dr);
-        di = igraph_Calloc(d_size, igraph_real_t); CHECKMEM(di);
-        resid = igraph_Calloc(options->n, igraph_real_t); CHECKMEM(resid);
-        select = igraph_Calloc(options->ncv, int); CHECKMEM(select);
-        workev = igraph_Calloc(3 * options->ncv, igraph_real_t); CHECKMEM(workev);
+        dr = IGRAPH_CALLOC(d_size, igraph_real_t); CHECKMEM(dr);
+        di = IGRAPH_CALLOC(d_size, igraph_real_t); CHECKMEM(di);
+        resid = IGRAPH_CALLOC(options->n, igraph_real_t); CHECKMEM(resid);
+        select = IGRAPH_CALLOC(options->ncv, int); CHECKMEM(select);
+        workev = IGRAPH_CALLOC(3 * options->ncv, igraph_real_t); CHECKMEM(workev);
 
 #undef CHECKMEM
 
@@ -1319,14 +1319,14 @@ int igraph_arpack_rnsolve(igraph_arpack_function_t *fun, void *extra,
 
     /* Clean up if needed */
     if (free_them) {
-        igraph_Free(workev);
-        igraph_Free(select);
-        igraph_Free(resid);
-        igraph_Free(di);
-        igraph_Free(dr);
-        igraph_Free(workd);
-        igraph_Free(workl);
-        igraph_Free(v);
+        IGRAPH_FREE(workev);
+        IGRAPH_FREE(select);
+        IGRAPH_FREE(resid);
+        IGRAPH_FREE(di);
+        IGRAPH_FREE(dr);
+        IGRAPH_FREE(workd);
+        IGRAPH_FREE(workl);
+        IGRAPH_FREE(v);
         IGRAPH_FINALLY_CLEAN(8);
     }
     return 0;

--- a/src/misc/cocitation.c
+++ b/src/misc/cocitation.c
@@ -456,7 +456,7 @@ int igraph_similarity_jaccard_pairs(const igraph_t *graph, igraph_vector_t *res,
     if (loops) {
         /* Add the loop edges */
         i = igraph_vcount(graph);
-        seen = igraph_Calloc(i, igraph_bool_t);
+        seen = IGRAPH_CALLOC(i, igraph_bool_t);
         if (seen == 0) {
             IGRAPH_ERROR("cannot calculate Jaccard similarity", IGRAPH_ENOMEM);
         }
@@ -474,7 +474,7 @@ int igraph_similarity_jaccard_pairs(const igraph_t *graph, igraph_vector_t *res,
             }
         }
 
-        igraph_Free(seen);
+        IGRAPH_FREE(seen);
         IGRAPH_FINALLY_CLEAN(1);
     }
 

--- a/src/misc/feedback_arc_set.c
+++ b/src/misc/feedback_arc_set.c
@@ -197,7 +197,7 @@ int igraph_i_feedback_arc_set_eades(const igraph_t *graph, igraph_vector_t *resu
     long int order_next_pos = 0, order_next_neg = -1;
     igraph_real_t diff, maxdiff;
 
-    ordering = igraph_Calloc(no_of_nodes, long int);
+    ordering = IGRAPH_CALLOC(no_of_nodes, long int);
     IGRAPH_FINALLY(igraph_free, ordering);
 
     IGRAPH_VECTOR_INIT_FINALLY(&indegrees, no_of_nodes);
@@ -468,7 +468,7 @@ int igraph_i_feedback_arc_set_ip(const igraph_t *graph, igraph_vector_t *result,
     IGRAPH_FINALLY(igraph_vector_ptr_destroy_all, &edges_by_components);
     for (i = 0; i < no_of_components; i++) {
         igraph_vector_t* vptr;
-        vptr = igraph_Calloc(1, igraph_vector_t);
+        vptr = IGRAPH_CALLOC(1, igraph_vector_t);
         if (vptr == 0) {
             IGRAPH_ERROR("cannot calculate feedback arc set using IP", IGRAPH_ENOMEM);
         }
@@ -480,7 +480,7 @@ int igraph_i_feedback_arc_set_ip(const igraph_t *graph, igraph_vector_t *result,
     IGRAPH_VECTOR_PTR_SET_ITEM_DESTRUCTOR(&vertices_by_components, igraph_vector_destroy);
     for (i = 0; i < no_of_components; i++) {
         igraph_vector_t* vptr;
-        vptr = igraph_Calloc(1, igraph_vector_t);
+        vptr = IGRAPH_CALLOC(1, igraph_vector_t);
         if (vptr == 0) {
             IGRAPH_ERROR("cannot calculate feedback arc set using IP", IGRAPH_ENOMEM);
         }

--- a/src/misc/motifs.c
+++ b/src/misc/motifs.c
@@ -237,13 +237,13 @@ int igraph_motifs_randesu_callback(const igraph_t *graph, int size,
         }
     }
 
-    added = igraph_Calloc(no_of_nodes, long int);
+    added = IGRAPH_CALLOC(no_of_nodes, long int);
     if (added == 0) {
         IGRAPH_ERROR("Cannot find motifs", IGRAPH_ENOMEM);
     }
     IGRAPH_FINALLY(igraph_free, added);
 
-    subg = igraph_Calloc(no_of_nodes, char);
+    subg = IGRAPH_CALLOC(no_of_nodes, char);
     if (subg == 0) {
         IGRAPH_ERROR("Cannot find motifs", IGRAPH_ENOMEM);
     }
@@ -411,8 +411,8 @@ int igraph_motifs_randesu_callback(const igraph_t *graph, int size,
 
     RNG_END();
 
-    igraph_Free(added);
-    igraph_Free(subg);
+    IGRAPH_FREE(added);
+    IGRAPH_FREE(subg);
     igraph_vector_destroy(&vids);
     igraph_vector_destroy(&adjverts);
     igraph_adjlist_destroy(&alloutneis);
@@ -479,7 +479,7 @@ int igraph_motifs_randesu_estimate(const igraph_t *graph, igraph_integer_t *est,
     long int sam;
     long int i;
 
-    added = igraph_Calloc(no_of_nodes, long int);
+    added = IGRAPH_CALLOC(no_of_nodes, long int);
     if (added == 0) {
         IGRAPH_ERROR("Cannot find motifs", IGRAPH_ENOMEM);
     }
@@ -492,7 +492,7 @@ int igraph_motifs_randesu_estimate(const igraph_t *graph, igraph_integer_t *est,
     IGRAPH_VECTOR_INIT_FINALLY(&neis, 0);
 
     if (parsample == 0) {
-        sample = igraph_Calloc(1, igraph_vector_t);
+        sample = IGRAPH_CALLOC(1, igraph_vector_t);
         if (sample == 0) {
             IGRAPH_ERROR("Cannot estimate motifs", IGRAPH_ENOMEM);
         }
@@ -627,11 +627,11 @@ int igraph_motifs_randesu_estimate(const igraph_t *graph, igraph_integer_t *est,
 
     if (parsample == 0) {
         igraph_vector_destroy(sample);
-        igraph_Free(sample);
+        IGRAPH_FREE(sample);
         IGRAPH_FINALLY_CLEAN(2);
     }
 
-    igraph_Free(added);
+    IGRAPH_FREE(added);
     igraph_vector_destroy(&vids);
     igraph_vector_destroy(&adjverts);
     igraph_stack_destroy(&stack);
@@ -675,7 +675,7 @@ int igraph_motifs_randesu_no(const igraph_t *graph, igraph_integer_t *no,
     long int father;
     long int i;
 
-    added = igraph_Calloc(no_of_nodes, long int);
+    added = IGRAPH_CALLOC(no_of_nodes, long int);
     if (added == 0) {
         IGRAPH_ERROR("Cannot find motifs", IGRAPH_ENOMEM);
     }
@@ -805,7 +805,7 @@ int igraph_motifs_randesu_no(const igraph_t *graph, igraph_integer_t *no,
 
     RNG_END();
 
-    igraph_Free(added);
+    IGRAPH_FREE(added);
     igraph_vector_destroy(&vids);
     igraph_vector_destroy(&adjverts);
     igraph_stack_destroy(&stack);

--- a/src/misc/scan.c
+++ b/src/misc/scan.c
@@ -287,7 +287,7 @@ static int igraph_i_local_scan_1_sumweights(const igraph_t *graph,
     IGRAPH_FINALLY(igraph_inclist_destroy, &allinc);
     IGRAPH_CHECK(igraph_i_trans4_il_simplify(graph, &allinc, &rank));
 
-    neis = igraph_Calloc(no_of_nodes, long int);
+    neis = IGRAPH_CALLOC(no_of_nodes, long int);
     if (neis == 0) {
         IGRAPH_ERROR("undirected local transitivity failed", IGRAPH_ENOMEM);
     }

--- a/src/misc/sir.c
+++ b/src/misc/sir.c
@@ -63,7 +63,7 @@ static void igraph_i_sir_destroy(igraph_vector_ptr_t *v) {
     for (i = 0; i < n; i++) {
         if ( VECTOR(*v)[i] ) {
             igraph_sir_destroy( VECTOR(*v)[i]) ;
-            igraph_Free( VECTOR(*v)[i] ); /* this also sets the vector_ptr element to NULL */
+            IGRAPH_FREE( VECTOR(*v)[i] ); /* this also sets the vector_ptr element to NULL */
         }
     }
 }
@@ -156,7 +156,7 @@ int igraph_sir(const igraph_t *graph, igraph_real_t beta,
     igraph_vector_ptr_null(result);
     IGRAPH_FINALLY(igraph_i_sir_destroy, result);
     for (i = 0; i < no_sim; i++) {
-        igraph_sir_t *sir = igraph_Calloc(1, igraph_sir_t);
+        igraph_sir_t *sir = IGRAPH_CALLOC(1, igraph_sir_t);
         if (!sir) {
             IGRAPH_ERROR("Cannot run SIR model", IGRAPH_ENOMEM);
         }

--- a/src/misc/spanning_trees.c
+++ b/src/misc/spanning_trees.c
@@ -218,12 +218,12 @@ static int igraph_i_minimum_spanning_tree_unweighted(const igraph_t* graph, igra
 
     igraph_vector_clear(res);
 
-    added_edges = igraph_Calloc(no_of_edges, char);
+    added_edges = IGRAPH_CALLOC(no_of_edges, char);
     if (added_edges == 0) {
         IGRAPH_ERROR("unweighted spanning tree failed", IGRAPH_ENOMEM);
     }
     IGRAPH_FINALLY(igraph_free, added_edges);
-    already_added = igraph_Calloc(no_of_nodes, char);
+    already_added = IGRAPH_CALLOC(no_of_nodes, char);
     if (already_added == 0) {
         IGRAPH_ERROR("unweighted spanning tree failed", IGRAPH_ENOMEM);
     }
@@ -262,9 +262,9 @@ static int igraph_i_minimum_spanning_tree_unweighted(const igraph_t* graph, igra
     }
 
     igraph_dqueue_destroy(&q);
-    igraph_Free(already_added);
+    IGRAPH_FREE(already_added);
     igraph_vector_destroy(&tmp);
-    igraph_Free(added_edges);
+    IGRAPH_FREE(added_edges);
     IGRAPH_FINALLY_CLEAN(4);
 
     return IGRAPH_SUCCESS;
@@ -295,12 +295,12 @@ static int igraph_i_minimum_spanning_tree_prim(
         IGRAPH_ERROR("Invalid weights length", IGRAPH_EINVAL);
     }
 
-    added_edges = igraph_Calloc(no_of_edges, char);
+    added_edges = IGRAPH_CALLOC(no_of_edges, char);
     if (added_edges == 0) {
         IGRAPH_ERROR("prim spanning tree failed", IGRAPH_ENOMEM);
     }
     IGRAPH_FINALLY(igraph_free, added_edges);
-    already_added = igraph_Calloc(no_of_nodes, char);
+    already_added = IGRAPH_CALLOC(no_of_nodes, char);
     if (already_added == 0) {
         IGRAPH_ERROR("prim spanning tree failed", IGRAPH_ENOMEM);
     }
@@ -363,9 +363,9 @@ static int igraph_i_minimum_spanning_tree_prim(
     } /* for all nodes */
 
     igraph_d_indheap_destroy(&heap);
-    igraph_Free(already_added);
+    IGRAPH_FREE(already_added);
     igraph_vector_destroy(&adj);
-    igraph_Free(added_edges);
+    IGRAPH_FREE(added_edges);
     IGRAPH_FINALLY_CLEAN(4);
 
     return IGRAPH_SUCCESS;

--- a/src/operators/connect_neighborhood.c
+++ b/src/operators/connect_neighborhood.c
@@ -82,7 +82,7 @@ int igraph_connect_neighborhood(igraph_t *graph, igraph_integer_t order,
     }
 
     IGRAPH_VECTOR_INIT_FINALLY(&edges, 0);
-    added = igraph_Calloc(no_of_nodes, long int);
+    added = IGRAPH_CALLOC(no_of_nodes, long int);
     if (added == 0) {
         IGRAPH_ERROR("Cannot connect neighborhood", IGRAPH_ENOMEM);
     }

--- a/src/operators/contract.c
+++ b/src/operators/contract.c
@@ -121,7 +121,7 @@ int igraph_contract_vertices(igraph_t *graph,
         igraph_vector_t sizes;
         igraph_vector_t *vecs;
 
-        vecs = igraph_Calloc(no_new_vertices, igraph_vector_t);
+        vecs = IGRAPH_CALLOC(no_new_vertices, igraph_vector_t);
         if (!vecs) {
             IGRAPH_ERROR("Cannot combine attributes while contracting"
                          " vertices", IGRAPH_ENOMEM);

--- a/src/operators/intersection.c
+++ b/src/operators/intersection.c
@@ -148,7 +148,7 @@ int igraph_intersection_many(igraph_t *res,
 
     if (edgemaps) {
         for (i = 0; i < no_of_graphs; i++) {
-            VECTOR(*edgemaps)[i] = igraph_Calloc(1, igraph_vector_t);
+            VECTOR(*edgemaps)[i] = IGRAPH_CALLOC(1, igraph_vector_t);
             if (!VECTOR(*edgemaps)[i]) {
                 IGRAPH_ERROR("Cannot intersect graphs", IGRAPH_ENOMEM);
             }
@@ -166,8 +166,8 @@ int igraph_intersection_many(igraph_t *res,
         IGRAPH_FINALLY(igraph_i_union_intersection_destroy_vector_longs, &order_vects);
     }
     for (i = 0; i < no_of_graphs; i++) {
-        VECTOR(edge_vects)[i] = igraph_Calloc(1, igraph_vector_t);
-        VECTOR(order_vects)[i] = igraph_Calloc(1, igraph_vector_long_t);
+        VECTOR(edge_vects)[i] = IGRAPH_CALLOC(1, igraph_vector_t);
+        VECTOR(order_vects)[i] = IGRAPH_CALLOC(1, igraph_vector_long_t);
         if (! VECTOR(edge_vects)[i] || ! VECTOR(order_vects)[i]) {
             IGRAPH_ERROR("Cannot intersect graphs", IGRAPH_ENOMEM);
         }

--- a/src/operators/misc_internal.c
+++ b/src/operators/misc_internal.c
@@ -33,7 +33,7 @@ void igraph_i_union_intersection_destroy_vectors(igraph_vector_ptr_t *v) {
     for (i = 0; i < n; i++) {
         if (VECTOR(*v)[i] != 0) {
             igraph_vector_destroy(VECTOR(*v)[i]);
-            igraph_Free(VECTOR(*v)[i]);
+            IGRAPH_FREE(VECTOR(*v)[i]);
         }
     }
     igraph_vector_ptr_destroy(v);
@@ -44,7 +44,7 @@ void igraph_i_union_intersection_destroy_vector_longs(igraph_vector_ptr_t *v) {
     for (i = 0; i < n; i++) {
         if (VECTOR(*v)[i] != 0) {
             igraph_vector_long_destroy(VECTOR(*v)[i]);
-            igraph_Free(VECTOR(*v)[i]);
+            IGRAPH_FREE(VECTOR(*v)[i]);
         }
     }
     igraph_vector_ptr_destroy(v);

--- a/src/operators/subgraph.c
+++ b/src/operators/subgraph.c
@@ -47,7 +47,7 @@ static int igraph_i_subgraph_copy_and_delete(const igraph_t *graph, igraph_t *re
     IGRAPH_FINALLY(igraph_vit_destroy, &vit);
 
     IGRAPH_VECTOR_INIT_FINALLY(&delete, 0);
-    remain = igraph_Calloc(no_of_nodes, char);
+    remain = IGRAPH_CALLOC(no_of_nodes, char);
     if (remain == 0) {
         IGRAPH_ERROR("subgraph failed", IGRAPH_ENOMEM);
     }
@@ -67,7 +67,7 @@ static int igraph_i_subgraph_copy_and_delete(const igraph_t *graph, igraph_t *re
         }
     }
 
-    igraph_Free(remain);
+    IGRAPH_FREE(remain);
     IGRAPH_FINALLY_CLEAN(1);
 
     /* must set res->attr to 0 before calling igraph_copy */
@@ -395,12 +395,12 @@ int igraph_subgraph_edges(const igraph_t *graph, igraph_t *res,
     IGRAPH_FINALLY(igraph_eit_destroy, &eit);
 
     IGRAPH_VECTOR_INIT_FINALLY(&delete, 0);
-    vremain = igraph_Calloc(no_of_nodes, char);
+    vremain = IGRAPH_CALLOC(no_of_nodes, char);
     if (vremain == 0) {
         IGRAPH_ERROR("subgraph_edges failed", IGRAPH_ENOMEM);
     }
     IGRAPH_FINALLY(igraph_free, vremain);
-    eremain = igraph_Calloc(no_of_edges, char);
+    eremain = IGRAPH_CALLOC(no_of_edges, char);
     if (eremain == 0) {
         IGRAPH_ERROR("subgraph_edges failed", IGRAPH_ENOMEM);
     }
@@ -423,7 +423,7 @@ int igraph_subgraph_edges(const igraph_t *graph, igraph_t *res,
         }
     }
 
-    igraph_Free(eremain);
+    IGRAPH_FREE(eremain);
     IGRAPH_FINALLY_CLEAN(1);
 
     /* Delete the unnecessary edges */
@@ -444,7 +444,7 @@ int igraph_subgraph_edges(const igraph_t *graph, igraph_t *res,
         }
     }
 
-    igraph_Free(vremain);
+    IGRAPH_FREE(vremain);
     IGRAPH_FINALLY_CLEAN(1);
 
     /* Delete the unnecessary vertices */

--- a/src/operators/union.c
+++ b/src/operators/union.c
@@ -147,7 +147,7 @@ int igraph_union_many(igraph_t *res, const igraph_vector_ptr_t *graphs,
 
     if (edgemaps) {
         for (i = 0; i < no_of_graphs; i++) {
-            VECTOR(*edgemaps)[i] = igraph_Calloc(1, igraph_vector_t);
+            VECTOR(*edgemaps)[i] = IGRAPH_CALLOC(1, igraph_vector_t);
             if (!VECTOR(*edgemaps)[i]) {
                 IGRAPH_ERROR("Cannot union graphs", IGRAPH_ENOMEM);
             }
@@ -164,8 +164,8 @@ int igraph_union_many(igraph_t *res, const igraph_vector_ptr_t *graphs,
         IGRAPH_FINALLY(igraph_i_union_intersection_destroy_vector_longs, &order_vects);
     }
     for (i = 0; i < no_of_graphs; i++) {
-        VECTOR(edge_vects)[i] = igraph_Calloc(1, igraph_vector_t);
-        VECTOR(order_vects)[i] = igraph_Calloc(1, igraph_vector_long_t);
+        VECTOR(edge_vects)[i] = IGRAPH_CALLOC(1, igraph_vector_t);
+        VECTOR(order_vects)[i] = IGRAPH_CALLOC(1, igraph_vector_long_t);
         if (! VECTOR(edge_vects)[i] || ! VECTOR(order_vects)[i]) {
             IGRAPH_ERROR("Cannot union graphs", IGRAPH_ENOMEM);
         }

--- a/src/paths/all_shortest_paths.c
+++ b/src/paths/all_shortest_paths.c
@@ -37,7 +37,7 @@ static void igraph_i_gasp_paths_destroy(igraph_vector_ptr_t *v) {
     for (i = 0; i < igraph_vector_ptr_size(v); i++) {
         if (VECTOR(*v)[i] != 0) {
             igraph_vector_destroy(VECTOR(*v)[i]);
-            igraph_Free(VECTOR(*v)[i]);
+            IGRAPH_FREE(VECTOR(*v)[i]);
         }
     }
     igraph_vector_ptr_destroy(v);
@@ -144,7 +144,7 @@ int igraph_get_all_shortest_paths(const igraph_t *graph,
      * is in the target vertex sequence. Otherwise it is
      * one larger than the length of the shortest path from the
      * source */
-    geodist = igraph_Calloc(no_of_nodes, long int);
+    geodist = IGRAPH_CALLOC(no_of_nodes, long int);
     if (geodist == 0) {
         IGRAPH_ERROR("Cannot calculate shortest paths", IGRAPH_ENOMEM);
     }
@@ -174,7 +174,7 @@ int igraph_get_all_shortest_paths(const igraph_t *graph,
     }
 
     /* from -> from */
-    vptr = igraph_Calloc(1, igraph_vector_t); /* TODO: dirty */
+    vptr = IGRAPH_CALLOC(1, igraph_vector_t); /* TODO: dirty */
     IGRAPH_CHECK(igraph_vector_ptr_push_back(&paths, vptr));
     IGRAPH_CHECK(igraph_vector_init(vptr, 1));
     VECTOR(*vptr)[0] = from;
@@ -246,7 +246,7 @@ int igraph_get_all_shortest_paths(const igraph_t *graph,
             fatherptr = (long int) VECTOR(ptrhead)[actnode];
             while (fatherptr != 0) {
                 /* allocate a new igraph_vector_t at the end of paths */
-                vptr = igraph_Calloc(1, igraph_vector_t);
+                vptr = IGRAPH_CALLOC(1, igraph_vector_t);
                 IGRAPH_CHECK(igraph_vector_ptr_push_back(&paths, vptr));
                 IGRAPH_CHECK(igraph_vector_copy(vptr, VECTOR(paths)[fatherptr - 1]));
                 IGRAPH_CHECK(igraph_vector_reserve(vptr, actdist + 2));
@@ -300,13 +300,13 @@ int igraph_get_all_shortest_paths(const igraph_t *graph,
             /* no, free them */
             while (fatherptr != 0) {
                 igraph_vector_destroy(VECTOR(paths)[fatherptr - 1]);
-                igraph_Free(VECTOR(paths)[fatherptr - 1]);
+                IGRAPH_FREE(VECTOR(paths)[fatherptr - 1]);
                 fatherptr = (long int) VECTOR(ptrlist)[fatherptr - 1];
             }
         }
     }
 
-    igraph_Free(geodist);
+    IGRAPH_FREE(geodist);
     igraph_vector_destroy(&ptrlist);
     igraph_vector_destroy(&ptrhead);
     igraph_vector_destroy(&neis);

--- a/src/paths/bellman_ford.c
+++ b/src/paths/bellman_ford.c
@@ -340,7 +340,7 @@ int igraph_get_shortest_paths_bellman_ford(const igraph_t *graph,
         IGRAPH_ERROR("Size of `edges' and `to' should match.", IGRAPH_EINVAL);
     }
 
-    parents = igraph_Calloc(no_of_nodes, long int);
+    parents = IGRAPH_CALLOC(no_of_nodes, long int);
     if (parents == 0) {
         IGRAPH_ERROR("Insufficient memory for shortest paths with Bellman-Ford.", IGRAPH_ENOMEM);
     }
@@ -477,7 +477,7 @@ int igraph_get_shortest_paths_bellman_ford(const igraph_t *graph,
     igraph_vit_destroy(&tovit);
     IGRAPH_FINALLY_CLEAN(1);
 
-    igraph_Free(parents);
+    IGRAPH_FREE(parents);
     igraph_dqueue_destroy(&Q);
     igraph_vector_destroy(&clean_vertices);
     igraph_vector_destroy(&num_queued);

--- a/src/paths/dijkstra.c
+++ b/src/paths/dijkstra.c
@@ -378,12 +378,12 @@ int igraph_get_shortest_paths_dijkstra(const igraph_t *graph,
     IGRAPH_VECTOR_INIT_FINALLY(&dists, no_of_nodes);
     igraph_vector_fill(&dists, -1.0);
 
-    parents = igraph_Calloc(no_of_nodes, long int);
+    parents = IGRAPH_CALLOC(no_of_nodes, long int);
     if (parents == 0) {
         IGRAPH_ERROR("Can't calculate shortest paths", IGRAPH_ENOMEM);
     }
     IGRAPH_FINALLY(igraph_free, parents);
-    is_target = igraph_Calloc(no_of_nodes, igraph_bool_t);
+    is_target = IGRAPH_CALLOC(no_of_nodes, igraph_bool_t);
     if (is_target == 0) {
         IGRAPH_ERROR("Can't calculate shortest paths", IGRAPH_ENOMEM);
     }
@@ -523,8 +523,8 @@ int igraph_get_shortest_paths_dijkstra(const igraph_t *graph,
     igraph_lazy_inclist_destroy(&inclist);
     igraph_2wheap_destroy(&Q);
     igraph_vector_destroy(&dists);
-    igraph_Free(is_target);
-    igraph_Free(parents);
+    IGRAPH_FREE(is_target);
+    IGRAPH_FREE(parents);
     igraph_vit_destroy(&vit);
     IGRAPH_FINALLY_CLEAN(6);
 
@@ -730,7 +730,7 @@ int igraph_get_all_shortest_paths_dijkstra(const igraph_t *graph,
     igraph_vector_ptr_set_item_destructor(&parents, (igraph_finally_func_t*)igraph_vector_destroy);
     for (i = 0; i < no_of_nodes; i++) {
         igraph_vector_t* parent_vec;
-        parent_vec = igraph_Calloc(1, igraph_vector_t);
+        parent_vec = IGRAPH_CALLOC(1, igraph_vector_t);
         if (parent_vec == 0) {
             IGRAPH_ERROR("cannot run igraph_get_all_shortest_paths", IGRAPH_ENOMEM);
         }
@@ -747,7 +747,7 @@ int igraph_get_all_shortest_paths_dijkstra(const igraph_t *graph,
     IGRAPH_VECTOR_INIT_FINALLY(&order, 0);
 
     /* boolean array to mark whether a given vertex is a target or not */
-    is_target = igraph_Calloc(no_of_nodes, unsigned char);
+    is_target = IGRAPH_CALLOC(no_of_nodes, unsigned char);
     if (is_target == 0) {
         IGRAPH_ERROR("Can't calculate shortest paths", IGRAPH_ENOMEM);
     }
@@ -957,7 +957,7 @@ int igraph_get_all_shortest_paths_dijkstra(const igraph_t *graph,
 
         /* by definition, the shortest path leading to the starting vertex
          * consists of the vertex itself only */
-        path = igraph_Calloc(1, igraph_vector_t);
+        path = IGRAPH_CALLOC(1, igraph_vector_t);
         if (path == 0)
             IGRAPH_ERROR("cannot run igraph_get_all_shortest_paths_dijkstra",
                          IGRAPH_ENOMEM);
@@ -1015,7 +1015,7 @@ int igraph_get_all_shortest_paths_dijkstra(const igraph_t *graph,
                         break;
                     }
 
-                    path = igraph_Calloc(1, igraph_vector_t);
+                    path = IGRAPH_CALLOC(1, igraph_vector_t);
                     if (path == 0)
                         IGRAPH_ERROR("cannot run igraph_get_all_shortest_paths_dijkstra",
                                      IGRAPH_ENOMEM);
@@ -1055,7 +1055,7 @@ int igraph_get_all_shortest_paths_dijkstra(const igraph_t *graph,
 
     /* free the allocated memory */
     igraph_vector_destroy(&order);
-    igraph_Free(is_target);
+    IGRAPH_FREE(is_target);
     igraph_vector_destroy(&dists);
     igraph_vector_ptr_destroy_all(&parents);
     IGRAPH_FINALLY_CLEAN(4);

--- a/src/paths/random_walk.c
+++ b/src/paths/random_walk.c
@@ -243,7 +243,7 @@ int igraph_random_edge_walk(const igraph_t *graph,
             if (IGRAPH_UNLIKELY(! *cd)) {
                 long j;
 
-                *cd = igraph_malloc(sizeof(igraph_vector_t));
+                *cd = IGRAPH_CALLOC(1, igraph_vector_t);
                 if (*cd == NULL) {
                     IGRAPH_ERROR("random edge walk failed", IGRAPH_ENOMEM);
                 }

--- a/src/paths/shortest_paths.c
+++ b/src/paths/shortest_paths.c
@@ -56,7 +56,7 @@ static int igraph_i_average_path_length_unweighted(
     igraph_adjlist_t allneis;
 
     *res = 0;
-    already_added = igraph_Calloc(no_of_nodes, long int);
+    already_added = IGRAPH_CALLOC(no_of_nodes, long int);
     if (already_added == 0) {
         IGRAPH_ERROR("Average path length calculation failed", IGRAPH_ENOMEM);
     }
@@ -128,7 +128,7 @@ static int igraph_i_average_path_length_unweighted(
         *unconnected_pairs = no_of_pairs - no_of_conn_pairs;
 
     /* clean */
-    igraph_Free(already_added);
+    IGRAPH_FREE(already_added);
     igraph_dqueue_destroy(&q);
     igraph_adjlist_destroy(&allneis);
     IGRAPH_FINALLY_CLEAN(3);
@@ -734,7 +734,7 @@ int igraph_local_efficiency(const igraph_t *graph, igraph_vector_t *res,
         igraph_adjlist_t adjlist;
         igraph_dqueue_t q = IGRAPH_DQUEUE_NULL;
 
-        already_counted = igraph_Calloc(no_of_nodes, long int);
+        already_counted = IGRAPH_CALLOC(no_of_nodes, long int);
         if (already_counted == 0) {
             IGRAPH_ERROR("Local efficiency calculation failed", IGRAPH_ENOMEM);
         }
@@ -761,7 +761,7 @@ int igraph_local_efficiency(const igraph_t *graph, igraph_vector_t *res,
 
         igraph_dqueue_destroy(&q);
         igraph_adjlist_destroy(&adjlist);
-        igraph_Free(already_counted);
+        IGRAPH_FREE(already_counted);
         IGRAPH_FINALLY_CLEAN(3);
     }
     else /* weighted case */
@@ -964,7 +964,7 @@ int igraph_diameter(const igraph_t *graph, igraph_real_t *pres,
     } else {
         dirmode = IGRAPH_ALL;
     }
-    already_added = igraph_Calloc(no_of_nodes, long int);
+    already_added = IGRAPH_CALLOC(no_of_nodes, long int);
     if (already_added == 0) {
         IGRAPH_ERROR("diameter failed", IGRAPH_ENOMEM);
     }
@@ -1046,7 +1046,7 @@ int igraph_diameter(const igraph_t *graph, igraph_real_t *pres,
     }
 
     /* clean */
-    igraph_Free(already_added);
+    IGRAPH_FREE(already_added);
     igraph_dqueue_destroy(&q);
     igraph_adjlist_destroy(&allneis);
     IGRAPH_FINALLY_CLEAN(3);

--- a/src/paths/unweighted.c
+++ b/src/paths/unweighted.c
@@ -104,7 +104,7 @@ int igraph_shortest_paths(const igraph_t *graph, igraph_matrix_t *res,
     IGRAPH_CHECK(igraph_adjlist_init(graph, &adjlist, mode, IGRAPH_LOOPS, IGRAPH_MULTIPLE));
     IGRAPH_FINALLY(igraph_adjlist_destroy, &adjlist);
 
-    already_counted = igraph_Calloc(no_of_nodes, long int);
+    already_counted = IGRAPH_CALLOC(no_of_nodes, long int);
     if (already_counted == 0) {
         IGRAPH_ERROR("shortest paths failed", IGRAPH_ENOMEM);
     }
@@ -179,7 +179,7 @@ int igraph_shortest_paths(const igraph_t *graph, igraph_matrix_t *res,
         IGRAPH_FINALLY_CLEAN(2);
     }
 
-    igraph_Free(already_counted);
+    IGRAPH_FREE(already_counted);
     igraph_dqueue_destroy(&q);
     igraph_vit_destroy(&fromvit);
     igraph_adjlist_destroy(&adjlist);
@@ -307,7 +307,7 @@ int igraph_get_shortest_paths(const igraph_t *graph,
         IGRAPH_ERROR("Size of the `edges' and the `to' should match", IGRAPH_EINVAL);
     }
 
-    father = igraph_Calloc(no_of_nodes, long int);
+    father = IGRAPH_CALLOC(no_of_nodes, long int);
     if (father == 0) {
         IGRAPH_ERROR("cannot get shortest paths", IGRAPH_ENOMEM);
     }
@@ -451,7 +451,7 @@ int igraph_get_shortest_paths(const igraph_t *graph,
     }
 
     /* Clean */
-    igraph_Free(father);
+    IGRAPH_FREE(father);
     igraph_dqueue_destroy(&q);
     igraph_vector_destroy(&tmp);
     igraph_vit_destroy(&vit);

--- a/src/properties/convergence_degree.c
+++ b/src/properties/convergence_degree.c
@@ -71,7 +71,7 @@ int igraph_convergence_degree(const igraph_t *graph, igraph_vector_t *result,
         igraph_vector_null(outs_p);
     }
 
-    geodist = igraph_Calloc(no_of_nodes, long int);
+    geodist = IGRAPH_CALLOC(no_of_nodes, long int);
     if (geodist == 0) {
         IGRAPH_ERROR("Cannot calculate convergence degrees", IGRAPH_ENOMEM);
     }
@@ -165,7 +165,7 @@ int igraph_convergence_degree(const igraph_t *graph, igraph_vector_t *result,
         IGRAPH_FINALLY_CLEAN(1);
     }
 
-    igraph_Free(geodist);
+    IGRAPH_FREE(geodist);
     igraph_dqueue_destroy(&q);
     IGRAPH_FINALLY_CLEAN(2);
 

--- a/src/properties/neighborhood.c
+++ b/src/properties/neighborhood.c
@@ -89,7 +89,7 @@ int igraph_neighborhood_size(const igraph_t *graph, igraph_vector_t *res,
                       IGRAPH_EINVAL, order, mindist);
     }
 
-    added = igraph_Calloc(no_of_nodes, long int);
+    added = IGRAPH_CALLOC(no_of_nodes, long int);
     if (added == 0) {
         IGRAPH_ERROR("Cannot calculate neighborhood size.", IGRAPH_ENOMEM);
     }
@@ -151,7 +151,7 @@ int igraph_neighborhood_size(const igraph_t *graph, igraph_vector_t *res,
     igraph_vector_destroy(&neis);
     igraph_vit_destroy(&vit);
     igraph_dqueue_destroy(&q);
-    igraph_Free(added);
+    IGRAPH_FREE(added);
     IGRAPH_FINALLY_CLEAN(4);
 
     return IGRAPH_SUCCESS;
@@ -221,7 +221,7 @@ int igraph_neighborhood(const igraph_t *graph, igraph_vector_ptr_t *res,
                      IGRAPH_EINVAL);
     }
 
-    added = igraph_Calloc(no_of_nodes, long int);
+    added = IGRAPH_CALLOC(no_of_nodes, long int);
     if (added == 0) {
         IGRAPH_ERROR("Cannot calculate neighborhood size", IGRAPH_ENOMEM);
     }
@@ -280,7 +280,7 @@ int igraph_neighborhood(const igraph_t *graph, igraph_vector_ptr_t *res,
 
         } /* while q not empty */
 
-        newv = igraph_Calloc(1, igraph_vector_t);
+        newv = IGRAPH_CALLOC(1, igraph_vector_t);
         if (newv == 0) {
             IGRAPH_ERROR("Cannot calculate neighborhood", IGRAPH_ENOMEM);
         }
@@ -294,7 +294,7 @@ int igraph_neighborhood(const igraph_t *graph, igraph_vector_ptr_t *res,
     igraph_vector_destroy(&neis);
     igraph_vit_destroy(&vit);
     igraph_dqueue_destroy(&q);
-    igraph_Free(added);
+    IGRAPH_FREE(added);
     IGRAPH_FINALLY_CLEAN(5);
 
     return IGRAPH_SUCCESS;
@@ -368,7 +368,7 @@ int igraph_neighborhood_graphs(const igraph_t *graph, igraph_vector_ptr_t *res,
                      IGRAPH_EINVAL);
     }
 
-    added = igraph_Calloc(no_of_nodes, long int);
+    added = IGRAPH_CALLOC(no_of_nodes, long int);
     if (added == 0) {
         IGRAPH_ERROR("Cannot calculate neighborhood size", IGRAPH_ENOMEM);
     }
@@ -427,7 +427,7 @@ int igraph_neighborhood_graphs(const igraph_t *graph, igraph_vector_ptr_t *res,
 
         } /* while q not empty */
 
-        newg = igraph_Calloc(1, igraph_t);
+        newg = IGRAPH_CALLOC(1, igraph_t);
         if (newg == 0) {
             IGRAPH_ERROR("Cannot create neighborhood graph", IGRAPH_ENOMEM);
         }
@@ -447,7 +447,7 @@ int igraph_neighborhood_graphs(const igraph_t *graph, igraph_vector_ptr_t *res,
     igraph_vector_destroy(&neis);
     igraph_vit_destroy(&vit);
     igraph_dqueue_destroy(&q);
-    igraph_Free(added);
+    IGRAPH_FREE(added);
     IGRAPH_FINALLY_CLEAN(5);
 
     return IGRAPH_SUCCESS;

--- a/src/properties/triangles.c
+++ b/src/properties/triangles.c
@@ -120,7 +120,7 @@ int igraph_transitivity_avglocal_undirected(const igraph_t *graph,
     IGRAPH_CHECK(igraph_adjlist_init(graph, &allneis, IGRAPH_ALL, IGRAPH_NO_LOOPS, IGRAPH_NO_MULTIPLE));
     IGRAPH_FINALLY(igraph_adjlist_destroy, &allneis);
 
-    neis = igraph_Calloc(no_of_nodes, long int);
+    neis = IGRAPH_CALLOC(no_of_nodes, long int);
     if (neis == 0) {
         IGRAPH_ERROR("Undirected average local transitivity failed.",
                      IGRAPH_ENOMEM);
@@ -171,7 +171,7 @@ int igraph_transitivity_avglocal_undirected(const igraph_t *graph,
     *res = sum / count;
 
     igraph_vector_destroy(&triangles);
-    igraph_Free(neis);
+    IGRAPH_FREE(neis);
     igraph_adjlist_destroy(&allneis);
     igraph_vector_destroy(&rank);
     igraph_vector_destroy(&order);
@@ -258,7 +258,7 @@ int igraph_transitivity_local_undirected2(const igraph_t *graph,
         VECTOR(rank)[ (long int) VECTOR(order)[i] ] = affected_nodes - i - 1;
     }
 
-    neis = igraph_Calloc(no_of_nodes, long int);
+    neis = IGRAPH_CALLOC(no_of_nodes, long int);
     if (neis == 0) {
         IGRAPH_ERROR("local transitivity calculation failed", IGRAPH_ENOMEM);
     }
@@ -666,7 +666,7 @@ int igraph_transitivity_undirected(const igraph_t *graph,
     IGRAPH_CHECK(igraph_adjlist_init(graph, &allneis, IGRAPH_ALL, IGRAPH_NO_LOOPS, IGRAPH_NO_MULTIPLE));
     IGRAPH_FINALLY(igraph_adjlist_destroy, &allneis);
 
-    neis = igraph_Calloc(no_of_nodes, long int);
+    neis = IGRAPH_CALLOC(no_of_nodes, long int);
     if (neis == 0) {
         IGRAPH_ERROR("undirected transitivity failed", IGRAPH_ENOMEM);
     }
@@ -701,7 +701,7 @@ int igraph_transitivity_undirected(const igraph_t *graph,
         }
     }
 
-    igraph_Free(neis);
+    IGRAPH_FREE(neis);
     igraph_adjlist_destroy(&allneis);
     igraph_vector_destroy(&rank);
     igraph_vector_destroy(&order);

--- a/src/properties/triangles_template.h
+++ b/src/properties/triangles_template.h
@@ -72,7 +72,7 @@ IGRAPH_CHECK(igraph_adjlist_init(graph, &allneis, IGRAPH_ALL, IGRAPH_LOOPS_TWICE
 IGRAPH_FINALLY(igraph_adjlist_destroy, &allneis);
 IGRAPH_CHECK(igraph_i_trans4_al_simplify(&allneis, &rank));
 
-neis = igraph_Calloc(no_of_nodes, long int);
+neis = IGRAPH_CALLOC(no_of_nodes, long int);
 if (neis == 0) {
     IGRAPH_ERROR("undirected local transitivity failed", IGRAPH_ENOMEM);
 }

--- a/src/properties/triangles_template1.h
+++ b/src/properties/triangles_template1.h
@@ -41,7 +41,7 @@ if (nodes_to_calc == 0) {
     return IGRAPH_SUCCESS;
 }
 
-neis = igraph_Calloc(no_of_nodes, long int);
+neis = IGRAPH_CALLOC(no_of_nodes, long int);
 if (neis == 0) {
     IGRAPH_ERROR("local undirected transitivity failed", IGRAPH_ENOMEM);
 }
@@ -88,6 +88,6 @@ for (i = 0; !IGRAPH_VIT_END(vit); IGRAPH_VIT_NEXT(vit), i++) {
 }
 
 igraph_lazy_adjlist_destroy(&adjlist);
-igraph_Free(neis);
+IGRAPH_FREE(neis);
 igraph_vit_destroy(&vit);
 IGRAPH_FINALLY_CLEAN(3);

--- a/src/random/random.c
+++ b/src/random/random.c
@@ -200,7 +200,7 @@ int igraph_rng_glibc2_seed(void *vstate, unsigned long int seed) {
 int igraph_rng_glibc2_init(void **state) {
     igraph_i_rng_glibc2_state_t *st;
 
-    st = igraph_Calloc(1, igraph_i_rng_glibc2_state_t);
+    st = IGRAPH_CALLOC(1, igraph_i_rng_glibc2_state_t);
     if (!st) {
         IGRAPH_ERROR("Cannot initialize RNG", IGRAPH_ENOMEM);
     }
@@ -214,7 +214,7 @@ int igraph_rng_glibc2_init(void **state) {
 void igraph_rng_glibc2_destroy(void *vstate) {
     igraph_i_rng_glibc2_state_t *state =
         (igraph_i_rng_glibc2_state_t*) vstate;
-    igraph_Free(state);
+    IGRAPH_FREE(state);
 }
 
 /**
@@ -270,7 +270,7 @@ int igraph_rng_rand_seed(void *vstate, unsigned long int seed) {
 int igraph_rng_rand_init(void **state) {
     igraph_i_rng_rand_state_t *st;
 
-    st = igraph_Calloc(1, igraph_i_rng_rand_state_t);
+    st = IGRAPH_CALLOC(1, igraph_i_rng_rand_state_t);
     if (!st) {
         IGRAPH_ERROR("Cannot initialize RNG", IGRAPH_ENOMEM);
     }
@@ -284,7 +284,7 @@ int igraph_rng_rand_init(void **state) {
 void igraph_rng_rand_destroy(void *vstate) {
     igraph_i_rng_rand_state_t *state =
         (igraph_i_rng_rand_state_t*) vstate;
-    igraph_Free(state);
+    IGRAPH_FREE(state);
 }
 
 /**
@@ -418,7 +418,7 @@ int igraph_rng_mt19937_seed(void *vstate, unsigned long int seed) {
 int igraph_rng_mt19937_init(void **state) {
     igraph_i_rng_mt19937_state_t *st;
 
-    st = igraph_Calloc(1, igraph_i_rng_mt19937_state_t);
+    st = IGRAPH_CALLOC(1, igraph_i_rng_mt19937_state_t);
     if (!st) {
         IGRAPH_ERROR("Cannot initialize RNG", IGRAPH_ENOMEM);
     }
@@ -432,7 +432,7 @@ int igraph_rng_mt19937_init(void **state) {
 void igraph_rng_mt19937_destroy(void *vstate) {
     igraph_i_rng_mt19937_state_t *state =
         (igraph_i_rng_mt19937_state_t*) vstate;
-    igraph_Free(state);
+    IGRAPH_FREE(state);
 }
 
 /**

--- a/src/scg/scg.c
+++ b/src/scg/scg.c
@@ -456,7 +456,7 @@ int igraph_scg_grouping(const igraph_matrix_t *V,
         igraph_i_scg_groups_t *g;
         int gr_nb = 0;
         
-        g = igraph_Calloc(no_of_nodes, igraph_i_scg_groups_t);
+        g = IGRAPH_CALLOC(no_of_nodes, igraph_i_scg_groups_t);
         IGRAPH_FINALLY(igraph_free, g);
 
         IGRAPH_CHECK(igraph_matrix_int_transpose(&gr_mat));
@@ -476,7 +476,7 @@ int igraph_scg_grouping(const igraph_matrix_t *V,
             VECTOR(*groups)[g[i].ind] = gr_nb;
         }
         
-        igraph_Free(g);
+        IGRAPH_FREE(g);
         IGRAPH_FINALLY_CLEAN(1);
     }
 

--- a/src/scg/scg_exact_scg.c
+++ b/src/scg/scg_exact_scg.c
@@ -39,7 +39,7 @@
 int igraph_i_exact_coarse_graining(const igraph_real_t *v,
                                    int *gr, int n) {
     int i, gr_nb;
-    igraph_i_scg_indval_t *w = igraph_Calloc(n, igraph_i_scg_indval_t);
+    igraph_i_scg_indval_t *w = IGRAPH_CALLOC(n, igraph_i_scg_indval_t);
 
     if (!w) {
         IGRAPH_ERROR("SCG error", IGRAPH_ENOMEM);
@@ -62,7 +62,7 @@ int igraph_i_exact_coarse_graining(const igraph_real_t *v,
         gr[w[i].ind] = gr_nb;
     }
 
-    igraph_Free(w);
+    IGRAPH_FREE(w);
     IGRAPH_FINALLY_CLEAN(1);
 
     return 0;

--- a/src/scg/scg_headers.h
+++ b/src/scg/scg_headers.h
@@ -123,6 +123,6 @@ int igraph_i_compare_int(const void *a, const void *b);
 igraph_real_t *igraph_i_real_sym_matrix(int size);
 #define igraph_i_real_sym_mat_get(S,i,j) S[i+j*(j+1)/2]
 #define igraph_i_real_sym_mat_set(S,i,j,val) S[i+j*(j+1)/2] = val
-#define igraph_i_free_real_sym_matrix(S) igraph_Free(S)
+#define igraph_i_free_real_sym_matrix(S) IGRAPH_FREE(S)
 
 #endif

--- a/src/scg/scg_optimal_method.c
+++ b/src/scg/scg_optimal_method.c
@@ -48,7 +48,7 @@ int igraph_i_optimal_partition(const igraph_real_t *v, int *gr, int n,
                                igraph_real_t *value) {
 
     int i, non_ties, q, j, l, part_ind, col;
-    igraph_i_scg_indval_t *vs = igraph_Calloc(n, igraph_i_scg_indval_t);
+    igraph_i_scg_indval_t *vs = IGRAPH_CALLOC(n, igraph_i_scg_indval_t);
     igraph_real_t *Cv, temp, sumOfSquares;
     igraph_vector_t ps;
     igraph_matrix_t F;
@@ -174,7 +174,7 @@ int igraph_i_optimal_partition(const igraph_real_t *v, int *gr, int n,
 
     igraph_matrix_destroy(&F);
     igraph_matrix_int_destroy(&Q);
-    igraph_Free(vs);
+    IGRAPH_FREE(vs);
     IGRAPH_FINALLY_CLEAN(3);
 
     if (value) {

--- a/src/scg/scg_utils.c
+++ b/src/scg/scg_utils.c
@@ -85,7 +85,7 @@ int igraph_i_compare_int(const void *a, const void *b) {
 /* allocate a igraph_real_t symmetrix matrix with dimension size x size
    in vector format*/
 igraph_real_t *igraph_i_real_sym_matrix(int size)  {
-    igraph_real_t *S = igraph_Calloc(size * (size + 1) / 2, igraph_real_t);
+    igraph_real_t *S = IGRAPH_CALLOC(size * (size + 1) / 2, igraph_real_t);
     if (!S) {
         igraph_error("allocation failure in real_sym_matrix()",
                      IGRAPH_FILE_BASENAME, __LINE__, IGRAPH_ENOMEM);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -735,3 +735,8 @@ add_legacy_tests(
   FOLDER tests/unit NAMES
   igraph_running_mean
 )
+# memory allocation
+add_legacy_tests(
+  FOLDER tests/unit NAMES
+  zero_allocs
+)

--- a/tests/unit/tls2.c
+++ b/tests/unit/tls2.c
@@ -95,13 +95,13 @@ void *thread_function(void *arg) {
     options.iparam[6] = options.mode;
     options.info = options.start;
 
-    v = igraph_Calloc(options.ldv * options.ncv, igraph_real_t);
-    workl = igraph_Calloc(options.lworkl, igraph_real_t);
-    workd = igraph_Calloc(3 * options.n, igraph_real_t);
-    d = igraph_Calloc(2 * options.ncv, igraph_real_t);
-    resid = igraph_Calloc(options.n, igraph_real_t);
-    ax = igraph_Calloc(options.n, igraph_real_t);
-    select = igraph_Calloc(options.ncv, int);
+    v = IGRAPH_CALLOC(options.ldv * options.ncv, igraph_real_t);
+    workl = IGRAPH_CALLOC(options.lworkl, igraph_real_t);
+    workd = IGRAPH_CALLOC(3 * options.n, igraph_real_t);
+    d = IGRAPH_CALLOC(2 * options.ncv, igraph_real_t);
+    resid = IGRAPH_CALLOC(options.n, igraph_real_t);
+    ax = IGRAPH_CALLOC(options.n, igraph_real_t);
+    select = IGRAPH_CALLOC(options.ncv, int);
 
     if (!v || !workl || !workd || !d || !resid || !ax || !select) {
         printf("Out of memory\n");

--- a/tests/unit/vector3.c
+++ b/tests/unit/vector3.c
@@ -29,29 +29,23 @@ int main() {
     igraph_vector_t v;
 
     igraph_vector_init_seq(&v, 1, 1000);
-    if (igraph_vector_capacity(&v) != 1000) {
-        return 1;
-    }
+    IGRAPH_ASSERT(igraph_vector_capacity(&v) == 1000);
 
     igraph_vector_push_back(&v, 1001);
-    if (igraph_vector_capacity(&v) != 2000) {
-        return 2;
-    }
+    IGRAPH_ASSERT(igraph_vector_capacity(&v) == 2000);
 
     igraph_vector_resize_min(&v);
-    if (igraph_vector_capacity(&v) != igraph_vector_size(&v)) {
-        return 3;
-    }
+    IGRAPH_ASSERT(igraph_vector_capacity(&v) == igraph_vector_size(&v));
 
     igraph_vector_destroy(&v);
-    
+
     /* regression test for #1479 -- calling resize_min() on an empty vector */
     igraph_vector_init_seq(&v, 1, 1000);
     igraph_vector_clear(&v);
     igraph_vector_resize_min(&v);
-    if (igraph_vector_capacity(&v) != 1 || igraph_vector_size(&v) != 0) {
-        return 4;
-    }
+    IGRAPH_ASSERT(igraph_vector_capacity(&v) == 0);
+    IGRAPH_ASSERT(igraph_vector_size(&v) == 0);
+    igraph_vector_destroy(&v);
 
     VERIFY_FINALLY_STACK();
 

--- a/tests/unit/vector3.c
+++ b/tests/unit/vector3.c
@@ -44,6 +44,14 @@ int main() {
     }
 
     igraph_vector_destroy(&v);
+    
+    /* regression test for #1479 -- calling resize_min() on an empty vector */
+    igraph_vector_init_seq(&v, 1, 1000);
+    igraph_vector_clear(&v);
+    igraph_vector_resize_min(&v);
+    if (igraph_vector_capacity(&v) != 1 || igraph_vector_size(&v) != 0) {
+        return 4;
+    }
 
     VERIFY_FINALLY_STACK();
 

--- a/tests/unit/vector_ptr.c
+++ b/tests/unit/vector_ptr.c
@@ -251,8 +251,8 @@ int main() {
     /* Testing destructor */
     igraph_vector_ptr_init(&custom_destructor_stack, 0);
     igraph_vector_ptr_init(&v1, 2);
-    block1 = igraph_Calloc(32, char);
-    block2 = igraph_Calloc(64, char);
+    block1 = IGRAPH_CALLOC(32, char);
+    block2 = IGRAPH_CALLOC(64, char);
     VECTOR(v1)[0] = block1;
     VECTOR(v1)[1] = block2;
     if (igraph_vector_ptr_get_item_destructor(&v1) != 0) {

--- a/tests/unit/zero_allocs.c
+++ b/tests/unit/zero_allocs.c
@@ -20,15 +20,15 @@
 #include "test_utilities.inc"
 
 int main() {
-    int *a = igraph_Calloc(0, int);
+    int *a = IGRAPH_CALLOC(0, int);
 
     IGRAPH_ASSERT(a);
 
-    a = igraph_Realloc(a, 0, int);
+    a = IGRAPH_REALLOC(a, 0, int);
 
     IGRAPH_ASSERT(a);
 
-    igraph_Free(a);
+    IGRAPH_FREE(a);
 
     IGRAPH_ASSERT(!a);
 

--- a/tests/unit/zero_allocs.c
+++ b/tests/unit/zero_allocs.c
@@ -32,14 +32,6 @@ int main() {
 
     IGRAPH_ASSERT(!a);
 
-    a = igraph_malloc(0);
-
-    IGRAPH_ASSERT(a);
-
-    igraph_free(a);
-
-    /*igraph_free does not set 'a' to NULL*/
-
     VERIFY_FINALLY_STACK();
     return 0;
 }

--- a/tests/unit/zero_allocs.c
+++ b/tests/unit/zero_allocs.c
@@ -1,0 +1,45 @@
+/*
+   IGraph library.
+   Copyright (C) 2021  The igraph development team <igraph@igraph.org>
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include <igraph.h>
+#include "test_utilities.inc"
+
+int main() {
+    int *a = igraph_Calloc(0, int);
+
+    IGRAPH_ASSERT(a);
+
+    a = igraph_Realloc(a, 0, int);
+
+    IGRAPH_ASSERT(a);
+
+    igraph_Free(a);
+
+    IGRAPH_ASSERT(!a);
+
+    a = igraph_malloc(0);
+
+    IGRAPH_ASSERT(a);
+
+    igraph_free(a);
+
+    /*igraph_free does not set 'a' to NULL*/
+
+    VERIFY_FINALLY_STACK();
+    return 0;
+}


### PR DESCRIPTION
Fixes #1479 

--------
I did check for code where size checks were now superfluous, and
There are more places that check for size, like this:
```
if (alloc_size <= 0) {
    alloc_size = 1;
}
```
But I didn't remove them when they also used alloc size in other
places, like:
```
g->stor_end = h_str_begin + alloc_size;
```
-----------

Avoiding double evaluation can still be combined with macro usage like this:

```
static void *igraph_i_calloc(size_t nitems, size_t size) {
    return calloc (nitems > 0 ? nitems : 1, size);
}

#define IGRAPH_CALLOC(n,t)    igraph_i_calloc( n, sizeof(t) )
```

So that's still an option, but I also wanted to you to be able to merge this if you don't want that.

----------------

https://github.com/igraph/igraph/issues/1479#issuecomment-791977594: 
> Could we then also remove IGRAPH_FREE and IGRAPH_CALLOC from the public headers and move them to an internal header?

Should this still be done? It makes sense to me, but I'm not sure how igraph internal headers work. 