### PR TITLE
UMAP: Custom initial layout

### DIFF
--- a/include/igraph_layout.h
+++ b/include/igraph_layout.h
@@ -139,20 +139,20 @@ IGRAPH_EXPORT igraph_error_t igraph_layout_bipartite(const igraph_t *graph,
                                           igraph_real_t vgap, igraph_integer_t maxiter);
 
 IGRAPH_EXPORT igraph_error_t igraph_layout_umap(const igraph_t *graph,
+                                                igraph_matrix_t *res,
+                                                igraph_bool_t use_seed,
                                                 const igraph_vector_t *distances,
-                                                igraph_matrix_t *layout,
                                                 igraph_real_t min_dist,
                                                 igraph_integer_t epochs,
-                                                igraph_real_t sampling_prob,
-                                                igraph_bool_t skip_initialization);
+                                                igraph_real_t sampling_prob);
 
 IGRAPH_EXPORT igraph_error_t igraph_layout_umap_3d(const igraph_t *graph,
+                                                igraph_matrix_t *res,
+                                                igraph_bool_t use_seed,
                                                 const igraph_vector_t *distances,
-                                                igraph_matrix_t *layout,
                                                 igraph_real_t min_dist,
                                                 igraph_integer_t epochs,
-                                                igraph_real_t sampling_prob,
-                                                igraph_bool_t skip_initialization);
+                                                igraph_real_t sampling_prob);
 
 /**
  * \struct igraph_layout_drl_options_t

--- a/include/igraph_layout.h
+++ b/include/igraph_layout.h
@@ -143,14 +143,16 @@ IGRAPH_EXPORT igraph_error_t igraph_layout_umap(const igraph_t *graph,
                                                 igraph_matrix_t *layout,
                                                 igraph_real_t min_dist,
                                                 igraph_integer_t epochs,
-                                                igraph_real_t sampling_prob);
+                                                igraph_real_t sampling_prob,
+                                                igraph_bool_t skip_initialization);
 
 IGRAPH_EXPORT igraph_error_t igraph_layout_umap_3d(const igraph_t *graph,
                                                 const igraph_vector_t *distances,
                                                 igraph_matrix_t *layout,
                                                 igraph_real_t min_dist,
                                                 igraph_integer_t epochs,
-                                                igraph_real_t sampling_prob);
+                                                igraph_real_t sampling_prob,
+                                                igraph_bool_t skip_initialization);
 
 /**
  * \struct igraph_layout_drl_options_t

--- a/src/layout/umap.c
+++ b/src/layout/umap.c
@@ -869,6 +869,21 @@ static igraph_error_t igraph_i_layout_umap(
         return IGRAPH_SUCCESS;
     }
 
+    if (skip_initialization) {
+        if((igraph_matrix_nrow(layout) != no_of_nodes) || (igraph_matrix_ncol(layout) != ndim)) {
+          IGRAPH_ERRORF("Initial layout should be %d x %d, got %d x %d.",
+                  IGRAPH_EINVAL, no_of_nodes, ndim,
+                  igraph_matrix_nrow(layout), igraph_matrix_ncol(layout));
+        }
+    } else {
+        /* Skip spectral embedding for now (see #1971), initialize at random */
+        if (ndim == 2) {
+            igraph_layout_random(graph, layout);
+        } else {
+            igraph_layout_random_3d(graph, layout);
+        }
+    }
+
     RNG_BEGIN();
     IGRAPH_VECTOR_INIT_FINALLY(&umap_weights, no_of_edges);
 
