### PR TITLE
Change community membership and csize to int vecs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,31 @@
    argument instead of an `int`. In practice, it has always been treated as a
    boolean.
 
+ - Functions that used an `igraph_vector_t` to represent cluster size
+   and cluster membership now use an `igraph_vector_int_t` instead. These are:
+   - `igraph_clusters()`
+   - `igraph_community_eb_get_merges()`
+   - `igraph_community_edge_betweenness()`
+   - `igraph_community_fastgreedy()`
+   - `igraph_community_fluid_communities()`
+   - `igraph_community_infomap()`
+   - `igraph_community_label_propagation()`
+   - `igraph_community_leading_eigenvector()`
+   - `igraph_community_leiden()`
+   - `igraph_community_multilevel()`
+   - `igraph_community_optimal_modularity()`
+   - `igraph_community_spinglass()`
+   - `igraph_community_spinglass_single()`
+   - `igraph_community_to_membership()`
+   - `igraph_community_walktrap()`
+   - `igraph_compare_communities()`
+   - `igraph_le_community_to_membership()`
+   - `igraph_modularity()`
+   - `igraph_reindex_membership()`
+   - `igraph_split_join_distance()`
+   `igraph_community_multilevel()` additionaly uses a `igraph_matrix_int_t`
+   instead of `igraph_matrix_t()` for its memberships parameter.
+
 ### Added
 
  - `igraph_adjlist_init_from_inclist()` to create an adjacency list from an already existing incidence list by resolving edge IDs to their corresponding endpoints. This function is useful for algorithms when both an adjacency and an incidence list is needed and they should be in the same order.

