### PR TITLE
ci: update homebrew formulae

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -81,7 +81,9 @@ jobs:
     pool:
       vmImage: macos-latest
     steps:
-      - script: brew install ninja ccache
+      - script: |
+          brew update
+          brew install ninja ccache
         displayName: Install dependencies
 
       - template: .azure/build.yml


### PR DESCRIPTION
This is to deal with the failing macOS tests, but it has a cost of 2+ minutes.

Alternatively, we can wait until Azure Pipelines updates their macOS images.

See https://github.com/actions/virtual-environments/issues/3165