### PR TITLE
Re-work automatic root selection for Reingold-Tilford layout

### DIFF
--- a/src/layout/reingold_tilford.c
+++ b/src/layout/reingold_tilford.c
@@ -646,6 +646,8 @@ int igraph_i_layout_reingold_tilford_select_roots(
  *   then the roots will be selected automatically. Currently, automatic root
  *   selection prefers low ecccentricity vertices in graphs with fewer than
  *   500 vertices, and high degree vertices (acording to \p mode) in larger graphs.
+ *   The root selecton heuristic may change without notice. To ensure a consistent
+ *   output, please specify the roots manually.
  * \param rootlevel This argument can be useful when drawing forests which are
  *   not trees (i.e. they are unconnected and have tree components). It specifies
  *   the level of the root vertices for every tree in the forest. It is only
@@ -910,6 +912,8 @@ int igraph_layout_reingold_tilford(const igraph_t *graph,
  *   then the roots will be selected automatically. Currently, automatic root
  *   selection prefers low ecccentricity vertices in graphs with fewer than
  *   500 vertices, and high degree vertices (acording to \p mode) in larger graphs.
+ *   The root selecton heuristic may change without notice. To ensure a consistent
+ *   output, please specify the roots manually.
  * \param rootlevel This argument can be useful when drawing forests which are
  *   not trees (i.e. they are unconnected and have tree components). It specifies
  *   the level of the root vertices for every tree in the forest. It is only

--- a/src/layout/reingold_tilford.c
+++ b/src/layout/reingold_tilford.c
@@ -31,7 +31,6 @@
 #include "igraph_paths.h"
 #include "igraph_progress.h"
 #include "igraph_structural.h"
-#include "igraph_topology.h"
 
 #include "core/math.h"
 

--- a/src/layout/reingold_tilford.c
+++ b/src/layout/reingold_tilford.c
@@ -490,7 +490,18 @@ int igraph_i_layout_reingold_tilford_cluster_degrees_directed(
     return IGRAPH_SUCCESS;
 }
 
-/* Heuristic method to choose "nice" roots for the Reingold-Tilford layout algorithm. */
+/* Heuristic method to choose "nice" roots for the Reingold-Tilford layout algorithm.
+ *
+ * The principle is to select a minimal set of roots so that all other vertices
+ * will be reachable from them.
+ *
+ * In the undirected case, one root is chosen from each connected component.
+ * In the directed case, one root is chosen from each strongly connected component
+ * that has no incoming (or outgoing) edges (depending on 'mode').
+ * When more than one root choice is possible, nodes are prioritized based on
+ * either lowest ecccentricity (if 'use_ecccentricity' is true) or based on
+ * highest degree (out- or in-degree in directed mode).
+ */
 int igraph_i_layout_reingold_tilford_select_roots(
         const igraph_t *graph,
         igraph_neimode_t mode,
@@ -628,13 +639,13 @@ int igraph_i_layout_reingold_tilford_select_roots(
  *   \c IGRAPH_ALL then all edges are used (this was the behavior in
  *   igraph 0.5 and before). This parameter also influences how the root
  *   vertices are calculated, if they are not given. See the \p roots parameter.
- * \param roots The index of the root vertex or root vertices.
- *   If this is a non-empty vector then the supplied vertex ids are used
- *   as the roots of the trees (or a single tree if the graph is connected).
- *   If it is a null pointer of a pointer to an empty vector, then the root
- *   vertices are automatically calculated based on topological sorting,
- *   performed with the opposite mode than the \p mode argument.
- *   After the vertices have been sorted, one is selected from each component.
+ * \param roots The index of the root vertex or root vertices. The set of roots
+ *   should be specified so that all vertices of the graph are reachable from them.
+ *   Simply put, in the udirected case, one root should be given from each
+ *   connected component. If \p roots is \c NULL or a pointer to an empty vector,
+ *   then the roots will be selected automatically. Currently, automatic root
+ *   selection prefers low ecccentricity vertices in graphs with fewer than
+ *   500 vertices, and high degree vertices (acording to \p mode) in larger graphs.
  * \param rootlevel This argument can be useful when drawing forests which are
  *   not trees (i.e. they are unconnected and have tree components). It specifies
  *   the level of the root vertices for every tree in the forest. It is only
@@ -892,13 +903,13 @@ int igraph_layout_reingold_tilford(const igraph_t *graph,
  *   \c IGRAPH_ALL then all edges are used (this was the behavior in
  *   igraph 0.5 and before). This parameter also influences how the root
  *   vertices are calculated, if they are not given. See the \p roots parameter.
- * \param roots The index of the root vertex or root vertices.
- *   If this is a non-empty vector then the supplied vertex ids are used
- *   as the roots of the trees (or a single tree if the graph is connected).
- *   If it is a null pointer of a pointer to an empty vector, then the root
- *   vertices are automatically calculated based on topological sorting,
- *   performed with the opposite mode than the \p mode argument.
- *   After the vertices have been sorted, one is selected from each component.
+ * \param roots The index of the root vertex or root vertices. The set of roots
+ *   should be specified so that all vertices of the graph are reachable from them.
+ *   Simply put, in the udirected case, one root should be given from each
+ *   connected component. If \p roots is \c NULL or a pointer to an empty vector,
+ *   then the roots will be selected automatically. Currently, automatic root
+ *   selection prefers low ecccentricity vertices in graphs with fewer than
+ *   500 vertices, and high degree vertices (acording to \p mode) in larger graphs.
  * \param rootlevel This argument can be useful when drawing forests which are
  *   not trees (i.e. they are unconnected and have tree components). It specifies
  *   the level of the root vertices for every tree in the forest. It is only

--- a/tests/unit/igraph_layout_reingold_tilford_circular.out
+++ b/tests/unit/igraph_layout_reingold_tilford_circular.out
@@ -29,8 +29,8 @@ Two minitrees with rootlevel 10 and 20:
         11 -19.0526 ]
 Graph with just loops, triple edges and disconnected vertices:
 [        1        0
-  -0.209057  1.98904
   -0.104528 0.994522
+  -0.209057  1.98904
   -0.978148 -0.207912
   0.309017 -0.951057 ]
 Checking proper error handling:


### PR DESCRIPTION
This PR improved automatic root selection for the Reingold-Tilford layout. The documentation and tests are not updated yet, but I'd like a review before I proceed. One test fails because the root selection has changed.

This is how the previous version worked:

 - Undirected: Choose the largest degree node from each connected component
 - Directed: Do a topological sort (only works if the graph is a DAG) and choose the first node in topological order from each weakly connected component.

Problems with the directed root selection:
 - It fails if the graph is not a DAG.
 - Even for a DAG, the root list would only be complete if it includes all source vertices (zero in-degree vertices). There may be more than one source vertex per _weakly_ connected component, thus not all were selected.

This is how the new version works:

 - Directed: We break the graph into _strongly_ connected components and find those components that have no incoming connections. One root will be chosen from each such component based on some "prioritization". If the graph is a DAG, this will simply select source vertices, regardless of prioritization (as each source vertex is a strongly connected component on its own).
 - Undirected: Select one root from each connected component based on the "prioritization".

I implemented two choices for prioritization:
 - Take the maximum degree (or out-degree) vertex. This is as before, and very fast.
 - Take a lowest eccentricity vertex. This is also called the [graph center](https://en.wikipedia.org/wiki/Graph_center). This minimizes the number of levels in the tree drawing, and often leads to nice outcomes. The drawback is that it is slower than the Reingold-Tilford layout itself.

To balance performance with quality, I use eccentricity for less than 500 vertices and max degree otherwise.
