### PR TITLE
fix: build 32-bits CXSparse properly

### DIFF
--- a/include/igraph_sparsemat.h
+++ b/include/igraph_sparsemat.h
@@ -29,11 +29,14 @@
 #include "igraph_vector.h"
 #include "igraph_datatype.h"
 #include "igraph_arpack.h"
+#include "igraph_config.h"
 
 #include <stdio.h>
 
 __BEGIN_DECLS
 
+#if IGRAPH_INTEGER_SIZE == 64
+#define CS_LONG
 struct cs_dl_sparse;
 struct cs_dl_symbolic;
 struct cs_dl_numeric;
@@ -49,6 +52,23 @@ typedef struct {
 typedef struct {
     struct cs_dl_numeric *numeric;
 } igraph_sparsemat_numeric_t;
+#else
+struct cs_di_sparse;
+struct cs_di_symbolic;
+struct cs_di_numeric;
+
+typedef struct {
+    struct cs_di_sparse *cs;
+} igraph_sparsemat_t;
+
+typedef struct {
+    struct cs_di_symbolic *symbolic;
+} igraph_sparsemat_symbolic_t;
+
+typedef struct {
+    struct cs_di_numeric *numeric;
+} igraph_sparsemat_numeric_t;
+#endif
 
 typedef enum { IGRAPH_SPARSEMAT_TRIPLET,
                IGRAPH_SPARSEMAT_CC

--- a/src/core/sparsemat.c
+++ b/src/core/sparsemat.c
@@ -40,7 +40,6 @@
  * need to use the cs_di_* variants of CXSparse functions instead of cs_dl_*
  */
 
-#define CS_LONG  /* we need the "long" versions of CXSparse functions */
 
 #include <cs.h>
 #undef cs  /* because otherwise it messes up the name of the 'cs' member in igraph_sparsemat_t */
@@ -3080,7 +3079,11 @@ igraph_error_t igraph_sparsemat_dense_multiply(const igraph_matrix_t *A,
 igraph_error_t igraph_sparsemat_view(igraph_sparsemat_t *A, igraph_integer_t nzmax, igraph_integer_t m, igraph_integer_t n,
                           igraph_integer_t *p, igraph_integer_t *i, igraph_real_t *x, igraph_integer_t nz) {
 
+#ifdef CS_LONG
     A->cs = IGRAPH_CALLOC(1, cs_dl);
+#else
+    A->cs = IGRAPH_CALLOC(1, cs_di);
+#endif
     A->cs->nzmax = nzmax;
     A->cs->m = m;
     A->cs->n = n;


### PR DESCRIPTION
I know very little about CXParse, so I just checked what was needed to pass the tests, and if there were any other `cs_dl`'s present in sparsemat.c. I'm also not sure about the right place for every macro.

