### PR TITLE
UMAP bugfix: Forbid sampling probability above one

### DIFF
--- a/src/layout/umap.c
+++ b/src/layout/umap.c
@@ -847,8 +847,8 @@ static igraph_error_t igraph_i_layout_umap(
                 IGRAPH_EINVAL, epochs);
     }
 
-    if (sampling_prob <= 0) {
-        IGRAPH_ERRORF("Sampling probability should be positive, but found %g.",
+    if ((sampling_prob <= 0) || (sampling_prob > 1)) {
+        IGRAPH_ERRORF("Sampling probability should be in ]0, 1], but found %g.",
                 IGRAPH_EINVAL, sampling_prob);
     }
 

--- a/tests/unit/igraph_layout_umap.c
+++ b/tests/unit/igraph_layout_umap.c
@@ -142,6 +142,9 @@ int main() {
     printf("Check error for negative sampling probability.\n");
     CHECK_ERROR(igraph_layout_umap(&empty_graph, NULL, &layout, 0.01, 500, -1), IGRAPH_EINVAL);
 
+    printf("Check error for sampling probability above one.\n");
+    CHECK_ERROR(igraph_layout_umap(&empty_graph, NULL, &layout, 0.01, 500, 1.1), IGRAPH_EINVAL);
+
     printf("Empty graph:\n");
     IGRAPH_ASSERT(igraph_layout_umap(&empty_graph, NULL, &layout, 0.01, 500, 1) == IGRAPH_SUCCESS);
     igraph_matrix_print(&layout);

--- a/tests/unit/igraph_layout_umap.out
+++ b/tests/unit/igraph_layout_umap.out
@@ -1,6 +1,7 @@
 Check error for negative min_dist.
 Check error for negative epochs.
 Check error for negative sampling probability.
+Check error for sampling probability above one.
 Empty graph:
 Singleton graph:
 UMAP layout seems fine.


### PR DESCRIPTION
ATM the user can set the sampling probability in UMAP above one and it's assumed to be one.

That might lead to confusion, so let's forbid it.