### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,35 +1,41 @@
 # Contributing to this project
 
-Please take a moment to review this document in order to make the contribution
-process easy and effective for everyone involved.
+Thank you for being interested in contributing to `igraph`! We need the help of
+volunteers to keep the package going, so every help is welcome. You can help out
+the project in several different ways. This repository only hosts the C code of
+the `igraph` project. Even if you are not so experienced with C, you can
+contribute in a number of ways.
 
-Following these guidelines helps to communicate that you respect the time of
-the developers managing and developing this open source project. In return,
-they should reciprocate that respect in addressing your issue or assessing
-patches and features.
+You can contribute to `igraph` in various ways:
 
+1. Respond to user questions on
+   our [support forum](https://igraph.discourse.group/).
+2. Correct or improve our [documentation](https://igraph.org/c/html/latest/).
+3. Go over [open issues](https://github.com/igraph/igraph/issues):
+   - Are some older issues still a problem in the most recent version?
+   - Can you reproduce some of the bugs that are reported?
+   - Some [issues point out problem with documentation](https://github.com/igraph/igraph/labels/documentation), perhaps you could help correct this?
+   - Looking to contribute code? Take a look at
+     some [good first issues](https://github.com/igraph/igraph/labels/good%20first%20issue).
 
 ## Using the issue tracker
 
-The issue tracker is the preferred channel for [bug reports](#bugs),
+- The issue tracker is the preferred channel for [bug reports](#bugs),
 [features requests](#features) and [submitting pull
-requests](#pull-requests), but please respect the following restrictions:
+requests](#pull-requests).
 
-* Please **do not** use the issue tracker for personal support requests (use
-  our [igraph support forum](https://igraph.discourse.group)).
+- Do you have a support question? Please use
+  our [igraph support forum](https://igraph.discourse.group) for support
+  requests.
 
-* Please **do not** derail or troll issues. Keep the discussion on topic and
-  respect the opinions of others.
-
-Please also take a look at our [tips on writing igraph code](#tips) before
-getting your hands dirty.
-
+- Please keep the discussion on topic and respect the opinions of others, and
+  adhere to our [Code of Conduct](https://igraph.org/code-of-conduct.html).
 
 <a name="bugs"></a>
 ## Bug reports
 
 A bug is a _demonstrable problem_ that is caused by the code in the repository.
-Good bug reports are extremely helpful - thank you!
+Good bug reports are extremely helpful &mdash; thank you for reporting!
 
 Guidelines for bug reports:
 
@@ -52,10 +58,10 @@ Guidelines for bug reports:
 4. **Isolate the problem** &mdash; create a [short, self-contained, correct
    example](http://sscce.org/).
 
-A good bug report shouldn't leave others needing to chase you up for more
-information. Please try to be as detailed as possible in your report. What is
-your environment? What steps will reproduce the issue? What would you expect to
-be the outcome? All these details will help people to fix any potential bugs.
+Please try to be as detailed as possible in your report and provide all
+necessary information. What is your environment? What steps will reproduce the
+issue? What would you expect to be the outcome? All these details will help us
+to fix any potential bugs.
 
 Example:
 
@@ -79,18 +85,21 @@ Example:
 <a name="features"></a>
 ## Feature requests
 
-Feature requests are welcome. But take a moment to find out whether your idea
-fits with the scope and aims of the project. It's up to *you* to make a strong
-case to convince the project's developers of the merits of this feature. Please
-provide as much detail and context as possible.
-
+Feature requests are always welcome. But take a moment to find out whether your
+idea fits with the scope and aims of the project. Please provide as much detail
+and context as possible, and where possible, references to relevant literature.
+Having said that, implementing new features can be quite time consuming, and as
+such they might not be implemented quickly. In addition, the development team
+might decide not to implement a certain feature. It's up to you to make a case
+to convince the project's developers of the merits of this feature.
 
 <a name="pull-requests"></a>
 ## Pull requests
 
-Good pull requests - patches, improvements, new features - are a fantastic
-help. They should remain focused in scope and avoid containing unrelated
-commits.
+Good pull requests - patches, improvements, new features - are a fantastic help.
+They should remain focused in scope and avoid containing unrelated commits.
+Please also take a look at our [tips on writing igraph code](#tips) before
+getting your hands dirty.
 
 **Please ask first** before embarking on any significant pull request (e.g.
 implementing features, refactoring code, porting to a different language),
@@ -100,8 +109,7 @@ project's developers might not want to merge into the project.
 Please adhere to the coding conventions used throughout a project (indentation,
 accurate comments, etc.) and any other requirements (such as test coverage).
 
-Follow this process if you'd like your work considered for inclusion in the
-project:
+Follow the following steps if you would like to make a new pull request:
 
 1. [Fork](http://help.github.com/fork-a-repo/) the project, clone your fork,
    and configure the remotes:
@@ -132,25 +140,25 @@ project:
    git checkout -b <topic-branch-name>
    ```
 
-4. Commit your changes in logical chunks. Please adhere to these [git commit
-   message guidelines](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)
-   or your code is unlikely be merged into the main project. Use Git's
-   [interactive rebase](https://help.github.com/articles/interactive-rebase)
-   feature to tidy up your commits before making them public.
+4. Please commit your changes in logical chunks, and try to provide clear commit
+   messages.
 
-5. We have a handy [checklist for new igraph
-   functions](https://github.com/igraph/igraph/wiki/Checklist-for-new-(and-old)-functions).
+5. We have a [checklist for new igraph functions](https://github.com/igraph/igraph/wiki/Checklist-for-new-(and-old)-functions).
    If you have added any new functions to igraph, please go through the
    checklist to ensure that your functions play nicely with the rest of the
    library.
 
-6. Locally merge (or rebase) the upstream development branch into your topic branch:
+6. Make sure that your PR is based off the latest code and locally merge (or
+   rebase) the upstream development branch into your topic branch:
 
    ```bash
    git pull [--rebase] upstream <dev-branch>
    ```
 
-7. Push your topic branch up to your fork:
+7. If necessary, you can use git's
+   [interactive rebase](https://help.github.com/articles/interactive-rebase)
+   feature to tidy up your commits before pushing them.
+   You can push your topic branch up to your fork:
 
    ```bash
    git push origin <topic-branch-name>
@@ -159,8 +167,9 @@ project:
 8. [Open a pull request](https://help.github.com/articles/using-pull-requests/)
     with a clear title and description.
 
-**IMPORTANT**: By submitting a pull request, you agree to allow the project owner to
-license your work under the same license as that used by the project.
+**IMPORTANT**: By submitting a pull request, you agree to allow the project
+owner to license your work under the same license as that used by the project,
+see also [Legal Stuff](#legal).
 
 <a name="branching"></a>
 ### Branching
@@ -182,16 +191,17 @@ In general, if you are not sure about something, please ask! You can
 open an issue on GitHub, open a thread in our
 [igraph support forum](https://igraph.discourse.group), or write to
 [@ntamas](https://github.com/ntamas), [@vtraag](https://github.com/vtraag),
-[@szhorvat](https://github.com/szhorvat) or
+[@szhorvat](https://github.com/szhorvat), [@iosonofabio](https://github.com/iosonofabio) or
 [@gaborcsardi](https://github.com/gaborcsardi).
-We prefer the igraph support forum, because then others can learn from it
+We prefer open communication channels, because then others can learn from it
 too.
 
+<a name="legal"></a>
 ## Legal Stuff
 
 This is a pain to deal with, but we can't avoid it, unfortunately.
 
-So, igraph is licensed under the "General Public License (GPL) version 2, or
+So, `igraph` is licensed under the "General Public License (GPL) version 2, or
 later". The igraph manual is licensed under the "GNU Free Documentation
 License". By submitting a patch or pull request, you agree to allow the project
 owner to license your work under the same license as that used by the project.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -174,11 +174,36 @@ see also [Legal Stuff](#legal).
 <a name="branching"></a>
 ### Branching
 
-`igraph` is committed to [semantic versioning](https://semver.org/). We are currently still in the development release (0.x), which in principle is a mark that the public API is not yet stable. Regardless, we try to maintain semantic versioning also for the development releases. We do so as follows. Any released minor version (0.x.z) will be API backwards-compatible with any previous release of the *same* minor version (0.x.y, with y < z). This means that *if* there is an API incompatible change, we will increase the minor version. For example, release 0.8.1 is API backwards-compatible with release 0.8.0, while release 0.9.0 is API incompatible with version 0.8.1. Note that this only concerns the *public* API, internal functions may change also within a minor version.
+`igraph` is committed to [semantic versioning](https://semver.org/). We are
+currently still in the development release (0.x), which in principle is a mark
+that the public API is not yet stable. Regardless, we try to maintain semantic
+versioning also for the development releases. We do so as follows. Any released
+minor version (0.x.z) will be API backwards-compatible with any previous release
+of the *same* minor version (0.x.y, with y < z). This means that *if* there is
+an API incompatible change, we will increase the minor version. For example,
+release 0.8.1 is API backwards-compatible with release 0.8.0, while release
+0.9.0 is API incompatible with version 0.8.1. Note that this only concerns the *
+public* API, internal functions may change also within a minor version.
 
-There will always be two versions of `igraph`: the most recent released version, and the next upcoming minor release, which is by definition not yet released. The most recent release version is in the `master` branch, while the next upcoming minor release is in the `develop` branch. If you make a change that is API incompatible with the most recent release, it **must** be merged to the `develop` branch. If the change is API backwards-compatible, it **can** be merged to the `master` branch. It is possible that you build on recent improvements in the `develop` branch, in which case your change should of course target the `develop` branch. If you only add new functionality, but do not change anything of the existing API, this should be backwards-compatible, and can be merged in the `master` branch.
+There will always be two versions of `igraph`: the most recent released version,
+and the next upcoming minor release, which is by definition not yet released.
+The most recent release version is in the `master` branch, while the next
+upcoming minor release is in the `develop` branch. If you make a change that is
+API incompatible with the most recent release, it **must** be merged to
+the `develop` branch. If the change is API backwards-compatible, it **can** be
+merged to the `master` branch. It is possible that you build on recent
+improvements in the `develop` branch, in which case your change should of course
+target the `develop` branch. If you only add new functionality, but do not
+change anything of the existing API, this should be backwards-compatible, and
+can be merged in the `master` branch.
 
-When you make a new pull request, please specify the correct target branch. The maintainers of `igraph` may decide to retarget your pull request to the correct branch. Retargeting you pull request may result in merge conflicts, so it is always good to decide **before** starting to work on something whether you should start from the `master` branch or from the `develop` branch. In most cases, changes in the `master` branch will also be merged to the `develop` branch by the maintainers.
+When you make a new pull request, please specify the correct target branch. The
+maintainers of `igraph` may decide to retarget your pull request to the correct
+branch. Retargeting you pull request may result in merge conflicts, so it is
+always good to decide **before** starting to work on something whether you
+should start from the `master` branch or from the `develop` branch. In most
+cases, changes in the `master` branch will also be merged to the `develop`
+branch by the maintainers.
 
 <a name="tips"></a>
 ## Writing igraph Code

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,27 +1,27 @@
 # Contributing to this project
 
 Thank you for being interested in contributing to `igraph`! We need the help of
-volunteers to keep the package going, so every help is welcome. You can help out
-the project in several different ways. This repository only hosts the C code of
-the `igraph` project. Even if you are not so experienced with C, you can
-contribute in a number of ways.
+volunteers to keep the package going, so every contribution is welcome. You can help out
+the project in several different ways.
 
-You can contribute to `igraph` in various ways:
+This repository only hosts the C code of the `igraph` project. Even if you are not so
+experienced with C, you can contribute in a number of ways:
 
-1. Respond to user questions on
-   our [support forum](https://igraph.discourse.group/).
+1. Respond to user questions on our [support forum](https://igraph.discourse.group/).
 2. Correct or improve our [documentation](https://igraph.org/c/html/latest/).
 3. Go over [open issues](https://github.com/igraph/igraph/issues):
-   - Are some older issues still a problem in the most recent version?
-   - Can you reproduce some of the bugs that are reported?
-   - Some [issues point out problem with documentation](https://github.com/igraph/igraph/labels/documentation), perhaps you could help correct this?
-   - Looking to contribute code? Take a look at
-     some [good first issues](https://github.com/igraph/igraph/labels/good%20first%20issue).
+   - Are some older issues still relevant in the most recent version? If not, write a
+     comment to the issue stating that you feel that the issue is not relevant any more.
+   - Can you reproduce some of the bugs that are reported? If so, write a comment to
+     the issue stating that this is still a problem in version X.
+   - Some [issues point out problems with the documentation](https://github.com/igraph/igraph/labels/documentation);
+     perhaps you could help correct these?
+   - Looking to contribute code? Take a look at some [good first issues](https://github.com/igraph/igraph/labels/good%20first%20issue).
 
 ## Using the issue tracker
 
 - The issue tracker is the preferred channel for [bug reports](#bugs),
-[features requests](#features) and [submitting pull
+[feature requests](#features) and [submitting pull
 requests](#pull-requests).
 
 - Do you have a support question? Please use
@@ -85,12 +85,12 @@ Example:
 <a name="features"></a>
 ## Feature requests
 
-Feature requests are always welcome. But take a moment to find out whether your
+Feature requests are always welcome. First, take a moment to find out whether your
 idea fits with the scope and aims of the project. Please provide as much detail
 and context as possible, and where possible, references to relevant literature.
 Having said that, implementing new features can be quite time consuming, and as
 such they might not be implemented quickly. In addition, the development team
-might decide not to implement a certain feature. It's up to you to make a case
+might decide not to implement a certain feature. It is up to you to make a case
 to convince the project's developers of the merits of this feature.
 
 <a name="pull-requests"></a>
@@ -182,8 +182,8 @@ minor version (0.x.z) will be API backwards-compatible with any previous release
 of the *same* minor version (0.x.y, with y < z). This means that *if* there is
 an API incompatible change, we will increase the minor version. For example,
 release 0.8.1 is API backwards-compatible with release 0.8.0, while release
-0.9.0 is API incompatible with version 0.8.1. Note that this only concerns the *
-public* API, internal functions may change also within a minor version.
+0.9.0 might be API incompatible with version 0.8.1. Note that this only concerns
+the *public* API, internal functions may change also within a minor version.
 
 There will always be two versions of `igraph`: the most recent released version,
 and the next upcoming minor release, which is by definition not yet released.
@@ -205,6 +205,10 @@ should start from the `master` branch or from the `develop` branch. In most
 cases, changes in the `master` branch will also be merged to the `develop`
 branch by the maintainers.
 
+If you are unsure about the branch to target, open an issue about your proposed
+feature and we can discuss the appropriate target branch in the issue before
+you send a PR.
+
 <a name="tips"></a>
 ## Writing igraph Code
 
@@ -218,7 +222,7 @@ open an issue on GitHub, open a thread in our
 [@ntamas](https://github.com/ntamas), [@vtraag](https://github.com/vtraag),
 [@szhorvat](https://github.com/szhorvat), [@iosonofabio](https://github.com/iosonofabio) or
 [@gaborcsardi](https://github.com/gaborcsardi).
-We prefer open communication channels, because then others can learn from it
+We prefer open communication channels, because others can then learn from it
 too.
 
 <a name="legal"></a>
@@ -226,7 +230,7 @@ too.
 
 This is a pain to deal with, but we can't avoid it, unfortunately.
 
-So, `igraph` is licensed under the "General Public License (GPL) version 2, or
+`igraph` is licensed under the "General Public License (GPL) version 2, or
 later". The igraph manual is licensed under the "GNU Free Documentation
 License". By submitting a patch or pull request, you agree to allow the project
 owner to license your work under the same license as that used by the project.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,12 +21,10 @@ experienced with C, you can contribute in a number of ways:
 ## Using the issue tracker
 
 - The issue tracker is the preferred channel for [bug reports](#bugs),
-[feature requests](#features) and [submitting pull
-requests](#pull-requests).
+  [feature requests](#features) and [submitting pull requests](#pull-requests).
 
-- Do you have a support question? Please use
-  our [igraph support forum](https://igraph.discourse.group) for support
-  requests.
+- Do you have a question? Please use our [igraph support forum](https://igraph.discourse.group)
+  for support requests.
 
 - Please keep the discussion on topic and respect the opinions of others, and
   adhere to our [Code of Conduct](https://igraph.org/code-of-conduct.html).
@@ -141,7 +139,10 @@ Follow the following steps if you would like to make a new pull request:
    ```
 
 4. Please commit your changes in logical chunks, and try to provide clear commit
-   messages.
+   messages. It helps us during the review process if we can follow your thought
+   process during the implementation. If you hit a dead end, use `git revert`
+   to revert your commits or just go back to an earlier commit with `git checkout`
+   and continue your work from there.
 
 5. We have a [checklist for new igraph functions](https://github.com/igraph/igraph/wiki/Checklist-for-new-(and-old)-functions).
    If you have added any new functions to igraph, please go through the
@@ -154,11 +155,13 @@ Follow the following steps if you would like to make a new pull request:
    ```bash
    git pull [--rebase] upstream <dev-branch>
    ```
+   
+   Rebasing is preferable over merging as you do not need to deal with merge
+   conflicts; however, if you already have many commits, merging the upstream
+   development branch may be faster.
 
-7. If necessary, you can use git's
-   [interactive rebase](https://help.github.com/articles/interactive-rebase)
-   feature to tidy up your commits before pushing them.
-   You can push your topic branch up to your fork:
+7. WHen your topic branch is up-to-date with the upstream development branch, you can
+   push your topic branch up to your fork:
 
    ```bash
    git push origin <topic-branch-name>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing to this project
 
 Thank you for being interested in contributing to `igraph`! We need the help of
-volunteers to keep the package going, so every contribution is welcome. You can help out
+volunteers to keep the package going, so every little bit is welcome. You can help out
 the project in several different ways.
 
 This repository only hosts the C code of the `igraph` project. Even if you are not so


### PR DESCRIPTION
I went over our existing CONTRIBUTING.md, and I thought it could use some updating. In particular, I thought it would be good to mention that people can also contribute to the project in other ways than reporting bugs and opening pull request. In particular, I also wanted to clarify to people that help on the support forum and on improving the documentation is helpful.

One other suggestion that I now make is that people can go over existing issues to see if they can help out. Some issues on documentation may be good starting points if people want to contribute, but don't necessarily want to delve intro coding. Some other possibilities would be to just go over some open issues that are already open for a long time and see if they are still relevant. 

I was thinking that it might perhaps be good to have a label for something like "replication needed", so that people can help out by trying to replicate some problem? In addition, we might perhaps clean up a bit our labelling. We now have "help wanted", "PR welcome", perhaps they can simply be combined. But I also wonder: do they actually signify something useful?

In addition, I made some of the language is bit friendlier (or what I would perceive as friendlier) and a bit more welcoming.

This may need some polishing still, feel free to make suggestions!

