### PR TITLE
Updates `qsort` to a more recent version

### DIFF
--- a/src/internal/hacks.h
+++ b/src/internal/hacks.h
@@ -56,11 +56,6 @@ __BEGIN_DECLS
     #endif
 #endif
 
-#if defined(_MSC_VER)
-#include <BaseTsd.h>
-typedef SSIZE_T ssize_t;
-#endif
-
 __END_DECLS
 
 #endif

--- a/src/internal/hacks.h
+++ b/src/internal/hacks.h
@@ -56,6 +56,11 @@ __BEGIN_DECLS
     #endif
 #endif
 
+#if defined(_MSC_VER)
+#include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
+#endif
+
 __END_DECLS
 
 #endif

--- a/src/internal/qsort.c
+++ b/src/internal/qsort.c
@@ -29,11 +29,7 @@
  * SUCH DAMAGE.
  */
 
-#include <sys/types.h> /* ssize_t on *nix platforms */
-
 #include "igraph_qsort.h"
-
-#include "internal/hacks.h" /* ssize_t on Windows */
 
 #ifdef _MSC_VER
     /* MSVC does not have inline when compiling C source files */
@@ -186,7 +182,7 @@ loop:
 	 * expression, to avoid sign ambiguity in the implied comparison.  es
 	 * is safely within [0, SSIZE_MAX].
 	 */
-	d1 = MIN(pd - pc, pn - pd - (ssize_t)es);
+	d1 = MIN(pd - pc, pn - pd - (ptrdiff_t)es);
 	vecswap(pb, pn - d1, d1);
 
 	d1 = pb - pa;

--- a/src/internal/qsort.c
+++ b/src/internal/qsort.c
@@ -29,7 +29,11 @@
  * SUCH DAMAGE.
  */
 
+#include <sys/types.h> /* ssize_t on *nix platforms */
+
 #include "igraph_qsort.h"
+
+#include "internal/hacks.h" /* ssize_t on Windows */
 
 #ifdef _MSC_VER
     /* MSVC does not have inline when compiling C source files */

--- a/src/internal/qsort.c
+++ b/src/internal/qsort.c
@@ -29,6 +29,14 @@
  * SUCH DAMAGE.
  */
 
+/* This file originates from the following URL:
+ *
+ * https://cgit.freebsd.org/src/commit/lib/libc/stdlib/qsort.c?id=7f8f79a5c444a565a32b0c6578b07f8d496f6c49
+ *
+ * Create a diff against the revision given above to see what we have changed
+ * to facilitate inclusion into igraph
+ */
+
 #include "igraph_qsort.h"
 
 #ifdef _MSC_VER

--- a/src/internal/qsort.c
+++ b/src/internal/qsort.c
@@ -1,6 +1,8 @@
 /*-
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  * Copyright (c) 1992, 1993
- *  The Regents of the University of California.  All rights reserved.
+ *	The Regents of the University of California.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -10,11 +12,7 @@
  * 2. Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- * 3. All advertising materials mentioning features or use of this software
- *    must display the following acknowledgement:
- *  This product includes software developed by the University of
- *  California, Berkeley and its contributors.
- * 4. Neither the name of the University nor the names of its contributors
+ * 3. Neither the name of the University nor the names of its contributors
  *    may be used to endorse or promote products derived from this software
  *    without specific prior written permission.
  *
@@ -40,183 +38,217 @@
 #endif
 
 #ifndef __unused
-    #define __unused    __attribute__ ((unused))
+  #define __unused    __attribute__ ((unused))
 #endif
 
 #if defined(LIBC_SCCS) && !defined(lint)
-    static char sccsid[] = "@(#)qsort.c	8.1 (Berkeley) 6/4/93";
+static char sccsid[] = "@(#)qsort.c	8.1 (Berkeley) 6/4/93";
 #endif /* LIBC_SCCS and not lint */
-/*#include <sys/cdefs.h> */
 
 #include <stdlib.h>
 
-#ifdef I_AM_QSORT_R
-    typedef int      cmp_t(void *, const void *, const void *);
+#if defined(I_AM_QSORT_R)
+typedef int		 cmp_t(void *, const void *, const void *);
+#elif defined(I_AM_QSORT_S)
+typedef int		 cmp_t(const void *, const void *, void *);
 #else
-    typedef int      cmp_t(const void *, const void *);
+typedef int		 cmp_t(const void *, const void *);
 #endif
-static inline char  *med3(char *, char *, char *, cmp_t *, void *);
-static inline void   swapfunc(char *, char *, int, int);
+static inline char	*med3(char *, char *, char *, cmp_t *, void *);
 
-#define igraph_min(a, b)    (a) < (b) ? a : b
+#define	MIN(a, b)	((a) < (b) ? a : b)
 
 /*
  * Qsort routine from Bentley & McIlroy's "Engineering a Sort Function".
  */