--- a/examples/simple/igraph_community_fastgreedy.c
+++ b/examples/simple/igraph_community_fastgreedy.c
@@ -24,11 +24,11 @@
 #include <igraph.h>
 
 void show_results(igraph_t *g, igraph_vector_t *mod, igraph_matrix_t *merges,
-                  igraph_vector_t *membership, FILE* f) {
+                  igraph_vector_int_t *membership, FILE* f) {
     long int i = 0;
-    igraph_vector_t our_membership;
+    igraph_vector_int_t our_membership;
 
-    igraph_vector_init(&our_membership, 0);
+    igraph_vector_int_init(&our_membership, 0);
 
     if (mod != 0) {
         i = igraph_vector_which_max(mod);
@@ -38,29 +38,30 @@ void show_results(igraph_t *g, igraph_vector_t *mod, igraph_matrix_t *merges,
     }
 
     if (membership != 0) {
-        igraph_vector_update(&our_membership, membership);
+        igraph_vector_int_update(&our_membership, membership);
     } else if (merges != 0) {
         igraph_community_to_membership(merges, igraph_vcount(g), i, &our_membership, 0);
     }
 
     printf("Membership: ");
-    for (i = 0; i < igraph_vector_size(&our_membership); i++) {
+    for (i = 0; i < igraph_vector_int_size(&our_membership); i++) {
         printf("%li ", (long int)VECTOR(our_membership)[i]);
     }
     printf("\n");
 
-    igraph_vector_destroy(&our_membership);
+    igraph_vector_int_destroy(&our_membership);
 }
 
 int main() {
     igraph_t g;
-    igraph_vector_t modularity, weights, membership;
+    igraph_vector_t modularity, weights;
+    igraph_vector_int_t membership;
     igraph_matrix_t merges;
 
     igraph_vector_init(&modularity, 0);
     igraph_matrix_init(&merges, 0, 0);
     igraph_vector_init(&weights, 0);
-    igraph_vector_init(&membership, 0);
+    igraph_vector_int_init(&membership, 0);
 
     /* Simple unweighted graph */
     igraph_small(&g, 10, IGRAPH_UNDIRECTED,
@@ -177,7 +178,7 @@ int main() {
     show_results(&g, 0, 0, &membership, stdout);
     igraph_destroy(&g);
 
-    igraph_vector_destroy(&membership);
+    igraph_vector_int_destroy(&membership);
     igraph_vector_destroy(&modularity);
     igraph_vector_destroy(&weights);
     igraph_matrix_destroy(&merges);

--- a/examples/simple/igraph_community_fluid_communities.c
+++ b/examples/simple/igraph_community_fluid_communities.c
@@ -29,30 +29,30 @@
 int main() {
     igraph_t g;
     igraph_integer_t k;
-    igraph_vector_t membership;
+    igraph_vector_int_t membership;
     igraph_real_t modularity;
 
     igraph_rng_seed(igraph_rng_default(), 247);
 
     /* Empty graph */
     igraph_small(&g, 0, IGRAPH_UNDIRECTED, -1);
-    igraph_vector_init(&membership, 0);
-    igraph_vector_push_back(&membership, 1);
+    igraph_vector_int_init(&membership, 0);
+    igraph_vector_int_push_back(&membership, 1);
     igraph_community_fluid_communities(&g, 2, &membership, &modularity);
-    if (!igraph_is_nan(modularity) || igraph_vector_size(&membership) != 0) {
+    if (!igraph_is_nan(modularity) || igraph_vector_int_size(&membership) != 0) {
         return 2;
     }
-    igraph_vector_destroy(&membership);
+    igraph_vector_int_destroy(&membership);
     igraph_destroy(&g);
 
     /* Graph with one vertex only */
     igraph_small(&g, 1, IGRAPH_UNDIRECTED, -1);
-    igraph_vector_init(&membership, 0);
+    igraph_vector_int_init(&membership, 0);
     igraph_community_fluid_communities(&g, 2, &membership, &modularity);
-    if (!igraph_is_nan(modularity) || igraph_vector_size(&membership) != 1 || VECTOR(membership)[0] != 0) {
+    if (!igraph_is_nan(modularity) || igraph_vector_int_size(&membership) != 1 || VECTOR(membership)[0] != 0) {
         return 3;
     }
-    igraph_vector_destroy(&membership);
+    igraph_vector_int_destroy(&membership);
     igraph_destroy(&g);
 
     /* Zachary Karate club -- this is just a quick smoke test */
@@ -75,18 +75,18 @@ int main() {
                  31, 32, 31, 33, 32, 33,
                  -1);
 
-    igraph_vector_init(&membership, 0);
+    igraph_vector_int_init(&membership, 0);
     k = 2;
     igraph_community_fluid_communities(&g, k, &membership,
                                        /*modularity=*/ 0);
-    if (!igraph_vector_contains(&membership, 0) || !igraph_vector_contains(&membership, 1)) {
+    if (!igraph_vector_int_contains(&membership, 0) || !igraph_vector_int_contains(&membership, 1)) {
         printf("Resulting graph does not have exactly 2 communities as expected.\n");
-        igraph_vector_print(&membership);
+        igraph_vector_int_print(&membership);
         return 1;
     }
 
     igraph_destroy(&g);
-    igraph_vector_destroy(&membership);
+    igraph_vector_int_destroy(&membership);
 
     VERIFY_FINALLY_STACK();
 

--- a/examples/simple/igraph_community_label_propagation.c
+++ b/examples/simple/igraph_community_label_propagation.c
@@ -23,7 +23,7 @@
 
 int main() {
     igraph_t graph;
-    igraph_vector_t membership;
+    igraph_vector_int_t membership;
     igraph_real_t modularity;
 
     igraph_famous(&graph, "Zachary"); /* We use Zachary's karate club network. */
@@ -33,18 +33,18 @@ int main() {
 
     /* All igraph functions that returns their result in an igraph_vector_t must be given
        an already initialized vector. */
-    igraph_vector_init(&membership, 0);
+    igraph_vector_int_init(&membership, 0);
     igraph_community_label_propagation(
                 &graph, &membership,
                 /* weights= */ NULL, /* initial= */ NULL, /* fixed= */ NULL,
                 &modularity);
 
     printf("%ld communities found; modularity score is %g.\n",
-           (long int) (igraph_vector_max(&membership) + 1),
+           (long int) (igraph_vector_int_max(&membership) + 1),
            modularity);
 
     /* Destroy data structures at the end. */
-    igraph_vector_destroy(&membership);
+    igraph_vector_int_destroy(&membership);
     igraph_destroy(&graph);
 
     return 0;

--- a/examples/simple/igraph_community_leading_eigenvector.c
+++ b/examples/simple/igraph_community_leading_eigenvector.c
@@ -23,18 +23,6 @@
 
 #include <igraph.h>
 
-int print_vector(const igraph_vector_t *v) {
-    long int i, n = igraph_vector_size(v);
-    for (i = 0; i < n; i++) {
-        printf("%.2g", (double)VECTOR(*v)[i]);
-        if (i != n - 1) {
-            printf(" ");
-        }
-    }
-    printf("\n");
-    return 0;
-}
-
 int print_matrix(const igraph_matrix_t *m) {
     long int i, j, nrow = igraph_matrix_nrow(m), ncol = igraph_matrix_ncol(m);
     for (i = 0; i < nrow; i++) {
@@ -53,7 +41,7 @@ int main() {
 
     igraph_t g;
     igraph_matrix_t merges;
-    igraph_vector_t membership;
+    igraph_vector_int_t membership;
     igraph_vector_t x;
     igraph_arpack_options_t options;
 
@@ -78,7 +66,7 @@ int main() {
                  -1);
 
     igraph_matrix_init(&merges, 0, 0);
-    igraph_vector_init(&membership, 0);
+    igraph_vector_int_init(&membership, 0);
     igraph_vector_init(&x, 0);
     igraph_arpack_options_init(&options);
 
@@ -91,7 +79,7 @@ int main() {
                                          /*callback_extra=*/ 0);
 
     print_matrix(&merges);
-    print_vector(&membership);
+    igraph_vector_int_print(&membership);
 
     printf("\n");
 
@@ -105,10 +93,10 @@ int main() {
                                          /*callback_extra=*/ 0);
 
     print_matrix(&merges);
-    print_vector(&membership);
+    igraph_vector_int_print(&membership);
 
     igraph_vector_destroy(&x);
-    igraph_vector_destroy(&membership);
+    igraph_vector_int_destroy(&membership);
     igraph_matrix_destroy(&merges);
     igraph_destroy(&g);
 

--- a/examples/simple/igraph_community_leiden.c
+++ b/examples/simple/igraph_community_leiden.c
@@ -25,7 +25,8 @@
 
 int main() {
     igraph_t graph;
-    igraph_vector_t membership, degree;
+    igraph_vector_int_t membership;
+    igraph_vector_t degree;
     igraph_integer_t nb_clusters;
     igraph_real_t quality;
 
@@ -39,12 +40,12 @@ int main() {
                  0, 5, -1);
 
     /* Perform Leiden algorithm using CPM */
-    igraph_vector_init(&membership, igraph_vcount(&graph));
+    igraph_vector_int_init(&membership, igraph_vcount(&graph));
     igraph_community_leiden(&graph, NULL, NULL, 0.05, 0.01, 0, &membership, &nb_clusters, &quality);
 
     printf("Leiden found %" IGRAPH_PRId " clusters using CPM (resolution parameter 0.05), quality is %.4f.\n", nb_clusters, quality);
     printf("Membership: ");
-    igraph_vector_print(&membership);
+    igraph_vector_int_print(&membership);
     printf("\n");
 
     /* Start from existing membership to improve it further */
@@ -52,7 +53,7 @@ int main() {
 
     printf("Iterated Leiden, using CPM (resolution parameter 0.05), quality is %.4f.\n", quality);
     printf("Membership: ");
-    igraph_vector_print(&membership);
+    igraph_vector_int_print(&membership);
     printf("\n");
 
     /* Initialize degree vector to use for optimizing modularity */
@@ -64,11 +65,11 @@ int main() {
 
     printf("Leiden found %" IGRAPH_PRId " clusters using modularity, quality is %.4f.\n", nb_clusters, quality);
     printf("Membership: ");
-    igraph_vector_print(&membership);
+    igraph_vector_int_print(&membership);
     printf("\n");
 
     igraph_vector_destroy(&degree);
-    igraph_vector_destroy(&membership);
+    igraph_vector_int_destroy(&membership);
     igraph_destroy(&graph);
 
     return 0;

--- a/examples/simple/igraph_community_multilevel.c
+++ b/examples/simple/igraph_community_multilevel.c
@@ -24,11 +24,11 @@
 
 #include <igraph.h>
 
-void show_results(igraph_t *g, igraph_vector_t *membership, igraph_matrix_t *memberships, igraph_vector_t *modularity, FILE* f) {
+void show_results(igraph_t *g, igraph_vector_int_t *membership, igraph_matrix_int_t *memberships, igraph_vector_t *modularity, FILE* f) {
     igraph_integer_t i, j, no_of_nodes = igraph_vcount(g);
 
     j = igraph_vector_which_max(modularity);
-    for (i = 0; i < igraph_vector_size(membership); i++) {
+    for (i = 0; i < igraph_vector_int_size(membership); i++) {
         if (VECTOR(*membership)[i] != MATRIX(*memberships, j, i)) {
             fprintf(f, "WARNING: best membership vector element %" IGRAPH_PRId " does not match the best one in the membership matrix\n", i);
         }
@@ -37,7 +37,7 @@ void show_results(igraph_t *g, igraph_vector_t *membership, igraph_matrix_t *mem
     fprintf(f, "Modularities:\n");
     igraph_vector_print(modularity);
 
-    for (i = 0; i < igraph_matrix_nrow(memberships); i++) {
+    for (i = 0; i < igraph_matrix_int_nrow(memberships); i++) {
         for (j = 0; j < no_of_nodes; j++) {
             fprintf(f, "%ld ", (long int)MATRIX(*memberships, i, j));
         }
@@ -49,13 +49,14 @@ void show_results(igraph_t *g, igraph_vector_t *membership, igraph_matrix_t *mem
 
 int main() {
     igraph_t g;
-    igraph_vector_t modularity, membership, edges;
-    igraph_matrix_t memberships;
+    igraph_vector_t modularity, edges;
+    igraph_vector_int_t membership;
+    igraph_matrix_int_t memberships;
     int i, j, k;
 
     igraph_vector_init(&modularity, 0);
-    igraph_vector_init(&membership, 0);
-    igraph_matrix_init(&memberships, 0, 0);
+    igraph_vector_int_init(&membership, 0);
+    igraph_matrix_int_init(&memberships, 0, 0);
 
     igraph_rng_seed(igraph_rng_default(), 42);
 
@@ -102,9 +103,9 @@ int main() {
     igraph_destroy(&g);
 
     igraph_vector_destroy(&modularity);
-    igraph_vector_destroy(&membership);
+    igraph_vector_int_destroy(&membership);
     igraph_vector_destroy(&edges);
-    igraph_matrix_destroy(&memberships);
+    igraph_matrix_int_destroy(&memberships);
 
     return 0;
 }

--- a/examples/simple/igraph_community_optimal_modularity.c
+++ b/examples/simple/igraph_community_optimal_modularity.c
@@ -48,7 +48,7 @@ int main() {
                               32, 33
                             };
 
-    igraph_vector_t membership;
+    igraph_vector_int_t membership;
     igraph_vector_t weights;
     igraph_real_t modularity;
     igraph_bool_t simple;
@@ -64,7 +64,7 @@ int main() {
         return 1;
     }
 
-    igraph_vector_init(&membership, 0);
+    igraph_vector_int_init(&membership, 0);
 
     igraph_set_error_handler(&igraph_error_handler_printignore);
 
@@ -103,7 +103,7 @@ int main() {
     }
     igraph_destroy(&graph);
 
-    igraph_vector_destroy(&membership);
+    igraph_vector_int_destroy(&membership);
     igraph_vector_destroy(&weights);
 
     return 0;

--- a/examples/simple/igraph_erdos_renyi_game.c
+++ b/examples/simple/igraph_erdos_renyi_game.c
@@ -3,7 +3,7 @@
 
 int main() {
     igraph_t graph;
-    igraph_vector_t component_sizes;
+    igraph_vector_int_t component_sizes;
 
     igraph_rng_seed(igraph_rng_default(), 42); /* make program deterministic */
 
@@ -16,14 +16,14 @@ int main() {
 
     /* Compute the fraction of vertices contained within the largest connected component */
 
-    igraph_vector_init(&component_sizes, 0);
+    igraph_vector_int_init(&component_sizes, 0);
     igraph_clusters(&graph, NULL, &component_sizes, NULL, IGRAPH_STRONG);
 
-    printf("Fraction of vertices in giant component: %g\n", (double) igraph_vector_max(&component_sizes) / igraph_vcount(&graph));
+    printf("Fraction of vertices in giant component: %g\n", (double) igraph_vector_int_max(&component_sizes) / igraph_vcount(&graph));
 
     /* Clean up data structures when no longer needed */
 
-    igraph_vector_destroy(&component_sizes);
+    igraph_vector_int_destroy(&component_sizes);
     igraph_destroy(&graph);
 
     return 0;

--- a/include/igraph_community.h
+++ b/include/igraph_community.h
@@ -52,15 +52,15 @@ IGRAPH_EXPORT igraph_error_t igraph_trussness(
 
 IGRAPH_EXPORT igraph_error_t igraph_community_optimal_modularity(const igraph_t *graph,
                                                       igraph_real_t *modularity,
-                                                      igraph_vector_t *membership,
+                                                      igraph_vector_int_t *membership,
                                                       const igraph_vector_t *weights);
 
 IGRAPH_EXPORT igraph_error_t igraph_community_spinglass(const igraph_t *graph,
                                              const igraph_vector_t *weights,
                                              igraph_real_t *modularity,
                                              igraph_real_t *temperature,
-                                             igraph_vector_t *membership,
-                                             igraph_vector_t *csize,
+                                             igraph_vector_int_t *membership,
+                                             igraph_vector_int_t *csize,
                                              igraph_integer_t spins,
                                              igraph_bool_t parupdate,
                                              igraph_real_t starttemp,
@@ -78,7 +78,7 @@ IGRAPH_EXPORT igraph_error_t igraph_community_spinglass(const igraph_t *graph,
 IGRAPH_EXPORT igraph_error_t igraph_community_spinglass_single(const igraph_t *graph,
                                                     const igraph_vector_t *weights,
                                                     igraph_integer_t vertex,
-                                                    igraph_vector_t *community,
+                                                    igraph_vector_int_t *community,
                                                     igraph_real_t *cohesion,
                                                     igraph_real_t *adhesion,
                                                     igraph_integer_t *inner_links,
@@ -92,13 +92,13 @@ IGRAPH_EXPORT igraph_error_t igraph_community_walktrap(const igraph_t *graph,
                                             int steps,
                                             igraph_matrix_t *merges,
                                             igraph_vector_t *modularity,
-                                            igraph_vector_t *membership);
+                                            igraph_vector_int_t *membership);
 
 IGRAPH_EXPORT igraph_error_t igraph_community_infomap(const igraph_t * graph,
                                            const igraph_vector_t *e_weights,
                                            const igraph_vector_t *v_weights,
                                            int nb_trials,
-                                           igraph_vector_t *membership,
+                                           igraph_vector_int_t *membership,
                                            igraph_real_t *codelength);
 
 IGRAPH_EXPORT igraph_error_t igraph_community_edge_betweenness(const igraph_t *graph,
@@ -107,7 +107,7 @@ IGRAPH_EXPORT igraph_error_t igraph_community_edge_betweenness(const igraph_t *g
                                                     igraph_matrix_t *merges,
                                                     igraph_vector_t *bridges,
                                                     igraph_vector_t *modularity,
-                                                    igraph_vector_t *membership,
+                                                    igraph_vector_int_t *membership,
                                                     igraph_bool_t directed,
                                                     const igraph_vector_t *weights);
 IGRAPH_EXPORT igraph_error_t igraph_community_eb_get_merges(const igraph_t *graph,
@@ -117,26 +117,26 @@ IGRAPH_EXPORT igraph_error_t igraph_community_eb_get_merges(const igraph_t *grap
                                                  igraph_matrix_t *merges,
                                                  igraph_vector_t *bridges,
                                                  igraph_vector_t *modularity,
-                                                 igraph_vector_t *membership);
+                                                 igraph_vector_int_t *membership);
 
 IGRAPH_EXPORT igraph_error_t igraph_community_fastgreedy(const igraph_t *graph,
                                               const igraph_vector_t *weights,
                                               igraph_matrix_t *merges,
                                               igraph_vector_t *modularity,
-                                              igraph_vector_t *membership);
+                                              igraph_vector_int_t *membership);
 
 IGRAPH_EXPORT igraph_error_t igraph_community_to_membership(const igraph_matrix_t *merges,
                                                  igraph_integer_t nodes,
                                                  igraph_integer_t steps,
-                                                 igraph_vector_t *membership,
-                                                 igraph_vector_t *csize);
+                                                 igraph_vector_int_t *membership,
+                                                 igraph_vector_int_t *csize);
 IGRAPH_EXPORT igraph_error_t igraph_le_community_to_membership(const igraph_matrix_t *merges,
                                                     igraph_integer_t steps,
-                                                    igraph_vector_t *membership,
-                                                    igraph_vector_t *csize);
+                                                    igraph_vector_int_t *membership,
+                                                    igraph_vector_int_t *csize);
 
 IGRAPH_EXPORT igraph_error_t igraph_modularity(const igraph_t *graph,
-                                    const igraph_vector_t *membership,
+                                    const igraph_vector_int_t *membership,
                                     const igraph_vector_t *weights,
                                     const igraph_real_t resolution,
                                     const igraph_bool_t directed,
@@ -148,7 +148,7 @@ IGRAPH_EXPORT igraph_error_t igraph_modularity_matrix(const igraph_t *graph,
                                            igraph_matrix_t *modmat,
                                            igraph_bool_t directed);
 
-IGRAPH_EXPORT igraph_error_t igraph_reindex_membership(igraph_vector_t *membership,
+IGRAPH_EXPORT igraph_error_t igraph_reindex_membership(igraph_vector_int_t *membership,
                                             igraph_vector_t *new_to_old,
                                             igraph_integer_t *nb_clusters);
 
@@ -187,7 +187,7 @@ typedef enum { IGRAPH_LEVC_HIST_SPLIT = 1,
  */
 
 typedef igraph_error_t igraph_community_leading_eigenvector_callback_t(
-    const igraph_vector_t *membership,
+    const igraph_vector_int_t *membership,
     long int comm,
     igraph_real_t eigenvalue,
     const igraph_vector_t *eigenvector,
@@ -198,7 +198,7 @@ typedef igraph_error_t igraph_community_leading_eigenvector_callback_t(
 IGRAPH_EXPORT igraph_error_t igraph_community_leading_eigenvector(const igraph_t *graph,
                                                        const igraph_vector_t *weights,
                                                        igraph_matrix_t *merges,
-                                                       igraph_vector_t *membership,
+                                                       igraph_vector_int_t *membership,
                                                        igraph_integer_t steps,
                                                        igraph_arpack_options_t *options,
                                                        igraph_real_t *modularity,
@@ -211,11 +211,11 @@ IGRAPH_EXPORT igraph_error_t igraph_community_leading_eigenvector(const igraph_t
 
 IGRAPH_EXPORT igraph_error_t igraph_community_fluid_communities(const igraph_t *graph,
                                                      igraph_integer_t no_of_communities,
-                                                     igraph_vector_t *membership,
+                                                     igraph_vector_int_t *membership,
                                                      igraph_real_t *modularity);
 
 IGRAPH_EXPORT igraph_error_t igraph_community_label_propagation(const igraph_t *graph,
-                                                     igraph_vector_t *membership,
+                                                     igraph_vector_int_t *membership,
                                                      const igraph_vector_t *weights,
                                                      const igraph_vector_t *initial,
                                                      igraph_vector_bool_t *fixed,
@@ -224,8 +224,8 @@ IGRAPH_EXPORT igraph_error_t igraph_community_label_propagation(const igraph_t *
 IGRAPH_EXPORT igraph_error_t igraph_community_multilevel(const igraph_t *graph,
                                               const igraph_vector_t *weights,
                                               const igraph_real_t resolution,
-                                              igraph_vector_t *membership,
-                                              igraph_matrix_t *memberships,
+                                              igraph_vector_int_t *membership,
+                                              igraph_matrix_int_t *memberships,
                                               igraph_vector_t *modularity);
 
 IGRAPH_EXPORT igraph_error_t igraph_community_leiden(const igraph_t *graph,
@@ -234,19 +234,19 @@ IGRAPH_EXPORT igraph_error_t igraph_community_leiden(const igraph_t *graph,
                                           const igraph_real_t resolution_parameter,
                                           const igraph_real_t beta,
                                           const igraph_bool_t start,
-                                          igraph_vector_t *membership,
+                                          igraph_vector_int_t *membership,
                                           igraph_integer_t *nb_clusters,
                                           igraph_real_t *quality);
 /* -------------------------------------------------- */
 /* Community Structure Comparison                     */
 /* -------------------------------------------------- */
 
-IGRAPH_EXPORT igraph_error_t igraph_compare_communities(const igraph_vector_t *comm1,
-                                             const igraph_vector_t *comm2,
+IGRAPH_EXPORT igraph_error_t igraph_compare_communities(const igraph_vector_int_t *comm1,
+                                             const igraph_vector_int_t *comm2,
                                              igraph_real_t* result,
                                              igraph_community_comparison_t method);
-IGRAPH_EXPORT igraph_error_t igraph_split_join_distance(const igraph_vector_t *comm1,
-                                             const igraph_vector_t *comm2,
+IGRAPH_EXPORT igraph_error_t igraph_split_join_distance(const igraph_vector_int_t *comm1,
+                                             const igraph_vector_int_t *comm2,
                                              igraph_integer_t* distance12,
                                              igraph_integer_t* distance21);
 

--- a/include/igraph_components.h
+++ b/include/igraph_components.h
@@ -37,8 +37,8 @@ __BEGIN_DECLS
 /* Components                                         */
 /* -------------------------------------------------- */
 
-IGRAPH_EXPORT igraph_error_t igraph_clusters(const igraph_t *graph, igraph_vector_t *membership,
-                                  igraph_vector_t *csize, igraph_integer_t *no,
+IGRAPH_EXPORT igraph_error_t igraph_clusters(const igraph_t *graph, igraph_vector_int_t *membership,
+                                  igraph_vector_int_t *csize, igraph_integer_t *no,
                                   igraph_connectedness_t mode);
 IGRAPH_EXPORT igraph_error_t igraph_is_connected(const igraph_t *graph, igraph_bool_t *res,
                                       igraph_connectedness_t mode);

--- a/include/igraph_operators.h
+++ b/include/igraph_operators.h
@@ -60,7 +60,7 @@ IGRAPH_EXPORT igraph_error_t igraph_complementer(igraph_t *res, const igraph_t *
 IGRAPH_EXPORT igraph_error_t igraph_compose(igraph_t *res, const igraph_t *g1, const igraph_t *g2,
                                  igraph_vector_t *edge_map1, igraph_vector_t *edge_map2);
 IGRAPH_EXPORT igraph_error_t igraph_contract_vertices(igraph_t *graph,
-                                           const igraph_vector_t *mapping,
+                                           const igraph_vector_int_t *mapping,
                                            const igraph_attribute_combination_t
                                      *vertex_comb);
 IGRAPH_EXPORT igraph_error_t igraph_permute_vertices(const igraph_t *graph, igraph_t *res,

--- a/interfaces/functions.def
+++ b/interfaces/functions.def
@@ -1000,7 +1000,7 @@ igraph_laplacian:
 #######################################
 
 igraph_clusters:
-        PARAMS: GRAPH graph, OUT VECTOR membership, OUT VECTOR csize, \
+        PARAMS: GRAPH graph, OUT VECTOR_INT membership, OUT VECTOR_INT csize, \
                 OUT INTEGERPTR no, CONNECTEDNESS mode=WEAK
         NAME-R: clusters
         IGNORE: RR
@@ -1293,20 +1293,20 @@ igraph_similarity_inverse_log_weighted:
 #######################################
 
 igraph_compare_communities:
-        PARAMS: VECTOR comm1, VECTOR comm2, OUT REALPTR res, \
+        PARAMS: VECTOR_INT comm1, VECTOR_INT comm2, OUT REALPTR res, \
                 COMMCMP method=VI
         IGNORE: RR, RNamespace
 
 igraph_community_spinglass:
         PARAMS: GRAPH graph, VECTOR_OR_0 weights, OUT REALPTR modularity,  \
-                OUT REALPTR temperature, OUT VECTOR membership, OUT VECTOR csize, \
+                OUT REALPTR temperature, OUT VECTOR_INT membership, OUT VECTOR_INT csize, \
                 INTEGER spins=25, BOOLEAN parupdate=False, REAL starttemp=1, REAL stoptemp=0.01, \
                 REAL coolfact=0.99, SPINCOMMUPDATE update_rule=CONFIG, REAL gamma=1.0, \
                 REAL gamma_minus=0, REAL d_p=0, REAL d_n=0
         IGNORE: RR, RC, RNamespace
 
 igraph_community_spinglass_single:
-        PARAMS: GRAPH graph, VECTOR_OR_0 weights, INTEGER vertex, OUT VECTOR community, \
+        PARAMS: GRAPH graph, VECTOR_OR_0 weights, INTEGER vertex, OUT VECTOR_INT community, \
                 OUT REALPTR cohesion, OUT REALPTR adhesion, \
                 OUT INTEGERPTR inner_links, OUT INTEGERPTR outer_links, \
                 INTEGER spins=25, SPINCOMMUPDATE update_rule=CONFIG, REAL gamma=1.0
@@ -1314,13 +1314,13 @@ igraph_community_spinglass_single:
 
 igraph_community_walktrap:
         PARAMS: GRAPH graph, VECTOR weights, INT steps=4, OUT MATRIX merges, \
-                OUT VECTOR modularity, OUT VECTOR membership
+                OUT VECTOR modularity, OUT VECTOR_INT membership
         IGNORE: RR, RC, RNamespace
 
 igraph_community_edge_betweenness:
         PARAMS: GRAPH graph, OUT VECTOR result, OUT VECTOR edge_betweenness, \
                 OUT MATRIX merges, OUT VECTOR bridges, \
-                OUT VECTOR_OR_0 modularity, OUT VECTOR_OR_0 membership, \
+                OUT VECTOR_OR_0 modularity, OUT VECTOR_INT_OR_0 membership, \
                 BOOLEAN directed=True, EDGEWEIGHTS weights=NULL
         DEPS: weights ON graph
         IGNORE: RR, RC, RNamespace
@@ -1328,27 +1328,27 @@ igraph_community_edge_betweenness:
 igraph_community_eb_get_merges:
         PARAMS: GRAPH graph, VECTOR edges, EDGEWEIGHTS weights=NULL, \
                 OUT MATRIX merges, OUT VECTOR bridges, \
-                OUT VECTOR_OR_0 modularity, OUT VECTOR_OR_0 membership
+                OUT VECTOR_OR_0 modularity, OUT VECTOR_INT_OR_0 membership
         DEPS: weights ON graph
         IGNORE: RR, RC, RNamespace
 
 igraph_community_fastgreedy:
-        PARAMS: GRAPH graph, VECTOR_OR_0 weights, OUT MATRIX merges, OUT VECTOR modularity, OUT VECTOR_OR_0 membership
+        PARAMS: GRAPH graph, VECTOR_OR_0 weights, OUT MATRIX merges, OUT VECTOR modularity, OUT VECTOR_INT_OR_0 membership
         IGNORE: RR, RC, RNamespace
 
 igraph_community_to_membership:
         PARAMS: GRAPH graph, MATRIX merges, INTEGER steps, \
-                OUT VECTOR membership, OUT VECTOR csize
+                OUT VECTOR_INT membership, OUT VECTOR_INT csize
         IGNORE: RR, RC, RNamespace
 
 igraph_le_community_to_membership:
-        PARAMS: MATRIX merges, INTEGER steps, INOUT VECTOR membership, \
-                OUT VECTOR_OR_0 csize
+        PARAMS: MATRIX merges, INTEGER steps, INOUT VECTOR_INT membership, \
+                OUT VECTOR_INT_OR_0 csize
         NAME-R: community.le.to.membership
         IGNORE: RR, RNamespace, RC
 
 igraph_modularity:
-        PARAMS: GRAPH graph, VECTOR membership, \
+        PARAMS: GRAPH graph, VECTOR_INT membership, \
                 IN VECTOR_OR_0 weights=NULL, \
                 REAL resolution=1.0, \
                 BOOLEAN directed=True,
@@ -1366,13 +1366,13 @@ igraph_modularity_matrix:
         IGNORE: RR
 
 igraph_reindex_membership:
-        PARAMS: INOUT VECTOR membership, OUT VECTOR_OR_0 new_to_old
+        PARAMS: INOUT VECTOR_INT membership, OUT VECTOR_OR_0 new_to_old
         NAME-R: reindex.membership
         IGNORE: RNamespace, RR, RC
 
 igraph_community_leading_eigenvector:
         PARAMS: GRAPH graph, EDGEWEIGHTS weights=NULL, \
-                OUT MATRIX merges, OUT VECTOR membership, \
+                OUT MATRIX merges, OUT VECTOR_INT membership, \
                 INTEGER steps=-1, \
                 INOUT ARPACKOPT options=arpack_defaults, \
                 OUT REALPTR modularity, BOOLEAN start=False, \
@@ -1387,11 +1387,11 @@ igraph_community_leading_eigenvector:
 
 igraph_community_fluid_communities:
         PARAMS: GRAPH graph, INTEGER no_of_communities, \
-		            OUT VECTOR membership, OUT REALPTR modularity
+		            OUT VECTOR_INT membership, OUT REALPTR modularity
         NAME-R: cluster_fluid_communities
 
 igraph_community_label_propagation:
-        PARAMS: GRAPH graph, OUT VECTOR membership, EDGEWEIGHTS weights=NULL, \
+        PARAMS: GRAPH graph, OUT VECTOR_INT membership, EDGEWEIGHTS weights=NULL, \
                 VECTOR_OR_0 initial=NULL, VECTOR_BOOL_OR_0 fixed=NULL, \
                 OUT REALPTR modularity
         DEPS: weights ON graph
@@ -1401,15 +1401,15 @@ igraph_community_label_propagation:
 igraph_community_multilevel:
         PARAMS: GRAPH graph, EDGEWEIGHTS weights=NULL, \
                 REAL resolution=1.0, \
-                OUT VECTOR membership, \
-		OUT MATRIX_OR_0 memberships, OUT VECTOR_OR_0 modularity
+                OUT VECTOR_INT membership, \
+		OUT MATRIX_INT_OR_0 memberships, OUT VECTOR_OR_0 modularity
         DEPS: weights ON graph
         NAME-R: cluster_louvain
         IGNORE: RR
 
 igraph_community_optimal_modularity:
         PARAMS: GRAPH graph, OUT REALPTR modularity, \
-                OUT VECTOR_OR_0 membership, \
+                OUT VECTOR_INT_OR_0 membership, \
                 EDGEWEIGHTS weights=NULL
         DEPS: weights ON graph
         NAME-R: cluster_optimal
@@ -1419,14 +1419,14 @@ igraph_community_leiden:
         PARAMS: GRAPH graph, EDGEWEIGHTS weights=NULL, \
                 VERTEXWEIGHTS vertex_weights=NULL, \
                 REAL resolution_parameter, REAL beta, \
-                BOOLEAN start, INOUT VECTOR_OR_0 membership, \
+                BOOLEAN start, INOUT VECTOR_INT_OR_0 membership, \
                 OUT INTEGERPTR nb_clusters, OUT REALPTR quality
         DEPS: weights ON graph, vertex_weights ON graph
         NAME-R: cluster_leiden
         IGNORE: RR
 
 igraph_split_join_distance:
-        PARAMS: VECTOR comm1, VECTOR comm2, OUT INTEGERPTR distance12, \
+        PARAMS: VECTOR_INT comm1, VECTOR_INT comm2, OUT INTEGERPTR distance12, \
 		        OUT INTEGERPTR distance21
         NAME-R: split.join.distance
         IGNORE: RR, RNamespace
@@ -1470,7 +1470,7 @@ igraph_hrg_create:
 igraph_community_infomap:
         PARAMS: GRAPH graph, EDGEWEIGHTS e_weights=NULL, \
                 VERTEXWEIGHTS v_weights=NULL, INT nb_trials=10, \
-                OUT VECTOR membership, OUT REALPTR codelength
+                OUT VECTOR_INT membership, OUT REALPTR codelength
         NAME-R: cluster_infomap
         DEPS: e_weights ON graph, v_weights ON graph
         IGNORE: RR

--- a/src/community/edge_betweenness.c
+++ b/src/community/edge_betweenness.c
@@ -36,12 +36,12 @@
 
 #include <string.h>
 
-static igraph_error_t igraph_i_rewrite_membership_vector(igraph_vector_t *membership) {
-    long int no = igraph_vector_max(membership) + 1;
+static igraph_error_t igraph_i_rewrite_membership_vector(igraph_vector_int_t *membership) {
+    long int no = igraph_vector_int_max(membership) + 1;
     igraph_vector_t idx;
     long int realno = 0;
     long int i;
-    igraph_integer_t len = igraph_vector_size(membership);
+    igraph_integer_t len = igraph_vector_int_size(membership);
 
     IGRAPH_VECTOR_INIT_FINALLY(&idx, no);
     for (i = 0; i < len; i++) {
@@ -66,9 +66,9 @@ static igraph_error_t igraph_i_community_eb_get_merges2(const igraph_t *graph,
                                              igraph_matrix_t *res,
                                              igraph_vector_t *bridges,
                                              igraph_vector_t *modularity,
-                                             igraph_vector_t *membership) {
+                                             igraph_vector_int_t *membership) {
 
-    igraph_vector_t mymembership;
+    igraph_vector_int_t mymembership;
     igraph_integer_t no_of_nodes = igraph_vcount(graph);
     igraph_integer_t i;
     igraph_real_t maxmod = -1;
@@ -76,10 +76,10 @@ static igraph_error_t igraph_i_community_eb_get_merges2(const igraph_t *graph,
     igraph_integer_t no_comps;
     igraph_bool_t use_directed = directed && igraph_is_directed(graph);
 
-    IGRAPH_VECTOR_INIT_FINALLY(&mymembership, no_of_nodes);
+    IGRAPH_VECTOR_INT_INIT_FINALLY(&mymembership, no_of_nodes);
 
     if (membership) {
-        IGRAPH_CHECK(igraph_vector_resize(membership, no_of_nodes));
+        IGRAPH_CHECK(igraph_vector_int_resize(membership, no_of_nodes));
     }
 
     if (modularity || res || bridges) {
@@ -104,7 +104,7 @@ static igraph_error_t igraph_i_community_eb_get_merges2(const igraph_t *graph,
         VECTOR(mymembership)[i] = i;
     }
     if (membership) {
-        igraph_vector_update(membership, &mymembership);
+        igraph_vector_int_update(membership, &mymembership);
     }
 
     IGRAPH_CHECK(igraph_modularity(graph, &mymembership, weights,
@@ -147,7 +147,7 @@ static igraph_error_t igraph_i_community_eb_get_merges2(const igraph_t *graph,
                 if (actmod > maxmod) {
                     maxmod = actmod;
                     if (membership) {
-                        igraph_vector_update(membership, &mymembership);
+                        igraph_vector_int_update(membership, &mymembership);
                     }
                 }
             }
@@ -160,7 +160,7 @@ static igraph_error_t igraph_i_community_eb_get_merges2(const igraph_t *graph,
         IGRAPH_CHECK(igraph_i_rewrite_membership_vector(membership));
     }
 
-    igraph_vector_destroy(&mymembership);
+    igraph_vector_int_destroy(&mymembership);
     IGRAPH_FINALLY_CLEAN(1);
 
     return IGRAPH_SUCCESS;
@@ -225,7 +225,7 @@ igraph_error_t igraph_community_eb_get_merges(const igraph_t *graph,
                                    igraph_matrix_t *res,
                                    igraph_vector_t *bridges,
                                    igraph_vector_t *modularity,
-                                   igraph_vector_t *membership) {
+                                   igraph_vector_int_t *membership) {
 
     igraph_integer_t no_of_nodes = igraph_vcount(graph);
     igraph_vector_t ptr;
@@ -244,7 +244,7 @@ igraph_error_t igraph_community_eb_get_merges(const igraph_t *graph,
             igraph_vector_clear(modularity);
         }
         if (membership) {
-            igraph_vector_clear(membership);
+            igraph_vector_int_clear(membership);
         }
         return IGRAPH_SUCCESS;
     }
@@ -392,7 +392,7 @@ igraph_error_t igraph_community_edge_betweenness(const igraph_t *graph,
                                       igraph_matrix_t *merges,
                                       igraph_vector_t *bridges,
                                       igraph_vector_t *modularity,
-                                      igraph_vector_t *membership,
+                                      igraph_vector_int_t *membership,
                                       igraph_bool_t directed,
                                       const igraph_vector_t *weights) {
 

--- a/src/community/fast_modularity.c
+++ b/src/community/fast_modularity.c
@@ -626,7 +626,7 @@ igraph_error_t igraph_community_fastgreedy(const igraph_t *graph,
                                 const igraph_vector_t *weights,
                                 igraph_matrix_t *merges,
                                 igraph_vector_t *modularity,
-                                igraph_vector_t *membership) {
+                                igraph_vector_int_t *membership) {
     igraph_integer_t no_of_edges, no_of_nodes, no_of_joins, total_joins;
     igraph_integer_t i, j, k, n, m, from, to, dummy, best_no_of_joins;
     igraph_integer_t ffrom, fto;

--- a/src/community/fluid.c
+++ b/src/community/fluid.c
@@ -64,7 +64,7 @@
  */
 igraph_error_t igraph_community_fluid_communities(const igraph_t *graph,
                                        igraph_integer_t no_of_communities,
-                                       igraph_vector_t *membership,
+                                       igraph_vector_int_t *membership,
                                        igraph_real_t *modularity) {
     /* Declaration of variables */
     long int no_of_nodes, i, j, k, kv1;
@@ -80,8 +80,8 @@ igraph_error_t igraph_community_fluid_communities(const igraph_t *graph,
     /* Checking input values */
     if (no_of_nodes < 2) {
         if (membership) {
-            IGRAPH_CHECK(igraph_vector_resize(membership, no_of_nodes));
-            igraph_vector_fill(membership, 0);
+            IGRAPH_CHECK(igraph_vector_int_resize(membership, no_of_nodes));
+            igraph_vector_int_fill(membership, 0);
         }
         if (modularity) {
             IGRAPH_CHECK(igraph_modularity(graph, membership, 0, 1, igraph_is_directed(graph), modularity));
@@ -111,7 +111,7 @@ igraph_error_t igraph_community_fluid_communities(const igraph_t *graph,
     max_density = 1.0;
 
     /* Resize membership vector (number of nodes) */
-    IGRAPH_CHECK(igraph_vector_resize(membership, no_of_nodes));
+    IGRAPH_CHECK(igraph_vector_int_resize(membership, no_of_nodes));
 
     /* Initialize density and com_to_numvertices vectors */
     IGRAPH_CHECK(igraph_vector_init(&density, no_of_communities));
@@ -124,7 +124,7 @@ igraph_error_t igraph_community_fluid_communities(const igraph_t *graph,
     IGRAPH_FINALLY(igraph_vector_destroy, &node_order);
 
     /* Initialize the membership vector with 0 values */
-    igraph_vector_null(membership);
+    igraph_vector_int_null(membership);
     /* Initialize densities to max_density */
     igraph_vector_fill(&density, max_density);
 

--- a/src/community/infomap/infomap.cc
+++ b/src/community/infomap/infomap.cc
@@ -274,7 +274,7 @@ igraph_error_t igraph_community_infomap(const igraph_t * graph,
                              const igraph_vector_t *e_weights,
                              const igraph_vector_t *v_weights,
                              int nb_trials,
-                             igraph_vector_t *membership,
+                             igraph_vector_int_t *membership,
                              igraph_real_t *codelength) {
 
     FlowGraph * fgraph = new FlowGraph(graph, e_weights, v_weights);
@@ -288,7 +288,7 @@ igraph_error_t igraph_community_infomap(const igraph_t * graph,
 
     // create membership vector
     igraph_integer_t Nnode = fgraph->Nnode;
-    IGRAPH_CHECK(igraph_vector_resize(membership, Nnode));
+    IGRAPH_CHECK(igraph_vector_int_resize(membership, Nnode));
 
     for (int trial = 0; trial < nb_trials; trial++) {
         cpy_fgraph = new FlowGraph(fgraph);

--- a/src/community/label_propagation.c
+++ b/src/community/label_propagation.c
@@ -71,7 +71,7 @@
  * \example examples/simple/igraph_community_label_propagation.c
  */
 igraph_error_t igraph_community_label_propagation(const igraph_t *graph,
-                                       igraph_vector_t *membership,
+                                       igraph_vector_int_t *membership,
                                        const igraph_vector_t *weights,
                                        const igraph_vector_t *initial,
                                        igraph_vector_bool_t *fixed,
@@ -114,7 +114,7 @@ igraph_error_t igraph_community_label_propagation(const igraph_t *graph,
         IGRAPH_WARNING("Ignoring fixed vertices as no initial labeling given.");
     }
 
-    IGRAPH_CHECK(igraph_vector_resize(membership, no_of_nodes));
+    IGRAPH_CHECK(igraph_vector_int_resize(membership, no_of_nodes));
 
     if (initial) {
         if (igraph_vector_size(initial) != no_of_nodes) {
@@ -141,7 +141,7 @@ igraph_error_t igraph_community_label_propagation(const igraph_t *graph,
             }
         }
 
-        i = igraph_vector_max(membership);
+        i = igraph_vector_int_max(membership);
         if (i > no_of_nodes) {
             IGRAPH_ERROR("Elements of the initial labeling vector must be between 0 and |V|-1.", IGRAPH_EINVAL);
         }
@@ -279,7 +279,7 @@ igraph_error_t igraph_community_label_propagation(const igraph_t *graph,
     igraph_vector_fill(&label_counters, -1);
     j = 0;
     for (i = 0; i < no_of_nodes; i++) {
-        k = (long)VECTOR(*membership)[i] - 1;
+        k = VECTOR(*membership)[i] - 1;
         if (k >= 0) {
             if (VECTOR(label_counters)[k] == -1) {
                 /* We have seen this label for the first time */

--- a/src/community/leading_eigenvector.c
+++ b/src/community/leading_eigenvector.c
@@ -79,13 +79,13 @@
  */
 
 typedef struct igraph_i_community_leading_eigenvector_data_t {
-    igraph_vector_t *idx;
+    igraph_vector_int_t *idx;
     igraph_vector_t *idx2;
     igraph_adjlist_t *adjlist;
     igraph_inclist_t *inclist;
     igraph_vector_t *tmp;
     long int no_of_edges;
-    igraph_vector_t *mymembership;
+    igraph_vector_int_t *mymembership;
     long int comm;
     const igraph_vector_t *weights;
     const igraph_t *graph;
@@ -99,13 +99,13 @@ static igraph_error_t igraph_i_community_leading_eigenvector(igraph_real_t *to,
 
     igraph_i_community_leading_eigenvector_data_t *data = extra;
     long int j, k, nlen, size = n;
-    igraph_vector_t *idx = data->idx;
+    igraph_vector_int_t *idx = data->idx;
     igraph_vector_t *idx2 = data->idx2;
     igraph_vector_t *tmp = data->tmp;
     igraph_adjlist_t *adjlist = data->adjlist;
     igraph_real_t ktx, ktx2;
     long int no_of_edges = data->no_of_edges;
-    igraph_vector_t *mymembership = data->mymembership;
+    igraph_vector_int_t *mymembership = data->mymembership;
     long int comm = data->comm;
 
     /* Ax */
@@ -160,13 +160,13 @@ static igraph_error_t igraph_i_community_leading_eigenvector2(igraph_real_t *to,
 
     igraph_i_community_leading_eigenvector_data_t *data = extra;
     long int j, k, nlen, size = n;
-    igraph_vector_t *idx = data->idx;
+    igraph_vector_int_t *idx = data->idx;
     igraph_vector_t *idx2 = data->idx2;
     igraph_vector_t *tmp = data->tmp;
     igraph_adjlist_t *adjlist = data->adjlist;
     igraph_real_t ktx, ktx2;
     long int no_of_edges = data->no_of_edges;
-    igraph_vector_t *mymembership = data->mymembership;
+    igraph_vector_int_t *mymembership = data->mymembership;
     long int comm = data->comm;
 
     /* Ax */
@@ -226,12 +226,12 @@ static igraph_error_t igraph_i_community_leading_eigenvector_weighted(igraph_rea
 
     igraph_i_community_leading_eigenvector_data_t *data = extra;
     long int j, k, nlen, size = n;
-    igraph_vector_t *idx = data->idx;
+    igraph_vector_int_t *idx = data->idx;
     igraph_vector_t *idx2 = data->idx2;
     igraph_vector_t *tmp = data->tmp;
     igraph_inclist_t *inclist = data->inclist;
     igraph_real_t ktx, ktx2;
-    igraph_vector_t *mymembership = data->mymembership;
+    igraph_vector_int_t *mymembership = data->mymembership;
     long int comm = data->comm;
     const igraph_vector_t *weights = data->weights;
     const igraph_t *graph = data->graph;
@@ -290,12 +290,12 @@ static igraph_error_t igraph_i_community_leading_eigenvector2_weighted(igraph_re
 
     igraph_i_community_leading_eigenvector_data_t *data = extra;
     long int j, k, nlen, size = n;
-    igraph_vector_t *idx = data->idx;
+    igraph_vector_int_t *idx = data->idx;
     igraph_vector_t *idx2 = data->idx2;
     igraph_vector_t *tmp = data->tmp;
     igraph_inclist_t *inclist = data->inclist;
     igraph_real_t ktx, ktx2;
-    igraph_vector_t *mymembership = data->mymembership;
+    igraph_vector_int_t *mymembership = data->mymembership;
     long int comm = data->comm;
     const igraph_vector_t *weights = data->weights;
     const igraph_t *graph = data->graph;
@@ -478,7 +478,7 @@ static void igraph_i_error_handler_none(const char *reason, const char *file,
 igraph_error_t igraph_community_leading_eigenvector(const igraph_t *graph,
         const igraph_vector_t *weights,
         igraph_matrix_t *merges,
-        igraph_vector_t *membership,
+        igraph_vector_int_t *membership,
         igraph_integer_t steps,
         igraph_arpack_options_t *options,
         igraph_real_t *modularity,
@@ -492,14 +492,15 @@ igraph_error_t igraph_community_leading_eigenvector(const igraph_t *graph,
     igraph_integer_t no_of_nodes = igraph_vcount(graph);
     igraph_integer_t no_of_edges = igraph_ecount(graph);
     igraph_dqueue_t tosplit;
-    igraph_vector_t idx, idx2, mymerges;
+    igraph_vector_int_t idx;
+    igraph_vector_t idx2, mymerges;
     igraph_vector_t strength, tmp;
     igraph_integer_t staken = 0;
     igraph_adjlist_t adjlist;
     igraph_inclist_t inclist;
     igraph_integer_t i, j, k, l;
     igraph_integer_t communities;
-    igraph_vector_t vmembership, *mymembership = membership;
+    igraph_vector_int_t vmembership, *mymembership = membership;
     igraph_i_community_leading_eigenvector_data_t extra;
     igraph_arpack_storage_t storage;
     igraph_real_t mod = 0;
@@ -525,12 +526,12 @@ igraph_error_t igraph_community_leading_eigenvector(const igraph_t *graph,
     }
 
     if (start && membership &&
-        igraph_vector_size(membership) != no_of_nodes) {
+        igraph_vector_int_size(membership) != no_of_nodes) {
         IGRAPH_ERROR("Wrong length for vector of predefined memberships",
                      IGRAPH_EINVAL);
     }
 
-    if (start && membership && igraph_vector_max(membership) >= no_of_nodes) {
+    if (start && membership && igraph_vector_int_max(membership) >= no_of_nodes) {
         IGRAPH_WARNING("Too many communities in membership start vector");
     }
 
@@ -544,12 +545,12 @@ igraph_error_t igraph_community_leading_eigenvector(const igraph_t *graph,
 
     if (!membership) {
         mymembership = &vmembership;
-        IGRAPH_VECTOR_INIT_FINALLY(mymembership, 0);
+        IGRAPH_VECTOR_INT_INIT_FINALLY(mymembership, 0);
     }
 
     IGRAPH_VECTOR_INIT_FINALLY(&mymerges, 0);
     IGRAPH_CHECK(igraph_vector_reserve(&mymerges, steps * 2));
-    IGRAPH_VECTOR_INIT_FINALLY(&idx, 0);
+    IGRAPH_VECTOR_INT_INIT_FINALLY(&idx, 0);
     if (eigenvalues)  {
         igraph_vector_clear(eigenvalues);
     }
@@ -564,7 +565,7 @@ igraph_error_t igraph_community_leading_eigenvector(const igraph_t *graph,
         /* Calculate the weakly connected components in the graph and use them as
          * an initial split */
         IGRAPH_CHECK(igraph_clusters(graph, mymembership, &idx, 0, IGRAPH_WEAK));
-        communities = igraph_vector_size(&idx);
+        communities = igraph_vector_int_size(&idx);
         IGRAPH_STATUSF(("Starting from %" IGRAPH_PRId " component(s).\n", 0, communities));
         if (history) {
             IGRAPH_CHECK(igraph_vector_push_back(history,
@@ -572,7 +573,7 @@ igraph_error_t igraph_community_leading_eigenvector(const igraph_t *graph,
         }
     } else {
         /* Just create the idx vector for the given membership vector */
-        communities = igraph_vector_max(mymembership) + 1;
+        communities = igraph_vector_int_max(mymembership) + 1;
         IGRAPH_STATUSF(("Starting from given membership vector with %" IGRAPH_PRId
                         " communities.\n", 0, communities));
         if (history) {
@@ -580,8 +581,8 @@ igraph_error_t igraph_community_leading_eigenvector(const igraph_t *graph,
                                                  IGRAPH_LEVC_HIST_START_GIVEN));
             IGRAPH_CHECK(igraph_vector_push_back(history, communities));
         }
-        IGRAPH_CHECK(igraph_vector_resize(&idx, communities));
-        igraph_vector_null(&idx);
+        IGRAPH_CHECK(igraph_vector_int_resize(&idx, communities));
+        igraph_vector_int_null(&idx);
         for (i = 0; i < no_of_nodes; i++) {
             igraph_integer_t t = (igraph_integer_t) VECTOR(*mymembership)[i];
             VECTOR(idx)[t] += 1;
@@ -620,8 +621,8 @@ igraph_error_t igraph_community_leading_eigenvector(const igraph_t *graph,
     staken = communities - 1;
 
     IGRAPH_VECTOR_INIT_FINALLY(&tmp, no_of_nodes);
-    IGRAPH_CHECK(igraph_vector_resize(&idx, no_of_nodes));
-    igraph_vector_null(&idx);
+    IGRAPH_CHECK(igraph_vector_int_resize(&idx, no_of_nodes));
+    igraph_vector_int_null(&idx);
     IGRAPH_VECTOR_INIT_FINALLY(&idx2, no_of_nodes);
     if (!weights) {
         IGRAPH_CHECK(igraph_adjlist_init(graph, &adjlist, IGRAPH_ALL, IGRAPH_LOOPS_TWICE, IGRAPH_MULTIPLE));
@@ -946,7 +947,7 @@ igraph_error_t igraph_community_leading_eigenvector(const igraph_t *graph,
 
     /* reform the mymerges vector */
     if (merges) {
-        igraph_vector_null(&idx);
+        igraph_vector_int_null(&idx);
         l = igraph_vector_size(&mymerges);
         k = communities;
         j = 0;
@@ -970,7 +971,7 @@ igraph_error_t igraph_community_leading_eigenvector(const igraph_t *graph,
     if (eigenvectors) {
         IGRAPH_FINALLY_CLEAN(1);
     }
-    igraph_vector_destroy(&idx);
+    igraph_vector_int_destroy(&idx);
     igraph_vector_destroy(&mymerges);
     IGRAPH_FINALLY_CLEAN(2);
 
@@ -981,7 +982,7 @@ igraph_error_t igraph_community_leading_eigenvector(const igraph_t *graph,
     }
 
     if (!membership) {
-        igraph_vector_destroy(mymembership);
+        igraph_vector_int_destroy(mymembership);
         IGRAPH_FINALLY_CLEAN(1);
     }
 
@@ -1012,15 +1013,15 @@ igraph_error_t igraph_community_leading_eigenvector(const igraph_t *graph,
  */
 igraph_error_t igraph_le_community_to_membership(const igraph_matrix_t *merges,
                                       igraph_integer_t steps,
-                                      igraph_vector_t *membership,
-                                      igraph_vector_t *csize) {
+                                      igraph_vector_int_t *membership,
+                                      igraph_vector_int_t *csize) {
 
-    igraph_integer_t no_of_nodes = igraph_vector_size(membership);
-    igraph_vector_t fake_memb;
+    igraph_integer_t no_of_nodes = igraph_vector_int_size(membership);
+    igraph_vector_int_t fake_memb;
     igraph_integer_t components, i;
 
     if (no_of_nodes > 0) {
-        components = igraph_vector_max(membership) + 1;
+        components = igraph_vector_int_max(membership) + 1;
     } else {
         components = 0;
     }
@@ -1033,7 +1034,7 @@ igraph_error_t igraph_le_community_to_membership(const igraph_matrix_t *merges,
                       IGRAPH_EINVAL, steps, components);
     }
 
-    IGRAPH_VECTOR_INIT_FINALLY(&fake_memb, components);
+    IGRAPH_VECTOR_INT_INIT_FINALLY(&fake_memb, components);
 
     /* Check membership vector */
     for (i = 0; i < no_of_nodes; i++) {
@@ -1057,8 +1058,8 @@ igraph_error_t igraph_le_community_to_membership(const igraph_matrix_t *merges,
        rewrite the original membership vector. */
 
     if (csize) {
-        IGRAPH_CHECK(igraph_vector_resize(csize, components - steps));
-        igraph_vector_null(csize);
+        IGRAPH_CHECK(igraph_vector_int_resize(csize, components - steps));
+        igraph_vector_int_null(csize);
     }
 
     for (i = 0; i < no_of_nodes; i++) {
@@ -1068,7 +1069,7 @@ igraph_error_t igraph_le_community_to_membership(const igraph_matrix_t *merges,
         }
     }
 
-    igraph_vector_destroy(&fake_memb);
+    igraph_vector_int_destroy(&fake_memb);
     IGRAPH_FINALLY_CLEAN(1);
     return IGRAPH_SUCCESS;
 }

--- a/src/community/modularity.c
+++ b/src/community/modularity.c
@@ -111,7 +111,7 @@
  * of edges.
  */
 igraph_error_t igraph_modularity(const igraph_t *graph,
-                      const igraph_vector_t *membership,
+                      const igraph_vector_int_t *membership,
                       const igraph_vector_t *weights,
                       const igraph_real_t resolution,
                       const igraph_bool_t directed,
@@ -127,7 +127,7 @@ igraph_error_t igraph_modularity(const igraph_t *graph,
     igraph_bool_t use_directed = directed && igraph_is_directed(graph);
     igraph_real_t directed_multiplier = (use_directed ? 1 : 2);
 
-    if (igraph_vector_size(membership) != igraph_vcount(graph)) {
+    if (igraph_vector_int_size(membership) != igraph_vcount(graph)) {
         IGRAPH_ERROR("Membership vector size differs from number of vertices.",
                      IGRAPH_EINVAL);
     }
@@ -147,9 +147,9 @@ igraph_error_t igraph_modularity(const igraph_t *graph,
     /* At this point, the 'membership' vector does not have length zero,
        thus it is safe to call igraph_vector_max() and min(). */
 
-    types = igraph_vector_max(membership) + 1;
+    types = igraph_vector_int_max(membership) + 1;
 
-    if (igraph_vector_min(membership) < 0) {
+    if (igraph_vector_int_min(membership) < 0) {
         IGRAPH_ERROR("Invalid membership vector: negative entry.", IGRAPH_EINVAL);
     }
 

--- a/src/community/optimal_modularity.c
+++ b/src/community/optimal_modularity.c
@@ -81,7 +81,7 @@
 
 igraph_error_t igraph_community_optimal_modularity(const igraph_t *graph,
                                         igraph_real_t *modularity,
-                                        igraph_vector_t *membership,
+                                        igraph_vector_int_t *membership,
                                         const igraph_vector_t *weights) {
 
 #ifndef HAVE_GLPK
@@ -123,8 +123,8 @@ igraph_error_t igraph_community_optimal_modularity(const igraph_t *graph,
     /* Avoid problems with the null graph */
     if (no_of_nodes < 2) {
         if (membership) {
-            IGRAPH_CHECK(igraph_vector_resize(membership, no_of_nodes));
-            igraph_vector_fill(membership, 0);
+            IGRAPH_CHECK(igraph_vector_int_resize(membership, no_of_nodes));
+            igraph_vector_int_fill(membership, 0);
         }
         if (modularity) {
             IGRAPH_CHECK(igraph_modularity(graph, membership, 0, 1, igraph_is_directed(graph), modularity));
@@ -151,8 +151,8 @@ igraph_error_t igraph_community_optimal_modularity(const igraph_t *graph,
             *modularity = IGRAPH_NAN;
         }
         if (membership) {
-            IGRAPH_CHECK(igraph_vector_resize(membership, no_of_nodes));
-            igraph_vector_null(membership);
+            IGRAPH_CHECK(igraph_vector_int_resize(membership, no_of_nodes));
+            igraph_vector_int_null(membership);
         }
     }
 
@@ -256,7 +256,7 @@ igraph_error_t igraph_community_optimal_modularity(const igraph_t *graph,
 
     if (membership) {
         long int comm = 0;   /* id of the last community that was found */
-        IGRAPH_CHECK(igraph_vector_resize(membership, no_of_nodes));
+        IGRAPH_CHECK(igraph_vector_int_resize(membership, no_of_nodes));
         for (i = 0; i < no_of_nodes; i++) {
 
             IGRAPH_ALLOW_INTERRUPTION();

--- a/src/community/spinglass/clustertool.cpp
+++ b/src/community/spinglass/clustertool.cpp
@@ -63,8 +63,8 @@ static igraph_error_t igraph_i_community_spinglass_orig(
         const igraph_vector_t *weights,
         igraph_real_t *modularity,
         igraph_real_t *temperature,
-        igraph_vector_t *membership,
-        igraph_vector_t *csize,
+        igraph_vector_int_t *membership,
+        igraph_vector_int_t *csize,
         igraph_integer_t spins,
         igraph_bool_t parupdate,
         igraph_real_t starttemp,
@@ -78,8 +78,8 @@ static igraph_error_t igraph_i_community_spinglass_negative(
         const igraph_vector_t *weights,
         igraph_real_t *modularity,
         igraph_real_t *temperature,
-        igraph_vector_t *membership,
-        igraph_vector_t *csize,
+        igraph_vector_int_t *membership,
+        igraph_vector_int_t *csize,
         igraph_integer_t spins,
         igraph_bool_t parupdate,
         igraph_real_t starttemp,
@@ -189,8 +189,8 @@ igraph_error_t igraph_community_spinglass(const igraph_t *graph,
                                const igraph_vector_t *weights,
                                igraph_real_t *modularity,
                                igraph_real_t *temperature,
-                               igraph_vector_t *membership,
-                               igraph_vector_t *csize,
+                               igraph_vector_int_t *membership,
+                               igraph_vector_int_t *csize,
                                igraph_integer_t spins,
                                igraph_bool_t parupdate,
                                igraph_real_t starttemp,
@@ -236,8 +236,8 @@ static igraph_error_t igraph_i_community_spinglass_orig(
         const igraph_vector_t *weights,
         igraph_real_t *modularity,
         igraph_real_t *temperature,
-        igraph_vector_t *membership,
-        igraph_vector_t *csize,
+        igraph_vector_int_t *membership,
+        igraph_vector_int_t *csize,
         igraph_integer_t spins,
         igraph_bool_t parupdate,
         igraph_real_t starttemp,
@@ -282,8 +282,8 @@ static igraph_error_t igraph_i_community_spinglass_orig(
        null and singleton graphs, so we catch them here. */
     if (no_of_nodes < 2) {
         if (membership) {
-            IGRAPH_CHECK(igraph_vector_resize(membership, no_of_nodes));
-            igraph_vector_fill(membership, 0);
+            IGRAPH_CHECK(igraph_vector_int_resize(membership, no_of_nodes));
+            igraph_vector_int_fill(membership, 0);
         }
         if (modularity) {
             IGRAPH_CHECK(igraph_modularity(graph, membership, 0, 1, igraph_is_directed(graph), modularity));
@@ -293,8 +293,8 @@ static igraph_error_t igraph_i_community_spinglass_orig(
         }
         if (csize) {
             /* 0 clusters for 0 nodes, 1 cluster for 1 node */
-            IGRAPH_CHECK(igraph_vector_resize(membership, no_of_nodes));
-            igraph_vector_fill(membership, 1);
+            IGRAPH_CHECK(igraph_vector_int_resize(membership, no_of_nodes));
+            igraph_vector_int_fill(membership, 1);
         }
         return IGRAPH_SUCCESS;
     }
@@ -437,7 +437,7 @@ static igraph_error_t igraph_i_community_spinglass_orig(
 igraph_error_t igraph_community_spinglass_single(const igraph_t *graph,
                                       const igraph_vector_t *weights,
                                       igraph_integer_t vertex,
-                                      igraph_vector_t *community,
+                                      igraph_vector_int_t *community,
                                       igraph_real_t *cohesion,
                                       igraph_real_t *adhesion,
                                       igraph_integer_t *inner_links,
@@ -512,8 +512,8 @@ static igraph_error_t igraph_i_community_spinglass_negative(
         const igraph_vector_t *weights,
         igraph_real_t *modularity,
         igraph_real_t *temperature,
-        igraph_vector_t *membership,
-        igraph_vector_t *csize,
+        igraph_vector_int_t *membership,
+        igraph_vector_int_t *csize,
         igraph_integer_t spins,
         igraph_bool_t parupdate,
         igraph_real_t starttemp,
@@ -569,8 +569,8 @@ static igraph_error_t igraph_i_community_spinglass_negative(
        null and singleton graphs, so we catch them here. */
     if (no_of_nodes < 2) {
         if (membership) {
-            IGRAPH_CHECK(igraph_vector_resize(membership, no_of_nodes));
-            igraph_vector_fill(membership, 0);
+            IGRAPH_CHECK(igraph_vector_int_resize(membership, no_of_nodes));
+            igraph_vector_int_fill(membership, 0);
         }
         if (modularity) {
             IGRAPH_CHECK(igraph_modularity(graph, membership, 0, 1, igraph_is_directed(graph), modularity));
@@ -580,8 +580,8 @@ static igraph_error_t igraph_i_community_spinglass_negative(
         }
         if (csize) {
             /* 0 clusters for 0 nodes, 1 cluster for 1 node */
-            IGRAPH_CHECK(igraph_vector_resize(membership, no_of_nodes));
-            igraph_vector_fill(membership, 1);
+            IGRAPH_CHECK(igraph_vector_int_resize(membership, no_of_nodes));
+            igraph_vector_int_fill(membership, 1);
         }
         return IGRAPH_SUCCESS;
     }

--- a/src/community/spinglass/pottsmodel_2.cpp
+++ b/src/community/spinglass/pottsmodel_2.cpp
@@ -894,7 +894,7 @@ double PottsModel::HeatBathLookup(double gamma, double prob, double kT, unsigned
 //###############################################################################################
 double PottsModel::FindCommunityFromStart(double gamma, double prob,
         char *nodename,
-        igraph_vector_t *result,
+        igraph_vector_int_t *result,
         igraph_real_t *cohesion,
         igraph_real_t *adhesion,
         igraph_integer_t *my_inner_links,
@@ -1126,11 +1126,11 @@ double PottsModel::FindCommunityFromStart(double gamma, double prob,
     }
     if (result) {
         node = iter.First(community);
-        igraph_vector_resize(result, 0);
+        igraph_vector_int_resize(result, 0);
         while (!iter.End()) {
             // printf("%s in community.\n",node->Get_Name());
             // fprintf(file,"%s\t%f\n",node->Get_Name(),node->Get_Affinity());
-            IGRAPH_CHECK(igraph_vector_push_back(result, node->Get_Index()));
+            IGRAPH_CHECK(igraph_vector_int_push_back(result, node->Get_Index()));
             node = iter.Next();
         }
     }
@@ -1147,8 +1147,8 @@ double PottsModel::FindCommunityFromStart(double gamma, double prob,
 //################################################################################################
 long PottsModel::WriteClusters(igraph_real_t *modularity,
                                igraph_real_t *temperature,
-                               igraph_vector_t *csize,
-                               igraph_vector_t *membership,
+                               igraph_vector_int_t *csize,
+                               igraph_vector_int_t *membership,
                                double kT, double gamma) {
     NNode *n_cur, *n_cur2;
     /*
@@ -1211,7 +1211,7 @@ long PottsModel::WriteClusters(igraph_real_t *modularity,
         }
     }
     if (csize) {
-        igraph_vector_resize(csize, 0);
+        igraph_vector_int_resize(csize, 0);
         for (unsigned long spin = 1; spin <= q; spin++) {
             if (nodes[spin] > 0) {
                 inner_links[spin] /= 2;
@@ -1240,7 +1240,7 @@ long PottsModel::WriteClusters(igraph_real_t *modularity,
                 p2=(0.5*n*(n-1)-lin + n*(N-n)-lout)*log((double)1.0-p);
                 */
                 //       fprintf(file,"%d\t%d\t%d\t%d\t%f\t%f\t%f\n",spin,nodes[spin], inner_links[spin], outer_links[spin], p_in, p_out,log_num_exp);
-                IGRAPH_CHECK(igraph_vector_push_back(csize, nodes[spin]));
+                IGRAPH_CHECK(igraph_vector_int_push_back(csize, nodes[spin]));
             }
         }
         //   fprintf(file,"\n");
@@ -1249,7 +1249,7 @@ long PottsModel::WriteClusters(igraph_real_t *modularity,
     //die Elemente der Cluster
     if (membership) {
         long int no = -1;
-        IGRAPH_CHECK(igraph_vector_resize(membership, num_of_nodes));
+        IGRAPH_CHECK(igraph_vector_int_resize(membership, num_of_nodes));
         for (unsigned long spin = 1; spin <= q; spin++) {
             if (nodes[spin] > 0) {
                 no++;
@@ -1987,8 +1987,8 @@ double PottsModelN::FindStartTemp(double gamma, double lambda, double ts) {
 
 long PottsModelN::WriteClusters(igraph_real_t *modularity,
                                 igraph_real_t *temperature,
-                                igraph_vector_t *community_size,
-                                igraph_vector_t *membership,
+                                igraph_vector_int_t *community_size,
+                                igraph_vector_int_t *membership,
                                 igraph_matrix_t *adhesion,
                                 igraph_matrix_t *normalised_adhesion,
                                 igraph_real_t *polarization,
@@ -2051,7 +2051,7 @@ long PottsModelN::WriteClusters(igraph_real_t *modularity,
 
     if (community_size) {
         //Initialize the vector
-        IGRAPH_CHECK(igraph_vector_resize(community_size, q));
+        IGRAPH_CHECK(igraph_vector_int_resize(community_size, q));
         for (unsigned long spin_opt = 1; spin_opt <= q; spin_opt++) {
             //Set the community size
             VECTOR(*community_size)[spin_opt - 1] = csize[spin_opt];
@@ -2060,7 +2060,7 @@ long PottsModelN::WriteClusters(igraph_real_t *modularity,
 
     //Set the membership
     if (membership) {
-        IGRAPH_CHECK(igraph_vector_resize(membership, num_nodes));
+        IGRAPH_CHECK(igraph_vector_int_resize(membership, num_nodes));
         for (unsigned long i = 0; i < num_nodes; i++) {
             VECTOR(*membership)[ i ] = spin[i] - 1;
         }

--- a/src/community/spinglass/pottsmodel_2.h
+++ b/src/community/spinglass/pottsmodel_2.h
@@ -106,14 +106,14 @@ public:
     double calculate_energy(double gamma);
     long   WriteClusters(igraph_real_t *modularity,
                          igraph_real_t *temperature,
-                         igraph_vector_t *csize, igraph_vector_t *membership,
+                         igraph_vector_int_t *csize, igraph_vector_int_t *membership,
                          double kT, double gamma);
     // long   WriteSoftClusters(char *filename, double threshold);
     double Get_Energy() const {
         return energy;
     }
     double FindCommunityFromStart(double gamma, double prob, char *nodename,
-                                  igraph_vector_t *result,
+                                  igraph_vector_int_t *result,
                                   igraph_real_t *cohesion,
                                   igraph_real_t *adhesion,
                                   igraph_integer_t *inner_links,
@@ -164,8 +164,8 @@ public:
     // double HeatBathLookupZeroTemp(double gamma, double lambda, unsigned int max_sweeps);
     long WriteClusters(igraph_real_t *modularity,
                        igraph_real_t *temperature,
-                       igraph_vector_t *community_size,
-                       igraph_vector_t *membership,
+                       igraph_vector_int_t *community_size,
+                       igraph_vector_int_t *membership,
                        igraph_matrix_t *adhesion,
                        igraph_matrix_t *normalised_adhesion,
                        igraph_real_t *polarization,

--- a/src/community/walktrap/walktrap.cpp
+++ b/src/community/walktrap/walktrap.cpp
@@ -121,7 +121,7 @@ igraph_error_t igraph_community_walktrap(const igraph_t *graph,
                               int steps,
                               igraph_matrix_t *merges,
                               igraph_vector_t *modularity,
-                              igraph_vector_t *membership) {
+                              igraph_vector_int_t *membership) {
 
     long int no_of_nodes = igraph_vcount(graph);
     int length = steps;

--- a/src/connectivity/components.c
+++ b/src/connectivity/components.c
@@ -37,11 +37,11 @@
 
 #include <limits.h>
 
-static igraph_error_t igraph_i_clusters_weak(const igraph_t *graph, igraph_vector_t *membership,
-                                  igraph_vector_t *csize, igraph_integer_t *no);
+static igraph_error_t igraph_i_clusters_weak(const igraph_t *graph, igraph_vector_int_t *membership,
+                                  igraph_vector_int_t *csize, igraph_integer_t *no);
 
-static igraph_error_t igraph_i_clusters_strong(const igraph_t *graph, igraph_vector_t *membership,
-                                    igraph_vector_t *csize, igraph_integer_t *no);
+static igraph_error_t igraph_i_clusters_strong(const igraph_t *graph, igraph_vector_int_t *membership,
+                                    igraph_vector_int_t *csize, igraph_integer_t *no);
 
 /**
  * \ingroup structural
@@ -74,8 +74,8 @@ static igraph_error_t igraph_i_clusters_strong(const igraph_t *graph, igraph_vec
  * edges in the graph.
  */
 
-igraph_error_t igraph_clusters(const igraph_t *graph, igraph_vector_t *membership,
-                    igraph_vector_t *csize, igraph_integer_t *no,
+igraph_error_t igraph_clusters(const igraph_t *graph, igraph_vector_int_t *membership,
+                    igraph_vector_int_t *csize, igraph_integer_t *no,
                     igraph_connectedness_t mode) {
     if (mode == IGRAPH_WEAK || !igraph_is_directed(graph)) {
         return igraph_i_clusters_weak(graph, membership, csize, no);
@@ -86,8 +86,8 @@ igraph_error_t igraph_clusters(const igraph_t *graph, igraph_vector_t *membershi
     IGRAPH_ERROR("Cannot calculate clusters", IGRAPH_EINVAL);
 }
 
-static igraph_error_t igraph_i_clusters_weak(const igraph_t *graph, igraph_vector_t *membership,
-                                  igraph_vector_t *csize, igraph_integer_t *no) {
+static igraph_error_t igraph_i_clusters_weak(const igraph_t *graph, igraph_vector_int_t *membership,
+                                  igraph_vector_int_t *csize, igraph_integer_t *no) {
 
     igraph_integer_t no_of_nodes = igraph_vcount(graph);
     char *already_added;
@@ -109,10 +109,10 @@ static igraph_error_t igraph_i_clusters_weak(const igraph_t *graph, igraph_vecto
 
     /* Memory for result, csize is dynamically allocated */
     if (membership) {
-        IGRAPH_CHECK(igraph_vector_resize(membership, no_of_nodes));
+        IGRAPH_CHECK(igraph_vector_int_resize(membership, no_of_nodes));
     }
     if (csize) {
-        igraph_vector_clear(csize);
+        igraph_vector_int_clear(csize);
     }
 
     /* The algorithm */
@@ -149,7 +149,7 @@ static igraph_error_t igraph_i_clusters_weak(const igraph_t *graph, igraph_vecto
         }
         no_of_clusters++;
         if (csize) {
-            IGRAPH_CHECK(igraph_vector_push_back(csize, act_cluster_size));
+            IGRAPH_CHECK(igraph_vector_int_push_back(csize, act_cluster_size));
         }
     }
 
@@ -167,8 +167,8 @@ static igraph_error_t igraph_i_clusters_weak(const igraph_t *graph, igraph_vecto
     return IGRAPH_SUCCESS;
 }
 
-static igraph_error_t igraph_i_clusters_strong(const igraph_t *graph, igraph_vector_t *membership,
-                                    igraph_vector_t *csize, igraph_integer_t *no) {
+static igraph_error_t igraph_i_clusters_strong(const igraph_t *graph, igraph_vector_int_t *membership,
+                                    igraph_vector_int_t *csize, igraph_integer_t *no) {
 
     igraph_integer_t no_of_nodes = igraph_vcount(graph);
     igraph_vector_t next_nei = IGRAPH_VECTOR_NULL;
@@ -191,13 +191,13 @@ static igraph_error_t igraph_i_clusters_strong(const igraph_t *graph, igraph_vec
     IGRAPH_DQUEUE_INIT_FINALLY(&q, 100);
 
     if (membership) {
-        IGRAPH_CHECK(igraph_vector_resize(membership, no_of_nodes));
+        IGRAPH_CHECK(igraph_vector_int_resize(membership, no_of_nodes));
     }
     IGRAPH_CHECK(igraph_vector_reserve(&out, no_of_nodes));
 
     igraph_vector_null(&out);
     if (csize) {
-        igraph_vector_clear(csize);
+        igraph_vector_int_clear(csize);
     }
 
     IGRAPH_CHECK(igraph_adjlist_init(graph, &adjlist, IGRAPH_OUT, IGRAPH_LOOPS_ONCE, IGRAPH_MULTIPLE));
@@ -306,7 +306,7 @@ static igraph_error_t igraph_i_clusters_strong(const igraph_t *graph, igraph_vec
 
         no_of_clusters++;
         if (csize) {
-            IGRAPH_CHECK(igraph_vector_push_back(csize, act_cluster_size));
+            IGRAPH_CHECK(igraph_vector_int_push_back(csize, act_cluster_size));
         }
     }
 

--- a/src/flow/flow.c
+++ b/src/flow/flow.c
@@ -172,7 +172,7 @@ static igraph_error_t igraph_i_maxflow_undirected(const igraph_t *graph,
     igraph_vector_t edges;
     igraph_vector_t newcapacity;
     igraph_t newgraph;
-    long int i;
+    igraph_integer_t i;
 
     /* We need to convert this to directed by hand, since we need to be
        sure that the edge ids will be handled properly to build the new
@@ -254,33 +254,33 @@ static igraph_error_t igraph_i_maxflow_undirected(const igraph_t *graph,
                                         &first, &current, &to, &excess,       \
                                         &rescap, &rev))
 
-static void igraph_i_mf_gap(long int b, igraph_maxflow_stats_t *stats,
+static void igraph_i_mf_gap(igraph_integer_t b, igraph_maxflow_stats_t *stats,
                             igraph_buckets_t *buckets, igraph_dbuckets_t *ibuckets,
-                            long int no_of_nodes,
+                            igraph_integer_t no_of_nodes,
                             igraph_vector_int_t *distance) {
 
     IGRAPH_UNUSED(buckets);
 
-    long int bo;
+    igraph_integer_t bo;
     (stats->nogap)++;
     for (bo = b + 1; bo <= no_of_nodes; bo++) {
         while (!igraph_dbuckets_empty_bucket(ibuckets, bo)) {
-            long int n = igraph_dbuckets_pop(ibuckets, bo);
+            igraph_integer_t n = igraph_dbuckets_pop(ibuckets, bo);
             (stats->nogapnodes)++;
             DIST(n) = no_of_nodes;
         }
     }
 }
 
-static void igraph_i_mf_relabel(long int v, long int no_of_nodes,
+static void igraph_i_mf_relabel(igraph_integer_t v, igraph_integer_t no_of_nodes,
                                 igraph_vector_int_t *distance,
                                 igraph_vector_int_t *first,
                                 igraph_vector_t *rescap, igraph_vector_int_t *to,
                                 igraph_vector_int_t *current,
                                 igraph_maxflow_stats_t *stats, int *nrelabelsince) {
 
-    long int min = no_of_nodes;
-    long int k, l, min_edge = 0;
+    igraph_integer_t min = no_of_nodes;
+    igraph_integer_t k, l, min_edge = 0;
     (stats->norelabel)++; (*nrelabelsince)++;
     DIST(v) = no_of_nodes;
     for (k = FIRST(v), l = LAST(v); k < l; k++) {
@@ -296,10 +296,10 @@ static void igraph_i_mf_relabel(long int v, long int no_of_nodes,
     }
 }
 
-static void igraph_i_mf_push(long int v, long int e, long int n,
+static void igraph_i_mf_push(igraph_integer_t v, igraph_integer_t e, igraph_integer_t n,
                              igraph_vector_int_t *current,
                              igraph_vector_t *rescap, igraph_vector_t *excess,
-                             long int target, long int source,
+                             igraph_integer_t target, igraph_integer_t source,
                              igraph_buckets_t *buckets, igraph_dbuckets_t *ibuckets,
                              igraph_vector_int_t *distance,
                              igraph_vector_int_t *rev, igraph_maxflow_stats_t *stats,
@@ -322,26 +322,26 @@ static void igraph_i_mf_push(long int v, long int e, long int n,
     EXCESS(v) -= delta;
 }
 
-static void igraph_i_mf_discharge(long int v,
+static void igraph_i_mf_discharge(igraph_integer_t v,
                                   igraph_vector_int_t *current,
                                   igraph_vector_int_t *first,
                                   igraph_vector_t *rescap,
                                   igraph_vector_int_t *to,
                                   igraph_vector_int_t *distance,
                                   igraph_vector_t *excess,
-                                  long int no_of_nodes, long int source,
-                                  long int target, igraph_buckets_t *buckets,
+                                  igraph_integer_t no_of_nodes, igraph_integer_t source,
+                                  igraph_integer_t target, igraph_buckets_t *buckets,
                                   igraph_dbuckets_t *ibuckets,
                                   igraph_vector_int_t *rev,
                                   igraph_maxflow_stats_t *stats,
                                   int *npushsince, int *nrelabelsince) {
     do {
-        long int i;
-        long int start = CURRENT(v);
-        long int stop = LAST(v);
+        igraph_integer_t i;
+        igraph_integer_t start = CURRENT(v);
+        igraph_integer_t stop = LAST(v);
         for (i = start; i < stop; i++) {
             if (RESCAP(i) > 0) {
-                long int nei = HEAD(i);
+                igraph_integer_t nei = HEAD(i);
                 if (DIST(v) == DIST(nei) + 1) {
                     PUSH((v), i, nei);
                     if (EXCESS(v) == 0) {
@@ -351,7 +351,7 @@ static void igraph_i_mf_discharge(long int v,
             }
         }
         if (i == stop) {
-            long int origdist = DIST(v);
+            igraph_integer_t origdist = DIST(v);
             RELABEL(v);
             if (igraph_buckets_empty_bucket(buckets, origdist) &&
                 igraph_dbuckets_empty_bucket(ibuckets, origdist)) {
@@ -369,15 +369,15 @@ static void igraph_i_mf_discharge(long int v,
 }
 
 static igraph_error_t igraph_i_mf_bfs(igraph_dqueue_int_t *bfsq,
-                            long int source, long int target,
-                            long int no_of_nodes, igraph_buckets_t *buckets,
+                            igraph_integer_t source, igraph_integer_t target,
+                            igraph_integer_t no_of_nodes, igraph_buckets_t *buckets,
                             igraph_dbuckets_t *ibuckets,
                             igraph_vector_int_t *distance,
                             igraph_vector_int_t *first, igraph_vector_int_t *current,
                             igraph_vector_int_t *to, igraph_vector_t *excess,
                             igraph_vector_t *rescap, igraph_vector_int_t *rev) {
 
-    long int k, l;
+    igraph_integer_t k, l;
 
     IGRAPH_UNUSED(source);
 
@@ -392,7 +392,7 @@ static igraph_error_t igraph_i_mf_bfs(igraph_dqueue_int_t *bfsq,
         igraph_integer_t ndist = DIST(node) + 1;
         for (k = FIRST(node), l = LAST(node); k < l; k++) {
             if (RESCAP(REV(k)) > 0) {
-                long int nei = HEAD(k);
+                igraph_integer_t nei = HEAD(k);
                 if (DIST(nei) == no_of_nodes) {
                     DIST(nei) = ndist;
                     CURRENT(nei) = FIRST(nei);
@@ -503,7 +503,7 @@ igraph_error_t igraph_maxflow(const igraph_t *graph, igraph_real_t *value,
 
     igraph_dqueue_int_t bfsq;
 
-    long int i, j, idx;
+    igraph_integer_t i, j, idx;
     int npushsince = 0, nrelabelsince = 0;
 
     igraph_maxflow_stats_t local_stats;   /* used if the user passed a null pointer for stats */
@@ -592,8 +592,8 @@ igraph_error_t igraph_maxflow(const igraph_t *graph, igraph_real_t *value,
     IGRAPH_CHECK(igraph_vector_rank(&edges, &rank, no_of_nodes));
 
     for (i = 0; i < no_of_edges; i += 2) {
-        long int pos = VECTOR(rank)[i];
-        long int pos2 = VECTOR(rank)[i + 1];
+        igraph_integer_t pos = VECTOR(rank)[i];
+        igraph_integer_t pos2 = VECTOR(rank)[i + 1];
         VECTOR(from)[pos] = VECTOR(edges)[i];
         VECTOR(to)[pos]   = VECTOR(edges)[i + 1];
         VECTOR(from)[pos2] = VECTOR(edges)[i + 1];
@@ -612,8 +612,8 @@ igraph_error_t igraph_maxflow(const igraph_t *graph, igraph_real_t *value,
         idx++; VECTOR(first)[idx] = 0;
     }
     for (i = 1; i < no_of_edges; i++) {
-        long int n = (VECTOR(from)[i] -
-                                 VECTOR(from)[ (long int) VECTOR(first)[idx] ]);
+        igraph_integer_t n = (VECTOR(from)[i] -
+                                 VECTOR(from)[ VECTOR(first)[idx] ]);
         for (j = 0; j < n; j++) {
             idx++; VECTOR(first)[idx] = i;
         }
@@ -659,7 +659,7 @@ igraph_error_t igraph_maxflow(const igraph_t *graph, igraph_real_t *value,
     (stats->nobfs)++;
 
     while (!igraph_buckets_empty(&buckets)) {
-        long int vertex = igraph_buckets_popmax(&buckets);
+        igraph_integer_t vertex = igraph_buckets_popmax(&buckets);
         DISCHARGE(vertex);
         if (npushsince > no_of_nodes / 2 && nrelabelsince > no_of_nodes) {
             (stats->nobfs)++;
@@ -680,7 +680,7 @@ igraph_error_t igraph_maxflow(const igraph_t *graph, igraph_real_t *value,
            backwards. */
         igraph_dqueue_t Q;
         igraph_vector_bool_t added;
-        long int marked = 0;
+        igraph_integer_t marked = 0;
 
         IGRAPH_CHECK(igraph_vector_bool_init(&added, no_of_nodes));
         IGRAPH_FINALLY(igraph_vector_bool_destroy, &added);
@@ -692,9 +692,9 @@ igraph_error_t igraph_maxflow(const igraph_t *graph, igraph_real_t *value,
         VECTOR(added)[target] = 1;
         marked++;
         while (!igraph_dqueue_empty(&Q)) {
-            long int actnode = igraph_dqueue_pop(&Q);
+            igraph_integer_t actnode = igraph_dqueue_pop(&Q);
             for (i = FIRST(actnode), j = LAST(actnode); i < j; i++) {
-                long int nei = HEAD(i);
+                igraph_integer_t nei = HEAD(i);
                 if (!VECTOR(added)[nei] && RESCAP(REV(i)) > 0.0) {
                     VECTOR(added)[nei] = 1;
                     marked++;
@@ -720,7 +720,7 @@ igraph_error_t igraph_maxflow(const igraph_t *graph, igraph_real_t *value,
         }
 
         if (partition2) {
-            long int x = 0;
+            igraph_integer_t x = 0;
             IGRAPH_CHECK(igraph_vector_resize(partition2, marked));
             for (i = 0; i < no_of_nodes; i++) {
                 if (VECTOR(added)[i]) {
@@ -730,7 +730,7 @@ igraph_error_t igraph_maxflow(const igraph_t *graph, igraph_real_t *value,
         }
 
         if (partition) {
-            long int x = 0;
+            igraph_integer_t x = 0;
             IGRAPH_CHECK(igraph_vector_resize(partition,
                                               no_of_nodes - marked));
             for (i = 0; i < no_of_nodes; i++) {
@@ -749,7 +749,7 @@ igraph_error_t igraph_maxflow(const igraph_t *graph, igraph_real_t *value,
            from the source */
         igraph_dqueue_t Q;
         igraph_vector_int_t added;
-        long int j, k, l;
+        igraph_integer_t j, k, l;
         igraph_t flow_graph;
         igraph_vector_t flow_edges;
         igraph_bool_t dag;
@@ -763,12 +763,12 @@ igraph_error_t igraph_maxflow(const igraph_t *graph, igraph_real_t *value,
         IGRAPH_CHECK(igraph_dqueue_push(&Q, 0));
         VECTOR(added)[source] = 1;
         while (!igraph_dqueue_empty(&Q)) {
-            long int actnode = igraph_dqueue_pop(&Q);
-            long int actdist = igraph_dqueue_pop(&Q);
+            igraph_integer_t actnode = igraph_dqueue_pop(&Q);
+            igraph_integer_t actdist = igraph_dqueue_pop(&Q);
             DIST(actnode) = actdist;
 
             for (i = FIRST(actnode), j = LAST(actnode); i < j; i++) {
-                long int nei = HEAD(i);
+                igraph_integer_t nei = HEAD(i);
                 if (!VECTOR(added)[nei] && RESCAP(REV(i)) > 0.0) {
                     VECTOR(added)[nei] = 1;
                     IGRAPH_CHECK(igraph_dqueue_push(&Q, nei));
@@ -791,13 +791,13 @@ igraph_error_t igraph_maxflow(const igraph_t *graph, igraph_real_t *value,
 
         /* Now we return the flow to the source */
         while (!igraph_buckets_empty(&buckets)) {
-            long int vertex = igraph_buckets_popmax(&buckets);
+            igraph_integer_t vertex = igraph_buckets_popmax(&buckets);
 
             /* DISCHARGE(vertex) comes here */
             do {
                 for (i = CURRENT(vertex), j = LAST(vertex); i < j; i++) {
                     if (RESCAP(i) > 0) {
-                        long int nei = HEAD(i);
+                        igraph_integer_t nei = HEAD(i);
 
                         if (DIST(vertex) == DIST(nei) + 1) {
                             igraph_real_t delta =
@@ -825,7 +825,7 @@ igraph_error_t igraph_maxflow(const igraph_t *graph, igraph_real_t *value,
 
                     /* RELABEL(vertex) comes here */
                     igraph_real_t min;
-                    long int min_edge = 0;
+                    igraph_integer_t min_edge = 0;
                     DIST(vertex) = min = no_of_nodes;
                     for (k = FIRST(vertex), l = LAST(vertex); k < l; k++) {
                         if (RESCAP(k) > 0) {
@@ -876,7 +876,7 @@ igraph_error_t igraph_maxflow(const igraph_t *graph, igraph_real_t *value,
 
         IGRAPH_VECTOR_INIT_FINALLY(&flow_edges, 0);
         for (i = 0, j = 0; i < no_of_edges; i += 2, j++) {
-            long int pos = VECTOR(rank)[i];
+            igraph_integer_t pos = VECTOR(rank)[i];
             if ((capacity ? VECTOR(*capacity)[j] : 1.0) > RESCAP(pos)) {
                 IGRAPH_CHECK(igraph_vector_push_back(&flow_edges,
                                                      IGRAPH_FROM(graph, j)));
@@ -906,8 +906,8 @@ igraph_error_t igraph_maxflow(const igraph_t *graph, igraph_real_t *value,
 #define MYCAP(i)      (VECTOR(mycap)[(i)])
 
             for (i = 0; i < no_of_edges; i += 2) {
-                long int pos = VECTOR(rank)[i];
-                long int pos2 = VECTOR(rank)[i + 1];
+                igraph_integer_t pos = VECTOR(rank)[i];
+                igraph_integer_t pos2 = VECTOR(rank)[i + 1];
                 MYCAP(pos) = (capacity ? VECTOR(*capacity)[i / 2] : 1.0) - RESCAP(pos);
                 MYCAP(pos2) = 0.0;
             }
@@ -922,9 +922,9 @@ igraph_error_t igraph_maxflow(const igraph_t *graph, igraph_real_t *value,
                 VECTOR(added)[source] = 1;
                 while (!igraph_vector_int_empty(&stack) &&
                        igraph_vector_int_tail(&stack) != target) {
-                    long int actnode = igraph_vector_int_tail(&stack);
-                    long int edge = FIRST(actnode) + CURRENT(actnode);
-                    long int nei;
+                    igraph_integer_t actnode = igraph_vector_int_tail(&stack);
+                    igraph_integer_t edge = FIRST(actnode) + CURRENT(actnode);
+                    igraph_integer_t nei;
                     while (edge < LAST(actnode) && MYCAP(edge) == 0.0) {
                         edge++;
                     }
@@ -942,10 +942,10 @@ igraph_error_t igraph_maxflow(const igraph_t *graph, igraph_real_t *value,
                            until we find 'nei' again, determine the flow along the
                            cycle. */
                         igraph_real_t thisflow = MYCAP(edge);
-                        long int idx;
+                        igraph_integer_t idx;
                         for (idx = igraph_vector_int_size(&stack) - 2;
                              idx >= 0 && VECTOR(stack)[idx + 1] != nei; idx -= 2) {
-                            long int e = VECTOR(stack)[idx];
+                            igraph_integer_t e = VECTOR(stack)[idx];
                             igraph_real_t rcap = e >= 0 ? MYCAP(e) : MYCAP(edge);
                             if (rcap < thisflow) {
                                 thisflow = rcap;
@@ -954,7 +954,7 @@ igraph_error_t igraph_maxflow(const igraph_t *graph, igraph_real_t *value,
                         MYCAP(edge) -= thisflow; RESCAP(edge) += thisflow;
                         for (idx = igraph_vector_int_size(&stack) - 2;
                              idx >= 0 && VECTOR(stack)[idx + 1] != nei; idx -= 2) {
-                            long int e = VECTOR(stack)[idx];
+                            igraph_integer_t e = VECTOR(stack)[idx];
                             if (e >= 0) {
                                 MYCAP(e) -= thisflow;
                                 RESCAP(e) += thisflow;
@@ -979,14 +979,14 @@ igraph_error_t igraph_maxflow(const igraph_t *graph, igraph_real_t *value,
                     igraph_integer_t pl = igraph_vector_int_size(&stack);
                     igraph_real_t thisflow = EXCESS(target);
                     for (i = 2; i < pl; i += 2) {
-                        long int edge = VECTOR(stack)[i];
+                        igraph_integer_t edge = VECTOR(stack)[i];
                         igraph_real_t rcap = MYCAP(edge);
                         if (rcap < thisflow) {
                             thisflow = rcap;
                         }
                     }
                     for (i = 2; i < pl; i += 2) {
-                        long int edge = VECTOR(stack)[i];
+                        igraph_integer_t edge = VECTOR(stack)[i];
                         MYCAP(edge) -= thisflow;
                     }
                 }
@@ -1003,7 +1003,7 @@ igraph_error_t igraph_maxflow(const igraph_t *graph, igraph_real_t *value,
 
         IGRAPH_CHECK(igraph_vector_resize(flow, no_of_orig_edges));
         for (i = 0, j = 0; i < no_of_edges; i += 2, j++) {
-            long int pos = VECTOR(rank)[i];
+            igraph_integer_t pos = VECTOR(rank)[i];
             VECTOR(*flow)[j] = (capacity ? VECTOR(*capacity)[j] : 1.0) -
                                RESCAP(pos);
         }
@@ -1181,12 +1181,12 @@ igraph_error_t igraph_st_mincut(const igraph_t *graph, igraph_real_t *value,
 /*                   igraph_real_t *res, */
 /*                   const igraph_vector_t *capacity) { */
 
-/*   long int no_of_edges=igraph_ecount(graph); */
-/*   long int no_of_nodes=igraph_vcount(graph); */
+/*   igraph_integer_t no_of_edges=igraph_ecount(graph); */
+/*   igraph_integer_t no_of_nodes=igraph_vcount(graph); */
 /*   igraph_vector_t edges; */
 /*   igraph_vector_t newcapacity; */
 /*   igraph_t newgraph; */
-/*   long int i; */
+/*   igraph_integer_t i; */
 
 /*   /\* We need to convert this to directed by hand, since we need to be */
 /*      sure that the edge ids will be handled properly to build the new */
@@ -1236,14 +1236,14 @@ static igraph_error_t igraph_i_mincut_undirected(const igraph_t *graph,
 
     igraph_i_cutheap_t heap;
     igraph_real_t mincut = IGRAPH_INFINITY; /* infinity */
-    long int i;
+    igraph_integer_t i;
 
     igraph_adjlist_t adjlist;
     igraph_inclist_t inclist;
 
     igraph_vector_t mergehist;
     igraph_bool_t calc_cut = partition || partition2 || cut;
-    long int act_step = 0, mincut_step = 0;
+    igraph_integer_t act_step = 0, mincut_step = 0;
 
     if (capacity && igraph_vector_size(capacity) != no_of_edges) {
         IGRAPH_ERROR("Invalid capacity vector size", IGRAPH_EINVAL);
@@ -1251,10 +1251,11 @@ static igraph_error_t igraph_i_mincut_undirected(const igraph_t *graph,
 
     /* Check if the graph is connected at all */
     {
-        igraph_vector_t memb, csize;
+        igraph_vector_int_t memb;
+        igraph_vector_int_t csize;
         igraph_integer_t no;
-        IGRAPH_VECTOR_INIT_FINALLY(&memb, 0);
-        IGRAPH_VECTOR_INIT_FINALLY(&csize, 0);
+        IGRAPH_VECTOR_INT_INIT_FINALLY(&memb, 0);
+        IGRAPH_VECTOR_INT_INIT_FINALLY(&csize, 0);
         IGRAPH_CHECK(igraph_clusters(graph, &memb, &csize, &no,
                                      /*mode=*/ IGRAPH_WEAK));
         if (no != 1) {
@@ -1267,7 +1268,7 @@ static igraph_error_t igraph_i_mincut_undirected(const igraph_t *graph,
             if (partition) {
                 int j = 0;
                 IGRAPH_CHECK(igraph_vector_resize(partition,
-                                                  (long int) VECTOR(csize)[0]));
+                                                  VECTOR(csize)[0]));
                 for (i = 0; i < no_of_nodes; i++) {
                     if (VECTOR(memb)[i] == 0) {
                         VECTOR(*partition)[j++] = i;
@@ -1277,7 +1278,7 @@ static igraph_error_t igraph_i_mincut_undirected(const igraph_t *graph,
             if (partition2) {
                 int j = 0;
                 IGRAPH_CHECK(igraph_vector_resize(partition2, no_of_nodes -
-                                                  (long int) VECTOR(csize)[0]));
+                                                  VECTOR(csize)[0]));
                 for (i = 0; i < no_of_nodes; i++) {
                     if (VECTOR(memb)[i] != 0) {
                         VECTOR(*partition2)[j++] = i;
@@ -1285,8 +1286,8 @@ static igraph_error_t igraph_i_mincut_undirected(const igraph_t *graph,
                 }
             }
         }
-        igraph_vector_destroy(&csize);
-        igraph_vector_destroy(&memb);
+        igraph_vector_int_destroy(&csize);
+        igraph_vector_int_destroy(&memb);
         IGRAPH_FINALLY_CLEAN(2);
 
         if (no != 1) {
@@ -1310,9 +1311,9 @@ static igraph_error_t igraph_i_mincut_undirected(const igraph_t *graph,
 
     while (igraph_i_cutheap_size(&heap) >= 2) {
 
-        long int last;
+        igraph_integer_t last;
         igraph_real_t acut;
-        long int a, n;
+        igraph_integer_t a, n;
 
         igraph_vector_int_t *edges, *edges2;
         igraph_vector_int_t *neis, *neis2;
@@ -1391,7 +1392,7 @@ static igraph_error_t igraph_i_mincut_undirected(const igraph_t *graph,
         n = igraph_vector_int_size(neis);
         for (i = 0; i < n; i++) {
             igraph_integer_t nei = (igraph_integer_t) VECTOR(*neis)[i];
-            long int n2, j;
+            igraph_integer_t n2, j;
             neis2 = igraph_adjlist_get(&adjlist, nei);
             n2 = igraph_vector_int_size(neis2);
             for (j = 0; j < n2; j++) {
@@ -1423,9 +1424,9 @@ static igraph_error_t igraph_i_mincut_undirected(const igraph_t *graph,
     IGRAPH_FINALLY_CLEAN(3);
 
     if (calc_cut) {
-        long int bignode = VECTOR(mergehist)[2 * mincut_step + 1];
-        long int i, idx;
-        long int size = 1;
+        igraph_integer_t bignode = VECTOR(mergehist)[2 * mincut_step + 1];
+        igraph_integer_t i, idx;
+        igraph_integer_t size = 1;
         char *mark;
         mark = IGRAPH_CALLOC(no_of_nodes, char);
         if (!mark) {
@@ -1436,9 +1437,9 @@ static igraph_error_t igraph_i_mincut_undirected(const igraph_t *graph,
         /* first count the vertices in the partition */
         mark[bignode] = 1;
         for (i = mincut_step - 1; i >= 0; i--) {
-            if ( mark[ (long int) VECTOR(mergehist)[2 * i] ] ) {
+            if ( mark[ (igraph_integer_t) VECTOR(mergehist)[2 * i] ] ) {
                 size++;
-                mark [ (long int) VECTOR(mergehist)[2 * i + 1] ] = 1;
+                mark [ (igraph_integer_t) VECTOR(mergehist)[2 * i + 1] ] = 1;
             }
         }
 
@@ -1448,7 +1449,7 @@ static igraph_error_t igraph_i_mincut_undirected(const igraph_t *graph,
             idx = 0;
             VECTOR(*partition)[idx++] = bignode;
             for (i = mincut_step - 1; i >= 0; i--) {
-                if (mark[ (long int) VECTOR(mergehist)[2 * i] ]) {
+                if (mark[ (igraph_integer_t) VECTOR(mergehist)[2 * i] ]) {
                     VECTOR(*partition)[idx++] = VECTOR(mergehist)[2 * i + 1];
                 }
             }
@@ -1497,7 +1498,7 @@ static igraph_error_t igraph_i_mincut_directed(const igraph_t *graph,
                                     igraph_vector_t *partition2,
                                     igraph_vector_t *cut,
                                     const igraph_vector_t *capacity) {
-    long int i;
+    igraph_integer_t i;
     igraph_integer_t no_of_nodes = igraph_vcount(graph);
     igraph_real_t flow;
     igraph_real_t minmaxflow = IGRAPH_INFINITY;
@@ -1724,7 +1725,7 @@ igraph_error_t igraph_mincut_value(const igraph_t *graph, igraph_real_t *res,
 
     igraph_integer_t no_of_nodes = igraph_vcount(graph);
     igraph_real_t minmaxflow, flow;
-    long int i;
+    igraph_integer_t i;
 
     minmaxflow = IGRAPH_INFINITY;
 
@@ -1770,7 +1771,7 @@ static igraph_error_t igraph_i_st_vertex_connectivity_directed(const igraph_t *g
     igraph_vector_t edges;
     igraph_real_t real_res;
     igraph_t newgraph;
-    long int i;
+    igraph_integer_t i;
     igraph_bool_t conn1;
 
     if (source < 0 || source >= no_of_nodes || target < 0 || target >= no_of_nodes) {
@@ -1964,7 +1965,7 @@ static igraph_error_t igraph_i_vertex_connectivity_directed(const igraph_t *grap
                                                  igraph_integer_t *res) {
 
     igraph_integer_t no_of_nodes = (igraph_integer_t) igraph_vcount(graph);
-    long int i, j;
+    igraph_integer_t i, j;
     igraph_integer_t minconn = no_of_nodes - 1, conn = 0;
 
     for (i = 0; i < no_of_nodes; i++) {

--- a/src/flow/flow_internal.h
+++ b/src/flow/flow_internal.h
@@ -29,8 +29,8 @@ __BEGIN_DECLS
 
 IGRAPH_PRIVATE_EXPORT igraph_error_t igraph_i_all_st_cuts_pivot(
    const igraph_t *graph, const igraph_marked_queue_t *S,
-   const igraph_estack_t *T, long int source, long int target,
-   long int *v, igraph_vector_t *Isv, void *arg);
+   const igraph_estack_t *T, igraph_integer_t source, igraph_integer_t target,
+   igraph_integer_t *v, igraph_vector_t *Isv, void *arg);
 
 __END_DECLS
 

--- a/src/flow/st-cuts.c
+++ b/src/flow/st-cuts.c
@@ -43,9 +43,9 @@
 typedef igraph_error_t igraph_provan_shier_pivot_t(const igraph_t *graph,
                                                    const igraph_marked_queue_t *S,
                                                    const igraph_estack_t *T,
-                                                   long int source,
-                                                   long int target,
-                                                   long int *v,
+                                                   igraph_integer_t source,
+                                                   igraph_integer_t target,
+                                                   igraph_integer_t *v,
                                                    igraph_vector_t *Isv,
                                                    void *arg);
 
@@ -88,12 +88,12 @@ igraph_error_t igraph_even_tarjan_reduction(const igraph_t *graph, igraph_t *gra
     igraph_integer_t no_of_nodes = igraph_vcount(graph);
     igraph_integer_t no_of_edges = igraph_ecount(graph);
 
-    long int new_no_of_nodes = no_of_nodes * 2;
-    long int new_no_of_edges = no_of_nodes + no_of_edges * 2;
+    igraph_integer_t new_no_of_nodes = no_of_nodes * 2;
+    igraph_integer_t new_no_of_edges = no_of_nodes + no_of_edges * 2;
 
     igraph_vector_t edges;
-    long int edgeptr = 0, capptr = 0;
-    long int i;
+    igraph_integer_t edgeptr = 0, capptr = 0;
+    igraph_integer_t i;
 
     IGRAPH_VECTOR_INIT_FINALLY(&edges, new_no_of_edges * 2);
 
@@ -146,8 +146,8 @@ static igraph_error_t igraph_i_residual_graph(const igraph_t *graph,
 
     igraph_integer_t no_of_nodes = igraph_vcount(graph);
     igraph_integer_t no_of_edges = igraph_ecount(graph);
-    long int i, no_new_edges = 0;
-    long int edgeptr = 0, capptr = 0;
+    igraph_integer_t i, no_new_edges = 0;
+    igraph_integer_t edgeptr = 0, capptr = 0;
 
     for (i = 0; i < no_of_edges; i++) {
         if (VECTOR(*flow)[i] < VECTOR(*capacity)[i]) {
@@ -214,8 +214,8 @@ static igraph_error_t igraph_i_reverse_residual_graph(const igraph_t *graph,
 
     igraph_integer_t no_of_nodes = igraph_vcount(graph);
     igraph_integer_t no_of_edges = igraph_ecount(graph);
-    long int i, no_new_edges = 0;
-    long int edgeptr = 0;
+    igraph_integer_t i, no_new_edges = 0;
+    igraph_integer_t edgeptr = 0;
 
     for (i = 0; i < no_of_edges; i++) {
         igraph_real_t cap = capacity ? VECTOR(*capacity)[i] : 1.0;
@@ -278,7 +278,7 @@ typedef struct igraph_i_dbucket_t {
     igraph_vector_int_t next;
 } igraph_i_dbucket_t;
 
-static igraph_error_t igraph_i_dbucket_init(igraph_i_dbucket_t *buck, long int size) {
+static igraph_error_t igraph_i_dbucket_init(igraph_i_dbucket_t *buck, igraph_integer_t size) {
     IGRAPH_VECTOR_INT_INIT_FINALLY(&buck->head, size);
     IGRAPH_CHECK(igraph_vector_int_init(&buck->next, size));
     IGRAPH_FINALLY_CLEAN(1);
@@ -290,26 +290,26 @@ static void igraph_i_dbucket_destroy(igraph_i_dbucket_t *buck) {
     igraph_vector_int_destroy(&buck->next);
 }
 
-static igraph_error_t igraph_i_dbucket_insert(igraph_i_dbucket_t *buck, long int bid,
-                                   long int elem) {
+static igraph_error_t igraph_i_dbucket_insert(igraph_i_dbucket_t *buck, igraph_integer_t bid,
+                                   igraph_integer_t elem) {
     /* Note: we can do this, since elem is not in any buckets */
     VECTOR(buck->next)[elem] = VECTOR(buck->head)[bid];
     VECTOR(buck->head)[bid] = elem + 1;
     return IGRAPH_SUCCESS;
 }
 
-static long int igraph_i_dbucket_empty(const igraph_i_dbucket_t *buck,
-                                       long int bid) {
+static igraph_integer_t igraph_i_dbucket_empty(const igraph_i_dbucket_t *buck,
+                                       igraph_integer_t bid) {
     return VECTOR(buck->head)[bid] == 0;
 }
 
-static long int igraph_i_dbucket_delete(igraph_i_dbucket_t *buck, long int bid) {
-    long int elem = VECTOR(buck->head)[bid] - 1;
+static igraph_integer_t igraph_i_dbucket_delete(igraph_i_dbucket_t *buck, igraph_integer_t bid) {
+    igraph_integer_t elem = VECTOR(buck->head)[bid] - 1;
     VECTOR(buck->head)[bid] = VECTOR(buck->next)[elem];
     return elem;
 }
 
-static igraph_error_t igraph_i_dominator_LINK(long int v, long int w,
+static igraph_error_t igraph_i_dominator_LINK(igraph_integer_t v, igraph_integer_t w,
                                    igraph_vector_int_t *ancestor) {
     VECTOR(*ancestor)[w] = v + 1;
     return IGRAPH_SUCCESS;
@@ -317,13 +317,13 @@ static igraph_error_t igraph_i_dominator_LINK(long int v, long int w,
 
 /* TODO: don't always reallocate path */
 
-static igraph_error_t igraph_i_dominator_COMPRESS(long int v,
+static igraph_error_t igraph_i_dominator_COMPRESS(igraph_integer_t v,
                                        igraph_vector_int_t *ancestor,
                                        igraph_vector_int_t *label,
                                        igraph_vector_int_t *semi) {
     igraph_stack_int_t path;
-    long int w = v;
-    long int top, pretop;
+    igraph_integer_t w = v;
+    igraph_integer_t top, pretop;
 
     IGRAPH_CHECK(igraph_stack_int_init(&path, 10));
     IGRAPH_FINALLY(igraph_stack_int_destroy, &path);
@@ -352,7 +352,7 @@ static igraph_error_t igraph_i_dominator_COMPRESS(long int v,
     return IGRAPH_SUCCESS;
 }
 
-static long int igraph_i_dominator_EVAL(long int v,
+static igraph_integer_t igraph_i_dominator_EVAL(igraph_integer_t v,
                                         igraph_vector_int_t *ancestor,
                                         igraph_vector_int_t *label,
                                         igraph_vector_int_t *semi) {
@@ -437,11 +437,11 @@ igraph_error_t igraph_dominator_tree(const igraph_t *graph,
 
     igraph_neimode_t invmode = mode == IGRAPH_IN ? IGRAPH_OUT : IGRAPH_IN;
 
-    long int i;
+    igraph_integer_t i;
 
     igraph_vector_t vdom, *mydom = dom;
 
-    long int component_size = 0;
+    igraph_integer_t component_size = 0;
 
     if (root < 0 || root >= no_of_nodes) {
         IGRAPH_ERROR("Invalid root vertex id for dominator tree",
@@ -493,15 +493,15 @@ igraph_error_t igraph_dominator_tree(const igraph_t *graph,
 
     for (i = 0; i < no_of_nodes; i++) {
         if (IGRAPH_FINITE(VECTOR(vertex)[i])) {
-            long int t = VECTOR(vertex)[i];
+            igraph_integer_t t = VECTOR(vertex)[i];
             VECTOR(semi)[t] = component_size + 1;
             VECTOR(vertex)[component_size] = t + 1;
             component_size++;
         }
     }
     if (leftout) {
-        long int n = no_of_nodes - component_size;
-        long int p = 0, j;
+        igraph_integer_t n = no_of_nodes - component_size;
+        igraph_integer_t p = 0, j;
         IGRAPH_CHECK(igraph_vector_resize(leftout, n));
         for (j = 0; j < no_of_nodes && p < n; j++) {
             if (!IGRAPH_FINITE(VECTOR(parent)[j])) {
@@ -516,7 +516,7 @@ igraph_error_t igraph_dominator_tree(const igraph_t *graph,
         igraph_vector_int_t *v = igraph_adjlist_get(&pred, i);
         igraph_integer_t j, n = igraph_vector_int_size(v);
         for (j = 0; j < n; ) {
-            long int v2 = VECTOR(*v)[j];
+            igraph_integer_t v2 = VECTOR(*v)[j];
             if (IGRAPH_FINITE(VECTOR(parent)[v2])) {
                 j++;
             } else {
@@ -530,22 +530,22 @@ igraph_error_t igraph_dominator_tree(const igraph_t *graph,
     /* Now comes the main algorithm, steps 2 & 3 */
 
     for (i = component_size - 1; i > 0; i--) {
-        long int w = VECTOR(vertex)[i] - 1;
+        igraph_integer_t w = VECTOR(vertex)[i] - 1;
         igraph_vector_int_t *predw = igraph_adjlist_get(&pred, w);
         igraph_integer_t j, n = igraph_vector_int_size(predw);
         for (j = 0; j < n; j++) {
-            long int v = VECTOR(*predw)[j];
-            long int u = igraph_i_dominator_EVAL(v, &ancestor, &label, &semi);
+            igraph_integer_t v = VECTOR(*predw)[j];
+            igraph_integer_t u = igraph_i_dominator_EVAL(v, &ancestor, &label, &semi);
             if (VECTOR(semi)[u] < VECTOR(semi)[w]) {
                 VECTOR(semi)[w] = VECTOR(semi)[u];
             }
         }
-        igraph_i_dbucket_insert(&bucket, (long int)
+        igraph_i_dbucket_insert(&bucket, (igraph_integer_t)
                                 VECTOR(vertex)[ VECTOR(semi)[w] - 1 ] - 1, w);
-        igraph_i_dominator_LINK((long int) VECTOR(parent)[w], w, &ancestor);
-        while (!igraph_i_dbucket_empty(&bucket, (long int) VECTOR(parent)[w])) {
-            long int v = igraph_i_dbucket_delete(&bucket, (long int) VECTOR(parent)[w]);
-            long int u = igraph_i_dominator_EVAL(v, &ancestor, &label, &semi);
+        igraph_i_dominator_LINK((igraph_integer_t) VECTOR(parent)[w], w, &ancestor);
+        while (!igraph_i_dbucket_empty(&bucket, (igraph_integer_t) VECTOR(parent)[w])) {
+            igraph_integer_t v = igraph_i_dbucket_delete(&bucket, (igraph_integer_t) VECTOR(parent)[w]);
+            igraph_integer_t u = igraph_i_dominator_EVAL(v, &ancestor, &label, &semi);
             VECTOR(*mydom)[v] = VECTOR(semi)[u] < VECTOR(semi)[v] ? u :
                                 VECTOR(parent)[w];
         }
@@ -554,9 +554,9 @@ igraph_error_t igraph_dominator_tree(const igraph_t *graph,
     /* Finally, step 4 */
 
     for (i = 1; i < component_size; i++) {
-        long int w = VECTOR(vertex)[i] - 1;
+        igraph_integer_t w = VECTOR(vertex)[i] - 1;
         if (VECTOR(*mydom)[w] != VECTOR(vertex)[VECTOR(semi)[w] - 1] - 1) {
-            VECTOR(*mydom)[w] = VECTOR(*mydom)[(long int)VECTOR(*mydom)[w]];
+            VECTOR(*mydom)[w] = VECTOR(*mydom)[(igraph_integer_t)VECTOR(*mydom)[w]];
         }
     }
     VECTOR(*mydom)[root] = -1;
@@ -573,7 +573,7 @@ igraph_error_t igraph_dominator_tree(const igraph_t *graph,
 
     if (domtree) {
         igraph_vector_t edges;
-        long int ptr = 0;
+        igraph_integer_t ptr = 0;
         IGRAPH_VECTOR_INIT_FINALLY(&edges, component_size * 2 - 2);
         for (i = 0; i < no_of_nodes; i++) {
             if (i != root && IGRAPH_FINITE(VECTOR(*mydom)[i])) {
@@ -608,7 +608,7 @@ typedef struct igraph_i_all_st_cuts_minimal_dfs_data_t {
     igraph_stack_t *stack;
     igraph_vector_bool_t *nomark;
     const igraph_vector_bool_t *GammaX;
-    long int root;
+    igraph_integer_t root;
     const igraph_vector_t *map;
 } igraph_i_all_st_cuts_minimal_dfs_data_t;
 
@@ -623,13 +623,13 @@ static igraph_error_t igraph_i_all_st_cuts_minimal_dfs_incb(
     igraph_vector_bool_t *nomark = data->nomark;
     const igraph_vector_bool_t *GammaX = data->GammaX;
     const igraph_vector_t *map = data->map;
-    long int realvid = VECTOR(*map)[vid];
+    igraph_integer_t realvid = VECTOR(*map)[vid];
 
     IGRAPH_UNUSED(graph); IGRAPH_UNUSED(dist);
 
     if (VECTOR(*GammaX)[realvid]) {
         if (!igraph_stack_empty(stack)) {
-            long int top = igraph_stack_top(stack);
+            igraph_integer_t top = igraph_stack_top(stack);
             VECTOR(*nomark)[top] = 1; /* we just found a smaller one */
         }
         IGRAPH_CHECK(igraph_stack_push(stack, realvid));
@@ -646,7 +646,7 @@ static igraph_error_t igraph_i_all_st_cuts_minimal_dfs_outcb(
     igraph_i_all_st_cuts_minimal_dfs_data_t *data = extra;
     igraph_stack_t *stack = data->stack;
     const igraph_vector_t *map = data->map;
-    long int realvid = VECTOR(*map)[vid];
+    igraph_integer_t realvid = VECTOR(*map)[vid];
 
     IGRAPH_UNUSED(graph); IGRAPH_UNUSED(dist);
 
@@ -660,7 +660,7 @@ static igraph_error_t igraph_i_all_st_cuts_minimal_dfs_outcb(
 
 static igraph_error_t igraph_i_all_st_cuts_minimal(const igraph_t *graph,
                                         const igraph_t *domtree,
-                                        long int root,
+                                        igraph_integer_t root,
                                         const igraph_marked_queue_t *X,
                                         const igraph_vector_bool_t *GammaX,
                                         const igraph_vector_t *invmap,
@@ -670,7 +670,7 @@ static igraph_error_t igraph_i_all_st_cuts_minimal(const igraph_t *graph,
     igraph_stack_t stack;
     igraph_vector_bool_t nomark;
     igraph_i_all_st_cuts_minimal_dfs_data_t data;
-    long int i;
+    igraph_integer_t i;
 
     IGRAPH_UNUSED(X);
 
@@ -722,8 +722,8 @@ static igraph_error_t igraph_i_all_st_cuts_minimal(const igraph_t *graph,
 /* not 'static' because used in igraph_all_st_cuts.c test program */
 igraph_error_t igraph_i_all_st_cuts_pivot(
     const igraph_t *graph, const igraph_marked_queue_t *S,
-    const igraph_estack_t *T, long int source, long int target,
-    long int *v, igraph_vector_t *Isv, void *arg
+    const igraph_estack_t *T, igraph_integer_t source, igraph_integer_t target,
+    igraph_integer_t *v, igraph_vector_t *Isv, void *arg
 ) {
 
     igraph_integer_t no_of_nodes = igraph_vcount(graph);
@@ -732,14 +732,14 @@ igraph_error_t igraph_i_all_st_cuts_pivot(
     igraph_vector_t keep;
     igraph_t domtree;
     igraph_vector_t leftout;
-    long int i, nomin, n;
-    long int root;
+    igraph_integer_t i, nomin, n;
+    igraph_integer_t root;
     igraph_vector_t M;
     igraph_vector_bool_t GammaS;
     igraph_vector_t Nuv;
     igraph_vector_t Isv_min;
     igraph_vector_t GammaS_vec;
-    long int Sbar_size;
+    igraph_integer_t Sbar_size;
 
     IGRAPH_UNUSED(arg);
 
@@ -784,18 +784,18 @@ igraph_error_t igraph_i_all_st_cuts_pivot(
     IGRAPH_CHECK(igraph_vector_bool_init(&GammaS, no_of_nodes));
     IGRAPH_FINALLY(igraph_vector_bool_destroy, &GammaS);
     if (igraph_marked_queue_size(S) == 0) {
-        VECTOR(GammaS)[(long int) VECTOR(Sbar_map)[source] - 1] = 1;
+        VECTOR(GammaS)[(igraph_integer_t) VECTOR(Sbar_map)[source] - 1] = 1;
     } else {
         for (i = 0; i < no_of_nodes; i++) {
             if (igraph_marked_queue_iselement(S, i)) {
                 igraph_vector_t neis;
-                long int j;
+                igraph_integer_t j;
                 IGRAPH_VECTOR_INIT_FINALLY(&neis, 0);
                 IGRAPH_CHECK(igraph_neighbors(graph, &neis, (igraph_integer_t) i,
                                               IGRAPH_OUT));
                 n = igraph_vector_size(&neis);
                 for (j = 0; j < n; j++) {
-                    long int nei = VECTOR(neis)[j];
+                    igraph_integer_t nei = VECTOR(neis)[j];
                     if (!igraph_marked_queue_iselement(S, nei)) {
                         VECTOR(GammaS)[nei] = 1;
                     }
@@ -812,8 +812,8 @@ igraph_error_t igraph_i_all_st_cuts_pivot(
        L, where L are the nodes in the dominator tree. */
     n = igraph_vector_size(&leftout);
     for (i = 0; i < n; i++) {
-        VECTOR(leftout)[i] = VECTOR(Sbar_invmap)[(long int)VECTOR(leftout)[i]];
-        VECTOR(GammaS)[(long int)VECTOR(leftout)[i]] = 0;
+        VECTOR(leftout)[i] = VECTOR(Sbar_invmap)[(igraph_integer_t)VECTOR(leftout)[i]];
+        VECTOR(GammaS)[(igraph_integer_t)VECTOR(leftout)[i]] = 0;
     }
 
     IGRAPH_VECTOR_INIT_FINALLY(&M, 0);
@@ -839,8 +839,8 @@ igraph_error_t igraph_i_all_st_cuts_pivot(
            Nu(v) contains all vertices that are dominated by v, for every
            v, this is a subtree of the dominator tree, rooted at v. The
            different subtrees are disjoint. */
-        long int min = VECTOR(Sbar_map)[(long int) VECTOR(M)[i] ] - 1;
-        long int nuvsize, isvlen, j;
+        igraph_integer_t min = VECTOR(Sbar_map)[(igraph_integer_t) VECTOR(M)[i] ] - 1;
+        igraph_integer_t nuvsize, isvlen, j;
         IGRAPH_CHECK(igraph_dfs(&domtree, (igraph_integer_t) min, IGRAPH_IN,
                                 /*unreachable=*/ 0, /*order=*/ &Nuv,
                                 /*order_out=*/ 0, /*father=*/ 0, /*dist=*/ 0,
@@ -850,7 +850,7 @@ igraph_error_t igraph_i_all_st_cuts_pivot(
         for (nuvsize = 0; nuvsize < Sbar_size; nuvsize++) {
             igraph_real_t t = VECTOR(Nuv)[nuvsize];
             if (IGRAPH_FINITE(t)) {
-                VECTOR(Nuv)[nuvsize] = VECTOR(Sbar_invmap)[(long int) t];
+                VECTOR(Nuv)[nuvsize] = VECTOR(Sbar_invmap)[(igraph_integer_t) t];
             } else {
                 break;
             }
@@ -879,7 +879,7 @@ igraph_error_t igraph_i_all_st_cuts_pivot(
            such a v is found, compute Isv={x|v[Nu(v) U K]x} and return v and
            Isv; otherwise return Isv={}. */
         for (j = 0; j < isvlen; j++) {
-            long int u = VECTOR(Isv_min)[j];
+            igraph_integer_t u = VECTOR(Isv_min)[j];
             if (igraph_estack_iselement(T, u) || u == target) {
                 break;
             }
@@ -929,15 +929,15 @@ igraph_error_t igraph_i_all_st_cuts_pivot(
 
 igraph_error_t igraph_provan_shier_list(
     const igraph_t *graph, igraph_marked_queue_t *S,
-    igraph_estack_t *T, long int source, long int target,
+    igraph_estack_t *T, igraph_integer_t source, igraph_integer_t target,
     igraph_vector_ptr_t *result, igraph_provan_shier_pivot_t *pivot,
     void *pivot_arg
 ) {
 
     igraph_integer_t no_of_nodes = igraph_vcount(graph);
     igraph_vector_t Isv;
-    long int v = 0;
-    long int i, n;
+    igraph_integer_t v = 0;
+    igraph_integer_t i, n;
 
     IGRAPH_CHECK(igraph_vector_init(&Isv, 0));
 
@@ -965,8 +965,8 @@ igraph_error_t igraph_provan_shier_list(
         IGRAPH_CHECK(igraph_marked_queue_start_batch(S));
         n = igraph_vector_size(&Isv);
         for (i = 0; i < n; i++) {
-            if (!igraph_marked_queue_iselement(S, (long int) VECTOR(Isv)[i])) {
-                IGRAPH_CHECK(igraph_marked_queue_push(S, (long int) VECTOR(Isv)[i]));
+            if (!igraph_marked_queue_iselement(S, (igraph_integer_t) VECTOR(Isv)[i])) {
+                IGRAPH_CHECK(igraph_marked_queue_push(S, (igraph_integer_t) VECTOR(Isv)[i]));
             }
         }
 
@@ -1036,7 +1036,7 @@ igraph_error_t igraph_all_st_cuts(const igraph_t *graph,
     igraph_marked_queue_t S;
     igraph_estack_t T;
     igraph_vector_ptr_t *mypartition1s = partition1s, vpartition1s;
-    long int i, nocuts;
+    igraph_integer_t i, nocuts;
 
     if (!igraph_is_directed(graph)) {
         IGRAPH_ERROR("Listing all s-t cuts only implemented for "
@@ -1076,19 +1076,19 @@ igraph_error_t igraph_all_st_cuts(const igraph_t *graph,
         for (i = 0; i < nocuts; i++) {
             igraph_vector_t *cut;
             igraph_vector_t *part = VECTOR(*mypartition1s)[i];
-            long int cutsize = 0;
+            igraph_integer_t cutsize = 0;
             igraph_integer_t j, partlen = igraph_vector_size(part);
             /* Mark elements */
             for (j = 0; j < partlen; j++) {
-                long int v = VECTOR(*part)[j];
+                igraph_integer_t v = VECTOR(*part)[j];
                 VECTOR(inS)[v] = i + 1;
             }
             /* Check how many edges */
             for (j = 0; j < no_of_edges; j++) {
                 igraph_integer_t from = IGRAPH_FROM(graph, j);
                 igraph_integer_t to = IGRAPH_TO(graph, j);
-                long int pfrom = VECTOR(inS)[from];
-                long int pto = VECTOR(inS)[to];
+                igraph_integer_t pfrom = VECTOR(inS)[from];
+                igraph_integer_t pto = VECTOR(inS)[to];
                 if (pfrom == i + 1 && pto != i + 1) {
                     cutsize++;
                 }
@@ -1103,8 +1103,8 @@ igraph_error_t igraph_all_st_cuts(const igraph_t *graph,
             for (j = 0; j < no_of_edges; j++) {
                 igraph_integer_t from = IGRAPH_FROM(graph, j);
                 igraph_integer_t to = IGRAPH_TO(graph, j);
-                long int pfrom = VECTOR(inS)[from];
-                long int pto = VECTOR(inS)[to];
+                igraph_integer_t pfrom = VECTOR(inS)[from];
+                igraph_integer_t pto = VECTOR(inS)[to];
                 if ((pfrom == i + 1 && pto != i + 1)) {
                     VECTOR(*cut)[cutsize++] = j;
                 }
@@ -1154,7 +1154,7 @@ static igraph_error_t igraph_i_all_st_mincuts_minimal(const igraph_t *Sbar,
 
     igraph_integer_t no_of_nodes = igraph_vcount(Sbar);
     igraph_vector_t indeg;
-    long int i, minsize;
+    igraph_integer_t i, minsize;
     igraph_vector_t neis;
 
     IGRAPH_VECTOR_INIT_FINALLY(&neis, 0);
@@ -1163,17 +1163,17 @@ static igraph_error_t igraph_i_all_st_mincuts_minimal(const igraph_t *Sbar,
     IGRAPH_CHECK(igraph_degree(Sbar, &indeg, igraph_vss_all(),
                                IGRAPH_IN, /*loops=*/ 1));
 
-#define ACTIVE(x) (VECTOR(*active)[(long int)VECTOR(*invmap)[(x)]])
+#define ACTIVE(x) (VECTOR(*active)[(igraph_integer_t)VECTOR(*invmap)[(x)]])
 #define ZEROIN(x) (VECTOR(indeg)[(x)]==0)
 
     for (i = 0; i < no_of_nodes; i++) {
         if (!ACTIVE(i)) {
-            long int j, n;
+            igraph_integer_t j, n;
             IGRAPH_CHECK(igraph_neighbors(Sbar, &neis, (igraph_integer_t) i,
                                           IGRAPH_OUT));
             n = igraph_vector_size(&neis);
             for (j = 0; j < n; j++) {
-                long int nei = VECTOR(neis)[j];
+                igraph_integer_t nei = VECTOR(neis)[j];
                 VECTOR(indeg)[nei] -= 1;
             }
         }
@@ -1210,9 +1210,9 @@ typedef struct igraph_i_all_st_mincuts_data_t {
 static igraph_error_t igraph_i_all_st_mincuts_pivot(const igraph_t *graph,
                                          const igraph_marked_queue_t *S,
                                          const igraph_estack_t *T,
-                                         long int source,
-                                         long int target,
-                                         long int *v,
+                                         igraph_integer_t source,
+                                         igraph_integer_t target,
+                                         igraph_integer_t *v,
                                          igraph_vector_t *Isv,
                                          void *arg) {
 
@@ -1220,12 +1220,12 @@ static igraph_error_t igraph_i_all_st_mincuts_pivot(const igraph_t *graph,
     const igraph_vector_bool_t *active = data->active;
 
     igraph_integer_t no_of_nodes = igraph_vcount(graph);
-    long int i, j;
+    igraph_integer_t i, j;
     igraph_vector_t Sbar_map, Sbar_invmap;
     igraph_vector_t keep;
     igraph_t Sbar;
     igraph_vector_t M;
-    long int nomin;
+    igraph_integer_t nomin;
 
     IGRAPH_UNUSED(source); IGRAPH_UNUSED(target);
 
@@ -1266,7 +1266,7 @@ static igraph_error_t igraph_i_all_st_mincuts_pivot(const igraph_t *graph,
     igraph_vector_clear(Isv);
     nomin = igraph_vector_size(&M);
     for (i = 0; i < nomin; i++) {
-        long int min = VECTOR(Sbar_invmap)[ (long int) VECTOR(M)[i] ];
+        igraph_integer_t min = VECTOR(Sbar_invmap)[ (igraph_integer_t) VECTOR(M)[i] ];
         if (min != target)
             if (!igraph_estack_iselement(T, min)) {
                 break;
@@ -1277,7 +1277,7 @@ static igraph_error_t igraph_i_all_st_mincuts_pivot(const igraph_t *graph,
            that can reach the pivot element */
         igraph_vector_t Isv_min;
         IGRAPH_VECTOR_INIT_FINALLY(&Isv_min, 0);
-        *v = VECTOR(Sbar_invmap)[ (long int) VECTOR(M)[i] ];
+        *v = VECTOR(Sbar_invmap)[ (igraph_integer_t) VECTOR(M)[i] ];
         /* TODO: restricted == keep ? */
         IGRAPH_CHECK(igraph_bfs(graph, /*root=*/ (igraph_integer_t) *v,/*roots=*/ 0,
                                 /*mode=*/ IGRAPH_IN, /*unreachable=*/ 0,
@@ -1363,15 +1363,15 @@ igraph_error_t igraph_all_st_mincuts(const igraph_t *graph, igraph_real_t *value
     igraph_integer_t no_of_edges = igraph_ecount(graph);
     igraph_vector_t flow;
     igraph_t residual;
-    igraph_vector_t NtoL;
-    long int newsource, newtarget;
+    igraph_vector_int_t NtoL;
+    igraph_integer_t newsource, newtarget;
     igraph_marked_queue_t S;
     igraph_estack_t T;
     igraph_i_all_st_mincuts_data_t pivot_data;
     igraph_vector_bool_t VE1bool;
     igraph_vector_t VE1;
-    long int VE1size = 0;
-    long int i, nocuts;
+    igraph_integer_t VE1size = 0;
+    igraph_integer_t i, nocuts;
     igraph_integer_t proj_nodes;
     igraph_vector_t revmap_ptr, revmap_next;
     igraph_vector_ptr_t closedsets;
@@ -1420,7 +1420,7 @@ igraph_error_t igraph_all_st_mincuts(const igraph_t *graph, igraph_real_t *value
 
     /* -------------------------------------------------------------------- */
     /* We shrink it to its strongly connected components */
-    IGRAPH_VECTOR_INIT_FINALLY(&NtoL, 0);
+    IGRAPH_VECTOR_INT_INIT_FINALLY(&NtoL, 0);
     IGRAPH_CHECK(igraph_clusters(&residual, /*membership=*/ &NtoL,
                                  /*csize=*/ 0, /*no=*/ &proj_nodes,
                                  IGRAPH_STRONG));
@@ -1443,8 +1443,8 @@ igraph_error_t igraph_all_st_mincuts(const igraph_t *graph, igraph_real_t *value
         if (VECTOR(flow)[i] > 0) {
             igraph_integer_t from = IGRAPH_FROM(graph, i);
             igraph_integer_t to = IGRAPH_TO(graph, i);
-            long int pfrom = VECTOR(NtoL)[from];
-            long int pto = VECTOR(NtoL)[to];
+            igraph_integer_t pfrom = VECTOR(NtoL)[from];
+            igraph_integer_t pto = VECTOR(NtoL)[to];
             if (!VECTOR(VE1bool)[pfrom]) {
                 VECTOR(VE1bool)[pfrom] = 1;
                 VE1size++;
@@ -1491,7 +1491,7 @@ igraph_error_t igraph_all_st_mincuts(const igraph_t *graph, igraph_real_t *value
     IGRAPH_VECTOR_INIT_FINALLY(&revmap_ptr, igraph_vcount(&residual));
     IGRAPH_VECTOR_INIT_FINALLY(&revmap_next, no_of_nodes);
     for (i = 0; i < no_of_nodes; i++) {
-        long int id = VECTOR(NtoL)[i];
+        igraph_integer_t id = VECTOR(NtoL)[i];
         VECTOR(revmap_next)[i] = VECTOR(revmap_ptr)[id];
         VECTOR(revmap_ptr)[id] = i + 1;
     }
@@ -1506,8 +1506,8 @@ igraph_error_t igraph_all_st_mincuts(const igraph_t *graph, igraph_real_t *value
         igraph_vector_t *cut = IGRAPH_CALLOC(1, igraph_vector_t);
         IGRAPH_VECTOR_INIT_FINALLY(cut, 0); /* TODO: better allocation */
         for (j = 0; j < supercutsize; j++) {
-            long int vtx = VECTOR(*supercut)[j];
-            long int ovtx = VECTOR(revmap_ptr)[vtx];
+            igraph_integer_t vtx = VECTOR(*supercut)[j];
+            igraph_integer_t ovtx = VECTOR(revmap_ptr)[vtx];
             while (ovtx != 0) {
                 ovtx--;
                 IGRAPH_CHECK(igraph_vector_push_back(cut, ovtx));
@@ -1543,7 +1543,7 @@ igraph_error_t igraph_all_st_mincuts(const igraph_t *graph, igraph_real_t *value
             }
             IGRAPH_VECTOR_INIT_FINALLY(v, 0);
             for (j = 0; j < n; j++) {
-                long int vtx = VECTOR(*part)[j];
+                igraph_integer_t vtx = VECTOR(*part)[j];
                 VECTOR(memb)[vtx] = i + 1;
             }
             for (j = 0; j < no_of_edges; j++) {
@@ -1566,7 +1566,7 @@ igraph_error_t igraph_all_st_mincuts(const igraph_t *graph, igraph_real_t *value
     igraph_marked_queue_destroy(&S);
     igraph_vector_bool_destroy(&VE1bool);
     igraph_vector_destroy(&VE1);
-    igraph_vector_destroy(&NtoL);
+    igraph_vector_int_destroy(&NtoL);
     igraph_destroy(&residual);
     igraph_vector_destroy(&flow);
     IGRAPH_FINALLY_CLEAN(7);

--- a/src/layout/reingold_tilford.c
+++ b/src/layout/reingold_tilford.c
@@ -537,13 +537,13 @@ igraph_error_t igraph_layout_reingold_tilford(const igraph_t *graph,
     if (!roots || igraph_vector_size(roots) == 0) {
 
         igraph_vector_int_t order;
-        igraph_vector_t membership;
+        igraph_vector_int_t membership;
         igraph_integer_t no_comps;
         long int i, noseen = 0;
 
         IGRAPH_VECTOR_INIT_FINALLY(&myroots, 0);
         IGRAPH_VECTOR_INT_INIT_FINALLY(&order, no_of_nodes);
-        IGRAPH_VECTOR_INIT_FINALLY(&membership, no_of_nodes);
+        IGRAPH_VECTOR_INT_INIT_FINALLY(&membership, no_of_nodes);
 
         if (mode != IGRAPH_ALL) {
             /* look for roots by swimming against the stream */
@@ -578,7 +578,7 @@ igraph_error_t igraph_layout_reingold_tilford(const igraph_t *graph,
             VECTOR(myroots)[i] -= 1;
         }
 
-        igraph_vector_destroy(&membership);
+        igraph_vector_int_destroy(&membership);
         igraph_vector_int_destroy(&order);
         IGRAPH_FINALLY_CLEAN(2);
 

--- a/src/layout/sugiyama.c
+++ b/src/layout/sugiyama.c
@@ -317,7 +317,7 @@ igraph_error_t igraph_layout_sugiyama(const igraph_t *graph, igraph_matrix_t *re
     long int next_extd_vertex_id = no_of_nodes;
     igraph_bool_t directed = igraph_is_directed(graph);
     igraph_integer_t no_of_components;  /* number of components of the original graph */
-    igraph_vector_t membership;         /* components of the original graph */
+    igraph_vector_int_t membership;         /* components of the original graph */
     igraph_vector_t extd_edgelist;   /* edge list of the extended graph */
     igraph_vector_t layers_own;  /* layer indices after having eliminated empty layers */
     igraph_real_t dx = 0, dx2 = 0; /* displacement of the current component on the X axis */
@@ -335,7 +335,7 @@ igraph_error_t igraph_layout_sugiyama(const igraph_t *graph, igraph_matrix_t *re
     }
 
     IGRAPH_CHECK(igraph_matrix_resize(res, no_of_nodes, 2));
-    IGRAPH_VECTOR_INIT_FINALLY(&membership, 0);
+    IGRAPH_VECTOR_INT_INIT_FINALLY(&membership, 0);
     IGRAPH_VECTOR_INIT_FINALLY(&layer_to_y, 0);
 
     /* 1. Find a feedback arc set if we don't have a layering yet. If we do have
@@ -575,7 +575,7 @@ igraph_error_t igraph_layout_sugiyama(const igraph_t *graph, igraph_matrix_t *re
 
     igraph_vector_destroy(&layers_own);
     igraph_vector_destroy(&layer_to_y);
-    igraph_vector_destroy(&membership);
+    igraph_vector_int_destroy(&membership);
     IGRAPH_FINALLY_CLEAN(3);
 
     if (extd_graph != 0) {

--- a/src/misc/feedback_arc_set.c
+++ b/src/misc/feedback_arc_set.c
@@ -451,14 +451,15 @@ igraph_error_t igraph_i_feedback_arc_set_ip(const igraph_t *graph, igraph_vector
     igraph_integer_t no_of_components;
     igraph_integer_t no_of_vertices = igraph_vcount(graph);
     igraph_integer_t no_of_edges = igraph_ecount(graph);
-    igraph_vector_t membership, ordering, vertex_remapping;
+    igraph_vector_int_t membership;
+    igraph_vector_t ordering, vertex_remapping;
     igraph_vector_ptr_t vertices_by_components, edges_by_components;
     igraph_integer_t i, j, k, l, m, n, from, to, no_of_rows;
     igraph_real_t weight;
     glp_prob *ip;
     glp_iocp parm;
 
-    IGRAPH_VECTOR_INIT_FINALLY(&membership, 0);
+    IGRAPH_VECTOR_INT_INIT_FINALLY(&membership, 0);
     IGRAPH_VECTOR_INIT_FINALLY(&ordering, 0);
     IGRAPH_VECTOR_INIT_FINALLY(&vertex_remapping, no_of_vertices);
 
@@ -668,7 +669,7 @@ igraph_error_t igraph_i_feedback_arc_set_ip(const igraph_t *graph, igraph_vector
     igraph_vector_ptr_destroy_all(&edges_by_components);
     igraph_vector_destroy(&vertex_remapping);
     igraph_vector_destroy(&ordering);
-    igraph_vector_destroy(&membership);
+    igraph_vector_int_destroy(&membership);
     IGRAPH_FINALLY_CLEAN(5);
 
     return IGRAPH_SUCCESS;

--- a/src/misc/spanning_trees.c
+++ b/src/misc/spanning_trees.c
@@ -468,12 +468,12 @@ igraph_error_t igraph_random_spanning_tree(const igraph_t *graph, igraph_vector_
     igraph_vector_clear(res);
 
     if (vid < 0) { /* generate random spanning forest: consider each component separately */
-        igraph_vector_t membership, csize;
+        igraph_vector_int_t membership, csize;
         igraph_integer_t comp_count;
         igraph_integer_t i;
 
-        IGRAPH_VECTOR_INIT_FINALLY(&membership, 0);
-        IGRAPH_VECTOR_INIT_FINALLY(&csize, 0);
+        IGRAPH_VECTOR_INT_INIT_FINALLY(&membership, 0);
+        IGRAPH_VECTOR_INT_INIT_FINALLY(&csize, 0);
 
         IGRAPH_CHECK(igraph_clusters(graph, &membership, &csize, &comp_count, IGRAPH_WEAK));
 
@@ -485,11 +485,11 @@ igraph_error_t igraph_random_spanning_tree(const igraph_t *graph, igraph_vector_
                 ++j;
             }
 
-            IGRAPH_CHECK(igraph_i_lerw(graph, res, j, (igraph_integer_t) VECTOR(csize)[i], &visited, &il));
+            IGRAPH_CHECK(igraph_i_lerw(graph, res, j, VECTOR(csize)[i], &visited, &il));
         }
 
-        igraph_vector_destroy(&membership);
-        igraph_vector_destroy(&csize);
+        igraph_vector_int_destroy(&membership);
+        igraph_vector_int_destroy(&csize);
         IGRAPH_FINALLY_CLEAN(2);
     } else { /* consider the component containing vid */
         igraph_vector_t comp_vertices;

--- a/src/operators/contract.c
+++ b/src/operators/contract.c
@@ -61,7 +61,7 @@ static void igraph_i_simplify_free(igraph_vector_ptr_t *p) {
  */
 
 igraph_error_t igraph_contract_vertices(igraph_t *graph,
-                             const igraph_vector_t *mapping,
+                             const igraph_vector_int_t *mapping,
                              const igraph_attribute_combination_t *vertex_comb) {
     igraph_vector_t edges;
     igraph_integer_t no_of_nodes = igraph_vcount(graph);
@@ -71,7 +71,7 @@ igraph_error_t igraph_contract_vertices(igraph_t *graph,
     long int e, last = -1;
     long int no_new_vertices;
 
-    if (igraph_vector_size(mapping) != no_of_nodes) {
+    if (igraph_vector_int_size(mapping) != no_of_nodes) {
         IGRAPH_ERROR("Invalid mapping vector length",
                      IGRAPH_EINVAL);
     }
@@ -80,7 +80,7 @@ igraph_error_t igraph_contract_vertices(igraph_t *graph,
     IGRAPH_CHECK(igraph_vector_reserve(&edges, no_of_edges * 2));
 
     if (no_of_nodes > 0) {
-        last = igraph_vector_max(mapping);
+        last = igraph_vector_int_max(mapping);
     }
 
     for (e = 0; e < no_of_edges; e++) {

--- a/src/paths/eulerian.c
+++ b/src/paths/eulerian.c
@@ -42,7 +42,8 @@ has_cycle is set to 1 if a cycle exists, 0 otherwise
 */
 static igraph_error_t igraph_i_is_eulerian_undirected(const igraph_t *graph, igraph_bool_t *has_path, igraph_bool_t *has_cycle, igraph_integer_t *start_of_path) {
     igraph_integer_t odd;
-    igraph_vector_t degree, csize;
+    igraph_vector_t degree;
+    igraph_vector_int_t csize;
     /* boolean vector to mark singletons: */
     igraph_vector_t nonsingleton;
     long int i, n, vsize;
@@ -64,10 +65,10 @@ static igraph_error_t igraph_i_is_eulerian_undirected(const igraph_t *graph, igr
     /* check for connectedness, but singletons are special since they affect
      * the Eulerian nature only if there is a self-loop AND another edge
      * somewhere else in the graph */
-    IGRAPH_VECTOR_INIT_FINALLY(&csize, 0);
+    IGRAPH_VECTOR_INT_INIT_FINALLY(&csize, 0);
     IGRAPH_CHECK(igraph_clusters(graph, NULL, &csize, NULL, IGRAPH_WEAK));
     cluster_count = 0;
-    vsize = igraph_vector_size(&csize);
+    vsize = igraph_vector_int_size(&csize);
     for (i = 0; i < vsize; i++) {
         if (VECTOR(csize)[i] > 1) {
             cluster_count++;
@@ -75,7 +76,7 @@ static igraph_error_t igraph_i_is_eulerian_undirected(const igraph_t *graph, igr
                 /* disconnected edges, they'll never reach each other */
                 *has_path = 0;
                 *has_cycle = 0;
-                igraph_vector_destroy(&csize);
+                igraph_vector_int_destroy(&csize);
                 IGRAPH_FINALLY_CLEAN(1);
 
                 return IGRAPH_SUCCESS;
@@ -83,7 +84,7 @@ static igraph_error_t igraph_i_is_eulerian_undirected(const igraph_t *graph, igr
         }
     }
 
-    igraph_vector_destroy(&csize);
+    igraph_vector_int_destroy(&csize);
     IGRAPH_FINALLY_CLEAN(1);
 
     /* the graph is connected except for singletons */
@@ -165,7 +166,8 @@ static igraph_error_t igraph_i_is_eulerian_directed(const igraph_t *graph, igrap
     igraph_integer_t incoming_excess, outgoing_excess, n;
     long int i, vsize;
     long int cluster_count;
-    igraph_vector_t out_degree, in_degree, csize;
+    igraph_vector_t out_degree, in_degree;
+    igraph_vector_int_t csize;
     /* boolean vector to mark singletons: */
     igraph_vector_t nonsingleton;
     /* number of self-looping singletons: */
@@ -188,11 +190,11 @@ static igraph_error_t igraph_i_is_eulerian_directed(const igraph_t *graph, igrap
     /* check for weak connectedness, but singletons are special since they affect
      * the Eulerian nature only if there is a self-loop AND another edge
      * somewhere else in the graph */
-    IGRAPH_VECTOR_INIT_FINALLY(&csize, 0);
+    IGRAPH_VECTOR_INT_INIT_FINALLY(&csize, 0);
 
     IGRAPH_CHECK(igraph_clusters(graph, NULL, &csize, NULL, IGRAPH_WEAK));
     cluster_count = 0;
-    vsize = igraph_vector_size(&csize);
+    vsize = igraph_vector_int_size(&csize);
     for (i = 0; i < vsize; i++) {
         if (VECTOR(csize)[i] > 1) {
             cluster_count++;
@@ -200,7 +202,7 @@ static igraph_error_t igraph_i_is_eulerian_directed(const igraph_t *graph, igrap
                 /* weakly disconnected edges, they'll never reach each other */
                 *has_path = 0;
                 *has_cycle = 0;
-                igraph_vector_destroy(&csize);
+                igraph_vector_int_destroy(&csize);
                 IGRAPH_FINALLY_CLEAN(1);
 
                 return IGRAPH_SUCCESS;
@@ -208,7 +210,7 @@ static igraph_error_t igraph_i_is_eulerian_directed(const igraph_t *graph, igrap
         }
     }
 
-    igraph_vector_destroy(&csize);
+    igraph_vector_int_destroy(&csize);
     IGRAPH_FINALLY_CLEAN(1);
 
     /* the graph is weakly connected except for singletons */

--- a/tests/unit/community_label_propagation.c
+++ b/tests/unit/community_label_propagation.c
@@ -28,7 +28,8 @@
 
 int main() {
     igraph_t g;
-    igraph_vector_t membership, weights, initial;
+    igraph_vector_int_t membership;
+    igraph_vector_t weights, initial;
     igraph_vector_bool_t fixed;
     long int i;
 
@@ -55,7 +56,7 @@ int main() {
                  31, 32, 31, 33, 32, 33,
                  -1);
 
-    igraph_vector_init(&membership, 0);
+    igraph_vector_int_init(&membership, 0);
     igraph_community_label_propagation(&g, &membership, 0, 0, 0,
                                        /*modularity=*/ 0);
 
@@ -95,7 +96,7 @@ int main() {
     igraph_vector_destroy(&initial);
     igraph_destroy(&g);
 
-    igraph_vector_destroy(&membership);
+    igraph_vector_int_destroy(&membership);
 
     VERIFY_FINALLY_STACK();
 

--- a/tests/unit/community_leiden.c
+++ b/tests/unit/community_leiden.c
@@ -27,27 +27,28 @@
 
 void run_leiden_CPM(const igraph_t *graph, const igraph_vector_t *edge_weights, const igraph_real_t resolution_parameter) {
 
-    igraph_vector_t membership;
+    igraph_vector_int_t membership;
     igraph_integer_t nb_clusters = igraph_vcount(graph);
     igraph_real_t quality;
 
     /* Initialize with singleton partition. */
-    igraph_vector_init(&membership, igraph_vcount(graph));
+    igraph_vector_int_init(&membership, igraph_vcount(graph));
 
     igraph_community_leiden(graph, edge_weights, NULL, resolution_parameter, 0.01, 0, &membership, &nb_clusters, &quality);
 
     printf("Leiden found %" IGRAPH_PRId " clusters using CPM (resolution parameter=%.2f), quality is %.4f.\n", nb_clusters, resolution_parameter, quality);
 
     printf("Membership: ");
-    igraph_vector_print(&membership);
+    igraph_vector_int_print(&membership);
     printf("\n");
 
-    igraph_vector_destroy(&membership);
+    igraph_vector_int_destroy(&membership);
 }
 
 void run_leiden_modularity(igraph_t *graph, igraph_vector_t *edge_weights) {
 
-    igraph_vector_t membership, degree;
+    igraph_vector_int_t membership;
+    igraph_vector_t degree;
     igraph_integer_t nb_clusters = igraph_vcount(graph);
     igraph_real_t quality;
     igraph_real_t m;
@@ -62,7 +63,7 @@ void run_leiden_modularity(igraph_t *graph, igraph_vector_t *edge_weights) {
     }
 
     /* Initialize with singleton partition. */
-    igraph_vector_init(&membership, igraph_vcount(graph));
+    igraph_vector_int_init(&membership, igraph_vcount(graph));
 
     igraph_community_leiden(graph, edge_weights, &degree, 1.0 / (2 * m), 0.01, 0, &membership, &nb_clusters, &quality);
 
@@ -73,10 +74,10 @@ void run_leiden_modularity(igraph_t *graph, igraph_vector_t *edge_weights) {
     }
 
     printf("Membership: ");
-    igraph_vector_print(&membership);
+    igraph_vector_int_print(&membership);
     printf("\n");
 
-    igraph_vector_destroy(&membership);
+    igraph_vector_int_destroy(&membership);
     igraph_vector_destroy(&degree);
 }
 

--- a/tests/unit/igraph_all_st_cuts.c
+++ b/tests/unit/igraph_all_st_cuts.c
@@ -31,10 +31,10 @@
 #include "test_utilities.inc"
 
 int test_all_st_cuts(const igraph_t *graph,
-                     long int source,
-                     long int target) {
+                     igraph_integer_t source,
+                     igraph_integer_t target) {
     igraph_vector_ptr_t cuts, partition1s;
-    long int n, i;
+    igraph_integer_t n, i;
 
     igraph_vector_ptr_init(&cuts, 0);
     igraph_vector_ptr_init(&partition1s, 0);
@@ -64,11 +64,11 @@ int test_all_st_cuts(const igraph_t *graph,
 int main() {
     igraph_t g;
     igraph_vector_ptr_t cuts, partition1s;
-    long int i, n;
+    igraph_integer_t i, n;
 
     igraph_marked_queue_t S;
     igraph_estack_t T;
-    long int v;
+    igraph_integer_t v;
     igraph_vector_t Isv;
 
     /* ----------------------------------------------------------- */
@@ -107,7 +107,7 @@ int main() {
                                &v, &Isv, NULL);
 
     /* Expected result: v=c, Isv={c,d,e,i} */
-    printf("%li; ", v);
+    printf("%" IGRAPH_PRId "; ", v);
     igraph_vector_print(&Isv);
 
     igraph_vector_destroy(&Isv);
@@ -129,7 +129,7 @@ int main() {
     igraph_i_all_st_cuts_pivot(&g, &S, &T,
                                /*source=*/ 0, /*target=*/ 2,
                                &v, &Isv, NULL);
-    printf("%li; ", v);
+    printf("%" IGRAPH_PRId "; ", v);
     igraph_vector_print(&Isv);
 
     igraph_vector_destroy(&Isv);
@@ -153,7 +153,7 @@ int main() {
     igraph_i_all_st_cuts_pivot(&g, &S, &T,
                                /*source=*/ 0, /*target=*/ 2,
                                &v, &Isv, NULL);
-    printf("%li; ", v);
+    printf("%" IGRAPH_PRId "; ", v);
     igraph_vector_print(&Isv);
 
     igraph_vector_destroy(&Isv);
@@ -177,7 +177,7 @@ int main() {
     igraph_i_all_st_cuts_pivot(&g, &S, &T,
                                /*source=*/ 0, /*target=*/ 2,
                                &v, &Isv, NULL);
-    printf("%li; ", v);
+    printf("%" IGRAPH_PRId "; ", v);
     igraph_vector_print(&Isv);
 
     igraph_vector_destroy(&Isv);
@@ -202,7 +202,7 @@ int main() {
     igraph_i_all_st_cuts_pivot(&g, &S, &T,
                                /*source=*/ 0, /*target=*/ 2,
                                &v, &Isv, NULL);
-    printf("%li; ", v);
+    printf("%" IGRAPH_PRId "; ", v);
     igraph_vector_print(&Isv);
 
     igraph_vector_destroy(&Isv);
@@ -227,7 +227,7 @@ int main() {
     igraph_i_all_st_cuts_pivot(&g, &S, &T,
                                /*source=*/ 0, /*target=*/ 2,
                                &v, &Isv, NULL);
-    printf("%li; ", v);
+    printf("%" IGRAPH_PRId "; ", v);
     igraph_vector_print(&Isv);
 
     igraph_vector_destroy(&Isv);

--- a/tests/unit/igraph_community_infomap.c
+++ b/tests/unit/igraph_community_infomap.c
@@ -31,30 +31,30 @@ void gsummary(const igraph_t * g) {
     printf("|V|=%d |E|=%d directed=%d\n", (int)igraph_vcount(g), (int)igraph_ecount(g), (int)igraph_is_directed(g));
 }
 
-void show_results(igraph_vector_t * membership, igraph_real_t codelength) {
+void show_results(igraph_vector_int_t * membership, igraph_real_t codelength) {
     int i;
-    printf("Codelength: %0.5f (in %d modules)\n", codelength, (int)igraph_vector_max(membership) + 1 );
+    printf("Codelength: %0.5f (in %" IGRAPH_PRId " modules)\n", codelength, igraph_vector_int_max(membership) + 1 );
     printf("Membership: ");
-    for (i = 0; i < igraph_vector_size(membership); i++) {
+    for (i = 0; i < igraph_vector_int_size(membership); i++) {
         printf("%li ", (long)VECTOR(*membership)[i] );
     }
     printf("\n");
 }
 
-void show_results_lite(igraph_vector_t * membership, igraph_real_t codelength) {
+void show_results_lite(igraph_vector_int_t * membership, igraph_real_t codelength) {
     int i;
-    printf("Codelength: %0.5f (in %d modules)\n", codelength, (int)igraph_vector_max(membership) + 1 );
+    printf("Codelength: %0.5f (in %" IGRAPH_PRId " modules)\n", codelength, igraph_vector_int_max(membership) + 1 );
     printf("Membership (1/100 of vertices): ");
-    for (i = 0; i < igraph_vector_size(membership); i += 100) {
+    for (i = 0; i < igraph_vector_int_size(membership); i += 100) {
         printf("%li ", (long)VECTOR(*membership)[i] );
     }
     printf("\n");
 }
 
 igraph_real_t infomap_weighted_test(const igraph_t * g, const igraph_vector_t *weights, igraph_bool_t smoke_test) {
-    igraph_vector_t membership;
+    igraph_vector_int_t membership;
     igraph_real_t codelength = 1000;
-    igraph_vector_init(&membership, 0);
+    igraph_vector_int_init(&membership, 0);
 
     igraph_community_infomap(/*in */ g, /*e_weight=*/ weights, NULL, /*nb_trials=*/5,
                                      /*out*/ &membership, &codelength);
@@ -66,7 +66,7 @@ igraph_real_t infomap_weighted_test(const igraph_t * g, const igraph_vector_t *w
         }
     }
 
-    igraph_vector_destroy(&membership);
+    igraph_vector_int_destroy(&membership);
 
     return codelength;
 }

--- a/tests/unit/igraph_community_leading_eigenvector2.c
+++ b/tests/unit/igraph_community_leading_eigenvector2.c
@@ -30,7 +30,7 @@ int main() {
 
     igraph_t g;
     igraph_matrix_t merges;
-    igraph_vector_t membership;
+    igraph_vector_int_t membership;
     igraph_vector_t x;
     igraph_arpack_options_t options;
     igraph_vector_t weights;
@@ -56,7 +56,7 @@ int main() {
                  -1);
 
     igraph_matrix_init(&merges, 0, 0);
-    igraph_vector_init(&membership, 0);
+    igraph_vector_int_init(&membership, 0);
     igraph_vector_init(&x, 0);
     igraph_arpack_options_init(&options);
     igraph_vector_init(&weights, igraph_ecount(&g));
@@ -71,7 +71,7 @@ int main() {
                                          /*callback_extra=*/ 0);
 
     print_matrix_round(&merges);
-    print_vector_round(&membership);
+    print_vector_int(&membership);
 
     printf("\n");
 
@@ -85,11 +85,11 @@ int main() {
                                          /*callback_extra=*/ 0);
 
     print_matrix_round(&merges);
-    print_vector_round(&membership);
+    print_vector_int(&membership);
 
     igraph_vector_destroy(&weights);
     igraph_vector_destroy(&x);
-    igraph_vector_destroy(&membership);
+    igraph_vector_int_destroy(&membership);
     igraph_matrix_destroy(&merges);
     igraph_destroy(&g);
 

--- a/tests/unit/igraph_compare_communities.c
+++ b/tests/unit/igraph_compare_communities.c
@@ -28,7 +28,7 @@ char *names[] = {
 };
 
 
-void compare_and_print(igraph_vector_t *comm1, igraph_vector_t *comm2, igraph_community_comparison_t t, igraph_error_type_t e) {
+void compare_and_print(igraph_vector_int_t *comm1, igraph_vector_int_t *comm2, igraph_community_comparison_t t, igraph_error_type_t e) {
     igraph_real_t result;
     printf("%s result: ", names[t]);
     IGRAPH_ASSERT(igraph_compare_communities(comm1, comm2, &result, t) == e);
@@ -42,13 +42,13 @@ void compare_and_print(igraph_vector_t *comm1, igraph_vector_t *comm2, igraph_co
 
 
 int main() {
-    igraph_vector_t comm1, comm2;
+    igraph_vector_int_t comm1, comm2;
 
     igraph_set_error_handler(igraph_error_handler_ignore);
 
     printf("Only one member, both partitions equal to whole set:\n");
-    igraph_vector_init_int(&comm1, 1, 0);
-    igraph_vector_init_int(&comm2, 1, 0);
+    igraph_vector_int_init_int(&comm1, 1, 0);
+    igraph_vector_int_init_int(&comm2, 1, 0);
 
 
     compare_and_print(&comm1, &comm2, IGRAPH_COMMCMP_VI, IGRAPH_SUCCESS);
@@ -57,44 +57,44 @@ int main() {
     compare_and_print(&comm1, &comm2, IGRAPH_COMMCMP_NMI, IGRAPH_SUCCESS);
     compare_and_print(&comm1, &comm2, IGRAPH_COMMCMP_SPLIT_JOIN, IGRAPH_SUCCESS);
 
-    igraph_vector_destroy(&comm1);
-    igraph_vector_destroy(&comm2);
+    igraph_vector_int_destroy(&comm1);
+    igraph_vector_int_destroy(&comm2);
 
     printf("\nEmpty sets:\n");
-    igraph_vector_init(&comm1, 0);
-    igraph_vector_init(&comm2, 0);
+    igraph_vector_int_init(&comm1, 0);
+    igraph_vector_int_init(&comm2, 0);
     compare_and_print(&comm1, &comm2, IGRAPH_COMMCMP_VI, IGRAPH_SUCCESS);
     compare_and_print(&comm1, &comm2, IGRAPH_COMMCMP_RAND, IGRAPH_EINVAL);
     compare_and_print(&comm1, &comm2, IGRAPH_COMMCMP_ADJUSTED_RAND, IGRAPH_EINVAL);
     compare_and_print(&comm1, &comm2, IGRAPH_COMMCMP_NMI, IGRAPH_SUCCESS);
     compare_and_print(&comm1, &comm2, IGRAPH_COMMCMP_SPLIT_JOIN, IGRAPH_SUCCESS);
 
-    igraph_vector_destroy(&comm1);
-    igraph_vector_destroy(&comm2);
+    igraph_vector_int_destroy(&comm1);
+    igraph_vector_int_destroy(&comm2);
 
     printf("\nTwo equal, differenly labeled partitions:\n");
-    igraph_vector_init_int(&comm1, 2, 0, 1);
-    igraph_vector_init_int(&comm2, 2, 1, 0);
+    igraph_vector_int_init_int(&comm1, 2, 0, 1);
+    igraph_vector_int_init_int(&comm2, 2, 1, 0);
     compare_and_print(&comm1, &comm2, IGRAPH_COMMCMP_VI, IGRAPH_SUCCESS);
     compare_and_print(&comm1, &comm2, IGRAPH_COMMCMP_RAND, IGRAPH_SUCCESS);
     compare_and_print(&comm1, &comm2, IGRAPH_COMMCMP_ADJUSTED_RAND, IGRAPH_SUCCESS);
     compare_and_print(&comm1, &comm2, IGRAPH_COMMCMP_NMI, IGRAPH_SUCCESS);
     compare_and_print(&comm1, &comm2, IGRAPH_COMMCMP_SPLIT_JOIN, IGRAPH_SUCCESS);
 
-    igraph_vector_destroy(&comm1);
-    igraph_vector_destroy(&comm2);
+    igraph_vector_int_destroy(&comm1);
+    igraph_vector_int_destroy(&comm2);
 
     printf("\nTwo different partitions: ((5,1), (8,3,4), (0,6,7,2,9)) and ((5,8), (1,3,4,0), (6,7,2,9))\n");
-    igraph_vector_init_int(&comm1, 10, 2, 0, 2, 1, 1, 0, 2, 2, 1, 2);
-    igraph_vector_init_int(&comm2, 10, 1, 1, 2, 1, 1, 0, 2, 2, 0, 2);
+    igraph_vector_int_init_int(&comm1, 10, 2, 0, 2, 1, 1, 0, 2, 2, 1, 2);
+    igraph_vector_int_init_int(&comm2, 10, 1, 1, 2, 1, 1, 0, 2, 2, 0, 2);
     compare_and_print(&comm1, &comm2, IGRAPH_COMMCMP_VI, IGRAPH_SUCCESS);
     compare_and_print(&comm1, &comm2, IGRAPH_COMMCMP_RAND, IGRAPH_SUCCESS);
     compare_and_print(&comm1, &comm2, IGRAPH_COMMCMP_ADJUSTED_RAND, IGRAPH_SUCCESS);
     compare_and_print(&comm1, &comm2, IGRAPH_COMMCMP_NMI, IGRAPH_SUCCESS);
     compare_and_print(&comm1, &comm2, IGRAPH_COMMCMP_SPLIT_JOIN, IGRAPH_SUCCESS);
 
-    igraph_vector_destroy(&comm1);
-    igraph_vector_destroy(&comm2);
+    igraph_vector_int_destroy(&comm1);
+    igraph_vector_int_destroy(&comm2);
 
     VERIFY_FINALLY_STACK();
     return 0;

--- a/tests/unit/igraph_le_community_to_membership.c
+++ b/tests/unit/igraph_le_community_to_membership.c
@@ -19,31 +19,31 @@
 #include <igraph.h>
 #include "test_utilities.inc"
 
-void print_and_destroy(igraph_vector_t *membership, igraph_vector_t *csize, igraph_matrix_t *mat) {
+void print_and_destroy(igraph_vector_int_t *membership, igraph_vector_int_t *csize, igraph_matrix_t *mat) {
     printf("Membership: ");
-    igraph_vector_print(membership);
+    igraph_vector_int_print(membership);
     printf("Csize: ");
-    igraph_vector_print(csize);
+    igraph_vector_int_print(csize);
     printf("\n");
-    igraph_vector_destroy(membership);
+    igraph_vector_int_destroy(membership);
     igraph_matrix_destroy(mat);
 }
 
 int main() {
     igraph_matrix_t merges;
-    igraph_vector_t membership;
-    igraph_vector_t csize;
+    igraph_vector_int_t membership;
+    igraph_vector_int_t csize;
 
-    igraph_vector_init_int(&csize, 0);
+    igraph_vector_int_init_int(&csize, 0);
 
     printf("One member:\n");
-    igraph_vector_init_int(&membership, 1, 0);
+    igraph_vector_int_init_int(&membership, 1, 0);
     igraph_matrix_init(&merges, 0, 2);
     IGRAPH_ASSERT(igraph_le_community_to_membership(&merges, /*steps*/ 0, &membership, &csize) == IGRAPH_SUCCESS);
     print_and_destroy(&membership, &csize, &merges);
 
     printf("Five singleton clusters, one merge:\n");
-    igraph_vector_init_int(&membership, 5, 0, 1, 2, 3, 4);
+    igraph_vector_int_init_int(&membership, 5, 0, 1, 2, 3, 4);
     {
         int elem[] = {1, 3};
         matrix_init_int_row_major(&merges, 1, 2, elem);
@@ -52,7 +52,7 @@ int main() {
     print_and_destroy(&membership, &csize, &merges);
 
     printf("Six clusters, two merges:\n");
-    igraph_vector_init_int(&membership, 12, 0, 0, 1, 2, 2, 3, 3, 4, 4, 5, 5, 5);
+    igraph_vector_int_init_int(&membership, 12, 0, 0, 1, 2, 2, 3, 3, 4, 4, 5, 5, 5);
     {
         int elem[] = {0,3, 2,5};
         matrix_init_int_row_major(&merges, 2, 2, elem);
@@ -66,46 +66,46 @@ int main() {
     igraph_set_error_handler(igraph_error_handler_ignore);
 
     printf("Five singleton clusters, two merges, but second merge refers to singleton which is already merged.\n");
-    igraph_vector_init_int(&membership, 5, 0, 1, 2, 3, 4);
+    igraph_vector_int_init_int(&membership, 5, 0, 1, 2, 3, 4);
     {
         int elem[] = {1,3, 1,4,};
         matrix_init_int_row_major(&merges, 2, 2, elem);
     }
     IGRAPH_ASSERT(igraph_le_community_to_membership(&merges, /*steps*/ 2, &membership, &csize) == IGRAPH_EINVAL);
-    igraph_vector_destroy(&membership);
+    igraph_vector_int_destroy(&membership);
     igraph_matrix_destroy(&merges);
 
     printf("Negative cluster index.\n");
-    igraph_vector_init_int(&membership, 5, -1, 0, 1, 2, 3);
+    igraph_vector_int_init_int(&membership, 5, -1, 0, 1, 2, 3);
     {
         int elem[] = {1,2, 3,4,};
         matrix_init_int_row_major(&merges, 2, 2, elem);
     }
     IGRAPH_ASSERT(igraph_le_community_to_membership(&merges, /*steps*/ 2, &membership, &csize) == IGRAPH_EINVAL);
-    igraph_vector_destroy(&membership);
+    igraph_vector_int_destroy(&membership);
     igraph_matrix_destroy(&merges);
 
     printf("Skip a cluster index.\n");
-    igraph_vector_init_int(&membership, 5, 0, 0, 2, 3, 4);
+    igraph_vector_int_init_int(&membership, 5, 0, 0, 2, 3, 4);
     {
         int elem[] = {1,2, 3,4,};
         matrix_init_int_row_major(&merges, 2, 2, elem);
     }
     IGRAPH_ASSERT(igraph_le_community_to_membership(&merges, /*steps*/ 2, &membership, &csize) == IGRAPH_EINVAL);
-    igraph_vector_destroy(&membership);
+    igraph_vector_int_destroy(&membership);
     igraph_matrix_destroy(&merges);
 
     printf("Too many steps.\n");
-    igraph_vector_init_int(&membership, 5, 0, 1, 2, 3, 4);
+    igraph_vector_int_init_int(&membership, 5, 0, 1, 2, 3, 4);
     {
         int elem[] = {1,2, 3,4,};
         matrix_init_int_row_major(&merges, 2, 2, elem);
     }
     IGRAPH_ASSERT(igraph_le_community_to_membership(&merges, /*steps*/ 20, &membership, &csize) == IGRAPH_EINVAL);
-    igraph_vector_destroy(&membership);
+    igraph_vector_int_destroy(&membership);
     igraph_matrix_destroy(&merges);
 
-    igraph_vector_destroy(&csize);
+    igraph_vector_int_destroy(&csize);
     VERIFY_FINALLY_STACK();
     return 0;
 }

--- a/tests/unit/igraph_modularity.c
+++ b/tests/unit/igraph_modularity.c
@@ -28,7 +28,7 @@
 int main() {
     igraph_t graph;
     igraph_vector_t weights;
-    igraph_vector_t membership;
+    igraph_vector_int_t membership;
     igraph_real_t modularity, resolution;
     igraph_attribute_combination_t comb;
 
@@ -43,7 +43,7 @@ int main() {
     igraph_rng_seed(igraph_rng_default(), 0);
 
     /* Null graph */
-    igraph_vector_init(&membership, 0);
+    igraph_vector_int_init(&membership, 0);
     igraph_small(&graph, 0, IGRAPH_UNDIRECTED, -1);
     igraph_modularity(&graph, &membership, 0, /* resolution */ 1, /* directed */ 0, &modularity);
     if (!igraph_is_nan(modularity)) {
@@ -58,7 +58,7 @@ int main() {
     /* Should not crash if we omit 'modularity' */
     igraph_modularity(&graph, &membership, 0, /* resolution */ 1, /* directed */ 0, /* modularity = */ 0);
     igraph_destroy(&graph);
-    igraph_vector_destroy(&membership);
+    igraph_vector_int_destroy(&membership);
 
     /* Simple unweighted graph */
     igraph_small(&graph, 10, IGRAPH_UNDIRECTED,
@@ -72,7 +72,7 @@ int main() {
     SETEANV(&graph, "weight", &weights);
 
     /* Set membership */
-    igraph_vector_init(&membership, igraph_vcount(&graph));
+    igraph_vector_int_init(&membership, igraph_vcount(&graph));
     VECTOR(membership)[0] = 0;
     VECTOR(membership)[1] = 0;
     VECTOR(membership)[2] = 0;
@@ -106,11 +106,11 @@ int main() {
 
     /* Recalculate modularity on contracted graph */
     igraph_contract_vertices(&graph, &membership, NULL);
-    igraph_vector_destroy(&membership);
+    igraph_vector_int_destroy(&membership);
 
     igraph_simplify(&graph, /* multiple */ 1, /* loops */ 0, &comb);
 
-    igraph_vector_init_seq(&membership, 0, igraph_vcount(&graph) - 1);
+    igraph_vector_int_init_seq(&membership, 0, igraph_vcount(&graph) - 1);
     EANV(&graph, "weight", &weights);
     for (resolution = 0.5; resolution <= 1.5; resolution += 0.5)
     {
@@ -120,7 +120,7 @@ int main() {
         printf("Modularity (resolution %.2f) is %f after aggregation.\n", resolution, modularity);
     }
 
-    igraph_vector_destroy(&membership);
+    igraph_vector_int_destroy(&membership);
     igraph_vector_destroy(&weights);
     igraph_destroy(&graph);
     igraph_attribute_combination_destroy(&comb);

--- a/tests/unit/igraph_modularity_matrix.c
+++ b/tests/unit/igraph_modularity_matrix.c
@@ -39,7 +39,8 @@ void test_print_destroy(igraph_t *g, igraph_vector_t *weights, float resolution,
 
 int main() {
     igraph_t g;
-    igraph_vector_t weights, membership;
+    igraph_vector_t weights;
+    igraph_vector_int_t membership;
     igraph_matrix_t modmat;
     igraph_real_t modularity, test_modularity;
     int i, j;
@@ -101,7 +102,7 @@ int main() {
     printf("Comparison with modularity:\n");
     igraph_small(&g, 5, /*directed*/1, 0,1, 0,2, 1,2, 3,4, 4,0, -1);
     igraph_vector_init_int(&weights, 5, 1, 2, 3, 4, 5);
-    igraph_vector_init_int(&membership, 5, 0, 0, 0, 1, 1);
+    igraph_vector_int_init_int(&membership, 5, 0, 0, 0, 1, 1);
     igraph_matrix_init(&modmat, 0, 0);
     IGRAPH_ASSERT(igraph_modularity_matrix(&g, &weights, 0.7, &modmat, 1) == IGRAPH_SUCCESS);
     IGRAPH_ASSERT(igraph_modularity(&g, &membership, &weights, 0.7, 1, &modularity) == IGRAPH_SUCCESS);
@@ -119,7 +120,7 @@ int main() {
     }
     printf("Modularity: %g, modularity via matrix: %g\n", modularity, test_modularity / igraph_vector_sum(&weights));
     igraph_destroy(&g);
-    igraph_vector_destroy(&membership);
+    igraph_vector_int_destroy(&membership);
     igraph_vector_destroy(&weights);
     igraph_matrix_destroy(&modmat);
 

--- a/tests/unit/igraph_split_join_distance.c
+++ b/tests/unit/igraph_split_join_distance.c
@@ -20,40 +20,40 @@
 #include "test_utilities.inc"
 
 int main() {
-    igraph_vector_t comm1, comm2;
+    igraph_vector_int_t comm1, comm2;
     igraph_integer_t distance12, distance21;
 
     printf("No vertices:\n");
-    igraph_vector_init_int(&comm1, 0);
-    igraph_vector_init_int(&comm2, 0);
+    igraph_vector_int_init_int(&comm1, 0);
+    igraph_vector_int_init_int(&comm2, 0);
     IGRAPH_ASSERT(igraph_split_join_distance(&comm1, &comm2, &distance12, &distance21) == IGRAPH_SUCCESS);
     printf("%" IGRAPH_PRId ", %" IGRAPH_PRId "\n", distance12, distance21);
-    igraph_vector_destroy(&comm1);
-    igraph_vector_destroy(&comm2);
+    igraph_vector_int_destroy(&comm1);
+    igraph_vector_int_destroy(&comm2);
 
     printf("Comparing 5 separate vertices and one 5-element cluster:\n");
-    igraph_vector_init_int(&comm1, 5, 0, 1, 2, 3, 4);
-    igraph_vector_init_int(&comm2, 5, 0, 0, 0, 0, 0);
+    igraph_vector_int_init_int(&comm1, 5, 0, 1, 2, 3, 4);
+    igraph_vector_int_init_int(&comm2, 5, 0, 0, 0, 0, 0);
     IGRAPH_ASSERT(igraph_split_join_distance(&comm1, &comm2, &distance12, &distance21) == IGRAPH_SUCCESS);
     printf("%" IGRAPH_PRId ", %" IGRAPH_PRId "\n", distance12, distance21);
-    igraph_vector_destroy(&comm1);
-    igraph_vector_destroy(&comm2);
+    igraph_vector_int_destroy(&comm1);
+    igraph_vector_int_destroy(&comm2);
 
     printf("Comparing ((6, 1), (2,4), (3,5,0)) with ((2), (6,0,3), (4,5), (1)):\n");
-    igraph_vector_init_int(&comm1, 7, 2, 0, 1, 2, 1, 2, 0);
-    igraph_vector_init_int(&comm2, 7, 1, 3, 0, 1, 2, 2, 1);
+    igraph_vector_int_init_int(&comm1, 7, 2, 0, 1, 2, 1, 2, 0);
+    igraph_vector_int_init_int(&comm2, 7, 1, 3, 0, 1, 2, 2, 1);
     IGRAPH_ASSERT(igraph_split_join_distance(&comm1, &comm2, &distance12, &distance21) == IGRAPH_SUCCESS);
     printf("%" IGRAPH_PRId ", %" IGRAPH_PRId "\n", distance12, distance21);
-    igraph_vector_destroy(&comm1);
-    igraph_vector_destroy(&comm2);
+    igraph_vector_int_destroy(&comm1);
+    igraph_vector_int_destroy(&comm2);
 
     printf("Comparing ((0,1), (), 2) with ((0), (), (1,2))\n");
-    igraph_vector_init_int(&comm1, 3, 0, 0, 2);
-    igraph_vector_init_int(&comm2, 3, 0, 2, 2);
+    igraph_vector_int_init_int(&comm1, 3, 0, 0, 2);
+    igraph_vector_int_init_int(&comm2, 3, 0, 2, 2);
     IGRAPH_ASSERT(igraph_split_join_distance(&comm1, &comm2, &distance12, &distance21) == IGRAPH_SUCCESS);
     printf("%" IGRAPH_PRId ", %" IGRAPH_PRId "\n", distance12, distance21);
-    igraph_vector_destroy(&comm1);
-    igraph_vector_destroy(&comm2);
+    igraph_vector_int_destroy(&comm1);
+    igraph_vector_int_destroy(&comm2);
 
     VERIFY_FINALLY_STACK();
     igraph_set_error_handler(igraph_error_handler_ignore);
@@ -61,18 +61,18 @@ int main() {
     printf("\nExpected to fail nicely:\n\n");
 
     printf("Differently sized clusterings\n");
-    igraph_vector_init_int(&comm1, 3, 0, 1, 2);
-    igraph_vector_init_int(&comm2, 5, 0, 0, 0, 0, 0);
+    igraph_vector_int_init_int(&comm1, 3, 0, 1, 2);
+    igraph_vector_int_init_int(&comm2, 5, 0, 0, 0, 0, 0);
     IGRAPH_ASSERT(igraph_split_join_distance(&comm1, &comm2, &distance12, &distance21) == IGRAPH_EINVAL);
-    igraph_vector_destroy(&comm1);
-    igraph_vector_destroy(&comm2);
+    igraph_vector_int_destroy(&comm1);
+    igraph_vector_int_destroy(&comm2);
 
     printf("Member index too high\n");
-    igraph_vector_init_int(&comm1, 3, 0, 1, 2);
-    igraph_vector_init_int(&comm2, 3, 9, 0, 0);
+    igraph_vector_int_init_int(&comm1, 3, 0, 1, 2);
+    igraph_vector_int_init_int(&comm2, 3, 9, 0, 0);
     IGRAPH_ASSERT(igraph_split_join_distance(&comm1, &comm2, &distance12, &distance21) == IGRAPH_EINVAL);
-    igraph_vector_destroy(&comm1);
-    igraph_vector_destroy(&comm2);
+    igraph_vector_int_destroy(&comm1);
+    igraph_vector_int_destroy(&comm2);
 
     VERIFY_FINALLY_STACK();
     return 0;

--- a/tests/unit/levc-stress.c
+++ b/tests/unit/levc-stress.c
@@ -35,7 +35,7 @@ int main() {
     for (k = 0; k < 20; k++) {
         igraph_t g;
         igraph_matrix_t merges;
-        igraph_vector_t membership;
+        igraph_vector_int_t membership;
         igraph_arpack_options_t options;
         double modularity;
         igraph_vector_t history;
@@ -45,7 +45,7 @@ int main() {
         fclose(DLFile);
 
         igraph_matrix_init(&merges, 0, 0);
-        igraph_vector_init(&membership, 0);
+        igraph_vector_int_init(&membership, 0);
         igraph_vector_init(&history, 0);
         igraph_arpack_options_init(&options);
 
@@ -58,7 +58,7 @@ int main() {
                                              /*callback_extra=*/ 0);
 
         igraph_vector_destroy(&history);
-        igraph_vector_destroy(&membership);
+        igraph_vector_int_destroy(&membership);
         igraph_matrix_destroy(&merges);
         igraph_destroy(&g);
     }

--- a/tests/unit/spinglass.c
+++ b/tests/unit/spinglass.c
@@ -24,7 +24,7 @@
 int main() {
     igraph_t g;
     igraph_real_t  modularity, temperature;
-    igraph_vector_t membership, csize;
+    igraph_vector_int_t membership, csize;
     /* long int i; */
     igraph_real_t cohesion, adhesion;
     igraph_integer_t inner_links;
@@ -36,8 +36,8 @@ int main() {
     igraph_small(&g, 10, IGRAPH_UNDIRECTED,
                  0, 1, 0, 2, 0, 3, 0, 4, 1, 2, 1, 3, 1, 4, 2, 3, 2, 4, 3, 4,
                  5, 6, 5, 7, 5, 8, 5, 9, 6, 7, 6, 8, 6, 9, 7, 8, 7, 9, 8, 9, 0, 5, -1);
-    igraph_vector_init(&membership, 0);
-    igraph_vector_init(&csize, 0);
+    igraph_vector_int_init(&membership, 0);
+    igraph_vector_int_init(&csize, 0);
 
     printf("\nOriginal implementation.\n");
     igraph_community_spinglass(&g,
@@ -56,13 +56,13 @@ int main() {
                                IGRAPH_SPINCOMM_IMP_ORIG,
                                /*gamma_minus =*/ 0);
 
-    IGRAPH_ASSERT(igraph_vector_size(&membership) == igraph_vcount(&g));
-    IGRAPH_ASSERT(igraph_vector_size(&csize) == igraph_vector_max(&membership) + 1);
+    IGRAPH_ASSERT(igraph_vector_int_size(&membership) == igraph_vcount(&g));
+    IGRAPH_ASSERT(igraph_vector_int_size(&csize) == igraph_vector_int_max(&membership) + 1);
 
     /* The following depend on the random seed, however, for this graph,
        the result is almost always the same (i.e. two clusters). */
     printf("Modularity: %g\n", modularity);
-    print_vector_round(&membership);
+    print_vector_int(&membership);
 
     printf("\nOriginal implementation, parallel updating.\n");
     igraph_community_spinglass(&g,
@@ -81,13 +81,13 @@ int main() {
                                IGRAPH_SPINCOMM_IMP_ORIG,
                                /*gamma_minus =*/ 0);
 
-    IGRAPH_ASSERT(igraph_vector_size(&membership) == igraph_vcount(&g));
-    IGRAPH_ASSERT(igraph_vector_size(&csize) == igraph_vector_max(&membership) + 1);
+    IGRAPH_ASSERT(igraph_vector_int_size(&membership) == igraph_vcount(&g));
+    IGRAPH_ASSERT(igraph_vector_int_size(&csize) == igraph_vector_int_max(&membership) + 1);
 
     /* The following depend on the random seed, however, for this graph,
        the result is almost always the same (i.e. two clusters). */
     printf("Modularity: %g\n", modularity);
-    print_vector_round(&membership);
+    print_vector_int(&membership);
 
     printf("\nNegative implementation.\n");
     igraph_community_spinglass(&g,
@@ -106,13 +106,13 @@ int main() {
                                IGRAPH_SPINCOMM_IMP_NEG,
                                /*gamma_minus =*/ 0);
 
-    IGRAPH_ASSERT(igraph_vector_size(&membership) == igraph_vcount(&g));
-    IGRAPH_ASSERT(igraph_vector_size(&csize) == igraph_vector_max(&membership) + 1);
+    IGRAPH_ASSERT(igraph_vector_int_size(&membership) == igraph_vcount(&g));
+    IGRAPH_ASSERT(igraph_vector_int_size(&csize) == igraph_vector_int_max(&membership) + 1);
 
     /* The following depend on the random seed, however, for this graph,
        the result is almost always the same (i.e. two clusters). */
     printf("Modularity: %g\n", modularity);
-    print_vector_round(&membership);
+    print_vector_int(&membership);
 
     /* Try to call this as well, we don't check the results currently.... */
 
@@ -129,8 +129,8 @@ int main() {
                                       /*gamma=       */ 1.0);
 
     igraph_destroy(&g);
-    igraph_vector_destroy(&membership);
-    igraph_vector_destroy(&csize);
+    igraph_vector_int_destroy(&membership);
+    igraph_vector_int_destroy(&csize);
 
     VERIFY_FINALLY_STACK();
     return 0;


### PR DESCRIPTION
I was working on changing `long int`s in flow to igraph_integer_t when i noticed some casts which seemed unnecessary. They were caused by membership and community size vectors using doubles instead of integers. So I changed them to integer vectors.

I didn't check all of the documentation, or the interface with R, but I wanted to see if people agree with the general plan. If so, I will continue working on this and fix the errors.