### PR TITLE
Create SUPPORT.md

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,12 +1,13 @@
 # Need help with the igraph C library?
 
-_Are you using igraph from a different programming language than C? See the repositories for the [R interface](https://github.com/igraph/rigraph/), [Python interface](https://github.com/igraph/python-igraph/) or [Mathematica interface](https://github.com/szhorvat/IGraphM)._
+_This repository is **only** about the C library of `igraph`. Do you use `igraph` from a different language? Then please see the repositories for the [R interface](https://github.com/igraph/rigraph/), the [Python interface](https://github.com/igraph/python-igraph/) or the [Mathematica interface](https://github.com/szhorvat/IGraphM)._
 
 Having problems with igraph?
 
- - First, check the [**documentation**](https://igraph.org/c/html/latest/):
-    * [Installation instructions.](https://igraph.org/c/html/latest/igraph-Installation.html)
-    * [Tutorial](https://igraph.org/c/html/latest/igraph-Tutorial.html): Writing your first igraph program.
- - Feel free to post **questions** on [our support forum at **https://igraph.discourse.group**](https://igraph.discourse.group/).
- - If you **found a bug**, you may [open a new issue on GitHub](https://github.com/igraph/igraph/issues) and provide a complete description of the problem. Please only use the issue tracker for bug reports, not for general questions.
+ - First, check our [documentation](https://igraph.org/c/html/latest/) for answers.
+    * Problems with installing `igraph`? Please check our [installation instructions](https://igraph.org/c/html/latest/igraph-Installation.html).
+    * Problems compiling your own code? Please check our [tutorial](https://igraph.org/c/html/latest/igraph-Tutorial.html) on writing your first `igraph` program.
+ - Do you have a question about `igraph`? Please post your question on our [support forum](https://igraph.discourse.group/).
+ - If you **found a bug**, please go ahead and [open a new issue](https://github.com/igraph/igraph/issues).
 
+ We use the [issue tracker](https://github.com/igraph/igraph/issues) for bug reports and feature requests, and the [support forum](https://igraph.discourse.group/) for questions.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,9 +1,12 @@
 # Need help with the igraph C library?
 
+_Are you using igraph from a different programming language than C? See the repositories for the [R interface](https://github.com/igraph/rigraph/), [Python interface](https://github.com/igraph/python-igraph/) or [Mathematica interface](https://github.com/szhorvat/IGraphM)._
+
+Having problems with igraph?
+
  - First, check the [**documentation**](https://igraph.org/c/html/latest/):
     * [Installation instructions.](https://igraph.org/c/html/latest/igraph-Installation.html)
     * [Tutorial](https://igraph.org/c/html/latest/igraph-Tutorial.html): Writing your first igraph program.
  - Feel free to post **questions** on [our support forum at **https://igraph.discourse.group**](https://igraph.discourse.group/).
  - If you **found a bug**, you may [open a new issue on GitHub](https://github.com/igraph/igraph/issues) and provide a complete description of the problem. Please only use the issue tracker for bug reports, not for general questions.
 
-Are you using igraph from a different programming language than C? See the repositories for the [R interface](https://github.com/igraph/rigraph/), [Python interface](https://github.com/igraph/python-igraph/) or [Mathematica interface](https://github.com/szhorvat/IGraphM).

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,9 @@
+# Need help with the igraph C library?
+
+ - First, check the [**documentation**](https://igraph.org/c/html/latest/):
+    * [Installation instructions.](https://igraph.org/c/html/latest/igraph-Installation.html)
+    * [Tutorial](https://igraph.org/c/html/latest/igraph-Tutorial.html): Writing your first igraph program.
+ - Feel free to post **questions** on [our support forum at **https://igraph.discourse.group**](https://igraph.discourse.group/).
+ - If you **found a bug**, you may [open a new issue on GitHub](https://github.com/igraph/igraph/issues) and provide a complete description of the problem. Please only use the issue tracker for bug reports, not for general questions.
+
+Are you using igraph from a different programming language than C? See the repositories for the [R interface](https://github.com/igraph/rigraph/), [Python interface](https://github.com/igraph/python-igraph/) or [Mathematica interface](https://github.com/szhorvat/IGraphM).


### PR DESCRIPTION
As suggested, we should add a `SUPPORT.md` files to the repos of all igraph interfaces. Here's GitHub's descritption of this file:

https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/adding-support-resources-to-your-project

It will be shown when people try to open a new issue. This should further reduce the number of support questions mistakenly posted in the issue tracker.

This PR is just a starting point in order to start a discussion.