@@ -877,15 +892,6 @@ static igraph_error_t igraph_i_layout_umap(
 
     /* From now on everything lives in probability space, it does not matter whether
      * the original graph was weighted/distanced or unweighted */
-
-    if (!skip_initialization) {
-        /* Skip spectral embedding for now (see #1971), initialize at random */
-        if (ndim == 2) {
-            igraph_layout_random(graph, layout);
-        } else {
-            igraph_layout_random_3d(graph, layout);
-        }
-    }
 
     /* Fit a and b parameter to find smooth approximation to
      * probability distribution in embedding space */

--- a/src/layout/umap.c
+++ b/src/layout/umap.c
@@ -1021,9 +1021,6 @@ static igraph_error_t igraph_i_layout_umap(
  * \param sampling_prob The fraction of vertices moved at each iteration of the stochastic gradient
  *   descent (epoch). At fixed number of epochs, a higher fraction makes the algorithm slower.
  *   Vice versa, a too low number will converge very slowly, possibly too slowly.
- * \param skip_initialization Whether to skip layout initialization and use the input
- *   layout as the starting point of the minimization. If this argument is true, you
- *   must ensure that the layout has the right dimensions before calling this function.
  *
  * \return Error code.
  *
@@ -1065,9 +1062,6 @@ igraph_error_t igraph_layout_umap(const igraph_t *graph,
  * \param sampling_prob The fraction of vertices moved at each iteration of the stochastic gradient
  *   descent (epoch). At fixed number of epochs, a higher fraction makes the algorithm slower.
  *   Vice versa, a too low number will converge very slowly, possibly too slowly.
- * \param skip_initialization Whether to skip layout initialization and use the input
- *   layout as the starting point of the minimization. If this argument is true, you
- *   must ensure that the layout has the right dimensions before calling this function.
  *
  * \return Error code.
  *

--- a/src/layout/umap.c
+++ b/src/layout/umap.c
@@ -1005,7 +1005,7 @@ static igraph_error_t igraph_i_layout_umap(
  * Leland McInnes, John Healy, and James Melville. https://arxiv.org/abs/1802.03426
  *
  * \param graph Pointer to the similarity graph to find a layout for (i.e. to embed).
- * \param res Pointer to the n x 2 matrix where the layout coordinates will be stored.
+ * \param res Pointer to the n by 2 matrix where the layout coordinates will be stored.
  * \param use_seed Logical, if true the supplied values in the \p res argument are used
  *   as an initial layout, if false a random initial layout is used.
  * \param distances Pointer to a vector of edge lengths. Similarity graphs for
@@ -1046,7 +1046,7 @@ igraph_error_t igraph_layout_umap(const igraph_t *graph,
  * igraph_layout_umap() for the 2D version).
  *
  * \param graph Pointer to the similarity graph to find a layout for (i.e. to embed).
- * \param res Pointer to the n x 3 matrix where the layout coordinates will be stored.
+ * \param res Pointer to the n by 3 matrix where the layout coordinates will be stored.
  * \param use_seed Logical, if true the supplied values in the \p res argument are used
  *   as an initial layout, if false a random initial layout is used.
  * \param distances Pointer to a vector of edge lengths. Similarity graphs for

--- a/src/layout/umap.c
+++ b/src/layout/umap.c
@@ -826,7 +826,9 @@ static igraph_error_t igraph_i_umap_check_distances(const igraph_vector_t *dista
 static igraph_error_t igraph_i_layout_umap(
         const igraph_t *graph, const igraph_vector_t *distances,
         igraph_matrix_t *layout,
-        igraph_real_t min_dist, igraph_integer_t epochs, igraph_real_t sampling_prob, igraph_integer_t ndim) {
+        igraph_real_t min_dist, igraph_integer_t epochs, igraph_real_t sampling_prob,
+        igraph_integer_t ndim,
+        igraph_bool_t skip_initialization) {
 
     igraph_integer_t no_of_edges = igraph_ecount(graph);
     igraph_integer_t no_of_nodes = igraph_vcount(graph);
@@ -876,11 +878,13 @@ static igraph_error_t igraph_i_layout_umap(
     /* From now on everything lives in probability space, it does not matter whether
      * the original graph was weighted/distanced or unweighted */
 
-    /* Skip spectral embedding for now (see #1971), initialize at random */
-    if (ndim == 2) {
-        igraph_layout_random(graph, layout);
-    } else {
-        igraph_layout_random_3d(graph, layout);
+    if (!skip_initialization) {
+        /* Skip spectral embedding for now (see #1971), initialize at random */
+        if (ndim == 2) {
+            igraph_layout_random(graph, layout);
+        } else {
+            igraph_layout_random_3d(graph, layout);
+        }
     }
 
     /* Fit a and b parameter to find smooth approximation to
@@ -1000,6 +1004,9 @@ static igraph_error_t igraph_i_layout_umap(
  * \param sampling_prob The fraction of vertices moved at each iteration of the stochastic gradient
  *   descent (epoch). At fixed number of epochs, a higher fraction makes the algorithm slower.
  *   Vice versa, a too low number will converge very slowly, possibly too slowly.
+ * \param skip_initialization Whether to skip layout initialization and use the input
+ *   layout as the starting point of the minimization. If this argument is true, you
+ *   must ensure that the layout has the right dimensions before calling this function.
  *
  * \return Error code.
  *
@@ -1010,8 +1017,10 @@ igraph_error_t igraph_layout_umap(const igraph_t *graph,
                                   igraph_matrix_t *layout,
                                   igraph_real_t min_dist,
                                   igraph_integer_t epochs,
-                                  igraph_real_t sampling_prob) {
-    return igraph_i_layout_umap(graph, distances, layout, min_dist, epochs, sampling_prob, 2);
+                                  igraph_real_t sampling_prob,
+                                  igraph_bool_t skip_initialization) {
+    return igraph_i_layout_umap(graph, distances, layout,
+            min_dist, epochs, sampling_prob, 2, skip_initialization);
 }
 
 
@@ -1037,6 +1046,9 @@ igraph_error_t igraph_layout_umap(const igraph_t *graph,
  * \param sampling_prob The fraction of vertices moved at each iteration of the stochastic gradient
  *   descent (epoch). At fixed number of epochs, a higher fraction makes the algorithm slower.
  *   Vice versa, a too low number will converge very slowly, possibly too slowly.
+ * \param skip_initialization Whether to skip layout initialization and use the input
+ *   layout as the starting point of the minimization. If this argument is true, you
+ *   must ensure that the layout has the right dimensions before calling this function.
  *
  * \return Error code.
  *
@@ -1047,6 +1059,8 @@ igraph_error_t igraph_layout_umap_3d(const igraph_t *graph,
                                      igraph_matrix_t *layout,
                                      igraph_real_t min_dist,
                                      igraph_integer_t epochs,
-                                     igraph_real_t sampling_prob) {
-    return igraph_i_layout_umap(graph, distances, layout, min_dist, epochs, sampling_prob, 3);
+                                     igraph_real_t sampling_prob,
+                                     igraph_bool_t skip_initialization) {
+    return igraph_i_layout_umap(graph, distances, layout,
+            min_dist, epochs, sampling_prob, 3, skip_initialization);
 }

--- a/src/layout/umap.c
+++ b/src/layout/umap.c
@@ -867,7 +867,7 @@ static igraph_error_t igraph_i_layout_umap(
 
     if (use_seed) {
         if((igraph_matrix_nrow(res) != no_of_nodes) || (igraph_matrix_ncol(res) != ndim)) {
-          IGRAPH_ERRORF("Seed layout should have %d points in %d dimensions, got %d points in %d dimensions.",
+          IGRAPH_ERRORF("Seed layout should have %" IGRAPH_PRId " points in %" IGRAPH_PRId " dimensions, got %" IGRAPH_PRId " points in %" IGRAPH_PRId " dimensions.",
                   IGRAPH_EINVAL, no_of_nodes, ndim,
                   igraph_matrix_nrow(res),
                   igraph_matrix_ncol(res));

--- a/tests/unit/igraph_layout_umap.c
+++ b/tests/unit/igraph_layout_umap.c
@@ -179,7 +179,7 @@ int main() {
 
     printf("Same graph, custom initial layout:\n");
     igraph_layout_random(&graph, &layout);
-    IGRAPH_ASSERT(igraph_layout_umap_3d(&graph, NULL, &layout, 0.01, 500, 0.8, 1) == IGRAPH_SUCCESS);
+    IGRAPH_ASSERT(igraph_layout_umap(&graph, NULL, &layout, 0.01, 500, 0.8, 1) == IGRAPH_SUCCESS);
     check_graph_twoclusters(&layout);
 
     igraph_matrix_destroy(&layout);

--- a/tests/unit/igraph_layout_umap.c
+++ b/tests/unit/igraph_layout_umap.c
@@ -134,52 +134,55 @@ int main() {
             );
 
     printf("Check error for negative min_dist.\n");
-    CHECK_ERROR(igraph_layout_umap(&empty_graph, NULL, &layout, -0.01, 500, 1, 0), IGRAPH_EINVAL);
+    CHECK_ERROR(igraph_layout_umap(&empty_graph, &layout, 0, NULL, -0.01, 500, 1), IGRAPH_EINVAL);
 
     printf("Check error for negative epochs.\n");
-    CHECK_ERROR(igraph_layout_umap(&empty_graph, NULL, &layout, 0.01, -1, 1, 0), IGRAPH_EINVAL);
+    CHECK_ERROR(igraph_layout_umap(&empty_graph, &layout, 0, NULL, 0.01, -1, 1), IGRAPH_EINVAL);
 
     printf("Check error for negative sampling probability.\n");
-    CHECK_ERROR(igraph_layout_umap(&empty_graph, NULL, &layout, 0.01, 500, -1, 0), IGRAPH_EINVAL);
+    CHECK_ERROR(igraph_layout_umap(&empty_graph, &layout, 0, NULL, 0.01, 500, -1), IGRAPH_EINVAL);
 
     printf("Check error for sampling probability above one.\n");
-    CHECK_ERROR(igraph_layout_umap(&empty_graph, NULL, &layout, 0.01, 500, 1.1, 0), IGRAPH_EINVAL);
+    CHECK_ERROR(igraph_layout_umap(&empty_graph, &layout, 0, NULL, 0.01, 500, 1.1), IGRAPH_EINVAL);
+
+    printf("Check error for seed layout with wrong dimensions.\n");
+    CHECK_ERROR(igraph_layout_umap(&empty_graph, &layout, 1, NULL, 0.01, 500, 1), IGRAPH_EINVAL);
 
     printf("Empty graph:\n");
-    IGRAPH_ASSERT(igraph_layout_umap(&empty_graph, NULL, &layout, 0.01, 500, 1, 0) == IGRAPH_SUCCESS);
+    IGRAPH_ASSERT(igraph_layout_umap(&empty_graph, &layout, 0, NULL, 0.01, 500, 1) == IGRAPH_SUCCESS);
     igraph_matrix_print(&layout);
     igraph_destroy(&empty_graph);
 
     printf("Singleton graph:\n");
-    IGRAPH_ASSERT(igraph_layout_umap(&singleton_graph, NULL, &layout, 0.01, 500, 0.2, 0) == IGRAPH_SUCCESS);
+    IGRAPH_ASSERT(igraph_layout_umap(&singleton_graph, &layout, 0, NULL, 0.01, 500, 0.2) == IGRAPH_SUCCESS);
     check_graph_singleton(&layout);
     igraph_destroy(&singleton_graph);
 
     printf("layout of two clusters of vertices with 2 articulation points:\n");
-    IGRAPH_ASSERT(igraph_layout_umap(&graph, &distances, &layout, 0.01, 500, 0.3, 0) == IGRAPH_SUCCESS);
+    IGRAPH_ASSERT(igraph_layout_umap(&graph, &layout, 0, &distances, 0.01, 500, 0.3) == IGRAPH_SUCCESS);
     check_graph_twoclusters(&layout);
 
     printf("same graph, different negative sampling probability:\n");
-    IGRAPH_ASSERT(igraph_layout_umap(&graph, &distances, &layout, 0.01, 500, 0.8, 0) == IGRAPH_SUCCESS);
+    IGRAPH_ASSERT(igraph_layout_umap(&graph, &layout, 0, &distances, 0.01, 500, 0.8) == IGRAPH_SUCCESS);
     check_graph_twoclusters(&layout);
 
     printf("same graph, different epochs:\n");
-    IGRAPH_ASSERT(igraph_layout_umap(&graph, &distances, &layout, 0.01, 5000, 0.8, 0) == IGRAPH_SUCCESS);
+    IGRAPH_ASSERT(igraph_layout_umap(&graph, &layout, 0, &distances, 0.01, 5000, 0.8) == IGRAPH_SUCCESS);
     check_graph_twoclusters(&layout);
     igraph_vector_destroy(&distances);
 
     printf("Same graph, no distances:\n");
-    IGRAPH_ASSERT(igraph_layout_umap(&graph, NULL, &layout, 0.01, 500, 0.8, 0) == IGRAPH_SUCCESS);
+    IGRAPH_ASSERT(igraph_layout_umap(&graph, &layout, 0, NULL, 0.01, 500, 0.8) == IGRAPH_SUCCESS);
     check_graph_twoclusters(&layout);
     igraph_matrix_resize(&layout, 0, 0);
 
     printf("Same graph, 3D layout:\n");
-    IGRAPH_ASSERT(igraph_layout_umap_3d(&graph, NULL, &layout, 0.01, 500, 0.8, 0) == IGRAPH_SUCCESS);
+    IGRAPH_ASSERT(igraph_layout_umap_3d(&graph, &layout, 0, NULL, 0.01, 500, 0.8) == IGRAPH_SUCCESS);
     check_graph_twoclusters(&layout);
 
     printf("Same graph, custom initial layout:\n");
     igraph_layout_random(&graph, &layout);
-    IGRAPH_ASSERT(igraph_layout_umap(&graph, NULL, &layout, 0.01, 500, 0.8, 1) == IGRAPH_SUCCESS);
+    IGRAPH_ASSERT(igraph_layout_umap(&graph, &layout, 1, NULL, 0.01, 500, 0.8) == IGRAPH_SUCCESS);
     check_graph_twoclusters(&layout);
 
     igraph_matrix_destroy(&layout);

--- a/tests/unit/igraph_layout_umap.c
+++ b/tests/unit/igraph_layout_umap.c
@@ -177,6 +177,11 @@ int main() {
     IGRAPH_ASSERT(igraph_layout_umap_3d(&graph, NULL, &layout, 0.01, 500, 0.8, 0) == IGRAPH_SUCCESS);
     check_graph_twoclusters(&layout);
 
+    printf("Same graph, custom initial layout:\n");
+    igraph_layout_random(&graph, &layout);
+    IGRAPH_ASSERT(igraph_layout_umap_3d(&graph, NULL, &layout, 0.01, 500, 0.8, 1) == IGRAPH_SUCCESS);
+    check_graph_twoclusters(&layout);
+
     igraph_matrix_destroy(&layout);
     igraph_destroy(&graph);
     VERIFY_FINALLY_STACK();

--- a/tests/unit/igraph_layout_umap.c
+++ b/tests/unit/igraph_layout_umap.c
@@ -134,47 +134,47 @@ int main() {
             );
 
     printf("Check error for negative min_dist.\n");
-    CHECK_ERROR(igraph_layout_umap(&empty_graph, NULL, &layout, -0.01, 500, 1), IGRAPH_EINVAL);
+    CHECK_ERROR(igraph_layout_umap(&empty_graph, NULL, &layout, -0.01, 500, 1, 0), IGRAPH_EINVAL);
 
     printf("Check error for negative epochs.\n");
-    CHECK_ERROR(igraph_layout_umap(&empty_graph, NULL, &layout, 0.01, -1, 1), IGRAPH_EINVAL);
+    CHECK_ERROR(igraph_layout_umap(&empty_graph, NULL, &layout, 0.01, -1, 1, 0), IGRAPH_EINVAL);
 
     printf("Check error for negative sampling probability.\n");
-    CHECK_ERROR(igraph_layout_umap(&empty_graph, NULL, &layout, 0.01, 500, -1), IGRAPH_EINVAL);
+    CHECK_ERROR(igraph_layout_umap(&empty_graph, NULL, &layout, 0.01, 500, -1, 0), IGRAPH_EINVAL);
 
     printf("Check error for sampling probability above one.\n");
-    CHECK_ERROR(igraph_layout_umap(&empty_graph, NULL, &layout, 0.01, 500, 1.1), IGRAPH_EINVAL);
+    CHECK_ERROR(igraph_layout_umap(&empty_graph, NULL, &layout, 0.01, 500, 1.1, 0), IGRAPH_EINVAL);
 
     printf("Empty graph:\n");
-    IGRAPH_ASSERT(igraph_layout_umap(&empty_graph, NULL, &layout, 0.01, 500, 1) == IGRAPH_SUCCESS);
+    IGRAPH_ASSERT(igraph_layout_umap(&empty_graph, NULL, &layout, 0.01, 500, 1, 0) == IGRAPH_SUCCESS);
     igraph_matrix_print(&layout);
     igraph_destroy(&empty_graph);
 
     printf("Singleton graph:\n");
-    IGRAPH_ASSERT(igraph_layout_umap(&singleton_graph, NULL, &layout, 0.01, 500, 0.2) == IGRAPH_SUCCESS);
+    IGRAPH_ASSERT(igraph_layout_umap(&singleton_graph, NULL, &layout, 0.01, 500, 0.2, 0) == IGRAPH_SUCCESS);
     check_graph_singleton(&layout);
     igraph_destroy(&singleton_graph);
 
     printf("layout of two clusters of vertices with 2 articulation points:\n");
-    IGRAPH_ASSERT(igraph_layout_umap(&graph, &distances, &layout, 0.01, 500, 0.3) == IGRAPH_SUCCESS);
+    IGRAPH_ASSERT(igraph_layout_umap(&graph, &distances, &layout, 0.01, 500, 0.3, 0) == IGRAPH_SUCCESS);
     check_graph_twoclusters(&layout);
 
     printf("same graph, different negative sampling probability:\n");
-    IGRAPH_ASSERT(igraph_layout_umap(&graph, &distances, &layout, 0.01, 500, 0.8) == IGRAPH_SUCCESS);
+    IGRAPH_ASSERT(igraph_layout_umap(&graph, &distances, &layout, 0.01, 500, 0.8, 0) == IGRAPH_SUCCESS);
     check_graph_twoclusters(&layout);
 
     printf("same graph, different epochs:\n");
-    IGRAPH_ASSERT(igraph_layout_umap(&graph, &distances, &layout, 0.01, 5000, 0.8) == IGRAPH_SUCCESS);
+    IGRAPH_ASSERT(igraph_layout_umap(&graph, &distances, &layout, 0.01, 5000, 0.8, 0) == IGRAPH_SUCCESS);
     check_graph_twoclusters(&layout);
     igraph_vector_destroy(&distances);
 
     printf("Same graph, no distances:\n");
-    IGRAPH_ASSERT(igraph_layout_umap(&graph, NULL, &layout, 0.01, 500, 0.8) == IGRAPH_SUCCESS);
+    IGRAPH_ASSERT(igraph_layout_umap(&graph, NULL, &layout, 0.01, 500, 0.8, 0) == IGRAPH_SUCCESS);
     check_graph_twoclusters(&layout);
     igraph_matrix_resize(&layout, 0, 0);
 
     printf("Same graph, 3D layout:\n");
-    IGRAPH_ASSERT(igraph_layout_umap_3d(&graph, NULL, &layout, 0.01, 500, 0.8) == IGRAPH_SUCCESS);
+    IGRAPH_ASSERT(igraph_layout_umap_3d(&graph, NULL, &layout, 0.01, 500, 0.8, 0) == IGRAPH_SUCCESS);
     check_graph_twoclusters(&layout);
 
     igraph_matrix_destroy(&layout);

--- a/tests/unit/igraph_layout_umap.out
+++ b/tests/unit/igraph_layout_umap.out
@@ -15,3 +15,5 @@ Same graph, no distances:
 UMAP layout seems fine.
 Same graph, 3D layout:
 UMAP layout seems fine.
+Same graph, custom initial layout:
+UMAP layout seems fine.

--- a/tests/unit/igraph_layout_umap.out
+++ b/tests/unit/igraph_layout_umap.out
@@ -2,6 +2,7 @@ Check error for negative min_dist.
 Check error for negative epochs.
 Check error for negative sampling probability.
 Check error for sampling probability above one.
+Check error for seed layout with wrong dimensions.
 Empty graph:
 Singleton graph:
 UMAP layout seems fine.


### PR DESCRIPTION
Let the user choose a custom initial layout for UMAP, especially useful for perturbative layouting.

Mentioned in igraph/python-igraph#529.

TODO:
- [x] Test case
- [x] Check custom initial layout dimensions