### PR TITLE
Add example demonstrating igraph_assortativity_nominal to example/simple

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -708,6 +708,7 @@ Some of the highlights are:
  - `igraph_get_laplacian()` and `igraph_get_laplacian_sparse()` return the Laplacian matrix of the graph as a dense or sparse matrix, with various kinds of normalizations. They replace the now-deprecated `igraph_laplacian()`. This makes the API consistent with `igraph_get_adjacency()` and `igraph_get_adjacency_sparse()`.
  - `igraph_enter_safelocale()` and `igraph_exit_safelocale()` for temporarily setting the locale to C. Foreign format readers and writers require a locale which uses a decimal point instead of decimal comma.
  - `igraph_vertex_path_from_edge_path()` converts a sequence of edge IDs representing a path to an equivalent sequence of vertex IDs that represent the vertices the path travelled through.
+ - `igraph_graph_count()` gives the number of unlabelled graphs on a given number of vertices. It is meant to find the maximum isoclass value.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -672,6 +672,12 @@ Some of the highlights are:
 
  - `igraph_st_vertex_connectivity()` now ignores edges between source and target for `IGRAPH_VCONN_NEI_IGNORE`
 
+ - The `igraph_community_eb_get_merges()` bridges parameter now starts the indices into the
+   edge removal vector at 0, not 1.
+
+ - The `igraph_community_eb_get_merges()` now reports an error when not all edges in the graph are
+   removed, instead of a nonsensical result.
+
 ### Added
 
  - A new container type, `igraph_vector_list_t` has been added, replacing most uses of `igraph_vector_ptr_t` in the API. It contains `igraph_vector_t` objects, and it is fully memory managed (i.e. its contents do not need to be allocated and destroyed manually). There are specializations for all vector types, such as for `igraph_vector_int_list_t`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -670,6 +670,8 @@ Some of the highlights are:
  - `igraph_write_graph_gml()` takes an additional bitfield parameter controlling some aspects of writing
    the GML file.
 
+ - `igraph_st_vertex_connectivity()` now ignores edges between source and target for `IGRAPH_VCONN_NEI_IGNORE`
+
 ### Added
 
  - A new container type, `igraph_vector_list_t` has been added, replacing most uses of `igraph_vector_ptr_t` in the API. It contains `igraph_vector_t` objects, and it is fully memory managed (i.e. its contents do not need to be allocated and destroyed manually). There are specializations for all vector types, such as for `igraph_vector_int_list_t`.

--- a/doc/isomorphism.xxml
+++ b/doc/isomorphism.xxml
@@ -48,11 +48,12 @@
 <!-- doxrox-include igraph_subisomorphic_lad -->
 </section>
 
-<section id="functions-for-graphs-with-3-or-4-vertices"><title>Functions for graphs with 3 or 4 vertices</title>
+<section id="functions-for-graphs-with-3-or-4-vertices"><title>Functions for small graphs</title>
 <!-- doxrox-include igraph_isomorphic_34 -->
 <!-- doxrox-include igraph_isoclass -->
 <!-- doxrox-include igraph_isoclass_subgraph -->
 <!-- doxrox-include igraph_isoclass_create -->
+<!-- doxrox-include igraph_graph_count -->
 </section>
 
 <section id="isomorphism-utility-functions"><title>Utility functions</title>

