### PR TITLE
Fix up igraph_diversity()

### DIFF
--- a/src/properties/basic_properties.c
+++ b/src/properties/basic_properties.c
@@ -92,6 +92,31 @@ int igraph_density(const igraph_t *graph, igraph_real_t *res,
     return 0;
 }
 
+static int igraph_i_diversity(
+        const igraph_t *graph, const igraph_vector_t *weights,
+        long int vid, igraph_vector_t *incident, igraph_real_t *res) {
+
+    igraph_real_t s = 0.0, ent = 0.0;
+    long int k, j;
+
+    IGRAPH_CHECK(igraph_incident(graph, incident, vid, /*mode=*/ IGRAPH_ALL));
+    k = igraph_vector_size(incident);
+    if (k == 0) {
+        *res = IGRAPH_NAN;
+    } else if (k == 1) {
+        *res = 0.0;
+    } else {
+        for (j = 0; j < k; j++) {
+            igraph_real_t w = VECTOR(*weights)[(long int)VECTOR(*incident)[j]];
+            if (w == 0) continue;
+            s += w;
+            ent += (w * log(w));
+        }
+        *res = (log(s) - ent / s) / log(k);
+    }
+    return IGRAPH_SUCCESS;
+}
+
 /**
  * \function igraph_diversity
  * Structural diversity index of the vertices
@@ -107,7 +132,8 @@ int igraph_density(const igraph_t *graph, igraph_real_t *res,
  * where p[i,j]=w[i,j]/sum(w[i,l], l=1..k[i]),  k[i] is the (total)
  * degree of vertex i, and w[i,j] is the weight of the edge(s) between
  * vertex i and j. The diversity of isolated vertices will be NaN
- * (not-a-number).
+ * (not-a-number), while that of vertices with a single connection
+ * will be zero.
  *
  * </para><para>
  * The measure works only if the graph is undirected and has no multiple edges.
@@ -117,7 +143,7 @@ int igraph_density(const igraph_t *graph, igraph_real_t *res,
  *
  * \param graph The undirected input graph.
  * \param weights The edge weights, in the order of the edge ids, must
- *    have appropriate length.
+ *    have appropriate length. Weights must be non-negative.
  * \param res An initialized vector, the results are stored here.
  * \param vids Vertex selector that specifies the vertices which to calculate
  *    the measure.
@@ -129,12 +155,10 @@ int igraph_density(const igraph_t *graph, igraph_real_t *res,
 int igraph_diversity(const igraph_t *graph, const igraph_vector_t *weights,
                      igraph_vector_t *res, const igraph_vs_t vids) {
 
-    int no_of_nodes = igraph_vcount(graph);
-    int no_of_edges = igraph_ecount(graph);
+    long int no_of_nodes = igraph_vcount(graph);
+    long int no_of_edges = igraph_ecount(graph);
+    long int i;
     igraph_vector_t incident;
-    igraph_vit_t vit;
-    igraph_real_t s, ent, w;
-    int i, j, k;
     igraph_bool_t has_multiple;
 
     if (igraph_is_directed(graph)) {
@@ -154,38 +178,34 @@ int igraph_diversity(const igraph_t *graph, const igraph_vector_t *weights,
         IGRAPH_ERROR("Diversity measure works only if the graph has no multiple edges.", IGRAPH_EINVAL);
     }
 
+    if (no_of_edges > 0) {
+        igraph_real_t minweight = igraph_vector_min(weights);
+        if (minweight < 0) {
+            IGRAPH_ERROR("Weight vector must be non-negative.", IGRAPH_EINVAL);
+        } else if (igraph_is_nan(minweight)) {
+            IGRAPH_ERROR("Weight vector must not contain NaN values.", IGRAPH_EINVAL);
+        }
+    }
+
     IGRAPH_VECTOR_INIT_FINALLY(&incident, 10);
 
     if (igraph_vs_is_all(&vids)) {
         IGRAPH_CHECK(igraph_vector_resize(res, no_of_nodes));
         for (i = 0; i < no_of_nodes; i++) {
-            s = ent = 0.0;
-            IGRAPH_CHECK(igraph_incident(graph, &incident, i, /*mode=*/ IGRAPH_ALL));
-            for (j = 0, k = (int) igraph_vector_size(&incident); j < k; j++) {
-                w = VECTOR(*weights)[(long int)VECTOR(incident)[j]];
-                s += w;
-                ent += (w * log(w));
-            }
-            VECTOR(*res)[i] = (log(s) - ent / s) / log(k);
+            IGRAPH_CHECK(igraph_i_diversity(graph, weights, i, &incident, &VECTOR(*res)[i]));
         }
     } else {
+        igraph_vit_t vit;
+
         IGRAPH_CHECK(igraph_vector_resize(res, 0));
         IGRAPH_CHECK(igraph_vit_create(graph, vids, &vit));
         IGRAPH_FINALLY(igraph_vit_destroy, &vit);
 
-        for (IGRAPH_VIT_RESET(vit), i = 0;
-             !IGRAPH_VIT_END(vit);
-             IGRAPH_VIT_NEXT(vit), i++) {
+        for (IGRAPH_VIT_RESET(vit); !IGRAPH_VIT_END(vit); IGRAPH_VIT_NEXT(vit)) {
+            igraph_real_t d;
             long int v = IGRAPH_VIT_GET(vit);
-            s = ent = 0.0;
-            IGRAPH_CHECK(igraph_incident(graph, &incident, (igraph_integer_t) v,
-                                         /*mode=*/ IGRAPH_ALL));
-            for (j = 0, k = (int) igraph_vector_size(&incident); j < k; j++) {
-                w = VECTOR(*weights)[(long int)VECTOR(incident)[j]];
-                s += w;
-                ent += (w * log(w));
-            }
-            IGRAPH_CHECK(igraph_vector_push_back(res, (log(s) - ent / s) / log(k)));
+            IGRAPH_CHECK(igraph_i_diversity(graph, weights, v, &incident, &d));
+            IGRAPH_CHECK(igraph_vector_push_back(res, d));
         }
 
         igraph_vit_destroy(&vit);
@@ -195,7 +215,7 @@ int igraph_diversity(const igraph_t *graph, const igraph_vector_t *weights,
     igraph_vector_destroy(&incident);
     IGRAPH_FINALLY_CLEAN(1);
 
-    return 0;
+    return IGRAPH_SUCCESS;
 }
 
 /**

--- a/tests/unit/igraph_diversity.c
+++ b/tests/unit/igraph_diversity.c
@@ -44,21 +44,38 @@ int main() {
     igraph_vector_destroy(&weights);
     igraph_destroy(&g);
 
+    /* degree-one vertices */
+    igraph_tree(&g, 10, 2, IGRAPH_TREE_UNDIRECTED);
+    igraph_vector_init_seq(&weights, 1, igraph_ecount(&g));
+
+    printf("Tree (having degree-one vertices):\n");
+    igraph_diversity(&g, &weights, &result, igraph_vss_all());
+    print_vector(&result);
+
+    igraph_vector_destroy(&weights);
+    igraph_destroy(&g);
+
     /* error conditions are tested from now on */
     VERIFY_FINALLY_STACK();
-    igraph_set_error_handler(igraph_error_handler_ignore);
 
     /* graph with multiple edges */
     igraph_small(&g, 3, IGRAPH_UNDIRECTED, 0,1, 0,2, 2,0, -1);
     igraph_vector_init_int_end(&weights, -1, 3, 2, 8, -1);
-    IGRAPH_ASSERT(igraph_diversity(&g, &weights, &result, igraph_vss_all()) == IGRAPH_EINVAL);
+    CHECK_ERROR(igraph_diversity(&g, &weights, &result, igraph_vss_all()), IGRAPH_EINVAL);
+    igraph_vector_destroy(&weights);
+    igraph_destroy(&g);
+
+    /* negative weights */
+    igraph_small(&g, 3, IGRAPH_UNDIRECTED, 0,1, 0,2, 2,1, -1);
+    igraph_vector_init_int_end(&weights, -1, 3, -2, 8, -1);
+    CHECK_ERROR(igraph_diversity(&g, &weights, &result, igraph_vss_all()), IGRAPH_EINVAL);
     igraph_vector_destroy(&weights);
     igraph_destroy(&g);
 
     /* directed graph */
     igraph_small(&g, 3, IGRAPH_DIRECTED, 0,1, 0,2, -1);
     igraph_vector_init_int_end(&weights, -1, 3, 2, -1);
-    IGRAPH_ASSERT(igraph_diversity(&g, &weights, &result, igraph_vss_all()) == IGRAPH_EINVAL);
+    CHECK_ERROR(igraph_diversity(&g, &weights, &result, igraph_vss_all()), IGRAPH_EINVAL);
     igraph_vector_destroy(&weights);
     igraph_destroy(&g);
 

--- a/tests/unit/igraph_diversity.out
+++ b/tests/unit/igraph_diversity.out
@@ -4,3 +4,5 @@ Empty graph:
 ( NaN NaN NaN NaN NaN )
 Graph with 4 nodes and 5 edges:
 ( 0.970951 0.75 0.69137 1 )
+Tree (having degree-one vertices):
+( 0.918296 0.88686 0.921463 0.934206 0.890492 0 0 0 0 0 )


### PR DESCRIPTION
fix: fix up igraph_diversity()

 - Simplify code and avoid duplication
 - Check that weights are non-negative and non-NaN
 - Now return 0 for degree-1 vertices

----

First, a recap on the definition of "diversity" (not a particularly popular measure).

Take a vertex and all its incident edges. Divide the edge weights by the vertex strengths to obtain "probabilities" (values that sum to the vertex). The compute the Shannon entropy of these values, `S = - \sum_i p_i log p_i`. Finally, normalize it by the maximum value, which is `log k` for `k` values.

----

This is partly triggered by the tidygraph test suite failure with `diversity()`. The reason for the failure is that now `igraph_diversity()` accepts only undirected graphs. This decision was correct in my opinion. Arguably, the definition used by the function only makes sense for undirected graphs. For directed ones, one might choose to take only out-edges or similar. However, I don't want igraph to take the lead on generalizing very niche graph measures, and the cited paper only deals with the undirected case (as I recall).

The test case used by tidygraph is a k-ary tree, effectively: `diversity(make_tree(10,2), weights=1:9)`. This triggers an error as this is a directed graph. But let's make it undirected and see what we get:

```
> diversity(make_tree(10,2,mode='undirected'), weights=1:9)
 [1] 0.9182958 0.8868595 0.9214632 0.9342064 0.8904916       NaN      -Inf       NaN
 [9]       NaN       NaN
```

Notice that the tree leaves (degree-1 vertices) get a NaN value, except for one, which gets -Inf. This is inconsistent, they should all be the same. This is likely the result of numerical roundoff.

This PR makes it so that degree-1 vertices always get a value of 0. This is the Shannon entropy when there is only one probability value (necessarily p=1). The normalized version would be 0/0 = NaN, but I think it makes sense to keep zeros as zero, even after using some sort of normalization.

Additionally, it now returns an explicit `IGRAPH_NAN` for isolated vertices instead of letting the NaN value arise as the result of calculations.

The function now checks that the weights are non-negative, which is necessary to take their logarithm. I opted to allow zero weights, and use 0*log(0) = 0, which is standard for entropy calculations.

Finally, the code has been refactored to avoid duplication.

Since some of these decisions may be controversial, here's a PR.  It should go in `master` and be part of R/igraph 1.3.0.