### PR TITLE
add st_vertex_connectivity tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -617,6 +617,8 @@ Some of the highlights are:
  - `igraph_adjacency()` no longer accepts a negative number of edges in its adjacency matrix.
    When negative entries are found, an error is generated.
 
+ - `igraph_st_vertex_connectivity()` now ignores edges between source and target for `IGRAPH_VCONN_NEI_IGNORE`
+
 ### Added
 
  - A new container type, `igraph_vector_list_t` has been added, replacing most uses of `igraph_vector_ptr_t` in the API. It contains `igraph_vector_t` objects, and it is fully memory managed (i.e. its contents do not need to be allocated and destroyed manually). There are specializations for all vector types, such as for `igraph_vector_int_list_t`.

--- a/src/flow/flow.c
+++ b/src/flow/flow.c
@@ -1801,16 +1801,13 @@ static igraph_error_t igraph_i_st_vertex_connectivity_check_errors(const igraph_
         break;
     case IGRAPH_VCONN_NEI_IGNORE:
         {
-            igraph_vector_int_t neis;
-            IGRAPH_VECTOR_INT_INIT_FINALLY(&neis, 0);
-            IGRAPH_CHECK(igraph_neighbors(graph, &neis, source, IGRAPH_OUT));
-            for (igraph_integer_t i = 0; i < igraph_vector_int_size(&neis); i++) {
-                if (VECTOR(neis)[i] == target) {
-                    (*no_conn)++;
-                }
+            igraph_integer_t eid;
+            igraph_vector_int_t multi;
+            igraph_get_eid(graph, &eid, source, target, /*directed=*/1, /*error=*/ 0);
+            if (eid >= 0) {
+                igraph_vector_int_view(&multi, no_conn, 1);
+                igraph_count_multiple(graph, &multi, igraph_ess_1(eid));
             }
-            igraph_vector_int_destroy(&neis);
-            IGRAPH_FINALLY_CLEAN(1);
             break;
         }
     default:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -532,6 +532,7 @@ add_legacy_tests(
   igraph_edge_disjoint_paths
   igraph_st_edge_connectivity
   igraph_st_mincut
+  igraph_st_vertex_connectivity
 )
 
 add_legacy_tests(

--- a/tests/unit/igraph_st_vertex_connectivity.c
+++ b/tests/unit/igraph_st_vertex_connectivity.c
@@ -42,7 +42,11 @@ int main() {
     print_and_destroy(&g, 0, 1, IGRAPH_VCONN_NEI_NUMBER_OF_NODES);
 
     printf("graph with two connected vertices, IGRAPH_VCONN_NEI_IGNORE: ");
-    igraph_small(&g, 2, IGRAPH_UNDIRECTED, 0,1, -1);
+    igraph_small(&g, 2, IGRAPH_UNDIRECTED, 0,1, 0,1, 0,1, -1);
+    print_and_destroy(&g, 0, 1, IGRAPH_VCONN_NEI_IGNORE);
+
+    printf("directed graph with two connected vertices, IGRAPH_VCONN_NEI_IGNORE: ");
+    igraph_small(&g, 2, IGRAPH_UNDIRECTED, 0,1, 0,1, 0,1, 1,0, 1,0, -1);
     print_and_destroy(&g, 0, 1, IGRAPH_VCONN_NEI_IGNORE);
 
     printf("line graph with 6 vertices: ");

--- a/tests/unit/igraph_st_vertex_connectivity.c
+++ b/tests/unit/igraph_st_vertex_connectivity.c
@@ -52,15 +52,18 @@ int main() {
     printf("line graph with 6 vertices: ");
     igraph_small(&g, 6, IGRAPH_UNDIRECTED, 0,1, 1,2, 2,3, 3,4, 4,5, -1);
     print_and_destroy(&g, 0, 5, IGRAPH_VCONN_NEI_ERROR);
-    VERIFY_FINALLY_STACK();
 
-    printf("full graph with 6 vertices: IGRAPH_VCONN_NEI_IGNORE: ");
+    printf("full graph with 6 vertices IGRAPH_VCONN_NEI_IGNORE: ");
     igraph_full(&g, 6, IGRAPH_UNDIRECTED, 0);
     print_and_destroy(&g, 0, 1, IGRAPH_VCONN_NEI_IGNORE);
 
-    printf("full graph with 6 vertices: IGRAPH_VCONN_NEI_IGNORE, directed: ");
+    printf("full graph with 6 vertices IGRAPH_VCONN_NEI_IGNORE, directed: ");
     igraph_full(&g, 6, IGRAPH_DIRECTED, 0);
     print_and_destroy(&g, 0, 1, IGRAPH_VCONN_NEI_IGNORE);
+
+    printf("line graph with 3 vertices, 6 edges: ");
+    igraph_small(&g, 3, IGRAPH_UNDIRECTED, 0,1, 0,1, 1,2, 1,2, 1,2, 1,2, -1);
+    print_and_destroy(&g, 0, 2, IGRAPH_VCONN_NEI_ERROR);
 
     VERIFY_FINALLY_STACK();
 

--- a/tests/unit/igraph_st_vertex_connectivity.c
+++ b/tests/unit/igraph_st_vertex_connectivity.c
@@ -1,0 +1,66 @@
+/* IGraph library.
+   Copyright (C) 2022  The igraph development team <igraph@igraph.org>
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include <igraph.h>
+#include "test_utilities.h"
+
+void print_and_destroy(igraph_t *g, igraph_integer_t source, igraph_integer_t target, igraph_vconn_nei_t neighbors) {
+    igraph_integer_t res;
+    igraph_st_vertex_connectivity(g, &res, source, target, neighbors);
+    printf("%" IGRAPH_PRId "\n", res);
+    igraph_destroy(g);
+}
+
+int main() {
+    igraph_t g;
+    igraph_integer_t res;
+
+    printf("graph with two unconnected vertices: ");
+    igraph_small(&g, 2, IGRAPH_UNDIRECTED, -1);
+    print_and_destroy(&g, 0, 1, IGRAPH_VCONN_NEI_ERROR);
+
+    printf("graph with two connected vertices, IGRAPH_VCONN_NEI_NEGATIVE: ");
+    igraph_small(&g, 2, IGRAPH_UNDIRECTED, 0,1, -1);
+    print_and_destroy(&g, 0, 1, IGRAPH_VCONN_NEI_NEGATIVE);
+
+    printf("graph with two connected vertices, IGRAPH_VCONN_NEI_NUMBER_OF_NODES: ");
+    igraph_small(&g, 2, IGRAPH_UNDIRECTED, 0,1, -1);
+    print_and_destroy(&g, 0, 1, IGRAPH_VCONN_NEI_NUMBER_OF_NODES);
+
+    printf("graph with two connected vertices, IGRAPH_VCONN_NEI_IGNORE: ");
+    igraph_small(&g, 2, IGRAPH_UNDIRECTED, 0,1, -1);
+    print_and_destroy(&g, 0, 1, IGRAPH_VCONN_NEI_IGNORE);
+
+    VERIFY_FINALLY_STACK();
+
+    printf("check error on graph with two connected vertices.\n");
+    igraph_small(&g, 2, IGRAPH_UNDIRECTED, 0,1, -1);
+    CHECK_ERROR(igraph_st_vertex_connectivity(&g, &res, 0, 0, IGRAPH_VCONN_NEI_ERROR), IGRAPH_EINVAL);
+    igraph_destroy(&g);
+
+    printf("check error on graph with no vertices.\n");
+    igraph_small(&g, 0, IGRAPH_UNDIRECTED, -1);
+    CHECK_ERROR(igraph_st_vertex_connectivity(&g, &res, 0, 0, IGRAPH_VCONN_NEI_ERROR), IGRAPH_EINVAL);
+    igraph_destroy(&g);
+
+    printf("check error on graph with one vertex.\n");
+    igraph_small(&g, 1, IGRAPH_UNDIRECTED, -1);
+    CHECK_ERROR(igraph_st_vertex_connectivity(&g, &res, 0, 0, IGRAPH_VCONN_NEI_ERROR), IGRAPH_EINVAL);
+    igraph_destroy(&g);
+
+    VERIFY_FINALLY_STACK();
+}

--- a/tests/unit/igraph_st_vertex_connectivity.c
+++ b/tests/unit/igraph_st_vertex_connectivity.c
@@ -45,6 +45,19 @@ int main() {
     igraph_small(&g, 2, IGRAPH_UNDIRECTED, 0,1, -1);
     print_and_destroy(&g, 0, 1, IGRAPH_VCONN_NEI_IGNORE);
 
+    printf("line graph with 6 vertices: ");
+    igraph_small(&g, 6, IGRAPH_UNDIRECTED, 0,1, 1,2, 2,3, 3,4, 4,5, -1);
+    print_and_destroy(&g, 0, 5, IGRAPH_VCONN_NEI_ERROR);
+    VERIFY_FINALLY_STACK();
+
+    printf("full graph with 6 vertices: IGRAPH_VCONN_NEI_IGNORE: ");
+    igraph_full(&g, 6, IGRAPH_UNDIRECTED, 0);
+    print_and_destroy(&g, 0, 1, IGRAPH_VCONN_NEI_IGNORE);
+
+    printf("full graph with 6 vertices: IGRAPH_VCONN_NEI_IGNORE, directed: ");
+    igraph_full(&g, 6, IGRAPH_DIRECTED, 0);
+    print_and_destroy(&g, 0, 1, IGRAPH_VCONN_NEI_IGNORE);
+
     VERIFY_FINALLY_STACK();
 
     printf("check error on graph with two connected vertices.\n");

--- a/tests/unit/igraph_st_vertex_connectivity.out
+++ b/tests/unit/igraph_st_vertex_connectivity.out
@@ -2,6 +2,7 @@ graph with two unconnected vertices: 0
 graph with two connected vertices, IGRAPH_VCONN_NEI_NEGATIVE: -1
 graph with two connected vertices, IGRAPH_VCONN_NEI_NUMBER_OF_NODES: 2
 graph with two connected vertices, IGRAPH_VCONN_NEI_IGNORE: 0
+directed graph with two connected vertices, IGRAPH_VCONN_NEI_IGNORE: 0
 line graph with 6 vertices: 1
 full graph with 6 vertices: IGRAPH_VCONN_NEI_IGNORE: 4
 full graph with 6 vertices: IGRAPH_VCONN_NEI_IGNORE, directed: 4

--- a/tests/unit/igraph_st_vertex_connectivity.out
+++ b/tests/unit/igraph_st_vertex_connectivity.out
@@ -4,8 +4,9 @@ graph with two connected vertices, IGRAPH_VCONN_NEI_NUMBER_OF_NODES: 2
 graph with two connected vertices, IGRAPH_VCONN_NEI_IGNORE: 0
 directed graph with two connected vertices, IGRAPH_VCONN_NEI_IGNORE: 0
 line graph with 6 vertices: 1
-full graph with 6 vertices: IGRAPH_VCONN_NEI_IGNORE: 4
-full graph with 6 vertices: IGRAPH_VCONN_NEI_IGNORE, directed: 4
+full graph with 6 vertices IGRAPH_VCONN_NEI_IGNORE: 4
+full graph with 6 vertices IGRAPH_VCONN_NEI_IGNORE, directed: 4
+line graph with 3 vertices, 6 edges: 1
 check error on graph with two connected vertices.
 check error on graph with no vertices.
 check error on graph with one vertex.

--- a/tests/unit/igraph_st_vertex_connectivity.out
+++ b/tests/unit/igraph_st_vertex_connectivity.out
@@ -1,0 +1,7 @@
+graph with two unconnected vertices: 0
+graph with two connected vertices, IGRAPH_VCONN_NEI_NEGATIVE: -1
+graph with two connected vertices, IGRAPH_VCONN_NEI_NUMBER_OF_NODES: 2
+graph with two connected vertices, IGRAPH_VCONN_NEI_IGNORE: 0
+check error on graph with two connected vertices.
+check error on graph with no vertices.
+check error on graph with one vertex.

--- a/tests/unit/igraph_st_vertex_connectivity.out
+++ b/tests/unit/igraph_st_vertex_connectivity.out
@@ -2,6 +2,9 @@ graph with two unconnected vertices: 0
 graph with two connected vertices, IGRAPH_VCONN_NEI_NEGATIVE: -1
 graph with two connected vertices, IGRAPH_VCONN_NEI_NUMBER_OF_NODES: 2
 graph with two connected vertices, IGRAPH_VCONN_NEI_IGNORE: 0
+line graph with 6 vertices: 1
+full graph with 6 vertices: IGRAPH_VCONN_NEI_IGNORE: 4
+full graph with 6 vertices: IGRAPH_VCONN_NEI_IGNORE, directed: 4
 check error on graph with two connected vertices.
 check error on graph with no vertices.
 check error on graph with one vertex.


### PR DESCRIPTION
I think two connected vertices with a IGRAPH_VCONN_NEI_IGNORE should return 0, not 1. Except for the direct path, there should be nothing to remove. Right?

In general, two connected vertices with a IGRAPH_VCONN_NEI_IGNORE seems to return one too many vertices, but maybe we want to change the docs, not the result.