--- a/examples/simple/igraph_assortativity_nominal.c
+++ b/examples/simple/igraph_assortativity_nominal.c
@@ -8,7 +8,7 @@ int main() {
     igraph_matrix_init(&pref_matrix, types, types);
 
     igraph_rng_seed(igraph_rng_default(), 42);
-    printf("Randomly generated graph with %ld nodes and %ld vertex types\n\n", (int)nodes, (int)types);
+    printf("Randomly generated graph with %" IGRAPH_PRId " nodes and %" IGRAPH_PRId " vertex types\n\n", nodes, types);
 
     /* Generate preference matrix giving connection probabilities for different vertex types */
     for (igraph_integer_t i = 0; i < types; i++) {

--- a/examples/simple/igraph_assortativity_nominal.c
+++ b/examples/simple/igraph_assortativity_nominal.c
@@ -8,7 +8,7 @@ int main() {
     igraph_matrix_init(&pref_matrix, types, types);
 
     igraph_rng_seed(igraph_rng_default(), 42);
-    printf("Randomly generated graph with %lld nodes and %lld vertex types\n\n", nodes, types);
+    printf("Randomly generated graph with %ld nodes and %ld vertex types\n\n", (int)nodes, (int)types);
 
     /* Generate preference matrix giving connection probabilities for different vertex types */
     for (igraph_integer_t i = 0; i < types; i++) {
@@ -19,11 +19,11 @@ int main() {
     
     igraph_t g;
     igraph_vector_int_t node_type_vec;
+    igraph_vector_int_init(&node_type_vec, nodes);
 
     // igraph_matrix_print(&pref_matrix);
     for (int i = 0; i < 5; i++) {
         igraph_real_t assortativity;
-        igraph_vector_int_init(&node_type_vec, nodes);
 
         /* Generate undirected graph with 1000 nodes and 50 vertex types */
         igraph_preference_game(&g, nodes, types, /* type_dist= */ NULL, /* fixed_sizes= */ 1, &pref_matrix, &node_type_vec, IGRAPH_UNDIRECTED, IGRAPH_LOOPS);
@@ -38,7 +38,7 @@ int main() {
         printf("Assortativity after rewiring = %g\n\n", assortativity);
 
         igraph_destroy(&g);    
-        igraph_vector_int_destroy(&node_type_vec);
     }
+    igraph_vector_int_destroy(&node_type_vec);
     igraph_matrix_destroy(&pref_matrix);
 }

--- a/examples/simple/igraph_assortativity_nominal.c
+++ b/examples/simple/igraph_assortativity_nominal.c
@@ -2,25 +2,26 @@
 #include <stdio.h>
 
 int main() {
-    igraph_integer_t nodes = 250, types = 5;
+    igraph_integer_t nodes = 120, types = 4;
 
     igraph_matrix_t pref_matrix;
     igraph_matrix_init(&pref_matrix, types, types);
 
     igraph_rng_seed(igraph_rng_default(), 42);
-    printf("Randomly generated graph with 250 nodes and 5 vertex types\n\n");
+    printf("Randomly generated graph with %ld nodes and %ld vertex types\n\n", nodes, types);
 
     /* Generate preference matrix giving connection probabilities for different vertex types */
     for (igraph_integer_t i = 0; i < types; i++) {
-        for (igraph_integer_t j = i; j < types; j++) {
-            MATRIX(pref_matrix, i, j) = RNG_UNIF01();
-            MATRIX(pref_matrix, j, i) = MATRIX(pref_matrix, i, j);
+        for (igraph_integer_t j = 0; j < types; j++) {
+            MATRIX(pref_matrix, i, j) = (i == j ? 0.1: 0.01);
         }
     }
 
+    // igraph_matrix_print(&pref_matrix);
+    igraph_vector_int_t node_type_vec;
+
     for (int i = 0; i < 5; i++) {
         igraph_t g;
-        igraph_vector_int_t node_type_vec;
         igraph_real_t assortativity;
         igraph_vector_int_init(&node_type_vec, nodes);
 
@@ -37,8 +38,8 @@ int main() {
         printf("Assortativity after rewiring = %g\n\n", assortativity);
 
         igraph_destroy(&g);
-        igraph_vector_int_destroy(&node_type_vec);
     }
-
+    
+    igraph_vector_int_destroy(&node_type_vec);
     igraph_matrix_destroy(&pref_matrix);
 }

--- a/examples/simple/igraph_assortativity_nominal.c
+++ b/examples/simple/igraph_assortativity_nominal.c
@@ -25,7 +25,7 @@ int main() {
     	igraph_vector_int_init(&node_type_vec, nodes);
 
         /* Generate undirected graph with 1000 nodes and 50 vertex types */
-        igraph_preference_game(&g, nodes, types, NULL, 1, &pref_matrix, &node_type_vec, IGRAPH_UNDIRECTED, IGRAPH_LOOPS);
+        igraph_preference_game(&g, nodes, types, /* type_dist= */ NULL, /* fixed_sizes= */ 1, &pref_matrix, &node_type_vec, IGRAPH_UNDIRECTED, IGRAPH_LOOPS);
 
         igraph_assortativity_nominal(&g, &node_type_vec, &assortativity, IGRAPH_UNDIRECTED, 1);
         printf("Assortativity before rewiring = %g\n", assortativity);

--- a/examples/simple/igraph_assortativity_nominal.c
+++ b/examples/simple/igraph_assortativity_nominal.c
@@ -2,9 +2,7 @@
 #include <stdio.h>
 
 int main() {
-    igraph_t g;
     igraph_integer_t nodes = 1000, types = 50;
-    igraph_vector_int_t node_type_vec;
 
     igraph_matrix_t pref_matrix;
     igraph_matrix_init(&pref_matrix, types, types);
@@ -21,15 +19,17 @@ int main() {
     }
 
     for (int i = 0; i < 5; i++) {
+        igraph_t g;
+        igraph_vector_int_t node_type_vec;
         igraph_real_t assortativity;
-    	igraph_vector_int_init(&node_type_vec, nodes);
+        igraph_vector_int_init(&node_type_vec, nodes);
 
         /* Generate undirected graph with 1000 nodes and 50 vertex types */
         igraph_preference_game(&g, nodes, types, /* type_dist= */ NULL, /* fixed_sizes= */ 1, &pref_matrix, &node_type_vec, IGRAPH_UNDIRECTED, IGRAPH_LOOPS);
 
         igraph_assortativity_nominal(&g, &node_type_vec, &assortativity, IGRAPH_UNDIRECTED, 1);
         printf("Assortativity before rewiring = %g\n", assortativity);
-        
+
         /* Rewire graph */
         igraph_rewire(&g, 10 * igraph_ecount(&g), IGRAPH_REWIRING_SIMPLE);
 

--- a/examples/simple/igraph_assortativity_nominal.c
+++ b/examples/simple/igraph_assortativity_nominal.c
@@ -25,7 +25,7 @@ int main() {
         igraph_t g;
 
         /* Generate undirected graph with 1000 nodes and 50 vertex types */
-        igraph_preference_game(&g, nodes, types, /* type_dist= */ NULL, /* fixed_sizes= */ 1, &pref_matrix, &node_type_vec, IGRAPH_UNDIRECTED, IGRAPH_LOOPS);
+        igraph_preference_game(&g, nodes, types, /* type_dist= */ NULL, /* fixed_sizes= */ 1, &pref_matrix, &node_type_vec, IGRAPH_UNDIRECTED, IGRAPH_NO_LOOPS);
 
         igraph_assortativity_nominal(&g, &node_type_vec, &assortativity, IGRAPH_UNDIRECTED, 1);
         printf("Assortativity before rewiring = %g\n", assortativity);

--- a/examples/simple/igraph_assortativity_nominal.c
+++ b/examples/simple/igraph_assortativity_nominal.c
@@ -17,13 +17,13 @@ int main() {
         }
     }
     
-    igraph_t g;
     igraph_vector_int_t node_type_vec;
     igraph_vector_int_init(&node_type_vec, nodes);
 
     // igraph_matrix_print(&pref_matrix);
     for (int i = 0; i < 5; i++) {
         igraph_real_t assortativity;
+        igraph_t g;
 
         /* Generate undirected graph with 1000 nodes and 50 vertex types */
         igraph_preference_game(&g, nodes, types, /* type_dist= */ NULL, /* fixed_sizes= */ 1, &pref_matrix, &node_type_vec, IGRAPH_UNDIRECTED, IGRAPH_LOOPS);

--- a/examples/simple/igraph_assortativity_nominal.c
+++ b/examples/simple/igraph_assortativity_nominal.c
@@ -1,7 +1,7 @@
 #include <igraph.h>
 #include <stdio.h>
 
-int main(){
+int main() {
     igraph_t g;
     igraph_integer_t nodes = 1000, types = 50;
     igraph_vector_int_t node_type_vec;

--- a/examples/simple/igraph_assortativity_nominal.c
+++ b/examples/simple/igraph_assortativity_nominal.c
@@ -8,7 +8,7 @@ int main() {
     igraph_matrix_init(&pref_matrix, types, types);
 
     igraph_rng_seed(igraph_rng_default(), 42);
-    printf("Randomly generated graph with %ld nodes and %ld vertex types\n\n", nodes, types);
+    printf("Randomly generated graph with %lld nodes and %lld vertex types\n\n", nodes, types);
 
     /* Generate preference matrix giving connection probabilities for different vertex types */
     for (igraph_integer_t i = 0; i < types; i++) {

--- a/examples/simple/igraph_assortativity_nominal.c
+++ b/examples/simple/igraph_assortativity_nominal.c
@@ -16,12 +16,13 @@ int main() {
             MATRIX(pref_matrix, i, j) = (i == j ? 0.1: 0.01);
         }
     }
+    
+    igraph_t g;
+    igraph_vector_int_t node_type_vec;
 
     // igraph_matrix_print(&pref_matrix);
     for (int i = 0; i < 5; i++) {
         igraph_real_t assortativity;
-        igraph_t g;
-        igraph_vector_int_t node_type_vec;
         igraph_vector_int_init(&node_type_vec, nodes);
 
         /* Generate undirected graph with 1000 nodes and 50 vertex types */

--- a/examples/simple/igraph_assortativity_nominal.c
+++ b/examples/simple/igraph_assortativity_nominal.c
@@ -20,7 +20,6 @@ int main() {
     igraph_vector_int_t node_type_vec;
     igraph_vector_int_init(&node_type_vec, nodes);
 
-    // igraph_matrix_print(&pref_matrix);
     for (int i = 0; i < 5; i++) {
         igraph_real_t assortativity;
         igraph_t g;

--- a/examples/simple/igraph_assortativity_nominal.c
+++ b/examples/simple/igraph_assortativity_nominal.c
@@ -2,7 +2,7 @@
 #include <stdio.h>
 
 int main() {
-    igraph_integer_t nodes = 1000, types = 50;
+    igraph_integer_t nodes = 250, types = 5;
 
     igraph_matrix_t pref_matrix;
     igraph_matrix_init(&pref_matrix, types, types);

--- a/examples/simple/igraph_assortativity_nominal.c
+++ b/examples/simple/igraph_assortativity_nominal.c
@@ -18,12 +18,12 @@ int main() {
     }
 
     // igraph_matrix_print(&pref_matrix);
+    igraph_t g;
     igraph_vector_int_t node_type_vec;
+    igraph_vector_int_init(&node_type_vec, nodes);
 
     for (int i = 0; i < 5; i++) {
-        igraph_t g;
         igraph_real_t assortativity;
-        igraph_vector_int_init(&node_type_vec, nodes);
 
         /* Generate undirected graph with 1000 nodes and 50 vertex types */
         igraph_preference_game(&g, nodes, types, /* type_dist= */ NULL, /* fixed_sizes= */ 1, &pref_matrix, &node_type_vec, IGRAPH_UNDIRECTED, IGRAPH_LOOPS);
@@ -36,10 +36,9 @@ int main() {
 
         igraph_assortativity_nominal(&g, &node_type_vec, &assortativity, IGRAPH_UNDIRECTED, 1);
         printf("Assortativity after rewiring = %g\n\n", assortativity);
-
-        igraph_destroy(&g);
     }
-    
+
+    igraph_destroy(&g);    
     igraph_vector_int_destroy(&node_type_vec);
     igraph_matrix_destroy(&pref_matrix);
 }

--- a/examples/simple/igraph_assortativity_nominal.c
+++ b/examples/simple/igraph_assortativity_nominal.c
@@ -13,8 +13,8 @@ int main() {
     printf("Randomly generated graph with 1000 nodes and 50 vertex types\n\n");
 
     /* Generate preference matrix giving connection probabilities for different vertex types */
-    for(igraph_integer_t i = 0; i < types; i++){
-        for(igraph_integer_t j = i; j < types; j++){
+    for (igraph_integer_t i = 0; i < types; i++) {
+        for (igraph_integer_t j = i; j < types; j++) {
             MATRIX(pref_matrix, i, j) = igraph_rng_get_unif(igraph_rng_default(), 0, 1);
             MATRIX(pref_matrix, j, i) = MATRIX(pref_matrix, i, j);
         }

--- a/examples/simple/igraph_assortativity_nominal.c
+++ b/examples/simple/igraph_assortativity_nominal.c
@@ -18,12 +18,11 @@ int main() {
     }
 
     // igraph_matrix_print(&pref_matrix);
-    igraph_t g;
-    igraph_vector_int_t node_type_vec;
-    igraph_vector_int_init(&node_type_vec, nodes);
-
     for (int i = 0; i < 5; i++) {
         igraph_real_t assortativity;
+        igraph_t g;
+        igraph_vector_int_t node_type_vec;
+        igraph_vector_int_init(&node_type_vec, nodes);
 
         /* Generate undirected graph with 1000 nodes and 50 vertex types */
         igraph_preference_game(&g, nodes, types, /* type_dist= */ NULL, /* fixed_sizes= */ 1, &pref_matrix, &node_type_vec, IGRAPH_UNDIRECTED, IGRAPH_LOOPS);
@@ -36,9 +35,9 @@ int main() {
 
         igraph_assortativity_nominal(&g, &node_type_vec, &assortativity, IGRAPH_UNDIRECTED, 1);
         printf("Assortativity after rewiring = %g\n\n", assortativity);
-    }
 
-    igraph_destroy(&g);    
-    igraph_vector_int_destroy(&node_type_vec);
+        igraph_destroy(&g);    
+        igraph_vector_int_destroy(&node_type_vec);
+    }
     igraph_matrix_destroy(&pref_matrix);
 }

--- a/examples/simple/igraph_assortativity_nominal.c
+++ b/examples/simple/igraph_assortativity_nominal.c
@@ -15,7 +15,7 @@ int main() {
     /* Generate preference matrix giving connection probabilities for different vertex types */
     for (igraph_integer_t i = 0; i < types; i++) {
         for (igraph_integer_t j = i; j < types; j++) {
-            MATRIX(pref_matrix, i, j) = igraph_rng_get_unif(igraph_rng_default(), 0, 1);
+            MATRIX(pref_matrix, i, j) = RNG_UNIF01();
             MATRIX(pref_matrix, j, i) = MATRIX(pref_matrix, i, j);
         }
     }

--- a/examples/simple/igraph_assortativity_nominal.c
+++ b/examples/simple/igraph_assortativity_nominal.c
@@ -8,7 +8,7 @@ int main() {
     igraph_matrix_init(&pref_matrix, types, types);
 
     igraph_rng_seed(igraph_rng_default(), 42);
-    printf("Randomly generated graph with 1000 nodes and 50 vertex types\n\n");
+    printf("Randomly generated graph with 250 nodes and 5 vertex types\n\n");
 
     /* Generate preference matrix giving connection probabilities for different vertex types */
     for (igraph_integer_t i = 0; i < types; i++) {

--- a/examples/simple/igraph_assortativity_nominal.c
+++ b/examples/simple/igraph_assortativity_nominal.c
@@ -1,0 +1,44 @@
+#include <igraph.h>
+#include <stdio.h>
+
+int main(){
+    igraph_t g;
+    igraph_integer_t nodes = 1000, types = 50;
+    igraph_vector_int_t node_type_vec;
+
+    igraph_matrix_t pref_matrix;
+    igraph_matrix_init(&pref_matrix, types, types);
+
+    igraph_rng_seed(igraph_rng_default(), 42);
+    printf("Randomly generated graph with 1000 nodes and 50 vertex types\n\n");
+
+    /* Generate preference matrix giving connection probabilities for different vertex types */
+    for(igraph_integer_t i = 0; i < types; i++){
+        for(igraph_integer_t j = i; j < types; j++){
+            MATRIX(pref_matrix, i, j) = igraph_rng_get_unif(igraph_rng_default(), 0, 1);
+            MATRIX(pref_matrix, j, i) = MATRIX(pref_matrix, i, j);
+        }
+    }
+
+    for (int i = 0; i < 5; i++) {
+        igraph_real_t assortativity;
+    	igraph_vector_int_init(&node_type_vec, nodes);
+
+        /* Generate undirected graph with 1000 nodes and 50 vertex types */
+        igraph_preference_game(&g, nodes, types, NULL, 1, &pref_matrix, &node_type_vec, IGRAPH_UNDIRECTED, IGRAPH_LOOPS);
+
+        igraph_assortativity_nominal(&g, &node_type_vec, &assortativity, IGRAPH_UNDIRECTED, 1);
+        printf("Assortativity before rewiring = %g\n", assortativity);
+        
+        /* Rewire graph */
+        igraph_rewire(&g, 10 * igraph_ecount(&g), IGRAPH_REWIRING_SIMPLE);
+
+        igraph_assortativity_nominal(&g, &node_type_vec, &assortativity, IGRAPH_UNDIRECTED, 1);
+        printf("Assortativity after rewiring = %g\n\n", assortativity);
+
+        igraph_destroy(&g);
+        igraph_vector_int_destroy(&node_type_vec);
+    }
+
+    igraph_matrix_destroy(&pref_matrix);
+}

--- a/examples/simple/igraph_assortativity_nominal.out
+++ b/examples/simple/igraph_assortativity_nominal.out
@@ -1,4 +1,4 @@
-Randomly generated graph with 1000 nodes and 50 vertex types
+Randomly generated graph with 250 nodes and 5 vertex types
 
 Assortativity before rewiring = 0.00585046
 Assortativity after rewiring = -0.00811945

--- a/examples/simple/igraph_assortativity_nominal.out
+++ b/examples/simple/igraph_assortativity_nominal.out
@@ -1,17 +1,17 @@
 Randomly generated graph with 120 nodes and 4 vertex types
 
-Assortativity before rewiring = 0.691229
-Assortativity after rewiring = 0.0847146
+Assortativity before rewiring = 0.641692
+Assortativity after rewiring = 0.00905375
 
-Assortativity before rewiring = 0.724321
-Assortativity after rewiring = 0.0864765
+Assortativity before rewiring = 0.669379
+Assortativity after rewiring = 0.00243781
 
-Assortativity before rewiring = 0.672891
-Assortativity after rewiring = -0.0307029
+Assortativity before rewiring = 0.727983
+Assortativity after rewiring = 0.0574285
 
-Assortativity before rewiring = 0.702714
-Assortativity after rewiring = 0.0376004
+Assortativity before rewiring = 0.662426
+Assortativity after rewiring = -0.0399467
 
-Assortativity before rewiring = 0.698315
-Assortativity after rewiring = 0.0653689
+Assortativity before rewiring = 0.709509
+Assortativity after rewiring = -0.00980129
 

--- a/examples/simple/igraph_assortativity_nominal.out
+++ b/examples/simple/igraph_assortativity_nominal.out
@@ -1,17 +1,17 @@
 Randomly generated graph with 1000 nodes and 50 vertex types
 
-Assortativity before rewiring = 0.0046342
-Assortativity after rewiring = 0.00121202
+Assortativity before rewiring = 0.00585046
+Assortativity after rewiring = -0.00811945
 
-Assortativity before rewiring = 0.00443165
-Assortativity after rewiring = 0.0010397
+Assortativity before rewiring = -0.000373488
+Assortativity after rewiring = -0.00575999
 
-Assortativity before rewiring = 0.00427292
-Assortativity after rewiring = 0.00126705
+Assortativity before rewiring = 0.00347426
+Assortativity after rewiring = -0.00328873
 
-Assortativity before rewiring = 0.0046915
-Assortativity after rewiring = 0.00119051
+Assortativity before rewiring = 0.0085769
+Assortativity after rewiring = -0.0127907
 
-Assortativity before rewiring = 0.00435892
-Assortativity after rewiring = 0.00103278
+Assortativity before rewiring = 0.00636642
+Assortativity after rewiring = -0.00840506
 

--- a/examples/simple/igraph_assortativity_nominal.out
+++ b/examples/simple/igraph_assortativity_nominal.out
@@ -1,17 +1,17 @@
-Randomly generated graph with 250 nodes and 5 vertex types
+Randomly generated graph with 120 nodes and 4 vertex types
 
-Assortativity before rewiring = 0.00585046
-Assortativity after rewiring = -0.00811945
+Assortativity before rewiring = 0.691229
+Assortativity after rewiring = 0.0847146
 
-Assortativity before rewiring = -0.000373488
-Assortativity after rewiring = -0.00575999
+Assortativity before rewiring = 0.724321
+Assortativity after rewiring = 0.0864765
 
-Assortativity before rewiring = 0.00347426
-Assortativity after rewiring = -0.00328873
+Assortativity before rewiring = 0.672891
+Assortativity after rewiring = -0.0307029
 
-Assortativity before rewiring = 0.0085769
-Assortativity after rewiring = -0.0127907
+Assortativity before rewiring = 0.702714
+Assortativity after rewiring = 0.0376004
 
-Assortativity before rewiring = 0.00636642
-Assortativity after rewiring = -0.00840506
+Assortativity before rewiring = 0.698315
+Assortativity after rewiring = 0.0653689
 

--- a/examples/simple/igraph_assortativity_nominal.out
+++ b/examples/simple/igraph_assortativity_nominal.out
@@ -1,0 +1,17 @@
+Randomly generated graph with 1000 nodes and 50 vertex types
+
+Assortativity before rewiring = 0.0046342
+Assortativity after rewiring = 0.00121202
+
+Assortativity before rewiring = 0.00443165
+Assortativity after rewiring = 0.0010397
+
+Assortativity before rewiring = 0.00427292
+Assortativity after rewiring = 0.00126705
+
+Assortativity before rewiring = 0.0046915
+Assortativity after rewiring = 0.00119051
+
+Assortativity before rewiring = 0.00435892
+Assortativity after rewiring = 0.00103278
+

--- a/examples/simple/igraph_subisomorphic_lad.c
+++ b/examples/simple/igraph_subisomorphic_lad.c
@@ -106,34 +106,45 @@ void test_k_motifs(const igraph_t *graph, const int k, const int class_count, ig
 
 void test_motifs() {
     igraph_t graph;
+    igraph_integer_t count;
 
     igraph_rng_seed(igraph_rng_default(), 42);
 
     igraph_erdos_renyi_game_gnm(&graph, 30, 400, /* directed = */ 1, /* loops = */ 0);
 
-    test_k_motifs(&graph, 3, 16, /* directed= */ 1); /* there are 16 size-3 directed graphs */
-    test_k_motifs(&graph, 4, 218, /* directed= */ 1); /* there are 218 size-4 directed graphs */
+    igraph_graph_count(3, IGRAPH_DIRECTED, &count);
+    test_k_motifs(&graph, 3, count, IGRAPH_DIRECTED);
+
+    igraph_graph_count(4, IGRAPH_DIRECTED, &count);
+    test_k_motifs(&graph, 4, count, IGRAPH_DIRECTED);
 
     igraph_destroy(&graph);
 }
 
 void test_motifs_undirected() {
     igraph_t graph;
+    igraph_integer_t count;
 
     igraph_rng_seed(igraph_rng_default(), 137);
 
     igraph_erdos_renyi_game_gnm(&graph, 18, 100, /* directed = */ 0, /* loops = */ 0);
 
-    test_k_motifs(&graph, 3, 4,   /* directed= */ 0);  /* there are 4   size-3 undirected graphs */
-    test_k_motifs(&graph, 4, 11,  /* directed= */ 0);  /* there are 11  size-4 undirected graphs */
+    igraph_graph_count(3, IGRAPH_UNDIRECTED, &count);
+    test_k_motifs(&graph, 3, count, IGRAPH_UNDIRECTED);
+
+    igraph_graph_count(4, IGRAPH_UNDIRECTED, &count);
+    test_k_motifs(&graph, 4, count, IGRAPH_UNDIRECTED);
 
     igraph_destroy(&graph);
 
     /* Use a smaller graph so that the test would not take too long. */
     igraph_erdos_renyi_game_gnm(&graph, 9, 36, /* directed = */ 0, /* loops = */ 0);
 
-    test_k_motifs(&graph, 5, 34,  /* directed= */ 0);  /* there are 34  size-5 undirected graphs */
-    test_k_motifs(&graph, 6, 156, /* directed= */ 0);  /* there are 156 size-6 undirected graphs */
+    igraph_graph_count(5, IGRAPH_UNDIRECTED, &count);
+    test_k_motifs(&graph, 5, count, IGRAPH_UNDIRECTED);
+
+    igraph_graph_count(6, IGRAPH_UNDIRECTED, &count);
+    test_k_motifs(&graph, 6, count, IGRAPH_UNDIRECTED);
 
     igraph_destroy(&graph);
 }

--- a/include/igraph_motifs.h
+++ b/include/igraph_motifs.h
@@ -43,14 +43,16 @@ __BEGIN_DECLS
  * function whenever a new motif is found during a motif search. This
  * callback function must be of type \c igraph_motifs_handler_t. It has
  * the following arguments:
+ *
  * \param graph The graph that that algorithm is working on. Of course
  *   this must not be modified.
  * \param vids The IDs of the vertices in the motif that has just been
  *   found. This vector is owned by the motif search algorithm, so do not
  *   modify or destroy it; make a copy of it if you need it later.
  * \param isoclass The isomorphism class of the motif that has just been
- *   found. Use \ref igraph_isoclass or \ref igraph_isoclass_subgraph to find
- *   out which isomorphism class belongs to a given motif.
+ *   found. Use \ref igraph_graph_count() to find the maximum possible
+ *   isoclass for graphs of a given size. See \ref igraph_isoclass and
+ *   \ref igraph_isoclass_subgraph for more information.
  * \param extra The extra argument that was passed to \ref
  *   igraph_motifs_randesu_callback().
  * \return \c IGRAPH_SUCCESS to continue the motif search,

--- a/include/igraph_topology.h
+++ b/include/igraph_topology.h
@@ -297,6 +297,8 @@ IGRAPH_EXPORT igraph_error_t igraph_isoclass_subgraph(const igraph_t *graph, con
 IGRAPH_EXPORT igraph_error_t igraph_isoclass_create(igraph_t *graph, igraph_integer_t size,
                                          igraph_integer_t number, igraph_bool_t directed);
 
+IGRAPH_EXPORT igraph_error_t igraph_graph_count(igraph_integer_t n, igraph_bool_t directed, igraph_integer_t *count);
+
 
 
 

--- a/src/isomorphism/isoclasses.c
+++ b/src/isomorphism/isoclasses.c
@@ -2525,6 +2525,7 @@ const unsigned int igraph_i_classedges_6u[] = { 4, 5, 3, 5, 2, 5, 1, 5, 0, 5, 3,
  * (between 0 and 15), for undirected graph it is only 4. For graphs
  * with four vertices it is 218 (directed) and 11 (undirected).
  * For 5 and 6 vertex undirected graphs, it is 34 and 156, respectively.
+ * These values can also be retrieved using \ref igraph_graph_count().
  * For more information, see https://oeis.org/A000273 and https://oeis.org/A000088.
  *
  * </para><para>
@@ -2872,5 +2873,61 @@ igraph_error_t igraph_isoclass_create(igraph_t *graph, igraph_integer_t size,
     igraph_vector_int_destroy(&edges);
     IGRAPH_FINALLY_CLEAN(1);
 
+    return IGRAPH_SUCCESS;
+}
+
+/* https://oeis.org/A000088 */
+static igraph_integer_t undirected_graph_counts[] = {
+    1, 1, 2, 4, 11, 34, 156, 1044, 12346, 274668, 12005168, 1018997864,
+#if IGRAPH_INTEGER_SIZE == 64
+    165091172592, 50502031367952, 29054155657235488
+#endif
+};
+
+/* https://oeis.org/A000273 */
+static igraph_integer_t directed_graph_counts[] = {
+    1, 1, 3, 16, 218, 9608, 1540944, 882033440,
+#if IGRAPH_INTEGER_SIZE == 64
+    1793359192848, 13027956824399552
+#endif
+};
+
+/**
+ * \function igraph_graph_count
+ * \brief The number of unlabelled graphs on the given number of vertices.
+ *
+ * Gives the number of unlabelled \em simple graphs on the specified number of vertices.
+ * The "isoclass" of a graph of this size is at most one less than this value.
+ *
+ * </para><para>
+ * This function is meant to be used in conjunction with isoclass and motif finder
+ * functions. It will only work for small \p n values for which the result is
+ * represetable in an \type igraph_integer_t. For larger \p n values, an overflow
+ * error is raised.
+ *
+ * \param n The number of vertices.
+ * \param directed Boolean, whether to consider directed graphs.
+ * \param count Pointer to an integer, the result will be stored here.
+ * \return Error code.
+ *
+ * \sa \ref igraph_isoclass(), \ref igraph_motifs_randesu_callback().
+ *
+ * Time complexity: O(1).
+ */
+igraph_error_t igraph_graph_count(igraph_integer_t n, igraph_bool_t directed, igraph_integer_t *count) {
+    if (n < 0) {
+        IGRAPH_ERROR("Graph size must not be negative.", IGRAPH_EINVAL);
+    }
+    if (directed) {
+        if (n >= (igraph_integer_t) (sizeof directed_graph_counts / sizeof directed_graph_counts[0])) {
+            IGRAPH_ERRORF("Graph size of % " IGRAPH_PRId " too large.", IGRAPH_EOVERFLOW, n);
+        }
+        *count = directed_graph_counts[n];
+    } else {
+        if (n >= (igraph_integer_t) (sizeof undirected_graph_counts / sizeof undirected_graph_counts[0])) {
+            IGRAPH_ERRORF("Graph size of % " IGRAPH_PRId " too large.", IGRAPH_EOVERFLOW, n);
+        }
+        *count = undirected_graph_counts[n];
+    }
     return IGRAPH_SUCCESS;
 }

--- a/src/misc/mixing.c
+++ b/src/misc/mixing.c
@@ -96,7 +96,7 @@
  * \ref igraph_modularity() to compute generalized modularity.
  *
  * \example examples/simple/igraph_assortativity_nominal.c
-*/
+ */
 
 igraph_error_t igraph_assortativity_nominal(const igraph_t *graph,
                                             const igraph_vector_int_t *types,

--- a/src/misc/mixing.c
+++ b/src/misc/mixing.c
@@ -94,7 +94,9 @@
  * \sa \ref igraph_assortativity() for computing the assortativity
  * based on continuous vertex values instead of discrete categories.
  * \ref igraph_modularity() to compute generalized modularity.
- */
+ *
+ * \example examples/simple/igraph_assortativity_nominal.c
+*/
 
 igraph_error_t igraph_assortativity_nominal(const igraph_t *graph,
                                             const igraph_vector_int_t *types,

--- a/src/misc/mixing.c
+++ b/src/misc/mixing.c
@@ -256,8 +256,6 @@ igraph_error_t igraph_assortativity_nominal(const igraph_t *graph,
  * categories instead of numeric labels, and \ref
  * igraph_assortativity_degree() for the special case of assortativity
  * based on vertex degrees.
- * 
- * \example examples/simple/igraph_assortativity_degree.c
  */
 
 igraph_error_t igraph_assortativity(const igraph_t *graph,
@@ -377,6 +375,8 @@ igraph_error_t igraph_assortativity(const igraph_t *graph,
  *
  * \sa \ref igraph_assortativity() for the general function
  * calculating assortativity for any kind of numeric vertex values.
+ * 
+ * \example examples/simple/igraph_assortativity_degree.c
  */
 
 igraph_error_t igraph_assortativity_degree(const igraph_t *graph,

--- a/src/misc/motifs.c
+++ b/src/misc/motifs.c
@@ -105,7 +105,9 @@ static igraph_error_t igraph_i_motifs_randesu_update_hist(
  * number of motifs of a given size in a graph;
  * \ref igraph_motifs_randesu_callback() for calling a callback function
  * for every motif found; \ref igraph_subisomorphic_lad() for finding
- * subgraphs on more than 4 (directed) or 6 (undirected) vertices.
+ * subgraphs on more than 4 (directed) or 6 (undirected) vertices;
+ * \ref igraph_graph_count() to find the number of graph on a given
+ * number of vertices, i.e. the length of the \p hist vector.
  *
  * Time complexity: TODO.
  *

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -235,6 +235,7 @@ add_examples(
   bellman_ford
   dijkstra
   igraph_assortativity_degree
+  igraph_assortativity_nominal
   igraph_average_path_length
   igraph_cocitation
   igraph_diameter


### PR DESCRIPTION
The example demonstrates that graphs with the same vertex types can have different assortativities.

Part of https://github.com/igraph/igraph/issues/1931.