-#define swapcode(TYPE, parmi, parmj, n) {       \
-        long i = (n) / sizeof (TYPE);           \
-        TYPE *pi = (TYPE *) (parmi);        \
-        TYPE *pj = (TYPE *) (parmj);        \
-        do {                        \
-            TYPE    t = *pi;        \
-            *pi++ = *pj;                \
-            *pj++ = t;              \
-        } while (--i > 0);              \
-    }
-
-
-/* Clang does not like SWAPINIT and will yield an error:
- * performing pointer subtraction with a null pointer has undefined behavior [-Werror,-Wnull-pointer-subtraction]
- * We therefore disable this warning */
-
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wnull-pointer-subtraction"
-#endif
-
-#define SWAPINIT(a, es) swaptype = ((char *)a - (char *)0) % sizeof(long) || \
-                                   es % sizeof(long) ? 2 : es == sizeof(long)? 0 : 1;
 
 static inline void
-swapfunc(char *a, char *b, int n, int swaptype)
+swapfunc(char *a, char *b, size_t es)
 {
-    if (swaptype <= 1)
-        swapcode(long, a, b, n)
-        else
-            swapcode(char, a, b, n)
-        }
+	char t;
 
-#define swap(a, b)                  \
-    if (swaptype == 0) {                \
-        long t = *(long *)(a);          \
-        *(long *)(a) = *(long *)(b);        \
-        *(long *)(b) = t;           \
-    } else                      \
-        swapfunc(a, b, es, swaptype)
+	do {
+		t = *a;
+		*a++ = *b;
+		*b++ = t;
+	} while (--es > 0);
+}
 
-#define vecswap(a, b, n)    if ((n) > 0) swapfunc(a, b, n, swaptype)
+#define	vecswap(a, b, n)				\
+	if ((n) > 0) swapfunc(a, b, n)
 
-#ifdef I_AM_QSORT_R
-    #define CMP(t, x, y) (cmp((t), (x), (y)))
+#if defined(I_AM_QSORT_R)
+#define	CMP(t, x, y) (cmp((t), (x), (y)))
+#elif defined(I_AM_QSORT_S)
+#define	CMP(t, x, y) (cmp((x), (y), (t)))
 #else
-    #define CMP(t, x, y) (cmp((x), (y)))
+#define	CMP(t, x, y) (cmp((x), (y)))
 #endif
 
 static inline char *
-med3(char *a, char *b, char *c, cmp_t *cmp, void *thunk)
+med3(char *a, char *b, char *c, cmp_t *cmp, void *thunk
+#if !defined(I_AM_QSORT_R) && !defined(I_AM_QSORT_S)
+__unused
+#endif
+)
 {
-    #ifndef I_AM_QSORT_R
-        IGRAPH_UNUSED(thunk);
-    #endif
-    return CMP(thunk, a, b) < 0 ?
-           (CMP(thunk, b, c) < 0 ? b : (CMP(thunk, a, c) < 0 ? c : a ))
-           : (CMP(thunk, b, c) > 0 ? b : (CMP(thunk, a, c) < 0 ? a : c ));
+	return CMP(thunk, a, b) < 0 ?
+	       (CMP(thunk, b, c) < 0 ? b : (CMP(thunk, a, c) < 0 ? c : a ))
+	      :(CMP(thunk, b, c) > 0 ? b : (CMP(thunk, a, c) < 0 ? a : c ));
 }
 
-#ifdef I_AM_QSORT_R
-    void
-    igraph_qsort_r(void *a, size_t n, size_t es, void *thunk, cmp_t *cmp)
-#else
-    #define thunk NULL
-    void
-    igraph_qsort(void *a, size_t n, size_t es, cmp_t *cmp)
+/*
+ * The actual qsort() implementation is static to avoid preemptible calls when
+ * recursing. Also give them different names for improved debugging.
+ */
+#if defined(I_AM_QSORT_R)
+#define local_qsort local_qsort_r
+#elif defined(I_AM_QSORT_S)
+#define local_qsort local_qsort_s
 #endif
