### PR TITLE
tests: add write_graph_dot

### DIFF
--- a/src/io/dot.c
+++ b/src/io/dot.c
@@ -73,7 +73,7 @@ static igraph_error_t igraph_i_dot_escape(const char *orig, char **result) {
             is_number = 0; need_quote = 1; newlen++;
         }
     }
-    if (is_number && orig[len - 1] == '.') {
+    if (is_number && len > 0 && orig[len - 1] == '.') {
         is_number = 0;
     }
     if (!is_number && isdigit(orig[0])) {
@@ -117,9 +117,8 @@ static igraph_error_t igraph_i_dot_escape(const char *orig, char **result) {
  * http://www.graphviz.org for details. The grammar of the DOT format
  * can be found here: http://www.graphviz.org/doc/info/lang.html
  *
- * </para><para>This is only a preliminary implementation, only the vertices
- * and the edges are written but not the attributes or any visualization
- * information.
+ * </para><para>This is only a preliminary implementation, no visualization
+ * information is written.
  *
  * \param graph The graph to write to the stream.
  * \param outstream The stream to write the file to.
@@ -220,8 +219,8 @@ igraph_error_t igraph_write_graph_dot(const igraph_t *graph, FILE* outstream) {
                 IGRAPH_FINALLY(igraph_free, newname);
                 if (VECTOR(vtypes)[j] == IGRAPH_ATTRIBUTE_NUMERIC) {
                     IGRAPH_CHECK(igraph_i_attribute_get_numeric_vertex_attr(graph, name, igraph_vss_1(i), &numv));
-                    if (VECTOR(numv)[0] == (igraph_integer_t)VECTOR(numv)[0]) {
-                        CHECK(fprintf(outstream, "    %s=%" IGRAPH_PRId "\n", newname, (igraph_integer_t)VECTOR(numv)[0]));
+                    if (VECTOR(numv)[0] == floor(VECTOR(numv)[0])) {
+                        CHECK(fprintf(outstream, "    %s=%g\n", newname, VECTOR(numv)[0]));
                     } else {
                         CHECK(fprintf(outstream, "    %s=", newname));
                         CHECK(igraph_real_fprintf_precise(outstream,
@@ -270,8 +269,8 @@ igraph_error_t igraph_write_graph_dot(const igraph_t *graph, FILE* outstream) {
                 if (VECTOR(etypes)[j] == IGRAPH_ATTRIBUTE_NUMERIC) {
                     IGRAPH_CHECK(igraph_i_attribute_get_numeric_edge_attr(graph,
                                  name, igraph_ess_1(i), &numv));
-                    if (VECTOR(numv)[0] == (igraph_integer_t)VECTOR(numv)[0]) {
-                        CHECK(fprintf(outstream, "    %s=%" IGRAPH_PRId "\n", newname, (igraph_integer_t)VECTOR(numv)[0]));
+                    if (VECTOR(numv)[0] == floor(VECTOR(numv)[0])) {
+                        CHECK(fprintf(outstream, "    %s=%g\n", newname, VECTOR(numv)[0]));
                     } else {
                         CHECK(fprintf(outstream, "    %s=", newname));
                         CHECK(igraph_real_fprintf_precise(outstream, VECTOR(numv)[0]));

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -453,6 +453,7 @@ add_legacy_tests(
   gml
   igraph_write_graph_leda
   igraph_write_graph_dimacs_flow
+  igraph_write_graph_dot
   lineendings
   ncol
   pajek

--- a/tests/unit/igraph_write_graph_dot.c
+++ b/tests/unit/igraph_write_graph_dot.c
@@ -1,0 +1,54 @@
+/*
+   IGraph library.
+   Copyright (C) 2022  The igraph development team <igraph@igraph.org>
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <igraph.h>
+#include "test_utilities.h"
+
+int main() {
+    igraph_t g;
+
+    igraph_set_warning_handler(igraph_warning_handler_ignore);
+    igraph_set_attribute_table(&igraph_cattribute_table);
+    igraph_small(&g, 6, IGRAPH_UNDIRECTED,
+            0,1, 0,2, 1,1, 1,3, 2,0, 2,3, 4,3, 4,3, -1);
+    /* Set vertex attributes */
+    SETVAN(&g, "VAN", 0, -1);
+    SETVAN(&g, "VAN", 1, 2.1);
+
+    SETVAS(&g, "VAS", 0, "foo");
+    SETVAS(&g, "VAS", 1, "bar");
+
+    SETVAB(&g, "VAB", 0, 1);
+    SETVAB(&g, "VAB", 1, 0);
+
+    /* Set edge attributes */
+    SETEAN(&g, "EAN", 0, -100.1);
+    SETEAN(&g, "EAN", 2, 100.0);
+
+    SETEAS(&g, "EAS", 0, "Blue");
+    SETEAS(&g, "EAS", 2, "RED");
+
+    SETEAB(&g, "EAB", 0, 1);
+    SETEAB(&g, "EAB", 2, 0);
+
+    igraph_write_graph_dot(&g, stdout);
+    igraph_destroy(&g);
+
+    VERIFY_FINALLY_STACK();
+    return 0;
+}

--- a/tests/unit/igraph_write_graph_dot.out
+++ b/tests/unit/igraph_write_graph_dot.out
@@ -1,0 +1,74 @@
+/* Created by igraph @VERSION@ */
+graph {
+  0 [
+    VAN=-1
+    VAS=foo
+    VAB=1
+  ];
+  1 [
+    VAN=2.1
+    VAS=bar
+    VAB=0
+  ];
+  2 [
+    VAN=NaN
+    VAS=
+    VAB=0
+  ];
+  3 [
+    VAN=NaN
+    VAS=
+    VAB=0
+  ];
+  4 [
+    VAN=NaN
+    VAS=
+    VAB=0
+  ];
+  5 [
+    VAN=NaN
+    VAS=
+    VAB=0
+  ];
+
+  1 -- 0 [
+    EAN=-100.1
+    EAS=Blue
+    EAB=1
+  ];
+  2 -- 0 [
+    EAN=NaN
+    EAS=
+    EAB=0
+  ];
+  1 -- 1 [
+    EAN=100
+    EAS=RED
+    EAB=0
+  ];
+  3 -- 1 [
+    EAN=NaN
+    EAS=
+    EAB=0
+  ];
+  2 -- 0 [
+    EAN=NaN
+    EAS=
+    EAB=0
+  ];
+  3 -- 2 [
+    EAN=NaN
+    EAS=
+    EAB=0
+  ];
+  4 -- 3 [
+    EAN=NaN
+    EAS=
+    EAB=0
+  ];
+  4 -- 3 [
+    EAN=NaN
+    EAS=
+    EAB=0
+  ];
+}


### PR DESCRIPTION
There is also an example, but this test also tests the attributes.

Fix one: remove undefined behaviour on NaN
Fix two: do not read out of bounds if orig parameter in
igraph_i_dot_escape has length 0