### PR TITLE
Check GLPK version in CMake

### DIFF
--- a/doc/installation.xml
+++ b/doc/installation.xml
@@ -53,7 +53,7 @@
     </listitem>
     <listitem>
       <para>
-        <ulink url="https://www.gnu.org/software/glpk/">GLPK</ulink>
+        <ulink url="https://www.gnu.org/software/glpk/">GLPK</ulink> (version 4.57 or later)
       </para>
     </listitem>
     <listitem>
@@ -257,7 +257,7 @@ cmake --build . --target check --config Release
       <section id="igraph-Installation-msys2">
       <title>MSYS2</title>
       <para>
-        MSYS2 can be installed from www.msys2.org. After installing MSYS2,
+        MSYS2 can be installed from <ulink url="https://www.msys2.org/">msys2.org</ulink>. After installing MSYS2,
         ensure that it is up to date by opening a terminal and running
         <literal>pacman -Syuu</literal>.
       </para>

--- a/etc/cmake/FindGLPK.cmake
+++ b/etc/cmake/FindGLPK.cmake
@@ -1,36 +1,81 @@
-# https://raw.githubusercontent.com/CGAL/releases/master/cmake/modules/FindGLPK.cmake
-#
-# This file sets up GLPK for CMake. Once done this will define
-#  GLPK_FOUND             - system has GLPK lib
-#  GLPK_INCLUDE_DIR       - the GLPK include directory
-#  GLPK_LIBRARIES         - Link these to use GLPK
+#[=======================================================================[.rst:
+FindGLPK
+--------
 
+Finds the GLPK library.
 
-# Is it already configured?
-if (NOT GLPK_FOUND)
+Result Variables
+^^^^^^^^^^^^^^^^
 
-    # first look in user defined locations
-    find_path(GLPK_INCLUDE_DIR
-                NAMES glpk.h
-                PATHS /usr/local/include/LASlib/
-                ENV GLPK_INC_DIR
-             )
+This will define the following variables:
 
-    find_library(GLPK_LIBRARIES
-                 NAMES libglpk glpk
-                 PATHS ENV LD_LIBRARY_PATH
-                       ENV LIBRARY_PATH
-                       /usr/local/lib
-                       ${GLPK_INCLUDE_DIR}/../lib
-                      ENV GLPK_LIB_DIR
-                )
+``GLPK_FOUND``
+  True if the system has the GLPK library.
+``GLPK_VERSION``
+  The version of the GLPK library which was found.
+``GLPK_INCLUDE_DIRS``
+  Include directories needed to use Foo.
+``GLPK_LIBRARIES``
+  Libraries needed to link to Foo.
 
-    # hide the introduced cmake cached variables in cmake GUIs
-    mark_as_advanced(GLPK_INCLUDE_DIR)
-    mark_as_advanced(GLPK_LIBRARIES)
+Cache Variables
+^^^^^^^^^^^^^^^
 
-    if(GLPK_LIBRARIES AND GLPK_INCLUDE_DIR)
-      set(GLPK_FOUND TRUE)
-    endif()
+The following cache variables may also be set:
 
+``GLPK_INCLUDE_DIR``
+  The directory containing ``glpk.h``.
+``GLPK_LIBRARY``
+  The path to the GLPK library.
+
+#]=======================================================================]
+
+find_path(GLPK_INCLUDE_DIR
+  NAMES glpk.h
+)
+
+find_library(GLPK_LIBRARY
+  NAMES glpk
+)
+
+# parse version from header
+if(GLPK_INCLUDE_DIR)
+  set(GLPK_VERSION_FILE ${GLPK_INCLUDE_DIR}/glpk.h)
+  file(READ ${GLPK_VERSION_FILE} GLPK_VERSION_FILE_CONTENTS)
+
+  string(REGEX MATCH "#define[ ]+GLP_MAJOR_VERSION[ ]+[0-9]+"
+    GLPK_VERSION_MAJOR "${GLPK_VERSION_FILE_CONTENTS}")
+  string(REGEX REPLACE "#define[ ]+GLP_MAJOR_VERSION[ ]+([0-9]+)" "\\1"
+    GLPK_VERSION_MAJOR "${GLPK_VERSION_MAJOR}")
+
+  string(REGEX MATCH "#define[ ]+GLP_MINOR_VERSION[ ]+[0-9]+"
+    GLPK_VERSION_MINOR "${GLPK_VERSION_FILE_CONTENTS}")
+  string(REGEX REPLACE "#define[ ]+GLP_MINOR_VERSION[ ]+([0-9]+)" "\\1"
+    GLPK_VERSION_MINOR "${GLPK_VERSION_MINOR}")
+
+  set(GLPK_VERSION "${GLPK_VERSION_MAJOR}.${GLPK_VERSION_MINOR}")
+
+  # compatibility variables
+  set(GLPK_VERSION_STRING "${GLPK_VERSION}")
+endif()
+
+# behave like a CMake module is supposed to behave
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(GLPK
+  FOUND_VAR GLPK_FOUND
+  REQUIRED_VARS
+    GLPK_LIBRARY
+    GLPK_INCLUDE_DIR
+  VERSION_VAR GLPK_VERSION
+)
+
+# hide the introduced cmake cached variables in cmake GUIs
+mark_as_advanced(
+  GLPK_INCLUDE_DIR
+  GLPK_LIBRARY
+)
+
+if(GLPK_FOUND)
+  set(GLPK_LIBRARIES ${GLPK_LIBRARY})
+  set(GLPK_INCLUDE_DIRS ${GLPK_INCLUDE_DIR})
 endif()

