### PR TITLE
Fix system plfit cmake detection

### DIFF
--- a/etc/cmake/FindPLFIT.cmake
+++ b/etc/cmake/FindPLFIT.cmake
@@ -10,6 +10,7 @@
 
 find_path(PLFIT_INCLUDE_DIR
   NAMES plfit.h
+  PATH_SUFFIXES plfit
 )
 
 find_library(PLFIT_LIBRARY


### PR DESCRIPTION
The headers are installed under a pflit subdir by default, so the current cmake module can't find them.