### PR TITLE
feat: normalization support for assortativity, and documentation updates

### DIFF
--- a/include/igraph_mixing.h
+++ b/include/igraph_mixing.h
@@ -38,8 +38,8 @@ IGRAPH_EXPORT igraph_error_t igraph_assortativity_nominal(const igraph_t *graph,
                                                igraph_bool_t normalized);
 
 IGRAPH_EXPORT igraph_error_t igraph_assortativity(const igraph_t *graph,
-                                       const igraph_vector_t *types1,
-                                       const igraph_vector_t *types2,
+                                       const igraph_vector_t *values,
+                                       const igraph_vector_t *values_in,
                                        igraph_real_t *res,
                                        igraph_bool_t directed,
                                        igraph_bool_t normalized);

--- a/include/igraph_mixing.h
+++ b/include/igraph_mixing.h
@@ -34,13 +34,15 @@ __BEGIN_DECLS
 IGRAPH_EXPORT igraph_error_t igraph_assortativity_nominal(const igraph_t *graph,
                                                const igraph_vector_int_t *types,
                                                igraph_real_t *res,
-                                               igraph_bool_t directed);
+                                               igraph_bool_t directed,
+                                               igraph_bool_t normalized);
 
 IGRAPH_EXPORT igraph_error_t igraph_assortativity(const igraph_t *graph,
                                        const igraph_vector_t *types1,
                                        const igraph_vector_t *types2,
                                        igraph_real_t *res,
-                                       igraph_bool_t directed);
+                                       igraph_bool_t directed,
+                                       igraph_bool_t normalized);
 
 IGRAPH_EXPORT igraph_error_t igraph_assortativity_degree(const igraph_t *graph,
                                               igraph_real_t *res,

--- a/interfaces/functions.yaml
+++ b/interfaces/functions.yaml
@@ -801,12 +801,12 @@ igraph_centralization_eigenvector_centrality_tmax:
 igraph_assortativity_nominal:
     PARAMS: |-
         GRAPH graph, INDEX_VECTOR types, OUT REAL res,
-        BOOLEAN directed=True
+        BOOLEAN directed=True, BOOLEAN normalized=True
 
 igraph_assortativity:
     PARAMS: |-
-        GRAPH graph, VECTOR types1, OPTIONAL VECTOR types2,
-        OUT REAL res, BOOLEAN directed=True
+        GRAPH graph, VECTOR values, OPTIONAL VECTOR values_in,
+        OUT REAL res, BOOLEAN directed=True, BOOLEAN normalized=True
 
 igraph_assortativity_degree:
     PARAMS: GRAPH graph, OUT REAL res, BOOLEAN directed=True

--- a/src/misc/mixing.c
+++ b/src/misc/mixing.c
@@ -28,7 +28,7 @@
 
 /**
  * \function igraph_assortativity_nominal
- * Assortativity of a graph based on vertex categories
+ * \brief Assortativity of a graph based on vertex categories.
  *
  * Assuming the vertices of the input graph belong to different
  * categories, this function calculates the assortativity coefficient of
@@ -37,31 +37,68 @@
  * minus one, if the network is perfectly disassortative. For a
  * randomly connected network it is (asymptotically) zero.
  *
- * </para><para>See equation (2) in M. E. J. Newman: Mixing patterns
- * in networks, Phys. Rev. E 67, 026126 (2003)
- * (http://arxiv.org/abs/cond-mat/0209450) for the proper
- * definition.
+ * </para><para>
+ * The unnormalized version, computed when \p normalization is set to false,
+ * is identical to the modularity, and is computed as follows for
+ * directed networks:
+ * </para><para>
+ * <code>1/m sum_ij (A_ij - k^out_i k^in_j / m) d(i,j)</code>,
+ * </para><para>
+ * where \c m denotes the number of edges, \c A_ij is the adjacency matrix,
+ * <code>k^out</code> and <code>k^in</code> are the out- and in-degrees,
+ * and <code>d(i,j)</code> is one if vertices \c i and \c j have the same type
+ * and zero otherwise.
+ *
+ * </para><para>
+ * The normalized assortativity coefficient is obtained through dividing by
+ * </para><para>
+ * <code>1/m sum_ij (m - k^out_i k^in_j d(i,j) / m)</code>.
+ * </para><para>
+ * It can take any value within the interval [-1, 1].
+ *
+ * </para><para>
+ * Undirected graphs are effectively treated as directed ones with all-reciprocal
+ * edges. Thus, self-loops are taken into account twice in undirected graphs.
+ *
+ * </para><para>
+ * References:
+ *
+ * </para><para>
+ * M. E. J. Newman: Mixing patterns in networks,
+ * Phys. Rev. E 67, 026126 (2003)
+ * https://doi.org/10.1103/PhysRevE.67.026126.
+ * See equation (2) for the definition.
+ *
+ * </para><para>
+ * For an educational overview of the concept of assortativity, see
+ * M. E. J. Newman,
+ * Networks: An Introduction, Oxford University Press (2010).
+ * https://doi.org/10.1093/acprof:oso/9780199206650.001.0001.
  *
  * \param graph The input graph, it can be directed or undirected.
- * \param types Vector giving the vertex types. They are assumed to be
- *    integer numbers, starting with zero.
+ * \param types Integer vector giving the vertex types.
  * \param res Pointer to a real variable, the result is stored here.
  * \param directed Boolean, it gives whether to consider edge
  *    directions in a directed graph. It is ignored for undirected
  *    graphs.
+ * \param normalized Boolean, whether to compute the usual normalized
+ *    assortativity. The unnormalized version is identical to
+ *    modularity. Supply true here to compute the standard assortativity.
  * \return Error code.
  *
  * Time complexity: O(|E|+t), |E| is the number of edges, t is the
  * number of vertex types.
  *
- * \sa \ref igraph_assortativity if the vertex types are defines by
- * numeric values (e.g. vertex degree), instead of categories.
+ * \sa \ref igraph_assortativity() for computing the assortativity
+ * based on continuous vertex values instead of discrete categories.
+ * \ref igraph_modularity() to compute generalized modularity.
  */
 
 igraph_error_t igraph_assortativity_nominal(const igraph_t *graph,
-                                 const igraph_vector_int_t *types,
-                                 igraph_real_t *res,
-                                 igraph_bool_t directed) {
+                                            const igraph_vector_int_t *types,
+                                            igraph_real_t *res,
+                                            igraph_bool_t directed,
+                                            igraph_bool_t normalized) {
 
     igraph_integer_t no_of_nodes = igraph_vcount(graph);
     igraph_integer_t no_of_edges = igraph_ecount(graph);
@@ -72,11 +109,7 @@ igraph_error_t igraph_assortativity_nominal(const igraph_t *graph,
     igraph_real_t sumaibi = 0.0, sumeii = 0.0;
 
     if (igraph_vector_int_size(types) != no_of_nodes) {
-        IGRAPH_ERROR("Invalid `types' vector length", IGRAPH_EINVAL);
-    }
-
-    if (igraph_vector_int_min(types) < 0) {
-        IGRAPH_ERROR("Invalid `types' vector", IGRAPH_EINVAL);
+        IGRAPH_ERROR("Invalid types vector length.", IGRAPH_EINVAL);
     }
 
     directed = directed && igraph_is_directed(graph);
@@ -116,7 +149,11 @@ igraph_error_t igraph_assortativity_nominal(const igraph_t *graph,
         sumeii  /= 2.0;
     }
 
-    *res = (sumeii - sumaibi) / (1.0 - sumaibi);
+    if (normalized) {
+        *res = (sumeii - sumaibi) / (1.0 - sumaibi);
+    } else {
+        *res = (sumeii - sumaibi);
+    }
 
     igraph_vector_int_destroy(&eii);
     igraph_vector_int_destroy(&bi);
@@ -128,26 +165,62 @@ igraph_error_t igraph_assortativity_nominal(const igraph_t *graph,
 
 /**
  * \function igraph_assortativity
- * Assortativity based on numeric properties of vertices
+ * \brief Assortativity based on numeric properties of vertices.
  *
- * This function calculates the assortativity coefficient of the input
- * graph. This coefficient is basically the correlation between the
- * actual connectivity patterns of the vertices and the pattern
- * expected from the distribution of the vertex types.
+ * This function calculates the assortativity coefficient of a
+ * graph with given values \c x_i for each vertex \c i. This coefficient
+ * is essentially the Pearson correllation of the values at the
+ * two ends of the edges. In undirected graphs, self-loops
+ * are taken into account twice.
  *
- * </para><para>See equation (21) in M. E. J. Newman: Mixing patterns
+ * </para><para>
+ * The unnormalized covariance of values, computed when \p normalized is
+ * set to false, is defined as follows in a directed graph:
+ * </para><para>
+ * <code>cov(x_i, x_j) = 1/m sum_ij (A_ij - k^out_i k^in_j / m) x_i x_j</code>,
+ * </para><para>
+ * where \c m denotes the number of edges, \c A_ij is the adjacency matrix, and
+ * <code>k^out</code> and <code>k^in</code> are the out- and in-degrees.
+ *
+ * </para><para>
+ * The normalized covariance, i.e. Pearson correlation, is divided by
+ * <code>sqrt(var(x_i)) sqrt(var(x_j))</code>, where
+ * </para><para>
+ * <code>var(x_i) = 1/m sum_i k^out_i x_i^2 - (1/m sum_i k^out_i x_i^2)^2</code>
+ * </para><para>
+ * <code>var(x_j) = 1/m sum_j k^in_j x_j^2 - (1/m sum_j k^in_j x_j^2)^2</code>
+ *
+ * </para><para>
+ * Undirected graphs are effectively treated as directed graphs where all edges
+ * are reciprocal.
+ *
+ * </para><para>
+ * References:
+ *
+ * </para><para>
+ * M. E. J. Newman: Mixing patterns
  * in networks, Phys. Rev. E 67, 026126 (2003)
- * (http://arxiv.org/abs/cond-mat/0209450) for the proper
- * definition. The actual calculation is performed using equation (26)
- * in the same paper for directed graphs, and equation (4) in
+ * https://doi.org/10.1103/PhysRevE.67.026126.
+ * See equation (21) in for the definition, and equation (26) for
+ * performing the calculation in directed graphs.
+ *
+ * </para><para>
  * M. E. J. Newman: Assortative mixing in networks,
  * Phys. Rev. Lett. 89, 208701 (2002)
- * (http://arxiv.org/abs/cond-mat/0205405/) for undirected graphs.
+ * http://doi.org/10.1103/PhysRevLett.89.208701.
+ * See equation (4) for performing the calculation in undirected
+ * graphs.
+ *
+ * </para><para>
+ * For an educational overview of the concept of assortativity, see
+ * M. E. J. Newman,
+ * Networks: An Introduction, Oxford University Press (2010).
+ * https://doi.org/10.1093/acprof:oso/9780199206650.001.0001.
  *
  * \param graph The input graph, it can be directed or undirected.
- * \param types1 The vertex values, these can be arbitrary numeric
+ * \param values The vertex values, these can be arbitrary numeric
  *     values.
- * \param types2 A second value vector to be using for the incoming
+ * \param values_in A second value vector to be used for the incoming
  *     edges when calculating assortativity for a directed graph.
  *     Supply a null pointer here if you want to use the same values
  *     for outgoing and incoming edges. This argument is ignored
@@ -156,6 +229,9 @@ igraph_error_t igraph_assortativity_nominal(const igraph_t *graph,
  * \param res Pointer to a real variable, the result is stored here.
  * \param directed Boolean, whether to consider edge directions for
  *     directed graphs. It is ignored for undirected graphs.
+ * \param normalized Boolean, whether to compute the normalized
+ *     covariance, i.e. Pearson correlation. Supply true here to
+ *     compute the standard assortativity.
  * \return Error code.
  *
  * Time complexity: O(|E|), linear in the number of edges of the
@@ -168,10 +244,11 @@ igraph_error_t igraph_assortativity_nominal(const igraph_t *graph,
  */
 
 igraph_error_t igraph_assortativity(const igraph_t *graph,
-                         const igraph_vector_t *types1,
-                         const igraph_vector_t *types2,
+                         const igraph_vector_t *values,
+                         const igraph_vector_t *values_in,
                          igraph_real_t *res,
-                         igraph_bool_t directed) {
+                         igraph_bool_t directed,
+                         igraph_bool_t normalized) {
 
     igraph_integer_t no_of_nodes = igraph_vcount(graph);
     igraph_integer_t no_of_edges = igraph_ecount(graph);
@@ -179,16 +256,16 @@ igraph_error_t igraph_assortativity(const igraph_t *graph,
 
     directed = directed && igraph_is_directed(graph);
 
-    if (!directed && types2) {
-        IGRAPH_WARNING("Only `types1' is used for undirected case");
+    if (!directed && values_in) {
+        IGRAPH_WARNING("Incoming vertex values ignored when calculating undirected assortativity.");
     }
 
-    if (igraph_vector_size(types1) != no_of_nodes) {
-        IGRAPH_ERROR("Invalid `types1' vector length", IGRAPH_EINVAL);
+    if (igraph_vector_size(values) != no_of_nodes) {
+        IGRAPH_ERROR("Invalid vertex values vector length.", IGRAPH_EINVAL);
     }
 
-    if (types2 && igraph_vector_size(types2) != no_of_nodes) {
-        IGRAPH_ERROR("Invalid `types2' vector length", IGRAPH_EINVAL);
+    if (values_in && igraph_vector_size(values_in) != no_of_nodes) {
+        IGRAPH_ERROR("Invalid incoming vertex values vector length.", IGRAPH_EINVAL);
     }
 
     if (!directed) {
@@ -197,48 +274,62 @@ igraph_error_t igraph_assortativity(const igraph_t *graph,
         for (e = 0; e < no_of_edges; e++) {
             igraph_integer_t from = IGRAPH_FROM(graph, e);
             igraph_integer_t to = IGRAPH_TO(graph, e);
-            igraph_real_t from_type = VECTOR(*types1)[from];
-            igraph_real_t to_type = VECTOR(*types1)[to];
+            igraph_real_t from_value = VECTOR(*values)[from];
+            igraph_real_t to_value = VECTOR(*values)[to];
 
-            num1 += from_type * to_type;
-            num2 += from_type + to_type;
-            den1 += from_type * from_type + to_type * to_type;
+            num1 += from_value * to_value;
+            num2 += from_value + to_value;
+            if (normalized) {
+                den1 += from_value * from_value + to_value * to_value;
+            }
         }
 
         num1 /= no_of_edges;
-        den1 /= no_of_edges * 2;
+        if (normalized) {
+            den1 /= no_of_edges * 2;
+        }
         num2 /= no_of_edges * 2;
         num2 = num2 * num2;
 
-        *res = (num1 - num2) / (den1 - num2);
+        if (normalized) {
+            *res = (num1 - num2) / (den1 - num2);
+        } else {
+            *res = (num1 - num2);
+        }
 
     } else {
         igraph_real_t num1 = 0.0, num2 = 0.0, num3 = 0.0,
                       den1 = 0.0, den2 = 0.0;
         igraph_real_t num, den;
 
-        if (!types2) {
-            types2 = types1;
+        if (!values_in) {
+            values_in = values;
         }
 
         for (e = 0; e < no_of_edges; e++) {
             igraph_integer_t from = IGRAPH_FROM(graph, e);
             igraph_integer_t to = IGRAPH_TO(graph, e);
-            igraph_real_t from_type = VECTOR(*types1)[from];
-            igraph_real_t to_type = VECTOR(*types2)[to];
+            igraph_real_t from_value = VECTOR(*values)[from];
+            igraph_real_t to_value = VECTOR(*values_in)[to];
 
-            num1 += from_type * to_type;
-            num2 += from_type;
-            num3 += to_type;
-            den1 += from_type * from_type;
-            den2 += to_type * to_type;
+            num1 += from_value * to_value;
+            num2 += from_value;
+            num3 += to_value;
+            if (normalized) {
+                den1 += from_value * from_value;
+                den2 += to_value * to_value;
+            }
         }
 
         num = num1 - num2 * num3 / no_of_edges;
-        den = sqrt(den1 - num2 * num2 / no_of_edges) *
-              sqrt(den2 - num3 * num3 / no_of_edges);
+        if (normalized) {
+            den = sqrt(den1 - num2 * num2 / no_of_edges) *
+                    sqrt(den2 - num3 * num3 / no_of_edges);
 
-        *res = num / den;
+            *res = num / den;
+        } else {
+            *res = num / no_of_edges;
+        }
     }
 
     return IGRAPH_SUCCESS;
@@ -246,16 +337,18 @@ igraph_error_t igraph_assortativity(const igraph_t *graph,
 
 /**
  * \function igraph_assortativity_degree
- * Assortativity of a graph based on vertex degree
+ * \brief Assortativity of a graph based on vertex degree.
  *
  * Assortativity based on vertex degree, please see the discussion at
  * the documentation of \ref igraph_assortativity() for details.
+ * This function simply calls \ref igraph_assortativity() with
+ * the degrees as the vertex values and normalization enabled.
  *
  * \param graph The input graph, it can be directed or undirected.
  * \param res Pointer to a real variable, the result is stored here.
  * \param directed Boolean, whether to consider edge directions for
  *     directed graphs. This argument is ignored for undirected
- *     graphs. Supply 1 (=TRUE) here to do the natural thing, i.e. use
+ *     graphs. Supply true here to do the natural thing, i.e. use
  *     directed version of the measure for directed graphs and the
  *     undirected version for undirected graphs.
  * \return Error code.
@@ -274,15 +367,15 @@ igraph_error_t igraph_assortativity_degree(const igraph_t *graph,
     directed = directed && igraph_is_directed(graph);
     igraph_integer_t no_of_nodes = igraph_vcount(graph);
 
+    /* This function uses igraph_strength() instead of igraph_degree() in order to obtain
+     * a vector of reals instead of a vector of integers. */
     if (directed) {
         igraph_vector_t indegree, outdegree;
         IGRAPH_VECTOR_INIT_FINALLY(&indegree, no_of_nodes);
         IGRAPH_VECTOR_INIT_FINALLY(&outdegree, no_of_nodes);
         IGRAPH_CHECK(igraph_strength(graph, &indegree, igraph_vss_all(), IGRAPH_IN, IGRAPH_LOOPS, 0));
         IGRAPH_CHECK(igraph_strength(graph, &outdegree, igraph_vss_all(), IGRAPH_OUT, IGRAPH_LOOPS, 0));
-        igraph_vector_add_constant(&indegree, -1);
-        igraph_vector_add_constant(&outdegree, -1);
-        IGRAPH_CHECK(igraph_assortativity(graph, &outdegree, &indegree, res, /*directed=*/ 1));
+        IGRAPH_CHECK(igraph_assortativity(graph, &outdegree, &indegree, res, /* directed */ 1, /* normalized */ 1));
         igraph_vector_destroy(&indegree);
         igraph_vector_destroy(&outdegree);
         IGRAPH_FINALLY_CLEAN(2);
@@ -290,8 +383,7 @@ igraph_error_t igraph_assortativity_degree(const igraph_t *graph,
         igraph_vector_t degree;
         IGRAPH_VECTOR_INIT_FINALLY(&degree, no_of_nodes);
         IGRAPH_CHECK(igraph_strength(graph, &degree, igraph_vss_all(), IGRAPH_ALL, IGRAPH_LOOPS, 0));
-        igraph_vector_add_constant(&degree, -1);
-        IGRAPH_CHECK(igraph_assortativity(graph, &degree, 0, res, /*directed=*/ 0));
+        IGRAPH_CHECK(igraph_assortativity(graph, &degree, 0, res, /* directed */ 0, /* normalized */ 1));
         igraph_vector_destroy(&degree);
         IGRAPH_FINALLY_CLEAN(1);
     }

--- a/src/misc/mixing.c
+++ b/src/misc/mixing.c
@@ -112,6 +112,10 @@ igraph_error_t igraph_assortativity_nominal(const igraph_t *graph,
         IGRAPH_ERROR("Invalid types vector length.", IGRAPH_EINVAL);
     }
 
+    if (igraph_vector_int_min(types) < 0) {
+        IGRAPH_ERROR("Vertex types must not be negative.", IGRAPH_EINVAL);
+    }
+
     directed = directed && igraph_is_directed(graph);
 
     no_of_types = igraph_vector_int_max(types) + 1;

--- a/src/misc/mixing.c
+++ b/src/misc/mixing.c
@@ -174,29 +174,31 @@ igraph_error_t igraph_assortativity_nominal(const igraph_t *graph,
  * This function calculates the assortativity coefficient of a
  * graph with given values \c x_i for each vertex \c i. This coefficient
  * is essentially the Pearson correllation of the values at the
- * two ends of the edges. In undirected graphs, self-loops
- * are taken into account twice.
+ * two ends of the edges.
  *
  * </para><para>
  * The unnormalized covariance of values, computed when \p normalized is
  * set to false, is defined as follows in a directed graph:
  * </para><para>
- * <code>cov(x_i, x_j) = 1/m sum_ij (A_ij - k^out_i k^in_j / m) x_i x_j</code>,
+ * <code>cov(x_out, x_in) = 1/m sum_ij (A_ij - k^out_i k^in_j / m) x_i x_j</code>,
  * </para><para>
  * where \c m denotes the number of edges, \c A_ij is the adjacency matrix, and
  * <code>k^out</code> and <code>k^in</code> are the out- and in-degrees.
+ * \c x_out and \c x_in refer to the vertex values at the start and end of
+ * the directed edges.
  *
  * </para><para>
  * The normalized covariance, i.e. Pearson correlation, is divided by
- * <code>sqrt(var(x_i)) sqrt(var(x_j))</code>, where
+ * <code>sqrt(var(x_out)) sqrt(var(x_in))</code>, where
  * </para><para>
- * <code>var(x_i) = 1/m sum_i k^out_i x_i^2 - (1/m sum_i k^out_i x_i^2)^2</code>
+ * <code>var(x_out) = 1/m sum_i k^out_i x_i^2 - (1/m sum_i k^out_i x_i^2)^2</code>
  * </para><para>
- * <code>var(x_j) = 1/m sum_j k^in_j x_j^2 - (1/m sum_j k^in_j x_j^2)^2</code>
+ * <code>var(x_in) = 1/m sum_j k^in_j x_j^2 - (1/m sum_j k^in_j x_j^2)^2</code>
  *
  * </para><para>
  * Undirected graphs are effectively treated as directed graphs where all edges
- * are reciprocal.
+ * are reciprocal. Therefore, self-loops are effectively considered twice in
+ * undirected graphs.
  *
  * </para><para>
  * References:
@@ -347,6 +349,8 @@ igraph_error_t igraph_assortativity(const igraph_t *graph,
  * the documentation of \ref igraph_assortativity() for details.
  * This function simply calls \ref igraph_assortativity() with
  * the degrees as the vertex values and normalization enabled.
+ * In the directed case, it uses out-degrees as out-values and
+ * in-degrees as in-values.
  *
  * \param graph The input graph, it can be directed or undirected.
  * \param res Pointer to a real variable, the result is stored here.
@@ -377,8 +381,8 @@ igraph_error_t igraph_assortativity_degree(const igraph_t *graph,
         igraph_vector_t indegree, outdegree;
         IGRAPH_VECTOR_INIT_FINALLY(&indegree, no_of_nodes);
         IGRAPH_VECTOR_INIT_FINALLY(&outdegree, no_of_nodes);
-        IGRAPH_CHECK(igraph_strength(graph, &indegree, igraph_vss_all(), IGRAPH_IN, IGRAPH_LOOPS, 0));
-        IGRAPH_CHECK(igraph_strength(graph, &outdegree, igraph_vss_all(), IGRAPH_OUT, IGRAPH_LOOPS, 0));
+        IGRAPH_CHECK(igraph_strength(graph, &indegree, igraph_vss_all(), IGRAPH_IN, IGRAPH_LOOPS, NULL));
+        IGRAPH_CHECK(igraph_strength(graph, &outdegree, igraph_vss_all(), IGRAPH_OUT, IGRAPH_LOOPS, NULL));
         IGRAPH_CHECK(igraph_assortativity(graph, &outdegree, &indegree, res, /* directed */ 1, /* normalized */ 1));
         igraph_vector_destroy(&indegree);
         igraph_vector_destroy(&outdegree);

--- a/tests/unit/assortativity.c
+++ b/tests/unit/assortativity.c
@@ -56,14 +56,6 @@ int main() {
     igraph_vector_t values;
     igraph_vector_int_t types;
 
-    igraph_integer_t football_types[] = {
-        7, 0, 2, 3, 7, 3, 2, 8, 8, 7, 3, 10, 6, 2, 6, 2, 7, 9, 6, 1, 9, 8, 8, 7, 10, 0, 6, 9,
-        11, 1, 1, 6, 2, 0, 6, 1, 5, 0, 6, 2, 3, 7, 5, 6, 4, 0, 11, 2, 4, 11, 10, 8, 3, 11, 6,
-        1, 9, 4, 11, 10, 2, 6, 9, 10, 2, 9, 4, 11, 8, 10, 9, 6, 3, 11, 3, 4, 9, 8, 8, 1, 5, 3,
-        5, 11, 3, 6, 4, 9, 11, 0, 5, 4, 4, 7, 1, 9, 9, 10, 3, 6, 2, 1, 3, 0, 7, 0, 2, 3, 8, 0,
-        4, 8, 4, 9, 11
-    };
-
     /* Assortativity based on vertex categories */
 
     igraph_famous(&g, "zachary");
@@ -116,7 +108,7 @@ int main() {
     /* Assortativity based on degrees */
 
     /* Normalized case */
-    printf("Degree assortativity, NORMALIZED\n");
+    printf("\nDegree assortativity, NORMALIZED\n");
 
     igraph_famous(&g, "zachary");
 
@@ -217,9 +209,18 @@ int main() {
 
     igraph_destroy(&g);
 
-    /*---------------------*/
+    /*------------------*/
+    /* Football network */
 
-    printf("\n\nFootball network: ");
+    igraph_integer_t football_types[] = {
+        7, 0, 2, 3, 7, 3, 2, 8, 8, 7, 3, 10, 6, 2, 6, 2, 7, 9, 6, 1, 9, 8, 8, 7, 10, 0, 6, 9,
+        11, 1, 1, 6, 2, 0, 6, 1, 5, 0, 6, 2, 3, 7, 5, 6, 4, 0, 11, 2, 4, 11, 10, 8, 3, 11, 6,
+        1, 9, 4, 11, 10, 2, 6, 9, 10, 2, 9, 4, 11, 8, 10, 9, 6, 3, 11, 3, 4, 9, 8, 8, 1, 5, 3,
+        5, 11, 3, 6, 4, 9, 11, 0, 5, 4, 4, 7, 1, 9, 9, 10, 3, 6, 2, 1, 3, 0, 7, 0, 2, 3, 8, 0,
+        4, 8, 4, 9, 11
+    };
+
+    printf("\nFootball network: ");
     igraph_small(&g, sizeof(football_types) / sizeof(football_types[0]),
                  IGRAPH_UNDIRECTED,
                  0, 1, 2, 3, 0, 4, 4, 5, 3, 5, 2, 6, 6, 7, 7, 8, 8, 9, 0, 9, 4, 9, 5, 10, 10, 11, 5, 11,

--- a/tests/unit/assortativity.c
+++ b/tests/unit/assortativity.c
@@ -45,7 +45,7 @@ int main() {
     igraph_vector_int_init(&int_types, 0);
     igraph_degree(&g, &int_types, igraph_vss_all(), IGRAPH_ALL, /*loops=*/ 1);
 
-    igraph_assortativity_nominal(&g, &int_types, &res, /*directed=*/ 0);
+    igraph_assortativity_nominal(&g, &int_types, &res, /*directed=*/ 0, /*normalized=*/ 1);
     printf("%.5f\n", res);
 
     igraph_destroy(&g);
@@ -60,7 +60,7 @@ int main() {
     igraph_strength(&g, &types, igraph_vss_all(), IGRAPH_ALL, /*loops=*/ 1, /* weights= */ 0);
     igraph_vector_add_constant(&types, -1);
 
-    igraph_assortativity(&g, &types, 0, &res, /*directed=*/ 0);
+    igraph_assortativity(&g, &types, 0, &res, /*directed=*/ 0, /*normalized=*/ 1);
     printf("%.5f\n", res);
 
     igraph_vector_destroy(&types);
@@ -145,7 +145,7 @@ int main() {
                  -1);
     igraph_simplify(&g, /*multiple=*/ 1, /*loops=*/ 1, /*edge_comb=*/ 0);
     igraph_vector_int_view(&int_types, football_types, sizeof(football_types) / sizeof(football_types[0]));
-    igraph_assortativity_nominal(&g, &int_types, &res, /*directed=*/ 0);
+    igraph_assortativity_nominal(&g, &int_types, &res, /*directed=*/ 0, /*normalized=*/ 1);
     printf("%.5f\n", res);
 
     igraph_destroy(&g);

--- a/tests/unit/assortativity.c
+++ b/tests/unit/assortativity.c
@@ -132,6 +132,8 @@ int main() {
     igraph_assortativity_degree(&g, &assort, /*directed=*/ 1);
     printf("Degree assortativity, directed: %g\n", assort);
 
+    igraph_destroy(&g);
+
     /* Verify handling of self-loops */
 
     igraph_small(&g, 0, IGRAPH_UNDIRECTED, 0,1, 1,2, 2,0, 0,3, 3,3, -1);
@@ -180,6 +182,8 @@ int main() {
 
     assortativity_unnormalized(&g, &assort, /*directed=*/ 1);
     printf("Degree assortativity, directed: %g\n", assort);
+
+    igraph_destroy(&g);
 
     /* Verify handling of self-loops */
 

--- a/tests/unit/assortativity.out
+++ b/tests/unit/assortativity.out
@@ -18,5 +18,4 @@ Degree assortativity, directed, with self-loop: -0.333333
 Degree assortativity, undirected, with multi-edges: -0.04
 Degree assortativity, directed, with multi-edges: -0.333333
 
-
 Football network: 0.607938

--- a/tests/unit/assortativity.out
+++ b/tests/unit/assortativity.out
@@ -2,6 +2,7 @@ Karate club, normalized assortativity based on degree categories: -0.077745
 Karate club, non-normalized assortativity based on degree categories: -0.0693623
 Assortativity based on values: 0.448049
 Assortativity based on values, unnormalized: 69.3478
+
 Degree assortativity, NORMALIZED
 Degree assortativity: -0.475613
 Degree assortativity, directed: -0.666667

--- a/tests/unit/assortativity.out
+++ b/tests/unit/assortativity.out
@@ -1,4 +1,22 @@
--0.07775
--0.47561
--0.47561
-0.60794
+Karate club, normalized assortativity based on degree categories: -0.077745
+Karate club, non-normalized assortativity based on degree categories: -0.0693623
+Assortativity based on values: 0.448049
+Assortativity based on values, unnormalized: 69.3478
+Degree assortativity, NORMALIZED
+Degree assortativity: -0.475613
+Degree assortativity, directed: -0.666667
+Degree assortativity, undirected, with self-loop: 0.166667
+Degree assortativity, directed, with self-loop: -0.707107
+Degree assortativity, undirected, with multi-edges: -0.111111
+Degree assortativity, directed, with multi-edges: -0.333333
+
+Degree assortativity, UNNORMALIZED
+Degree assortativity: -13.6943
+Degree assortativity, directed: -0.16
+Degree assortativity, undirected, with self-loop: 0.04
+Degree assortativity, directed, with self-loop: -0.333333
+Degree assortativity, undirected, with multi-edges: -0.04
+Degree assortativity, directed, with multi-edges: -0.333333
+
+
+Football network: 0.607938


### PR DESCRIPTION
Changes:

 - Update the docs of assortativity. This was done quickly, feel free to push to this PR and improve it.
 - Add a `normalized` parameter to support non-normalized assortativity.
 - Do not refer to vertex values as "types" for valued assortativity.