+static void
+local_qsort(void *a, size_t n, size_t es, cmp_t *cmp, void *thunk)
 {
-    char *pa, *pb, *pc, *pd, *pl, *pm, *pn;
-    int d, r, swaptype, swap_cnt;
+	char *pa, *pb, *pc, *pd, *pl, *pm, *pn;
+	size_t d1, d2;
+	int cmp_result;
+	int swap_cnt;
 
-loop:   SWAPINIT(a, es);
-    swap_cnt = 0;
-    if (n < 7) {
-        for (pm = (char *)a + es; pm < (char *)a + n * es; pm += es)
-            for (pl = pm;
-                 pl > (char *)a && CMP(thunk, pl - es, pl) > 0;
-                 pl -= es) {
-                swap(pl, pl - es);
-            }
-        return;
-    }
-    pm = (char *)a + (n / 2) * es;
-    if (n > 7) {
-        pl = a;
-        pn = (char *)a + (n - 1) * es;
-        if (n > 40) {
-            d = (n / 8) * es;
-            pl = med3(pl, pl + d, pl + 2 * d, cmp, thunk);
-            pm = med3(pm - d, pm, pm + d, cmp, thunk);
-            pn = med3(pn - 2 * d, pn - d, pn, cmp, thunk);
-        }
-        pm = med3(pl, pm, pn, cmp, thunk);
-    }
-    swap(a, pm);
-    pa = pb = (char *)a + es;
+loop:
+	swap_cnt = 0;
+	if (n < 7) {
+		for (pm = (char *)a + es; pm < (char *)a + n * es; pm += es)
+			for (pl = pm;
+			     pl > (char *)a && CMP(thunk, pl - es, pl) > 0;
+			     pl -= es)
+				swapfunc(pl, pl - es, es);
+		return;
+	}
+	pm = (char *)a + (n / 2) * es;
+	if (n > 7) {
+		pl = a;
+		pn = (char *)a + (n - 1) * es;
+		if (n > 40) {
+			size_t d = (n / 8) * es;
 
-    pc = pd = (char *)a + (n - 1) * es;
-    for (;;) {
-        while (pb <= pc && (r = CMP(thunk, pb, a)) <= 0) {
-            if (r == 0) {
-                swap_cnt = 1;
-                swap(pa, pb);
-                pa += es;
-            }
-            pb += es;
-        }
-        while (pb <= pc && (r = CMP(thunk, pc, a)) >= 0) {
-            if (r == 0) {
-                swap_cnt = 1;
-                swap(pc, pd);
-                pd -= es;
-            }
-            pc -= es;
-        }
-        if (pb > pc) {
-            break;
-        }
-        swap(pb, pc);
-        swap_cnt = 1;
-        pb += es;
-        pc -= es;
-    }
-    if (swap_cnt == 0) {  /* Switch to insertion sort */
-        for (pm = (char *)a + es; pm < (char *)a + n * es; pm += es)
-            for (pl = pm;
-                 pl > (char *)a && CMP(thunk, pl - es, pl) > 0;
-                 pl -= es) {
-                swap(pl, pl - es);
-            }
-        return;
-    }
+			pl = med3(pl, pl + d, pl + 2 * d, cmp, thunk);
+			pm = med3(pm - d, pm, pm + d, cmp, thunk);
+			pn = med3(pn - 2 * d, pn - d, pn, cmp, thunk);
+		}
+		pm = med3(pl, pm, pn, cmp, thunk);
+	}
+	swapfunc(a, pm, es);
+	pa = pb = (char *)a + es;
 
-    pn = (char *)a + n * es;
-    r = igraph_min(pa - (char *)a, pb - pa);
-    vecswap(a, pb - r, r);
-    r = igraph_min((size_t)(pd - pc), (size_t)(pn - pd - es));
-    vecswap(pb, pn - r, r);
-    if ((size_t)(r = pb - pa) > es)
-#ifdef I_AM_QSORT_R
-        igraph_qsort_r(a, r / es, es, thunk, cmp);
-#else
-        igraph_qsort(a, r / es, es, cmp);
-#endif
-    if ((size_t)(r = pd - pc) > es) {
-        /* Iterate rather than recurse to save stack space */
-        a = pn - r;
-        n = r / es;
-        goto loop;
-    }
-    /*      qsort(pn - r, r / es, es, cmp);*/
+	pc = pd = (char *)a + (n - 1) * es;
+	for (;;) {
+		while (pb <= pc && (cmp_result = CMP(thunk, pb, a)) <= 0) {
+			if (cmp_result == 0) {
+				swap_cnt = 1;
+				swapfunc(pa, pb, es);
+				pa += es;
+			}
+			pb += es;
+		}
+		while (pb <= pc && (cmp_result = CMP(thunk, pc, a)) >= 0) {
+			if (cmp_result == 0) {
+				swap_cnt = 1;
+				swapfunc(pc, pd, es);
+				pd -= es;
+			}
+			pc -= es;
+		}
+		if (pb > pc)
+			break;
+		swapfunc(pb, pc, es);
+		swap_cnt = 1;
+		pb += es;
+		pc -= es;
+	}
+	if (swap_cnt == 0) {  /* Switch to insertion sort */
+		for (pm = (char *)a + es; pm < (char *)a + n * es; pm += es)
+			for (pl = pm;
+			     pl > (char *)a && CMP(thunk, pl - es, pl) > 0;
+			     pl -= es)
+				swapfunc(pl, pl - es, es);
+		return;
+	}
+
+	pn = (char *)a + n * es;
+	d1 = MIN(pa - (char *)a, pb - pa);
+	vecswap(a, pb - d1, d1);
+	/*
+	 * Cast es to preserve signedness of right-hand side of MIN()
+	 * expression, to avoid sign ambiguity in the implied comparison.  es
+	 * is safely within [0, SSIZE_MAX].
+	 */
+	d1 = MIN(pd - pc, pn - pd - (ssize_t)es);
+	vecswap(pb, pn - d1, d1);
+
+	d1 = pb - pa;
+	d2 = pd - pc;
+	if (d1 <= d2) {
+		/* Recurse on left partition, then iterate on right partition */
+		if (d1 > es) {
+			local_qsort(a, d1 / es, es, cmp, thunk);
+		}
+		if (d2 > es) {
+			/* Iterate rather than recurse to save stack space */
+			/* qsort(pn - d2, d2 / es, es, cmp); */
+			a = pn - d2;
+			n = d2 / es;
+			goto loop;
+		}
+	} else {
+		/* Recurse on right partition, then iterate on left partition */
+		if (d2 > es) {
+			local_qsort(pn - d2, d2 / es, es, cmp, thunk);
+		}
+		if (d1 > es) {
+			/* Iterate rather than recurse to save stack space */
+			/* qsort(a, d1 / es, es, cmp); */
+			n = d1 / es;
+			goto loop;
+		}
+	}
 }
 
