### PR TITLE
fix: correct error handling when reading Pajek file

### DIFF
--- a/src/io/pajek-header.h
+++ b/src/io/pajek-header.h
@@ -30,6 +30,7 @@ typedef struct {
     void *scanner;
     int eof;
     char errmsg[300];
+    igraph_error_t igraph_errcode;
     igraph_vector_int_t *vector;
     igraph_bool_t directed;
     igraph_integer_t vcount, vcount2;

--- a/src/io/pajek-header.h
+++ b/src/io/pajek-header.h
@@ -30,7 +30,7 @@ typedef struct {
     void *scanner;
     int eof;
     char errmsg[300];
-    igraph_error_t igraph_errcode;
+    igraph_error_t igraph_errno;
     igraph_vector_int_t *vector;
     igraph_bool_t directed;
     igraph_integer_t vcount, vcount2;

--- a/src/io/pajek-parser.y
+++ b/src/io/pajek-parser.y
@@ -135,8 +135,8 @@ extern igraph_real_t igraph_pajek_get_number(const char *str, yy_size_t len);
 %lex-param { void *scanner }
 
 %union {
-  long int intnum;
-  double   realnum;
+  igraph_integer_t intnum;
+  igraph_real_t    realnum;
   struct {
     char *str;
     size_t len;
@@ -526,8 +526,18 @@ adjmatrixentry: number {
 
 /* -----------------------------------------------------*/
 
-longint: NUM { $$=igraph_pajek_get_number(igraph_pajek_yyget_text(scanner),
-                                          igraph_pajek_yyget_leng(scanner)); };
+longint: NUM { 
+  igraph_integer_t i;
+  igraph_real_t    f;
+  f=igraph_pajek_get_number(igraph_pajek_yyget_text(scanner),
+                            igraph_pajek_yyget_leng(scanner)); 
+  i=(igraph_integer_t)f;
+  if (f != (igraph_real_t) i) {
+    IGRAPH_YY_ERRORF("Non-representable integer (%.17g) while parsing Pajek file.", 
+                      IGRAPH_PARSEERROR, f);
+  }
+  $$=i; 
+};
 
 number: NUM  { $$=igraph_pajek_get_number(igraph_pajek_yyget_text(scanner),
                                           igraph_pajek_yyget_leng(scanner)); };

--- a/src/io/pajek-parser.y
+++ b/src/io/pajek-parser.y
@@ -60,6 +60,16 @@
 #include "io/parsers/pajek-lexer.h"
 #include "internal/hacks.h"
 
+#define IGRAPH_YY_CHECK(expr) \
+    do { \
+        igraph_error_t igraph_i_ret = (expr); \
+        if (IGRAPH_UNLIKELY(igraph_i_ret != IGRAPH_SUCCESS)) { \
+            context->igraph_errcode = igraph_i_ret; \
+            if (igraph_i_ret == IGRAPH_ENOMEM) { YYNOMEM; } \
+            else { YYABORT; } \
+        } \
+    } while (0)
+
 int igraph_pajek_yyerror(YYLTYPE* locp,
                          igraph_i_pajek_parsedata_t *context,
                          const char *s);
@@ -199,7 +209,7 @@ verticeshead: VERTICESLINE longint {
             | VERTICESLINE longint longint {
   context->vcount=$2;
   context->vcount2=$3;
-  igraph_i_pajek_add_bipartite_type(context);
+  IGRAPH_YY_CHECK(igraph_i_pajek_add_bipartite_type(context));
 };
 
 vertdefs: /* empty */  | vertdefs vertexline;
@@ -212,23 +222,23 @@ vertexline: NEWLINE |
 vertex: longint { $$=$1; context->mode=1; };
 
 vertexid: word {
-  igraph_i_pajek_add_string_vertex_attribute("id", $1.str, $1.len, context);
-  igraph_i_pajek_add_string_vertex_attribute("name", $1.str, $1.len, context);
+  IGRAPH_YY_CHECK(igraph_i_pajek_add_string_vertex_attribute("id", $1.str, $1.len, context));
+  IGRAPH_YY_CHECK(igraph_i_pajek_add_string_vertex_attribute("name", $1.str, $1.len, context));
 };
 
 vertexcoords: /* empty */
             | number number {
-  igraph_i_pajek_add_numeric_vertex_attribute("x", $1, context);
-  igraph_i_pajek_add_numeric_vertex_attribute("y", $2, context);
+  IGRAPH_YY_CHECK(igraph_i_pajek_add_numeric_vertex_attribute("x", $1, context));
+  IGRAPH_YY_CHECK(igraph_i_pajek_add_numeric_vertex_attribute("y", $2, context));
             }
             | number number number {
-  igraph_i_pajek_add_numeric_vertex_attribute("x", $1, context);
-  igraph_i_pajek_add_numeric_vertex_attribute("y", $2, context);
-  igraph_i_pajek_add_numeric_vertex_attribute("z", $3, context);
+  IGRAPH_YY_CHECK(igraph_i_pajek_add_numeric_vertex_attribute("x", $1, context));
+  IGRAPH_YY_CHECK(igraph_i_pajek_add_numeric_vertex_attribute("y", $2, context));
+  IGRAPH_YY_CHECK(igraph_i_pajek_add_numeric_vertex_attribute("z", $3, context));
             };
 
 shape: /* empty */ | word {
-  igraph_i_pajek_add_string_vertex_attribute("shape", $1.str, $1.len, context);
+  IGRAPH_YY_CHECK(igraph_i_pajek_add_string_vertex_attribute("shape", $1.str, $1.len, context));
 };
 
 params: /* empty */ | params param;
@@ -236,76 +246,76 @@ params: /* empty */ | params param;
 param:
        vpword
      | VP_X_FACT number {
-         igraph_i_pajek_add_numeric_vertex_attribute("xfact", $2, context);
+         IGRAPH_YY_CHECK(igraph_i_pajek_add_numeric_vertex_attribute("xfact", $2, context));
        }
      | VP_Y_FACT number {
-         igraph_i_pajek_add_numeric_vertex_attribute("yfact", $2, context);
+         IGRAPH_YY_CHECK(igraph_i_pajek_add_numeric_vertex_attribute("yfact", $2, context));
        }
      | VP_IC number number number { /* RGB color */
-         igraph_i_pajek_add_numeric_vertex_attribute("color-red", $2, context);
-         igraph_i_pajek_add_numeric_vertex_attribute("color-green", $3, context);
-         igraph_i_pajek_add_numeric_vertex_attribute("color-blue", $4, context);
+         IGRAPH_YY_CHECK(igraph_i_pajek_add_numeric_vertex_attribute("color-red", $2, context));
+         IGRAPH_YY_CHECK(igraph_i_pajek_add_numeric_vertex_attribute("color-green", $3, context));
+         IGRAPH_YY_CHECK(igraph_i_pajek_add_numeric_vertex_attribute("color-blue", $4, context));
        }
      | VP_BC number number number {
-         igraph_i_pajek_add_numeric_vertex_attribute("framecolor-red", $2, context);
-         igraph_i_pajek_add_numeric_vertex_attribute("framecolor-green", $3, context);
-         igraph_i_pajek_add_numeric_vertex_attribute("framecolor-blue", $4, context);
+         IGRAPH_YY_CHECK(igraph_i_pajek_add_numeric_vertex_attribute("framecolor-red", $2, context));
+         IGRAPH_YY_CHECK(igraph_i_pajek_add_numeric_vertex_attribute("framecolor-green", $3, context));
+         IGRAPH_YY_CHECK(igraph_i_pajek_add_numeric_vertex_attribute("framecolor-blue", $4, context));
        }
      | VP_LC number number number {
-         igraph_i_pajek_add_numeric_vertex_attribute("labelcolor-red", $2, context);
-         igraph_i_pajek_add_numeric_vertex_attribute("labelcolor-green", $3, context);
-         igraph_i_pajek_add_numeric_vertex_attribute("labelcolor-blue", $4, context);
+         IGRAPH_YY_CHECK(igraph_i_pajek_add_numeric_vertex_attribute("labelcolor-red", $2, context));
+         IGRAPH_YY_CHECK(igraph_i_pajek_add_numeric_vertex_attribute("labelcolor-green", $3, context));
+         IGRAPH_YY_CHECK(igraph_i_pajek_add_numeric_vertex_attribute("labelcolor-blue", $4, context));
        }
      | VP_LR number {
-         igraph_i_pajek_add_numeric_vertex_attribute("labeldist", $2, context);
+         IGRAPH_YY_CHECK(igraph_i_pajek_add_numeric_vertex_attribute("labeldist", $2, context));
      }
      | VP_LPHI number {
-         igraph_i_pajek_add_numeric_vertex_attribute("labeldegree2", $2, context);
+         IGRAPH_YY_CHECK(igraph_i_pajek_add_numeric_vertex_attribute("labeldegree2", $2, context));
      }
      | VP_BW number {
-         igraph_i_pajek_add_numeric_vertex_attribute("framewidth", $2, context);
+         IGRAPH_YY_CHECK(igraph_i_pajek_add_numeric_vertex_attribute("framewidth", $2, context));
      }
      | VP_FOS number {
-         igraph_i_pajek_add_numeric_vertex_attribute("fontsize", $2, context);
+         IGRAPH_YY_CHECK(igraph_i_pajek_add_numeric_vertex_attribute("fontsize", $2, context));
      }
      | VP_PHI number {
-         igraph_i_pajek_add_numeric_vertex_attribute("rotation", $2, context);
+         IGRAPH_YY_CHECK(igraph_i_pajek_add_numeric_vertex_attribute("rotation", $2, context));
      }
      | VP_R number {
-         igraph_i_pajek_add_numeric_vertex_attribute("radius", $2, context);
+         IGRAPH_YY_CHECK(igraph_i_pajek_add_numeric_vertex_attribute("radius", $2, context));
      }
      | VP_Q number {
-         igraph_i_pajek_add_numeric_vertex_attribute("diamondratio", $2, context);
+         IGRAPH_YY_CHECK(igraph_i_pajek_add_numeric_vertex_attribute("diamondratio", $2, context));
      }
      | VP_LA number {
-         igraph_i_pajek_add_numeric_vertex_attribute("labeldegree", $2, context);
+         IGRAPH_YY_CHECK(igraph_i_pajek_add_numeric_vertex_attribute("labeldegree", $2, context));
      }
      | VP_SIZE number {
-         igraph_i_pajek_add_numeric_vertex_attribute("vertexsize", $2, context);
+         IGRAPH_YY_CHECK(igraph_i_pajek_add_numeric_vertex_attribute("vertexsize", $2, context));
      }
 ;
 
 vpword: VP_FONT { context->mode=3; } vpwordpar {
          context->mode=1;
-         igraph_i_pajek_add_string_vertex_attribute("font", $3.str, $3.len, context);
+         IGRAPH_YY_CHECK(igraph_i_pajek_add_string_vertex_attribute("font", $3.str, $3.len, context));
      }
      | VP_URL { context->mode=3; } vpwordpar {
          context->mode=1;
-         igraph_i_pajek_add_string_vertex_attribute("url", $3.str, $3.len, context);
+         IGRAPH_YY_CHECK(igraph_i_pajek_add_string_vertex_attribute("url", $3.str, $3.len, context));
      }
      | VP_IC { context->mode=3; } vpwordpar {
          context->mode=1;
-         igraph_i_pajek_add_string_vertex_attribute("color", $3.str, $3.len, context);
+         IGRAPH_YY_CHECK(igraph_i_pajek_add_string_vertex_attribute("color", $3.str, $3.len, context));
      }
      | VP_BC { context->mode=3; } vpwordpar {
          context->mode=1;
-         igraph_i_pajek_add_string_vertex_attribute("framecolor",
-                                                    $3.str, $3.len, context);
+         IGRAPH_YY_CHECK(igraph_i_pajek_add_string_vertex_attribute("framecolor",
+                                                    $3.str, $3.len, context));
      }
      | VP_LC { context->mode=3; } vpwordpar {
          context->mode=1;
-         igraph_i_pajek_add_string_vertex_attribute("labelcolor",
-                                                    $3.str, $3.len, context);
+         IGRAPH_YY_CHECK(igraph_i_pajek_add_string_vertex_attribute("labelcolor",
+                                                    $3.str, $3.len, context));
      }
 ;
 
@@ -321,8 +331,8 @@ arcsdefs: /* empty */ | arcsdefs arcsline;
 arcsline: NEWLINE |
           arcfrom arcto { context->actedge++;
                           context->mode=2; } weight edgeparams NEWLINE  {
-  igraph_vector_int_push_back(context->vector, $1-1);
-  igraph_vector_int_push_back(context->vector, $2-1); }
+  IGRAPH_YY_CHECK(igraph_vector_int_push_back(context->vector, $1-1));
+  IGRAPH_YY_CHECK(igraph_vector_int_push_back(context->vector, $2-1)); }
 ;
 
 arcfrom: longint;
@@ -337,8 +347,8 @@ edgesdefs: /* empty */ | edgesdefs edgesline;
 edgesline: NEWLINE |
           edgefrom edgeto { context->actedge++;
                             context->mode=2; } weight edgeparams NEWLINE {
-  igraph_vector_int_push_back(context->vector, $1-1);
-  igraph_vector_int_push_back(context->vector, $2-1); }
+  IGRAPH_YY_CHECK(igraph_vector_int_push_back(context->vector, $1-1));
+  IGRAPH_YY_CHECK(igraph_vector_int_push_back(context->vector, $2-1)); }
 ;
 
 edgefrom: longint;
@@ -346,7 +356,7 @@ edgefrom: longint;
 edgeto: longint;
 
 weight: /* empty */ | number {
-  igraph_i_pajek_add_numeric_edge_attribute("weight", $1, context);
+  IGRAPH_YY_CHECK(igraph_i_pajek_add_numeric_edge_attribute("weight", $1, context));
 };
 
 edgeparams: /* empty */ | edgeparams edgeparam;
@@ -354,76 +364,76 @@ edgeparams: /* empty */ | edgeparams edgeparam;
 edgeparam:
      epword
    | EP_C number number number {
-       igraph_i_pajek_add_numeric_edge_attribute("color-red", $2, context);
-       igraph_i_pajek_add_numeric_edge_attribute("color-green", $3, context);
-       igraph_i_pajek_add_numeric_edge_attribute("color-blue", $4, context);
+       IGRAPH_YY_CHECK(igraph_i_pajek_add_numeric_edge_attribute("color-red", $2, context));
+       IGRAPH_YY_CHECK(igraph_i_pajek_add_numeric_edge_attribute("color-green", $3, context));
+       IGRAPH_YY_CHECK(igraph_i_pajek_add_numeric_edge_attribute("color-blue", $4, context));
    }
    | EP_S number {
-       igraph_i_pajek_add_numeric_edge_attribute("arrowsize", $2, context);
+       IGRAPH_YY_CHECK(igraph_i_pajek_add_numeric_edge_attribute("arrowsize", $2, context));
    }
    | EP_W number {
-       igraph_i_pajek_add_numeric_edge_attribute("edgewidth", $2, context);
+       IGRAPH_YY_CHECK(igraph_i_pajek_add_numeric_edge_attribute("edgewidth", $2, context));
    }
    | EP_H1 number {
-       igraph_i_pajek_add_numeric_edge_attribute("hook1", $2, context);
+       IGRAPH_YY_CHECK(igraph_i_pajek_add_numeric_edge_attribute("hook1", $2, context));
    }
    | EP_H2 number {
-       igraph_i_pajek_add_numeric_edge_attribute("hook2", $2, context);
+       IGRAPH_YY_CHECK(igraph_i_pajek_add_numeric_edge_attribute("hook2", $2, context));
    }
    | EP_A1 number {
-       igraph_i_pajek_add_numeric_edge_attribute("angle1", $2, context);
+       IGRAPH_YY_CHECK(igraph_i_pajek_add_numeric_edge_attribute("angle1", $2, context));
    }
    | EP_A2 number {
-       igraph_i_pajek_add_numeric_edge_attribute("angle2", $2, context);
+       IGRAPH_YY_CHECK(igraph_i_pajek_add_numeric_edge_attribute("angle2", $2, context));
    }
    | EP_K1 number {
-       igraph_i_pajek_add_numeric_edge_attribute("velocity1", $2, context);
+       IGRAPH_YY_CHECK(igraph_i_pajek_add_numeric_edge_attribute("velocity1", $2, context));
    }
    | EP_K2 number {
-       igraph_i_pajek_add_numeric_edge_attribute("velocity2", $2, context);
+       IGRAPH_YY_CHECK(igraph_i_pajek_add_numeric_edge_attribute("velocity2", $2, context));
    }
    | EP_AP number {
-       igraph_i_pajek_add_numeric_edge_attribute("arrowpos", $2, context);
+       IGRAPH_YY_CHECK(igraph_i_pajek_add_numeric_edge_attribute("arrowpos", $2, context));
    }
    | EP_LP number {
-       igraph_i_pajek_add_numeric_edge_attribute("labelpos", $2, context);
+       IGRAPH_YY_CHECK(igraph_i_pajek_add_numeric_edge_attribute("labelpos", $2, context));
    }
    | EP_LR number {
-       igraph_i_pajek_add_numeric_edge_attribute("labelangle", $2, context);
+       IGRAPH_YY_CHECK(igraph_i_pajek_add_numeric_edge_attribute("labelangle", $2, context));
    }
    | EP_LPHI number {
-       igraph_i_pajek_add_numeric_edge_attribute("labelangle2", $2, context);
+       IGRAPH_YY_CHECK(igraph_i_pajek_add_numeric_edge_attribute("labelangle2", $2, context));
    }
    | EP_LA number {
-       igraph_i_pajek_add_numeric_edge_attribute("labeldegree", $2, context);
+       IGRAPH_YY_CHECK(igraph_i_pajek_add_numeric_edge_attribute("labeldegree", $2, context));
    }
    | EP_SIZE number { /* what is this??? */
-       igraph_i_pajek_add_numeric_edge_attribute("arrowsize", $2, context);
+       IGRAPH_YY_CHECK(igraph_i_pajek_add_numeric_edge_attribute("arrowsize", $2, context));
    }
    | EP_FOS number {
-       igraph_i_pajek_add_numeric_edge_attribute("fontsize", $2, context);
+       IGRAPH_YY_CHECK(igraph_i_pajek_add_numeric_edge_attribute("fontsize", $2, context));
    }
 ;
 
 epword: EP_A { context->mode=4; } epwordpar {
       context->mode=2;
-      igraph_i_pajek_add_string_edge_attribute("arrowtype", $3.str, $3.len, context);
+      IGRAPH_YY_CHECK(igraph_i_pajek_add_string_edge_attribute("arrowtype", $3.str, $3.len, context));
     }
     | EP_P { context->mode=4; } epwordpar {
       context->mode=2;
-      igraph_i_pajek_add_string_edge_attribute("linepattern", $3.str, $3.len, context);
+      IGRAPH_YY_CHECK(igraph_i_pajek_add_string_edge_attribute("linepattern", $3.str, $3.len, context));
     }
     | EP_L { context->mode=4; } epwordpar {
       context->mode=2;
-      igraph_i_pajek_add_string_edge_attribute("label", $3.str, $3.len, context);
+      IGRAPH_YY_CHECK(igraph_i_pajek_add_string_edge_attribute("label", $3.str, $3.len, context));
     }
     | EP_LC { context->mode=4; } epwordpar {
       context->mode=2;
-      igraph_i_pajek_add_string_edge_attribute("labelcolor", $3.str, $3.len, context);
+      IGRAPH_YY_CHECK(igraph_i_pajek_add_string_edge_attribute("labelcolor", $3.str, $3.len, context));
     }
     | EP_C { context->mode=4; } epwordpar {
       context->mode=2;
-      igraph_i_pajek_add_string_edge_attribute("color", $3.str, $3.len, context);
+      IGRAPH_YY_CHECK(igraph_i_pajek_add_string_edge_attribute("color", $3.str, $3.len, context));
     }
 ;
 
@@ -440,8 +450,8 @@ arctolist: /* empty */ | arctolist arclistto;
 arclistfrom: longint { context->mode=0; context->actfrom=labs($1)-1; };
 
 arclistto: longint {
-  igraph_vector_int_push_back(context->vector, context->actfrom);
-  igraph_vector_int_push_back(context->vector, labs($1)-1);
+  IGRAPH_YY_CHECK(igraph_vector_int_push_back(context->vector, context->actfrom));
+  IGRAPH_YY_CHECK(igraph_vector_int_push_back(context->vector, labs($1)-1));
 };
 
 edgeslist: EDGESLISTLINE NEWLINE edgelistlines { context->directed=0; };
@@ -455,8 +465,8 @@ edgetolist: /* empty */ | edgetolist edgelistto;
 edgelistfrom: longint { context->mode=0; context->actfrom=labs($1)-1; };
 
 edgelistto: longint {
-  igraph_vector_int_push_back(context->vector, context->actfrom);
-  igraph_vector_int_push_back(context->vector, labs($1)-1);
+  IGRAPH_YY_CHECK(igraph_vector_int_push_back(context->vector, context->actfrom));
+  IGRAPH_YY_CHECK(igraph_vector_int_push_back(context->vector, labs($1)-1));
 };
 
 /* -----------------------------------------------------*/
@@ -478,15 +488,15 @@ adjmatrixentry: number {
   if ($1 != 0) {
     if (context->vcount2==0) {
       context->actedge++;
-      igraph_i_pajek_add_numeric_edge_attribute("weight", $1, context);
-      igraph_vector_int_push_back(context->vector, context->actfrom);
-      igraph_vector_int_push_back(context->vector, context->actto);
+      IGRAPH_YY_CHECK(igraph_i_pajek_add_numeric_edge_attribute("weight", $1, context));
+      IGRAPH_YY_CHECK(igraph_vector_int_push_back(context->vector, context->actfrom));
+      IGRAPH_YY_CHECK(igraph_vector_int_push_back(context->vector, context->actto));
     } else if (context->vcount2 + context->actto < context->vcount) {
       context->actedge++;
-      igraph_i_pajek_add_numeric_edge_attribute("weight", $1, context);
-      igraph_vector_int_push_back(context->vector, context->actfrom);
-      igraph_vector_int_push_back(context->vector,
-                              context->vcount2+context->actto);
+      IGRAPH_YY_CHECK(igraph_i_pajek_add_numeric_edge_attribute("weight", $1, context));
+      IGRAPH_YY_CHECK(igraph_vector_int_push_back(context->vector, context->actfrom));
+      IGRAPH_YY_CHECK(igraph_vector_int_push_back(context->vector,
+                              context->vcount2+context->actto));
     }
   }
   context->actto++;

--- a/src/io/pajek-parser.y
+++ b/src/io/pajek-parser.y
@@ -83,6 +83,13 @@
         YYABORT; \
     } while (0)
 
+/* According to Pajek's author, limits of the Pajek program as of 2022-1-1 are:
+ * "At the moment regular Pajek has limit one billion vertices, 
+ *  PajekXXL two billions, while Pajek 3XL ten billions."
+ * Hard-coding the limit INT32_MAX is safe when compiling wiht 32-bit integers,
+ * and likely sufficient for practical applications.
+ */
+#define IGRAPH_PAJEK_MAX_VERTEX_COUNT INT32_MAX
 
 int igraph_pajek_yyerror(YYLTYPE* locp,
                          igraph_i_pajek_parsedata_t *context,
@@ -219,10 +226,28 @@ vertices: verticeshead NEWLINE vertdefs;
 verticeshead: VERTICESLINE longint {
   context->vcount=$2;
   context->vcount2=0;
+  if (context->vcount < 0) {
+    IGRAPH_YY_ERRORF("Invalid vertex count in Pajek file (%"IGRAPH_PRId").", IGRAPH_EINVAL, context->vcount);
+  }
+  if (context->vcount > IGRAPH_PAJEK_MAX_VERTEX_COUNT) {
+    IGRAPH_YY_ERRORF("Vertex count too large in Pajek file (%"IGRAPH_PRId").", IGRAPH_EINVAL, context->vcount);
+  }
             }
             | VERTICESLINE longint longint {
   context->vcount=$2;
   context->vcount2=$3;
+  if (context->vcount < 0) {
+    IGRAPH_YY_ERRORF("Invalid vertex count in Pajek file (%"IGRAPH_PRId").", IGRAPH_EINVAL, context->vcount);
+  }
+  if (context->vcount > IGRAPH_PAJEK_MAX_VERTEX_COUNT) {
+    IGRAPH_YY_ERRORF("Vertex count too large in Pajek file (%"IGRAPH_PRId").", IGRAPH_EINVAL, context->vcount);
+  }
+  if (context->vcount2 < 0) {
+    IGRAPH_YY_ERRORF("Invalid two-mode vertex count in Pajek file (%"IGRAPH_PRId").", IGRAPH_EINVAL, context->vcount2);
+  }
+  if (context->vcount2 > IGRAPH_PAJEK_MAX_VERTEX_COUNT) {
+    IGRAPH_YY_ERRORF("2-mode vertex count too large in Pajek file (%"IGRAPH_PRId").", IGRAPH_EINVAL, context->vcount2);
+  }
   IGRAPH_YY_CHECK(igraph_i_pajek_add_bipartite_type(context));
 };
 

--- a/src/io/pajek-parser.y
+++ b/src/io/pajek-parser.y
@@ -592,7 +592,7 @@ igraph_error_t igraph_i_pajek_add_numeric_attribute(igraph_trie_t *names,
   if (igraph_vector_size(na) == vid) {
     IGRAPH_CHECK(igraph_vector_push_back(na, number));
   } else if (igraph_vector_size(na) < vid) {
-    long int origsize=igraph_vector_size(na);
+    igraph_integer_t origsize=igraph_vector_size(na);
     IGRAPH_CHECK(igraph_vector_resize(na, vid+1));
     for (;origsize<count; origsize++) {
       VECTOR(*na)[origsize] = IGRAPH_NAN;

--- a/src/io/pajek-parser.y
+++ b/src/io/pajek-parser.y
@@ -60,11 +60,13 @@
 #include "io/parsers/pajek-lexer.h"
 #include "internal/hacks.h"
 
-/* The old version of Bison that ships with macOS does not provide YYNOMEM. */
+/* YYNOMEM is available only in Bison 3.8 and later.
+ * Fall back to YYABORT for older versions. */
 #ifndef YYNOMEM
 #define YYNOMEM YYABORT
 #endif
 
+/* This macro must be used only in Bison actions, in place of IGRAPH_CHECK(). */
 #define IGRAPH_YY_CHECK(expr) \
     do { \
         igraph_error_t igraph_i_ret = (expr); \
@@ -75,6 +77,7 @@
         } \
     } while (0)
 
+/* This macro must be used only in Bison actions, in place of IGRAPH_CHECK(). */
 #define IGRAPH_YY_ERRORF(reason, errno, ...) \
     do { \
         igraph_errorf(reason, IGRAPH_FILE_BASENAME, __LINE__, \

--- a/src/io/pajek-parser.y
+++ b/src/io/pajek-parser.y
@@ -69,17 +69,17 @@
     do { \
         igraph_error_t igraph_i_ret = (expr); \
         if (IGRAPH_UNLIKELY(igraph_i_ret != IGRAPH_SUCCESS)) { \
-            context->igraph_errcode = igraph_i_ret; \
+            context->igraph_errno = igraph_i_ret; \
             if (igraph_i_ret == IGRAPH_ENOMEM) { YYNOMEM; } \
             else { YYABORT; } \
         } \
     } while (0)
 
-#define IGRAPH_YY_ERRORF(reason, igraph_errno, ...) \
+#define IGRAPH_YY_ERRORF(reason, errno, ...) \
     do { \
         igraph_errorf(reason, IGRAPH_FILE_BASENAME, __LINE__, \
-                      igraph_errno, __VA_ARGS__) ; \
-        context->igraph_errcode = igraph_errno; \
+                      errno, __VA_ARGS__) ; \
+        context->igraph_errno = errno; \
         YYABORT; \
     } while (0)
 

--- a/src/io/pajek-parser.y
+++ b/src/io/pajek-parser.y
@@ -60,6 +60,11 @@
 #include "io/parsers/pajek-lexer.h"
 #include "internal/hacks.h"
 
+/* The old version of Bison that ships with macOS does not provide YYNOMEM. */
+#ifndef YYNOMEM
+#define YYNOMEM YYABORT
+#endif
+
 #define IGRAPH_YY_CHECK(expr) \
     do { \
         igraph_error_t igraph_i_ret = (expr); \

--- a/src/io/pajek.c
+++ b/src/io/pajek.c
@@ -202,8 +202,12 @@ igraph_error_t igraph_read_graph_pajek(igraph_t *graph, FILE *instream) {
     case 2: /* out of memory */
         IGRAPH_ERROR("Cannot read Pajek file.", IGRAPH_ENOMEM);
         break;
-    default:
-        /* Must never reach here. */
+    default: /* must never reach here */
+        /* Hint: This will usually be triggered if an IGRAPH_CHECK() is used in a Bison
+         * action instead of an IGRAPH_YY_CHECK(), resulting in an igraph errno being
+         * returned in place of a Bison error code.
+         * TODO: What if future Bison versions introduce error codes other than 0, 1 and 2?
+         */
         IGRAPH_FATALF("Parser returned unexpected error code (%d) when reading Pajek file.", err);
     }
 

--- a/src/io/pajek.c
+++ b/src/io/pajek.c
@@ -158,7 +158,7 @@ igraph_error_t igraph_read_graph_pajek(igraph_t *graph, FILE *instream) {
     context.actedge = 0;
     context.eof = 0;
     context.errmsg[0] = '\0';
-    context.igraph_errcode = IGRAPH_SUCCESS;
+    context.igraph_errno = IGRAPH_SUCCESS;
 
     igraph_pajek_yylex_init_extra(&context, &context.scanner);
     IGRAPH_FINALLY(igraph_pajek_yylex_destroy, context.scanner);
@@ -171,8 +171,8 @@ igraph_error_t igraph_read_graph_pajek(igraph_t *graph, FILE *instream) {
     case 1: /* parse error */
         if (context.errmsg[0] != 0) {
             IGRAPH_ERROR(context.errmsg, IGRAPH_PARSEERROR);
-        } else if (context.igraph_errcode != IGRAPH_SUCCESS) {
-            IGRAPH_ERROR("", context.igraph_errcode);
+        } else if (context.igraph_errno != IGRAPH_SUCCESS) {
+            IGRAPH_ERROR("", context.igraph_errno);
         } else {
             IGRAPH_ERROR("Cannot read Pajek file.", IGRAPH_PARSEERROR);
         }

--- a/src/io/pajek.c
+++ b/src/io/pajek.c
@@ -40,6 +40,24 @@ void igraph_pajek_yylex_destroy (void *scanner );
 int igraph_pajek_yyparse (igraph_i_pajek_parsedata_t* context);
 void igraph_pajek_yyset_in  (FILE * in_str, void* yyscanner );
 
+void igraph_i_pajek_destroy_attr_vector(igraph_vector_ptr_t *attrs) {
+    for (igraph_integer_t i = 0; i < igraph_vector_ptr_size(attrs); i++) {
+        igraph_attribute_record_t *rec = VECTOR(*attrs)[i];
+        if (rec->type == IGRAPH_ATTRIBUTE_NUMERIC) {
+            igraph_vector_t *vec = (igraph_vector_t*) rec->value;
+            igraph_vector_destroy(vec);
+            IGRAPH_FREE(vec);
+        } else if (rec->type == IGRAPH_ATTRIBUTE_STRING) {
+            igraph_strvector_t *strvec = (igraph_strvector_t *)rec->value;
+            igraph_strvector_destroy(strvec);
+            IGRAPH_FREE(strvec);
+        }
+        igraph_free( (char*)(rec->name));
+        IGRAPH_FREE(rec);
+    }
+    igraph_vector_ptr_destroy(attrs);
+}
+
 /**
  * \function igraph_read_graph_pajek
  * \brief Reads a file in Pajek format
@@ -143,9 +161,12 @@ igraph_error_t igraph_read_graph_pajek(igraph_t *graph, FILE *instream) {
     IGRAPH_VECTOR_INT_INIT_FINALLY(&edges, 0);
 
     IGRAPH_TRIE_INIT_FINALLY(&vattrnames, 1);
-    IGRAPH_VECTOR_PTR_INIT_FINALLY(&vattrs, 0);
+    igraph_vector_ptr_init(&vattrs, 0);
+    IGRAPH_FINALLY(igraph_i_pajek_destroy_attr_vector, &vattrs);
+
     IGRAPH_TRIE_INIT_FINALLY(&eattrnames, 1);
-    IGRAPH_VECTOR_PTR_INIT_FINALLY(&eattrs, 0);
+    igraph_vector_ptr_init(&eattrs, 0);
+    IGRAPH_FINALLY(igraph_i_pajek_destroy_attr_vector, &eattrs);
 
     context.vector = &edges;
     context.mode = 0;
@@ -227,44 +248,14 @@ igraph_error_t igraph_read_graph_pajek(igraph_t *graph, FILE *instream) {
     IGRAPH_CHECK(igraph_add_vertices(graph, context.vcount, &vattrs));
     IGRAPH_CHECK(igraph_add_edges(graph, &edges, &eattrs));
 
-    for (i = 0; i < igraph_vector_ptr_size(&vattrs); i++) {
-        igraph_attribute_record_t *rec = VECTOR(vattrs)[i];
-        if (rec->type == IGRAPH_ATTRIBUTE_NUMERIC) {
-            igraph_vector_t *vec = (igraph_vector_t*) rec->value;
-            igraph_vector_destroy(vec);
-            IGRAPH_FREE(vec);
-        } else if (rec->type == IGRAPH_ATTRIBUTE_STRING) {
-            igraph_strvector_t *strvec = (igraph_strvector_t *)rec->value;
-            igraph_strvector_destroy(strvec);
-            IGRAPH_FREE(strvec);
-        }
-        igraph_free( (char*)(rec->name));
-        IGRAPH_FREE(rec);
-    }
-
-    for (i = 0; i < igraph_vector_ptr_size(&eattrs); i++) {
-        igraph_attribute_record_t *rec = VECTOR(eattrs)[i];
-        if (rec->type == IGRAPH_ATTRIBUTE_NUMERIC) {
-            igraph_vector_t *vec = (igraph_vector_t*) rec->value;
-            igraph_vector_destroy(vec);
-            IGRAPH_FREE(vec);
-        } else if (rec->type == IGRAPH_ATTRIBUTE_STRING) {
-            igraph_strvector_t *strvec = (igraph_strvector_t *)rec->value;
-            igraph_strvector_destroy(strvec);
-            IGRAPH_FREE(strvec);
-        }
-        igraph_free( (char*)(rec->name));
-        IGRAPH_FREE(rec);
-    }
-
     igraph_vector_int_destroy(&edges);
-    igraph_vector_ptr_destroy(&eattrs);
+    igraph_i_pajek_destroy_attr_vector(&eattrs);
     igraph_trie_destroy(&eattrnames);
-    igraph_vector_ptr_destroy(&vattrs);
+    igraph_i_pajek_destroy_attr_vector(&vattrs);
     igraph_trie_destroy(&vattrnames);
     igraph_pajek_yylex_destroy(context.scanner);
-
     IGRAPH_FINALLY_CLEAN(7);
+
     return IGRAPH_SUCCESS;
 }
 

--- a/src/io/pajek.c
+++ b/src/io/pajek.c
@@ -186,7 +186,8 @@ igraph_error_t igraph_read_graph_pajek(igraph_t *graph, FILE *instream) {
 
     igraph_pajek_yyset_in(instream, context.scanner);
 
-    switch (igraph_pajek_yyparse(&context)) {
+    int err = igraph_pajek_yyparse(&context);
+    switch (err) {
     case 0: /* success */
         break;
     case 1: /* parse error */
@@ -203,25 +204,7 @@ igraph_error_t igraph_read_graph_pajek(igraph_t *graph, FILE *instream) {
         break;
     default:
         /* Must never reach here. */
-        IGRAPH_FATAL("Parser returned unexpected error code when reading Pajek file.");
-    }
-
-    /* TODO: Find out maximum reasonable vertex count for Pajek.
-     * There should be a limit because the vertex count is explicit in Pajek
-     * files, thus a malformed file may trigger extreme memory allocation.
-     */
-    const igraph_integer_t pajek_max_vertex_count = INT32_MAX;
-    if (context.vcount < 0) {
-        IGRAPH_ERROR("Invalid vertex count in Pajek file.", IGRAPH_EINVAL);
-    }
-    if (context.vcount > pajek_max_vertex_count) {
-        IGRAPH_ERROR("Vertex count too large in Pajek file.", IGRAPH_EINVAL);
-    }
-    if (context.vcount2 < 0) {
-        IGRAPH_ERROR("Invalid 2-mode vertex count in Pajek file.", IGRAPH_EINVAL);
-    }
-    if (context.vcount2 > pajek_max_vertex_count) {
-        IGRAPH_ERROR("2-mode vertex count too large in Pajek file.", IGRAPH_EINVAL);
+        IGRAPH_FATALF("Parser returned unexpected error code (%d) when reading Pajek file.", err);
     }
 
     for (i = 0; i < igraph_vector_ptr_size(&eattrs); i++) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -787,6 +787,7 @@ add_legacy_tests(
 add_legacy_tests(
   FOLDER tests/regression NAMES
   igraph_read_graph_gml_invalid_inputs
+  igraph_read_graph_pajek_invalid_inputs
 )
 
 # non-graph

--- a/tests/regression/igraph_read_graph_pajek_invalid_inputs.c
+++ b/tests/regression/igraph_read_graph_pajek_invalid_inputs.c
@@ -1,0 +1,70 @@
+/*
+   IGraph library.
+   Copyright (C) 2021  The igraph development team
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+   02110-1301 USA
+*/
+
+#include "igraph.h"
+#include <stdio.h>
+
+int test_file(const char* fname) {
+    FILE *ifile;
+    igraph_t g;
+    int retval;
+
+    ifile = fopen(fname, "r");
+    if (ifile == 0) {
+        return 1;
+    }
+
+    retval = igraph_read_graph_pajek(&g, ifile);
+    if (!retval) {
+        /* input was accepted, this is a bug; attempt to clean up after
+         * ourselves nevertheless */
+        igraph_destroy(&g);
+        fclose(ifile);
+        return 2;
+    }
+
+    fclose(ifile);
+
+    return 0;
+}
+
+#define RUN_TEST(fname) {   \
+    index++;                \
+    if (test_file(fname)) { \
+        return index;       \
+    }                       \
+}
+
+int main(int argc, char* argv[]) {
+    int index = 0;
+
+    /* Turn on attribute handling */
+    igraph_set_attribute_table(&igraph_cattribute_table);
+
+    /* We do not care about errors; all we care about is that the library
+     * should not segfault and should not accept invalid input either */
+    igraph_set_error_handler(igraph_error_handler_ignore);
+
+    RUN_TEST("invalid_pajek1.net");
+    RUN_TEST("invalid_pajek2.net");
+    RUN_TEST("invalid_pajek3.net");
+
+    return 0;
+}

--- a/tests/regression/invalid_pajek1.net
+++ b/tests/regression/invalid_pajek1.net
@@ -1,0 +1,1 @@
+*Vertices 1 3

--- a/tests/regression/invalid_pajek2.net
+++ b/tests/regression/invalid_pajek2.net
@@ -1,0 +1,3 @@
+*Network TRALALA
+*vertices 4 1
+  -3 "3."

--- a/tests/regression/invalid_pajek3.net
+++ b/tests/regression/invalid_pajek3.net
@@ -1,0 +1,2 @@
+%foo
+*Vertices 1 2 1


### PR DESCRIPTION
@ntamas I need some input here because I am completely new to Bison. If this approach is good, we can use it for all the parsers.

With this fix, the locally run fuzzer did not find crashes, but it does hit the memory limit occasionally. This happens because Pajek files are explicit about the number of vertices, and it is very easy to just use a number which is too large.
