### PR TITLE
Multi-level error handling

### DIFF
--- a/include/igraph_error.h
+++ b/include/igraph_error.h
@@ -580,7 +580,7 @@ IGRAPH_EXPORT const char* igraph_strerror(const igraph_error_t igraph_errno);
  * information. We don't use the exception handling code though.  */
 
 struct igraph_i_protectedPtr {
-    int all;
+    int level;
     void *ptr;
     void (*func)(void*);
 };
@@ -615,6 +615,9 @@ IGRAPH_EXPORT void IGRAPH_FINALLY_CLEAN(int num);
  */
 
 IGRAPH_EXPORT void IGRAPH_FINALLY_FREE(void);
+
+IGRAPH_EXPORT void IGRAPH_FINALLY_ENTER(void);
+IGRAPH_EXPORT void IGRAPH_FINALLY_EXIT(void);
 
 /**
  * \function IGRAPH_FINALLY_STACK_SIZE

--- a/src/core/error.c
+++ b/src/core/error.c
@@ -283,6 +283,14 @@ int IGRAPH_FINALLY_STACK_SIZE(void) {
 }
 
 void IGRAPH_FINALLY_ENTER(void) {
+    int no = igraph_i_finally_stack_size;
+    /* Level indices must always be in increasing order in the finally stack */
+    if (no > 0 && igraph_i_finally_stack[no-1].level > igraph_i_finally_stack_level) {
+        /* Reset finally stack in case fatal error handler does a longjmp instead of terminating the process: */
+        igraph_i_finally_stack_size = 0;
+        igraph_i_finally_stack_level = 0;
+        IGRAPH_FATAL("Corrupt finally stack: cannot create new finally stack level before last one is freed.");
+    }
     igraph_i_finally_stack_level++;
 }
 
@@ -292,7 +300,7 @@ void IGRAPH_FINALLY_EXIT(void) {
         /* Reset finally stack in case fatal error handler does a longjmp instead of terminating the process: */
         igraph_i_finally_stack_size = 0;
         igraph_i_finally_stack_level = 0;
-        IGRAPH_FATAL("Corrupt finally stack: trying to decrement level below zero.");
+        IGRAPH_FATAL("Corrupt finally stack: trying to exit outermost finally stack level.");
     }
 }
 