-#ifdef __clang__
-#pragma clang diagnostic pop
+#if defined(I_AM_QSORT_R)
+void
+igraph_qsort_r(void *a, size_t n, size_t es, void *thunk, cmp_t *cmp)
+{
+	local_qsort_r(a, n, es, cmp, thunk);
+}
+#elif defined(I_AM_QSORT_S)
+errno_t
+igraph_qsort_s(void *a, rsize_t n, rsize_t es, cmp_t *cmp, void *thunk)
+{
+	if (n > RSIZE_MAX) {
+		__throw_constraint_handler_s("qsort_s : n > RSIZE_MAX", EINVAL);
+		return (EINVAL);
+	} else if (es > RSIZE_MAX) {
+		__throw_constraint_handler_s("qsort_s : es > RSIZE_MAX",
+		    EINVAL);
+		return (EINVAL);
+	} else if (n != 0) {
+		if (a == NULL) {
+			__throw_constraint_handler_s("qsort_s : a == NULL",
+			    EINVAL);
+			return (EINVAL);
+		} else if (cmp == NULL) {
+			__throw_constraint_handler_s("qsort_s : cmp == NULL",
+			    EINVAL);
+			return (EINVAL);
+		}
+	}
+
+	local_qsort_s(a, n, es, cmp, thunk);
+	return (0);
+}
+#else
+void
+igraph_qsort(void *a, size_t n, size_t es, cmp_t *cmp)
+{
+	local_qsort(a, n, es, cmp, NULL);
+}
 #endif


### PR DESCRIPTION
As suggested by @szhorvat in #1824 we should update `qsort`. This PR addresses this and updates `qsort` to a more recent version as available from FreeBSD. To be specific, the source was pulled from  the most recent commit https://cgit.freebsd.org/src/commit/a670e1c13a522df4fb8c63bb023b88b1d65de797.

I have made the minimal necessary changes to make it easier to include any possible subsequent updates of `qsort.c`. At the moment, the code already works with a "local" version of `qsort` making it easy to do the necessary changes. For future reference and to be complete: these are the changes with respect to the original file from FreeBSD:

```diff
31a32,43
> #include "igraph_qsort.h"
> 
> #ifdef _MSC_VER
>     /* MSVC does not have inline when compiling C source files */
>     #define inline __inline
>     #define __unused
> #endif
> 
> #ifndef __unused
>   #define __unused    __attribute__ ((unused))
> #endif
> 
35,36d46
< #include <sys/cdefs.h>
< __FBSDID("$FreeBSD$");
38,39d47
< #include <errno.h>
< #include <stdint.h>
41,42d48
< #include <string.h>
< #include "libc_private.h"
212c218
< qsort_r(void *a, size_t n, size_t es, void *thunk, cmp_t *cmp)
---
> igraph_qsort_r(void *a, size_t n, size_t es, void *thunk, cmp_t *cmp)
218c224
< qsort_s(void *a, rsize_t n, rsize_t es, cmp_t *cmp, void *thunk)
---
> igraph_qsort_s(void *a, rsize_t n, rsize_t es, cmp_t *cmp, void *thunk)
244c250
< qsort(void *a, size_t n, size_t es, cmp_t *cmp)
---
> igraph_qsort(void *a, size_t n, size_t es, cmp_t *cmp)
```