### PR TITLE
Remove vector_permdelete

### DIFF
--- a/include/igraph_vector_pmt.h
+++ b/include/igraph_vector_pmt.h
@@ -281,8 +281,6 @@ IGRAPH_EXPORT igraph_error_t FUNCTION(igraph_vector, move_interval)(
 IGRAPH_EXPORT IGRAPH_DEPRECATED igraph_error_t FUNCTION(igraph_vector, move_interval2)(
         TYPE(igraph_vector) *v, igraph_integer_t begin, igraph_integer_t end,
         igraph_integer_t to);
-IGRAPH_EXPORT void FUNCTION(igraph_vector, permdelete)
-        (TYPE(igraph_vector) *v, const igraph_vector_int_t *index, igraph_integer_t nremove);
 #ifndef NOTORDERED
 IGRAPH_EXPORT igraph_error_t FUNCTION(igraph_vector, filter_smaller)(TYPE(igraph_vector) *v, BASE elem);
 #endif

--- a/src/core/vector.pmt
+++ b/src/core/vector.pmt
@@ -1787,26 +1787,6 @@ igraph_error_t FUNCTION(igraph_vector, move_interval2)(TYPE(igraph_vector) *v,
     return FUNCTION(igraph_vector, move_interval)(v, begin, end, to);
 }
 
-/**
- * \ingroup vector
- * \function igraph_vector_permdelete
- * \brief Remove elements of a vector (for internal use).
- */
-
-void FUNCTION(igraph_vector, permdelete)(TYPE(igraph_vector) *v,
-        const igraph_vector_int_t *index, igraph_integer_t nremove) {
-    igraph_integer_t i, n;
-    IGRAPH_ASSERT(v != NULL);
-    IGRAPH_ASSERT(v->stor_begin != NULL);
-    n = FUNCTION(igraph_vector, size)(v);
-    for (i = 0; i < n; i++) {
-        if (VECTOR(*index)[i] != 0) {
-            VECTOR(*v)[ VECTOR(*index)[i] - 1 ] = VECTOR(*v)[i];
-        }
-    }
-    v->end -= nremove;
-}
-
 #ifndef NOTORDERED
 
 /**

--- a/tests/unit/vector.c
+++ b/tests/unit/vector.c
@@ -310,8 +310,6 @@ int main() {
     print_vector_format(&v, stdout, "%g");
     igraph_vector_destroy(&v);
 
-    printf("Test igraph_vector_permdelete\n");
-
     printf("Test order2\n");
     igraph_vector_init_int_end(&v, -1, 10, 9, 8, 7, 6, 7, 8, 9, 10, -1);
     igraph_vector_order2(&v);

--- a/tests/unit/vector.out
+++ b/tests/unit/vector.out
@@ -48,7 +48,6 @@ Test igraph_vector_init_real
 ( 1 2 3 4 5 6 7 8 9 10 )
 Test igraph_vector_init_int
 ( 1 2 3 4 5 6 7 8 9 10 )
-Test igraph_vector_permdelete
 Test order2
 ( 0 8 1 7 6 2 3 5 4 )
 Test filter_smaller, quite special....


### PR DESCRIPTION
It said it's for internal use only, but is not used internally.

It was once used here, for example: https://github.com/igraph/igraph/commit/0988d600b2e70454b8920c4394249230bbc06377#diff-a9e323228f51816f9d45d22cbcede355646cbd280c8132719b3c0ea3f01c21e4R633