### PR TITLE
Fix initial modularity for walktrap

### DIFF
--- a/examples/simple/walktrap.out
+++ b/examples/simple/walktrap.out
@@ -1,5 +1,5 @@
 Merges:
- 6 +  8 -> 10 (modularity 0.00)
+ 6 +  8 -> 10 (modularity -0.10)
  1 +  2 -> 11 (modularity -0.07)
  7 + 10 -> 12 (modularity -0.04)
  3 + 11 -> 13 (modularity 0.02)

--- a/src/community/walktrap/walktrap_communities.cpp
+++ b/src/community/walktrap/walktrap_communities.cpp
@@ -482,6 +482,13 @@ Communities::Communities(Graph* graph, int random_walks_length,
         /*     } */
     }
 
+    double Q = 0.;
+    for (int i = 0; i < nb_communities; i++) {
+      if (communities[i].sub_community_of == 0) {
+        Q += (communities[i].internal_weight - communities[i].total_weight * communities[i].total_weight / G->total_weight) / G->total_weight;
+      }
+    }
+    VECTOR(*modularity)[mergeidx] = Q;
 }
 
 Communities::~Communities() {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -558,6 +558,7 @@ add_legacy_tests(
   igraph_split_join_distance
   levc-stress
   spinglass
+  community_walktrap
 )
 add_legacy_tests(
   FOLDER tests/regression NAMES

--- a/tests/unit/community_walktrap.c
+++ b/tests/unit/community_walktrap.c
@@ -1,0 +1,63 @@
+/* -*- mode: C -*-  */
+/*
+   IGraph library.
+   Copyright (C) 2006-2012  Gabor Csardi <csardi.gabor@gmail.com>
+   334 Harvard street, Cambridge, MA 02139 USA
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc.,  51 Franklin Street, Fifth Floor, Boston, MA
+   02110-1301 USA
+
+*/
+
+#include <igraph.h>
+
+#include "test_utilities.inc"
+
+int main() {
+  igraph_t graph;
+
+  igraph_matrix_int_t merges;
+  igraph_vector_t modularity;
+  igraph_vector_int_t membership;
+
+  /* Set default seed to get reproducible results */
+  igraph_rng_seed(igraph_rng_default(), 42);
+
+  /* Simple unweighted graph */
+  igraph_small(&graph, 3, IGRAPH_UNDIRECTED,
+      0,1, 1,2, 2,0, -1);
+
+  igraph_matrix_int_init(&merges, 0, 0);
+  igraph_vector_init(&modularity, 0);
+  igraph_vector_int_init(&membership, 0);
+
+  igraph_community_walktrap(&graph, NULL, 4, &merges, &modularity, &membership);
+  printf("Merges:\n");
+  igraph_matrix_int_print(&merges);
+
+  printf("Modularity: ");
+  igraph_vector_print(&modularity);
+
+  printf("Membership: ");
+  igraph_vector_int_print(&membership);
+
+  igraph_destroy(&graph);
+
+
+
+  VERIFY_FINALLY_STACK();
+
+  return 0;
+}

--- a/tests/unit/community_walktrap.c
+++ b/tests/unit/community_walktrap.c
@@ -53,9 +53,10 @@ int main() {
   printf("Membership: ");
   igraph_vector_int_print(&membership);
 
+  igraph_vector_int_destroy(&membership);
+  igraph_vector_destroy(&modularity);
+  igraph_matrix_int_destroy(&merges);
   igraph_destroy(&graph);
-
-
 
   VERIFY_FINALLY_STACK();
 

--- a/tests/unit/community_walktrap.out
+++ b/tests/unit/community_walktrap.out
@@ -1,0 +1,5 @@
+Merges:
+1 2
+0 3
+Modularity: -0.333333 -0.222222 0
+Membership: 0 0 0


### PR DESCRIPTION
Walktrap maintains a list of modularity along each step of its merging of various communities. The initial modularity was always incorrectly set to 0, instead of the modularity of the singleton partition. Walktrap returns the actual membership that contains the maximum modularity.

The actual partition that was identified in walktrap in #1927 is the partition that puts the whole graph into a single cluster, which has a modularity of 0. However, because the initial modularity before any merge was incorrectly set to 0, it incorrectly returned the singleton partition instead. This PR fixes #1927.