### PR TITLE
fix: ignore io/parsers for coverage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,7 +101,7 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME AND IGRAPH_ENABLE_CODE_COVERAGE)
     # problems with them. Yes, the exclusion is correct, it refers to a nonexistent
     # directory that somehow gets into the coverage results. /Applications and
     # /Library/Developer are for macOS -- they exclude files from the macOS SDK.
-    EXCLUDE "io/*.l" "src/io/parsers/*" "/Applications/Xcode*" "/Library/Developer/*" "examples/*" "interfaces/*" "tests/*"
+    EXCLUDE "io/*.l" "src/io/parsers/*" "io/parsers/*" "/Applications/Xcode*" "/Library/Developer/*" "examples/*" "interfaces/*" "tests/*"
   )
 endif()
 


### PR DESCRIPTION
To prevent error on reading 'io/parsers/gml-lexer.c'