--- a/src/core/trie.c
+++ b/src/core/trie.c
@@ -302,18 +302,18 @@ igraph_error_t igraph_trie_get(igraph_trie_t *t, const char *key, igraph_integer
         }
     } else {
         igraph_error_t ret;
-        igraph_error_handler_t *oldhandler;
-        oldhandler = igraph_set_error_handler(igraph_error_handler_ignore);
+
+        IGRAPH_FINALLY_ENTER();
         /* Add it to the string vector first, we can undo this later */
         ret = igraph_strvector_push_back(&t->keys, key);
         if (ret != IGRAPH_SUCCESS) {
-            igraph_set_error_handler(oldhandler);
+            IGRAPH_FINALLY_EXIT();
             IGRAPH_ERROR("cannot get element from trie", ret);
         }
         ret = igraph_i_trie_get_node((igraph_trie_node_t*) t, key, t->maxvalue + 1, id);
         if (ret != IGRAPH_SUCCESS) {
-            igraph_strvector_resize(&t->keys, igraph_strvector_size(&t->keys) - 1);
-            igraph_set_error_handler(oldhandler);
+            igraph_strvector_resize(&t->keys, igraph_strvector_size(&t->keys) - 1); /* shrinks, error safe */
+            IGRAPH_FINALLY_EXIT();
             IGRAPH_ERROR("cannot get element from trie", ret);
         }
 
@@ -321,9 +321,9 @@ igraph_error_t igraph_trie_get(igraph_trie_t *t, const char *key, igraph_integer
         if (*id > t->maxvalue) {
             t->maxvalue = *id;
         } else {
-            igraph_strvector_resize(&t->keys, igraph_strvector_size(&t->keys) - 1);
+            igraph_strvector_resize(&t->keys, igraph_strvector_size(&t->keys) - 1); /* shrinks, error safe */
         }
-        igraph_set_error_handler(oldhandler);
+        IGRAPH_FINALLY_EXIT();
     }
 
     return IGRAPH_SUCCESS;

--- a/src/graph/type_indexededgelist.c
+++ b/src/graph/type_indexededgelist.c
@@ -224,7 +224,6 @@ igraph_error_t igraph_add_edges(igraph_t *graph, const igraph_vector_int_t *edge
     igraph_integer_t edges_to_add = igraph_vector_int_size(edges) / 2;
     igraph_integer_t new_no_of_edges;
     igraph_integer_t i = 0;
-    igraph_error_t ret1, ret2;
     igraph_vector_int_t newoi, newii;
     igraph_bool_t directed = igraph_is_directed(graph);
 
@@ -254,51 +253,55 @@ igraph_error_t igraph_add_edges(igraph_t *graph, const igraph_vector_int_t *edge
         }
     }
 
+    /* If an error occurs while the edges are being added, we make the necessary fixup
+     * to ensure that the graph is still in a consistent state when this function returns.
+     * The graph may already be on the finally stack when calling this function. We use
+     * a separate finally stack level to avoid its destructor from being called on error,
+     * so that the fixup can succeed.
+     */
+
+#define CHECK_ERR(expr) \
+    do { \
+        igraph_error_t err = (expr); \
+        if (err != IGRAPH_SUCCESS) { \
+            igraph_vector_int_resize(&graph->from, no_of_edges); /* gets smaller, error safe */ \
+            igraph_vector_int_resize(&graph->to, no_of_edges);   /* gets smaller, error safe */ \
+            IGRAPH_FINALLY_EXIT(); \
+            IGRAPH_ERROR("Cannot add edges.", err); \
+        } \
+    } while (0)
+
     /* oi & ii */
     IGRAPH_FINALLY_ENTER();
-    ret1 = igraph_vector_int_init(&newoi, no_of_edges);
-    ret2 = igraph_vector_int_init(&newii, no_of_edges);
-    IGRAPH_FINALLY_EXIT();
-    if (ret1 != IGRAPH_SUCCESS || ret2 != IGRAPH_SUCCESS) {
-        igraph_vector_int_resize(&graph->from, no_of_edges); /* gets smaller */
-        igraph_vector_int_resize(&graph->to, no_of_edges);   /* gets smaller */
-        IGRAPH_ERROR("cannot add edges", IGRAPH_ERROR_SELECT_2(ret1, ret2));
-    }
-    IGRAPH_FINALLY_ENTER();
-    ret1 = igraph_vector_int_pair_order(&graph->from, &graph->to, &newoi, graph->n);
-    ret2 = igraph_vector_int_pair_order(&graph->to, &graph->from, &newii, graph->n);
-    IGRAPH_FINALLY_EXIT();
-    if (ret1 != IGRAPH_SUCCESS || ret2 != IGRAPH_SUCCESS) {
-        igraph_vector_int_resize(&graph->from, no_of_edges);
-        igraph_vector_int_resize(&graph->to, no_of_edges);
-        igraph_vector_int_destroy(&newoi);
-        igraph_vector_int_destroy(&newii);
-        IGRAPH_ERROR("cannot add edges", IGRAPH_ERROR_SELECT_2(ret1, ret2));
-    }
+    {
+        CHECK_ERR(igraph_vector_int_init(&newoi, no_of_edges));
+        IGRAPH_FINALLY(igraph_vector_int_destroy, &newoi);
+        CHECK_ERR(igraph_vector_int_init(&newii, no_of_edges));
+        IGRAPH_FINALLY(igraph_vector_int_destroy, &newii);
+        CHECK_ERR(igraph_vector_int_pair_order(&graph->from, &graph->to, &newoi, graph->n));
+        CHECK_ERR(igraph_vector_int_pair_order(&graph->to, &graph->from, &newii, graph->n));
 
-    /* Attributes */
-    if (graph->attr) {
-        IGRAPH_FINALLY_ENTER();
-        ret1 = igraph_i_attribute_add_edges(graph, edges, attr);
-        IGRAPH_FINALLY_EXIT();
-        if (ret1 != IGRAPH_SUCCESS) {
-            igraph_vector_int_resize(&graph->from, no_of_edges);
-            igraph_vector_int_resize(&graph->to, no_of_edges);
-            igraph_vector_int_destroy(&newoi);
-            igraph_vector_int_destroy(&newii);
-            IGRAPH_ERROR("cannot add edges", ret1);
+        /* Attributes */
+        if (graph->attr) {
+            /* TODO: Does this keep the attribute table in a consistent state upon failure? */
+            CHECK_ERR(igraph_i_attribute_add_edges(graph, edges, attr));
         }
+
+        /* os & is, its length does not change, error safe */
+        igraph_i_create_start(&graph->os, &graph->from, &newoi, graph->n);
+        igraph_i_create_start(&graph->is, &graph->to, &newii, graph->n);
+
+        /* everything went fine  */
+        igraph_vector_int_destroy(&graph->oi);
+        igraph_vector_int_destroy(&graph->ii);
+        IGRAPH_FINALLY_CLEAN(2);
+
+        graph->oi = newoi;
+        graph->ii = newii;
     }
+    IGRAPH_FINALLY_EXIT();
 
-    /* os & is, its length does not change, error safe */
-    igraph_i_create_start(&graph->os, &graph->from, &newoi, graph->n);
-    igraph_i_create_start(&graph->is, &graph->to, &newii, graph->n);
-
-    /* everything went fine  */
-    igraph_vector_int_destroy(&graph->oi);
-    igraph_vector_int_destroy(&graph->ii);
-    graph->oi = newoi;
-    graph->ii = newii;
+#undef CHECK_ERR
 
     return IGRAPH_SUCCESS;
 }

--- a/src/hrg/hrg.cc
+++ b/src/hrg/hrg.cc
@@ -338,26 +338,32 @@ igraph_integer_t igraph_hrg_size(const igraph_hrg_t *hrg) {
 
 igraph_error_t igraph_hrg_resize(igraph_hrg_t *hrg, igraph_integer_t newsize) {
     igraph_integer_t origsize = igraph_hrg_size(hrg);
-    int ret = 0;
-    igraph_error_handler_t *oldhandler =
-        igraph_set_error_handler(igraph_error_handler_ignore);
 
-    ret  = igraph_vector_int_resize(&hrg->left, newsize - 1);
-    ret |= igraph_vector_int_resize(&hrg->right, newsize - 1);
-    ret |= igraph_vector_resize(&hrg->prob, newsize - 1);
-    ret |= igraph_vector_int_resize(&hrg->edges, newsize - 1);
-    ret |= igraph_vector_int_resize(&hrg->vertices, newsize - 1);
+    /* The data structure must be left in a consistent state if resizing fails. */
 
-    igraph_set_error_handler(oldhandler);
+#define CHECK_ERR(expr) \
+    do { \
+        igraph_error_t err = (expr); \
+        if (err != IGRAPH_SUCCESS) { \
+            igraph_vector_int_resize(&hrg->left, origsize); \
+            igraph_vector_int_resize(&hrg->right, origsize); \
+            igraph_vector_resize(&hrg->prob, origsize); \
+            igraph_vector_int_resize(&hrg->edges, origsize); \
+            igraph_vector_int_resize(&hrg->vertices, origsize); \
+            IGRAPH_FINALLY_EXIT(); \
+            IGRAPH_ERROR("Cannot resize HRG.", IGRAPH_ENOMEM); /* LCOV_EXCL_LINE */ \
+        } \
+    } while (0)
 
-    if (ret) {
-        igraph_vector_int_resize(&hrg->left, origsize);
-        igraph_vector_int_resize(&hrg->right, origsize);
-        igraph_vector_resize(&hrg->prob, origsize);
-        igraph_vector_int_resize(&hrg->edges, origsize);
-        igraph_vector_int_resize(&hrg->vertices, origsize);
-        IGRAPH_ERROR("Cannot resize HRG", IGRAPH_ENOMEM); /* LCOV_EXCL_LINE */
+    IGRAPH_FINALLY_ENTER();
+    {
+        CHECK_ERR(igraph_vector_int_resize(&hrg->left, newsize - 1));
+        CHECK_ERR(igraph_vector_int_resize(&hrg->right, newsize - 1));
+        CHECK_ERR(igraph_vector_resize(&hrg->prob, newsize - 1));
+        CHECK_ERR(igraph_vector_int_resize(&hrg->edges, newsize - 1));
+        CHECK_ERR(igraph_vector_int_resize(&hrg->vertices, newsize - 1));
     }
+    IGRAPH_FINALLY_EXIT();
 
     return IGRAPH_SUCCESS;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -314,6 +314,7 @@ add_legacy_tests(
   FOLDER tests/regression NAMES
   bug_1760
   bug_1814
+  bug_1970
 )
 
 # components.at

--- a/tests/regression/bug_1970.c
+++ b/tests/regression/bug_1970.c
@@ -1,0 +1,23 @@
+
+#include <igraph.h>
+
+int main() {
+    FILE *file;
+    igraph_t graph;
+    igraph_error_t err;
+
+    igraph_set_attribute_table(&igraph_cattribute_table);
+
+    igraph_set_error_handler(igraph_error_handler_printignore);
+
+    file = fopen("bug_1970.graphml", "r");
+    IGRAPH_ASSERT(file);
+
+    err = igraph_read_graph_graphml(&graph, file, 0);
+    fclose(file);
+    IGRAPH_ASSERT(err != IGRAPH_SUCCESS);
+
+    /* graph creation should have failed, no need to destroy 'graph' */
+
+    return 0;
+}

--- a/tests/regression/bug_1970.graphml
+++ b/tests/regression/bug_1970.graphml
@@ -1,0 +1,1 @@
+<graphml><key id="one" for="edge" attr.type="double"/><key id="one" for="edge" attr.type="string"></key><graph></graph></graphml>


### PR DESCRIPTION
This is an attempt at fixing #1970 

The idea is that the finally stack is now structured into separate levels:

```
8   ...           LEVEL 2 (CURRENT LEVEL)
7   ...
------------
6   ...
5   ...           LEVEL 1
4   ...
------------
3   ...
2   ...           LEVEL 0
1   destr2()
0   destr1()
```

When `IGRAPH_FINALLY_FREE()` is called by the error handler*, then destructors are executed only from the topmost level. This ensures that we have a chance to still work with data structures that are present at lower levels in the stack.

This is useful not only for #1970, but also for cases when using a library that operates with callback functions. This applies to almost every graph reader (Bison based parsers do effectively this) as well as some other functions.  We might need to set up a data structure for the library to work with, then call the library, which then calls back to a function provided by us. If a failure occurs in this function, it should be result in destroying the data that the library works with. That should be deferred until the library has fully returned. This can be ensured by "entering" a new finally stack level before calling the library.

Entering/exiting a level is done with `IGRAPH_FINALLY_ENTER()/EXIT()`. See the changes to `igraph_add_edges()` in this PR to see the typical programming patterns this leads to. We may want to wrap it up into a simpler-to-use macro, but I'm not sure it's actually worth it.

----

**TODO**

 - [ ] Agree on and finalize design
 - [ ] Use it in `igraph_trie_get()` (which sets special error handlers)
 - [ ] Use it in GraphML reader (which sets special error handlers for a similar purpose)
 - [ ] Use it in Bison-based graph readers, where the current error handling relies on Bison (not) allocating memory in a certain way

----

Footnotes:

\* If we go with a solution like this, we might as well make calling `IGRAPH_FINALLY_FREE()` mandatory and do it in `igraph_error()` instead of leaving it to the error handler.