### PR TITLE
Add solve_lsap unit tests

### DIFF
--- a/src/internal/lsap.c
+++ b/src/internal/lsap.c
@@ -615,10 +615,51 @@ void preprocess(AP *p) {
     }
 }
 
+/**
+ * \function igraph_solve_lsap
+ * \brief Solve a balanced linear assignment problem.
+ *
+ * This functions solves a linear assinment problem using the Hungarian
+ * method. A number of tasks, an equal number of agents, and the cost
+ * of each agent to perform the tasks is given. This function then
+ * assigns one task to each agent in such a way that the total cost is
+ * minimized.
+ *
+ * </param><param>
+ * If the cost should be maximized instead of minimized, the cost matrix
+ * should be negated.
+ *
+ * </param><param>
+ * To solve an unbalanced assignment problem, where the number of agents
+ * is greater than the number of tasks, an extra task with zero cost
+ * should be added.
+ *
+ * \param c The assignment problem, where the number of rows is the
+ *          number of agents, the number of columns is the number of
+ *          tasks, and each element is the cost of an agent to perform
+ *          the task.
+ * \param n The number of rows and columns of \p c.
+ * \param p An initialized vector which will store the result. The nth
+ *          entry gives the task the nth agent is assigned to minimize
+ *          the total cost.
+ * \return Error code.
+ *
+ * Time complexity: O(n^3), where n is the number of agents.
+ */
 int igraph_solve_lsap(igraph_matrix_t *c, igraph_integer_t n,
                       igraph_vector_int_t *p) {
     AP *ap;
 
+    if(n != igraph_matrix_nrow(c)) {
+        IGRAPH_ERRORF("n (%" IGRAPH_PRId ") "
+                      "not equal to number of agents(%ld)", IGRAPH_EINVAL,
+                      n, igraph_matrix_nrow(c));
+    }
+    if(n != igraph_matrix_ncol(c)) {
+        IGRAPH_ERRORF("n (%" IGRAPH_PRId ") "
+                      "not equal to number of tasks(%ld)", IGRAPH_EINVAL,
+                      n, igraph_matrix_ncol(c));
+    }
     IGRAPH_CHECK(igraph_vector_int_resize(p, n));
     igraph_vector_int_null(p);
 
@@ -627,5 +668,5 @@ int igraph_solve_lsap(igraph_matrix_t *c, igraph_integer_t n,
     ap_assignment(ap, VECTOR(*p));
     ap_free(ap);
 
-    return 0;
+    return IGRAPH_SUCCESS;
 }

--- a/src/internal/lsap.c
+++ b/src/internal/lsap.c
@@ -652,12 +652,12 @@ int igraph_solve_lsap(igraph_matrix_t *c, igraph_integer_t n,
 
     if(n != igraph_matrix_nrow(c)) {
         IGRAPH_ERRORF("n (%" IGRAPH_PRId ") "
-                      "not equal to number of agents(%ld)", IGRAPH_EINVAL,
+                      "not equal to number of agents (%ld).", IGRAPH_EINVAL,
                       n, igraph_matrix_nrow(c));
     }
     if(n != igraph_matrix_ncol(c)) {
         IGRAPH_ERRORF("n (%" IGRAPH_PRId ") "
-                      "not equal to number of tasks(%ld)", IGRAPH_EINVAL,
+                      "not equal to number of tasks (%ld).", IGRAPH_EINVAL,
                       n, igraph_matrix_ncol(c));
     }
     IGRAPH_CHECK(igraph_vector_int_resize(p, n));

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -748,6 +748,7 @@ add_legacy_tests(
 add_legacy_tests(
   FOLDER tests/unit NAMES
   igraph_running_mean
+  igraph_solve_lsap
 )
 
 # memory allocation

--- a/tests/unit/igraph_solve_lsap.c
+++ b/tests/unit/igraph_solve_lsap.c
@@ -1,0 +1,66 @@
+/*
+   IGraph library.
+   Copyright (C) 2021  The igraph development team <igraph@igraph.org>
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include <igraph.h>
+#include "test_utilities.inc"
+
+int main() {
+    igraph_vector_int_t result;
+    igraph_matrix_t m_pdc, m_0, m_m34, m_m43;
+    int pdc[] = {9, 2, 7, 8,
+                 6, 4, 3, 7,
+                 5, 8, 1, 8,
+                 7, 6, 9, 4};
+    int m34[] = {3, 3, 2, 3,
+                 2, 3, 3, 3,
+                 3, 2, 3, 3};
+    int m43[] = {3, 3, 2,
+                 2, 3, 3,
+                 3, 2, 3,
+                 2, 3, 3};
+    igraph_vector_int_init(&result, 0);
+    matrix_init_int_row_major(&m_pdc, 4, 4, pdc);
+    matrix_init_int_row_major(&m_m34, 3, 4, m34);
+    matrix_init_int_row_major(&m_m43, 4, 3, m43);
+    igraph_matrix_init(&m_0, 0, 0);
+
+    printf("4 tasks, 4 agents:\n");
+    igraph_solve_lsap(&m_pdc, 4, &result);
+    print_vector_int(&result);
+
+    printf("\n0 tasks, 0 agents:\n");
+    igraph_solve_lsap(&m_0, 0, &result);
+    print_vector_int(&result);
+
+    igraph_set_error_handler(igraph_error_handler_ignore);
+
+    printf("\n4 tasks, 3 agents, n = 4.\n");
+    IGRAPH_ASSERT(igraph_solve_lsap(&m_m34, 4, &result) == IGRAPH_EINVAL);
+
+    printf("\n3 tasks, 4 agents, n = 4.\n");
+    IGRAPH_ASSERT(igraph_solve_lsap(&m_m43, 4, &result) == IGRAPH_EINVAL);
+
+    igraph_vector_int_destroy(&result);
+    igraph_matrix_destroy(&m_pdc);
+    igraph_matrix_destroy(&m_0);
+    igraph_matrix_destroy(&m_m34);
+    igraph_matrix_destroy(&m_m43);
+
+    VERIFY_FINALLY_STACK();
+    return 0;
+}

--- a/tests/unit/igraph_solve_lsap.out
+++ b/tests/unit/igraph_solve_lsap.out
@@ -1,0 +1,9 @@
+4 tasks, 4 agents:
+( 1 0 2 3 )
+
+0 tasks, 0 agents:
+( )
+
+4 tasks, 3 agents, n = 4.
+
+3 tasks, 4 agents, n = 4.


### PR DESCRIPTION
Part of #1592

I only noticed this was in /src/internal after adding tests.
It is not used internally. I therefore only did the minimal amount
of work to check that this works correctly in some cases, and disallow other
cases. If we want this to be part of public igraph, I can fix some
more things, like missing IGRAPH_CHECK calls, the malloc and calloc
calls, and the superfluous *n* parameter which can be taken from the matrix.

I think it's useful, and as it can be seen as a bipartite weighted graph problem I think it fits igraph, and it's worth the work to clean it up a bit. 