### PR TITLE
Clean up ncol tests

### DIFF
--- a/tests/unit/ncol.c
+++ b/tests/unit/ncol.c
@@ -40,8 +40,7 @@ int main() {
     SETVAS(&g_in, "vertex_attr", 2, "vertex_name2");
     SETVAS(&g_in, "vertex_attr", 3, "vertex_name3");
 
-    char filename[] = "ncol.tmp.XXXXXX"; /* XXXXXX is replaced by mktemp() */
-    mktemp(filename);
+    char filename[] = "ncol.tmp";
     file = fopen(filename, "w");
     IGRAPH_ASSERT(file); /* make sure that the file was created successfully */
 
@@ -69,8 +68,8 @@ int main() {
     unlink(filename);
     igraph_destroy(&g_in);
     igraph_destroy(&g_out);
- 
+
     VERIFY_FINALLY_STACK();
- 
+
     return 0;
 }

--- a/tests/unit/ncol.c
+++ b/tests/unit/ncol.c
@@ -61,8 +61,7 @@ int main() {
         abort();
     }
 
-    /* Simple way to verify that attributes are correct. */
-    igraph_write_graph_graphml(&g_out, stdout, 0);
+    print_attributes(&g_out);
 
     fclose(file);
     unlink(filename);

--- a/tests/unit/ncol.out
+++ b/tests/unit/ncol.out
@@ -1,37 +1,11 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<graphml xmlns="http://graphml.graphdrawing.org/xmlns"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns
-         http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">
-<!-- Created by igraph -->
-  <key id="name" for="node" attr.name="name" attr.type="string"/>
-  <key id="weight" for="edge" attr.name="weight" attr.type="double"/>
-  <graph id="G" edgedefault="directed">
-    <node id="n0">
-      <data key="name">vertex_name0</data>
-    </node>
-    <node id="n1">
-      <data key="name">vertex_name1</data>
-    </node>
-    <node id="n2">
-      <data key="name">vertex_name2</data>
-    </node>
-    <node id="n3">
-      <data key="name">vertex_name3</data>
-    </node>
-    <edge source="n0" target="n1">
-      <data key="weight">12.3</data>
-    </edge>
-    <edge source="n0" target="n1">
-    </edge>
-    <edge source="n0" target="n1">
-    </edge>
-    <edge source="n1" target="n2">
-    </edge>
-    <edge source="n2" target="n3">
-      <data key="weight">-Inf</data>
-    </edge>
-    <edge source="n3" target="n0">
-    </edge>
-  </graph>
-</graphml>
+Vertex 0: name="vertex_name0"
+Vertex 1: name="vertex_name1"
+Vertex 2: name="vertex_name2"
+Vertex 3: name="vertex_name3"
+Edge 0 (0-1): weight=12.3
+Edge 1 (0-1): weight=NaN
+Edge 2 (0-1): weight=NaN
+Edge 3 (1-2): weight=NaN
+Edge 4 (2-3): weight=-Inf
+Edge 5 (3-0): weight=NaN
+


### PR DESCRIPTION
fix one: use a fixed filename instead of a temporary file, which gives an amazing amount of problems.
fix two: use print_attributes instead of igraph_write_graph_graphml, to have a much cleaner output.