### PR TITLE
perf: minor speedup and refactor for weak connectedness

### DIFF
--- a/src/connectivity/components.c
+++ b/src/connectivity/components.c
@@ -359,10 +359,18 @@ static int igraph_is_connected_weak(const igraph_t *graph, igraph_bool_t *res);
 
 int igraph_is_connected(const igraph_t *graph, igraph_bool_t *res,
                         igraph_connectedness_t mode) {
-    if (igraph_vcount(graph) == 0) {
+
+    long int no_of_nodes = igraph_vcount(graph);
+
+    if (no_of_nodes == 0) {
         /* Changed in igraph 0.9; see https://github.com/igraph/igraph/issues/1538
          * for the reasoning behind the change */
         *res = 0;
+        return IGRAPH_SUCCESS;
+    }
+
+    if (no_of_nodes == 1) {
+        *res = 1;
         return IGRAPH_SUCCESS;
     }
 
@@ -371,7 +379,15 @@ int igraph_is_connected(const igraph_t *graph, igraph_bool_t *res,
     } else if (mode == IGRAPH_STRONG) {
         int retval;
         igraph_integer_t no;
-        retval = igraph_i_clusters_strong(graph, 0, 0, &no);
+
+        /* A strongly connected graph has at least as many edges as vertices,
+         * except for the singleton graph, which is handled above. */
+        if (igraph_ecount(graph) < no_of_nodes) {
+            *res = 0;
+            return IGRAPH_SUCCESS;
+        }
+
+        retval = igraph_i_clusters_strong(graph, NULL, NULL, &no);
         *res = (no == 1);
         return retval;
     }

--- a/src/connectivity/components.c
+++ b/src/connectivity/components.c
@@ -335,6 +335,12 @@ static int igraph_is_connected_weak(const igraph_t *graph, igraph_bool_t *res);
  * \function igraph_is_connected
  * \brief Decides whether the graph is (weakly or strongly) connected.
  *
+ * A graph is considered connected when any of its vertices is reachable
+ * from any other. A directed graph with this property is called
+ * \em strongly connected. A directed graph that would be connected when
+ * ignoring the directions of its edges is called \em weakly connected.
+ *
+ * </para><para>
  * A graph with zero vertices (i.e. the null graph) is \em not connected by
  * definition. This behaviour changed in igraph 0.9; earlier versions assumed
  * that the null graph is connected. See the following issue on Github for the
@@ -392,7 +398,7 @@ int igraph_is_connected(const igraph_t *graph, igraph_bool_t *res,
         return retval;
     }
 
-    IGRAPH_ERROR("mode argument", IGRAPH_EINVAL);
+    IGRAPH_ERROR("Invalid connectedness mode.", IGRAPH_EINVAL);
 }
 
 static int igraph_is_connected_weak(const igraph_t *graph, igraph_bool_t *res) {

--- a/src/connectivity/components.c
+++ b/src/connectivity/components.c
@@ -328,7 +328,7 @@ static int igraph_i_clusters_strong(const igraph_t *graph, igraph_vector_t *memb
     return 0;
 }
 
-int igraph_is_connected_weak(const igraph_t *graph, igraph_bool_t *res);
+static int igraph_is_connected_weak(const igraph_t *graph, igraph_bool_t *res);
 
 /**
  * \ingroup structural
@@ -379,26 +379,7 @@ int igraph_is_connected(const igraph_t *graph, igraph_bool_t *res,
     IGRAPH_ERROR("mode argument", IGRAPH_EINVAL);
 }
 
-/**
- * \ingroup structural
- * \function igraph_is_connected_weak
- * \brief Query whether the graph is weakly connected.
- *
- * A graph with zero vertices (i.e. the null graph) is weakly connected by
- * definition. A directed graph is weakly connected if its undirected version
- * is connected. In the case of undirected graphs, weakly connected and
- * connected are equivalent.
- *
- * \param graph The graph object to analyze.
- * \param res Pointer to a logical variable; the result will be stored here.
- * \return Error code:
- *        \c IGRAPH_ENOMEM: unable to allocate requested memory.
- *
- * Time complexity: O(|V|+|E|), the number of vertices plus the number of
- * edges in the graph.
- */
-
-int igraph_is_connected_weak(const igraph_t *graph, igraph_bool_t *res) {
+static int igraph_is_connected_weak(const igraph_t *graph, igraph_bool_t *res) {
 
     long int no_of_nodes = igraph_vcount(graph), no_of_edges = igraph_ecount(graph);
     long int added_count;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -271,6 +271,7 @@ add_legacy_tests(
   igraph_get_shortest_paths2
   igraph_get_shortest_paths_bellman_ford
   igraph_is_bipartite
+  igraph_is_connected
   igraph_is_chordal
   igraph_is_mutual
   igraph_is_tree

--- a/tests/unit/igraph_is_connected.c
+++ b/tests/unit/igraph_is_connected.c
@@ -1,0 +1,85 @@
+
+#include <igraph.h>
+
+#include "test_utilities.inc"
+
+int main() {
+    igraph_t graph;
+    igraph_bool_t conn;
+
+    /* Null graph */
+    igraph_empty(&graph, 0, IGRAPH_DIRECTED);
+
+    igraph_is_connected(&graph, &conn, IGRAPH_WEAK);
+    IGRAPH_ASSERT(! conn);
+
+    igraph_is_connected(&graph, &conn, IGRAPH_STRONG);
+    IGRAPH_ASSERT(! conn);
+
+    igraph_destroy(&graph);
+
+    /* Singleton graph */
+    igraph_empty(&graph, 1, IGRAPH_DIRECTED);
+
+    igraph_is_connected(&graph, &conn, IGRAPH_WEAK);
+    IGRAPH_ASSERT(conn);
+
+    igraph_is_connected(&graph, &conn, IGRAPH_STRONG);
+    IGRAPH_ASSERT(conn);
+
+    igraph_destroy(&graph);
+
+    /* Two isolated vertices, one with a self-loop */
+    igraph_small(&graph, 2, IGRAPH_DIRECTED,
+                 0,0, -1);
+
+    igraph_is_connected(&graph, &conn, IGRAPH_WEAK);
+    IGRAPH_ASSERT(! conn);
+
+    igraph_is_connected(&graph, &conn, IGRAPH_STRONG);
+    IGRAPH_ASSERT(! conn);
+
+    igraph_destroy(&graph);
+
+    /* Two isolated vertices, three self-loops */
+    igraph_small(&graph, 2, IGRAPH_DIRECTED,
+                 0,0, 0,0, 1,1, -1);
+
+    igraph_is_connected(&graph, &conn, IGRAPH_WEAK);
+    IGRAPH_ASSERT(! conn);
+
+    igraph_is_connected(&graph, &conn, IGRAPH_STRONG);
+    IGRAPH_ASSERT(! conn);
+
+    igraph_destroy(&graph);
+
+    /* Weakly connected directed */
+    igraph_small(&graph, 4, IGRAPH_DIRECTED,
+                 0,1, 2,0, 1,2, 3,2,
+                 -1);
+
+    igraph_is_connected(&graph, &conn, IGRAPH_WEAK);
+    IGRAPH_ASSERT(conn);
+
+    igraph_is_connected(&graph, &conn, IGRAPH_STRONG);
+    IGRAPH_ASSERT(! conn);
+
+    igraph_destroy(&graph);
+
+    /* Directed cycle */
+    igraph_small(&graph, 4, IGRAPH_DIRECTED,
+                 0,1, 2,0, 1,3, 3,2,
+                 -1);
+
+    igraph_is_connected(&graph, &conn, IGRAPH_WEAK);
+    IGRAPH_ASSERT(conn);
+
+    igraph_is_connected(&graph, &conn, IGRAPH_STRONG);
+    IGRAPH_ASSERT(conn);
+
+    igraph_destroy(&graph);
+
+    VERIFY_FINALLY_STACK();
+
+    return 0;
+}


### PR DESCRIPTION
`igraph_is_connected_weak()`:

 - terminate the search as soon as all nodes have been reached
 - avoid repeated calls to igraph_vector_size()
 - refactor for readability

I change the behaviour of `igraph_is_connected_weak()` for the null graph. This makes no difference as this is an internal function that was not used anywhere except from `igraph_is_connected()`, which already caught the case of the null graph. But let's be consistent: `igraph_is_connected_weak()` should always return the same result as `igraph_is_connected()` called in WEAK mode.

There were also some sloppinesses in there, e.g. `already_added[neighbor]++` actually only ever incremented a 0 to a 1. Using `++` is confusing because it suggest repeated increments. The type is a `char`, which could overflow with repeated increments, so at first I thought something was wrong.

@ntamas, if you don't like where I put some of the declarations, let me know and I'll move them all to the top. The principle was to combine declaration with initialization.