### PR TITLE
benchmarks: plfit folder: specify

### DIFF
--- a/tests/benchmarks/igraph_power_law_fit.c
+++ b/tests/benchmarks/igraph_power_law_fit.c
@@ -1,5 +1,5 @@
 #include <igraph.h>
-#include <plfit_sampling.h>
+#include <plfit/plfit_sampling.h>
 
 #include "bench.h"
 


### PR DESCRIPTION
 This patch specify the folder of the `plfit` headers
 for the benchmark `igraph_power_law_fit.c`.