### PR TITLE
use CMAKE_INSTALL_FULL_<dir> in igraph.pc

### DIFF
--- a/igraph.pc.in
+++ b/igraph.pc.in
@@ -1,7 +1,5 @@
-prefix=@CMAKE_INSTALL_PREFIX@
-exec_prefix=@CMAKE_INSTALL_PREFIX@
-libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 
 Name: libigraph
 Description: @PROJECT_DESCRIPTION@


### PR DESCRIPTION
`CMAKE_INSTALL_<dir>` cannot be assumed to be relative to `CMAKE_INSTALL_PREFIX`.
See https://github.com/NixOS/nixpkgs/pull/117512#issuecomment-808059541.