--- a/etc/cmake/FindGMP.cmake
+++ b/etc/cmake/FindGMP.cmake
@@ -9,10 +9,13 @@
 # Some modifications made by Tamas Nepusz to ensure that the module fits better
 # with the de facto conventions of FindXXX.cmake scripts
 
-set(GMP_PREFIX "" CACHE PATH "Path to GMP prefix")
+find_path(GMP_INCLUDE_DIR 
+  NAMES gmp.h
+)
 
-find_path(GMP_INCLUDE_DIR gmp.h PATHS ${GMP_PREFIX}/include /usr/include /usr/local/include)
-find_library(GMP_LIBRARY gmp PATHS ${GMP_PREFIX}/lib /usr/lib /usr/local/lib)
+find_library(GMP_LIBRARY
+  NAMES gmp
+)
 
 # behave like a CMake module is supposed to behave
 include(FindPackageHandleStandardArgs)
@@ -24,10 +27,10 @@ find_package_handle_standard_args(
 )
 
 # hide the introduced cmake cached variables in cmake GUIs
-mark_as_advanced(GMP_PREFIX)
 mark_as_advanced(GMP_INCLUDE_DIR)
 mark_as_advanced(GMP_LIBRARY)
 
 if(GMP_FOUND)
   set(GMP_LIBRARIES ${GMP_LIBRARY})
+  set(GMP_INCLUDE_DIRS ${GMP_INCLUDE_DIR})
 endif()

--- a/etc/cmake/dependencies.cmake
+++ b/etc/cmake/dependencies.cmake
@@ -7,9 +7,12 @@ include(CheckSymbolExists)
 include(FindThreads)
 
 macro(find_dependencies)
-  # Declare the list of dependencies that _may_ be vendored and those that may not
+  # Declare the list of dependencies that _may_ be vendored
   set(VENDORABLE_DEPENDENCIES BLAS CXSparse GLPK LAPACK ARPACK GMP)
-  set(NONVENDORABLE_DEPENDENCIES GLPK OpenMP)
+
+  # Declare optional dependencies associated with IGRAPH_..._SUPPORT flags
+  # Note that GLPK is both vendorable and optional
+  set(OPTIONAL_DEPENDENCIES GLPK OpenMP)
 
   # Declare configuration options for dependencies
   tristate(IGRAPH_USE_INTERNAL_GMP "Compile igraph with internal Mini-GMP" AUTO)
@@ -24,13 +27,16 @@ macro(find_dependencies)
   set(OPTIONAL_DEPENDENCIES FLEX BISON OpenMP)
   set(VENDORED_DEPENDENCIES "")
 
+  # Declare minimum supported version for some dependencies
+  set(GLPK_VERSION_MIN "4.57") # 4.57 is the firt version providing glp_on_error()
+
   # Extend dependencies depending on whether we will be using the vendored
   # copies or not
   foreach(DEPENDENCY ${VENDORABLE_DEPENDENCIES})
     string(TOUPPER "${DEPENDENCY}" LIBNAME_UPPER)
 
     if(IGRAPH_USE_INTERNAL_${LIBNAME_UPPER} STREQUAL "AUTO")
-      find_package(${DEPENDENCY})
+      find_package(${DEPENDENCY} ${${DEPENDENCY}_VERSION_MIN})
       if(${LIBNAME_UPPER}_FOUND)
         set(IGRAPH_USE_INTERNAL_${LIBNAME_UPPER} OFF)
       else()
@@ -45,13 +51,13 @@ macro(find_dependencies)
     endif()
   endforeach()
 
-  # For nonvendorable dependencies, figure out whether we should attempt to
+  # For optional dependencies, figure out whether we should attempt to
   # link to them based on the value of the IGRAPH_..._SUPPORT option
-  foreach(DEPENDENCY ${NONVENDORABLE_DEPENDENCIES})
+  foreach(DEPENDENCY ${OPTIONAL_DEPENDENCIES})
     string(TOUPPER "${DEPENDENCY}" LIBNAME_UPPER)
 
     if(IGRAPH_${LIBNAME_UPPER}_SUPPORT STREQUAL "AUTO")
-      find_package(${DEPENDENCY})
+    find_package(${DEPENDENCY} ${${DEPENDENCY}_VERSION_MIN})
       if(${LIBNAME_UPPER}_FOUND)
         set(IGRAPH_${LIBNAME_UPPER}_SUPPORT ON)
       else()
@@ -104,7 +110,7 @@ macro(find_dependencies)
     endif()
 
     if(NEED_THIS_DEPENDENCY AND NOT DEFINED ${DEPENDENCY}_FOUND)
-      find_package(${DEPENDENCY})
+      find_package(${DEPENDENCY} ${${DEPENDENCY}_VERSION_MIN})
     endif()
   endforeach()
 


### PR DESCRIPTION
 - Rewrite `FindGLPK.cmake` to allow for version check
 - Simplify `FindGMP.cmake`. While it looks in fewer places, it is consistent with `FindGLPK.cmake`. We can maybe do this for other libraries too. `GMP_PREFIX` is not necessary because there is the standard `GMP_ROOT` (provided automatically by CMake for any package)
 - Provide support for checking package versions in `dependencies.cmake` and check that GLPK >= 4.57

Fixes #1879 