### PR TITLE
Add stack_ptr_destroy_all unit tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -86,6 +86,7 @@ add_legacy_tests(
   igraph_sparsemat_view
   igraph_sparsemat_which_minmax
   igraph_spmatrix_add_col_values
+  igraph_stack_ptr_destroy_all
   igraph_vector_floor
   igraph_vector_lex_cmp
   matrix

--- a/tests/unit/igraph_stack_ptr_destroy_all.c
+++ b/tests/unit/igraph_stack_ptr_destroy_all.c
@@ -1,0 +1,33 @@
+/*
+   IGraph library.
+   Copyright (C) 2021  The igraph development team <igraph@igraph.org>
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include <igraph.h>
+#include "test_utilities.inc"
+
+int main() {
+    igraph_stack_ptr_t stack;
+    int *some_pointer = IGRAPH_CALLOC(2, int);
+
+    igraph_stack_ptr_init(&stack, 0);
+    igraph_stack_ptr_push(&stack, some_pointer);
+
+    igraph_stack_ptr_destroy_all(&stack);
+
+    VERIFY_FINALLY_STACK();
+    return 0;
+}


### PR DESCRIPTION
Part of #1592

This just lets the memory checker do all the work.