### PR TITLE
Basic character entity support for GML reader/writer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -667,6 +667,9 @@ Some of the highlights are:
 
  - `igraph_incidence()` does not accept negative incidences anymore.
 
+ - `igraph_write_graph_gml()` takes an additional bitfield parameter controlling some aspects of writing
+   the GML file.
+
 ### Added
 
  - A new container type, `igraph_vector_list_t` has been added, replacing most uses of `igraph_vector_ptr_t` in the API. It contains `igraph_vector_t` objects, and it is fully memory managed (i.e. its contents do not need to be allocated and destroyed manually). There are specializations for all vector types, such as for `igraph_vector_int_list_t`.
@@ -716,6 +719,7 @@ Some of the highlights are:
  - `igraph_read_graph_gml()` now supports graph attributes (in addition to vertex and edge attributes).
  - `igraph_read_graph_gml()` now uses NaN as the default numerical attribute values instead of 0.
    `igraph_write_graph_gml()` skips writing NaN values. These two changes ensure consistent round-tripping.
+ - `igraph_write_graph_gml()` and `igraph_read_graph_gml()` now have limited support for entity encoding.
  - Foreign format readers now present more informative error messages.
  - `igraph_get_adjacency()` and `igraph_get_adjacency_sparse()` now counts loop edges _twice_ in undirected graphs when using `IGRAPH_GET_ADJACENCY_BOTH`. This is to ensure consistency with `IGRAPH_GET_ADJACENCY_UPPER` and `IGRAPH_GET_ADJACENCY_LOWER` such that the sum of the upper and the lower triangle matrix is equal to the full adjacency matrix even in the presence of loop edges.
 
@@ -729,6 +733,7 @@ Some of the highlights are:
  - The GML parser no longer mixes up Inf and NaN and -Inf now works.
  - The GML parser now supports nodes with no id field.
  - The GML parser now performs more stringent checks on the input file, such as verifying that `id`, `source`, `target` and `directed` fields are not duplicated.
+ - `igraph_write_graph_gml()` no longer produces corrupt output when some string attribute values contain `"` characters.
  - Graphs no longer lose all their attributes after calling `igraph_contract_vertices()`.
  - `igraph_matrix_complex_create()` and `igraph_matrix_complex_create_polar()` now set their sizes correctly.
  - The core data structures (vector, etc.) have overflow checks now.

--- a/examples/simple/cattributes2.c
+++ b/examples/simple/cattributes2.c
@@ -61,7 +61,7 @@ int main() {
      * print warnings about boolean attributes being converted to numbers, and
      * we don't care about these */
     oldwarnhandler = igraph_set_warning_handler(igraph_warning_handler_ignore);
-    igraph_write_graph_gml(&g, stdout, 0, "");
+    igraph_write_graph_gml(&g, stdout, IGRAPH_WRITE_GML_DEFAULT_SW, 0, "");
     igraph_set_warning_handler(oldwarnhandler);
 
     /* Back to business */

--- a/examples/simple/gml.c
+++ b/examples/simple/gml.c
@@ -44,7 +44,7 @@ int main() {
 
     /* Output as GML */
     printf("\n-----------------\n");
-    igraph_write_graph_gml(&graph, stdout, 0, "");
+    igraph_write_graph_gml(&graph, stdout,IGRAPH_WRITE_GML_DEFAULT_SW,  0, "");
 
     igraph_destroy(&graph);
 

--- a/examples/simple/safelocale.c
+++ b/examples/simple/safelocale.c
@@ -35,7 +35,7 @@ int main() {
         fprintf(stderr, "Reading %s failed.\n", filename);
         abort();
     }
-    igraph_write_graph_gml(&graph, stdout, NULL, "");
+    igraph_write_graph_gml(&graph, stdout, IGRAPH_WRITE_GML_DEFAULT_SW, NULL, "");
     igraph_exit_safelocale(&loc);
 
     igraph_destroy(&graph);

--- a/include/igraph_foreign.h
+++ b/include/igraph_foreign.h
@@ -69,6 +69,13 @@ IGRAPH_EXPORT igraph_error_t igraph_read_graph_gml(igraph_t *graph, FILE *instre
 IGRAPH_EXPORT igraph_error_t igraph_read_graph_dl(igraph_t *graph, FILE *instream,
                                        igraph_bool_t directed);
 
+typedef unsigned int igraph_write_gml_sw_t;
+
+enum {
+    IGRAPH_WRITE_GML_DEFAULT_SW          = 0x0, /* default settings */
+    IGRAPH_WRITE_GML_ENCODE_ONLY_QUOT_SW = 0x1  /* only encode " characters, nothing else */
+};
+
 IGRAPH_EXPORT igraph_error_t igraph_write_graph_edgelist(const igraph_t *graph, FILE *outstream);
 IGRAPH_EXPORT igraph_error_t igraph_write_graph_ncol(const igraph_t *graph, FILE *outstream,
                                           const char *names, const char *weights);
@@ -85,7 +92,8 @@ IGRAPH_EXPORT igraph_error_t igraph_write_graph_dimacs_flow(const igraph_t *grap
                                             igraph_integer_t source, igraph_integer_t target,
                                             const igraph_vector_t *capacity);
 IGRAPH_EXPORT igraph_error_t igraph_write_graph_gml(const igraph_t *graph, FILE *outstream,
-                                         const igraph_vector_t *id, const char *creator);
+                                                    igraph_write_gml_sw_t options,
+                                                    const igraph_vector_t *id, const char *creator);
 IGRAPH_EXPORT igraph_error_t igraph_write_graph_dot(const igraph_t *graph, FILE *outstream);
 IGRAPH_EXPORT igraph_error_t igraph_write_graph_leda(const igraph_t *graph, FILE *outstream,
                                           const char* vertex_attr_name, const char* edge_attr_name);

--- a/interfaces/functions.yaml
+++ b/interfaces/functions.yaml
@@ -1606,7 +1606,7 @@ igraph_write_graph_dimacs_flow:
         VECTOR capacity
 
 igraph_write_graph_gml:
-    PARAMS: GRAPH graph, OUTFILE outstream, VECTOR id, CSTRING creator="igraph"
+    PARAMS: GRAPH graph, OUTFILE outstream, WRITE_GML_SW options=DEFAULT, VECTOR id, CSTRING creator=NULL
 
 igraph_write_graph_dot:
     PARAMS: GRAPH graph, OUTFILE outstream

--- a/interfaces/types.yaml
+++ b/interfaces/types.yaml
@@ -471,6 +471,11 @@ EDGE_TYPE_SW:
     CTYPE: igraph_edge_type_sw_t
     FLAGS: BITS
 
+WRITE_GML_SW:
+    # Flag bitfield that specifies how to write GML files.
+    CTYPE: igraph_write_gml_sw_t
+    FLAGS: BITS
+
 ###############################################################################
 # Callbacks
 ###############################################################################

--- a/src/io/gml.c
+++ b/src/io/gml.c
@@ -28,7 +28,7 @@
 
 #include "core/trie.h"
 #include "graph/attributes.h"
-#include "internal/hacks.h" /* strdup */
+#include "internal/hacks.h" /* strdup, strncasecmp */
 #include "io/gml-header.h"
 
 #include <ctype.h>
@@ -39,6 +39,116 @@ int igraph_gml_yylex_init_extra(igraph_i_gml_parsedata_t *user_defined, void *sc
 void igraph_gml_yylex_destroy(void *scanner);
 int igraph_gml_yyparse(igraph_i_gml_parsedata_t *context);
 void igraph_gml_yyset_in(FILE *in_str, void *yyscanner);
+
+/* Checks if a null-terminated string needs encoding or decoding.
+ *
+ * Encoding is needed when an " or & character is present.
+ *
+ * Decoding is needed when an &xyz; style entity is present, so it's sufficient to look
+ * for & characters. " characters are never present in the raw strings returned by the
+ * GML parser, so we can use the same function to detect the need for either encoding
+ * or decoding.
+ */
+static igraph_bool_t needs_coding(const char *str) {
+    while (*str) {
+        if (*str == '&' || *str == '"') {
+            return 1;
+        }
+        str++;
+    }
+    return 0;
+}
+
+/* Encode & and " character in 'src' to &amp; and &quot;
+ * '*dest' must be deallocated by the caller.
+ */
+static igraph_error_t entity_encode(const char *src, char **dest) {
+    igraph_integer_t destlen = 0;
+    const char *s;
+    char *d;
+
+    for (s = src; *s != '\0'; s++, destlen++) {
+        switch (*s) {
+        case '&': /* &amp; */
+            destlen += 4; break;
+        case '"': /* &quot; */
+            destlen += 5; break;
+        }
+    }
+    *dest = IGRAPH_CALLOC(destlen + 1, char);
+    IGRAPH_CHECK_OOM(dest, "Not enough memory to encode string for GML export.");
+    for (s = src, d = *dest; *s != '\0'; s++, d++) {
+        switch (*s) {
+        case '&':
+            strcpy(d, "&amp;"); d += 4; break;
+        case '"':
+            strcpy(d, "&quot;"); d += 5; break;
+        default:
+            *d = *s;
+        }
+    }
+    *d = '\0';
+    return IGRAPH_SUCCESS;
+}
+
+/* Decode the five standard predefined XML entities. Unknown entities or stray & characters
+ * will be passed through unchanged. '*dest' must be deallocated by the caller.
+ * If '*warned' is false, warnings will be issued for unsupported entities and
+ * '*warned' will be set to true. This is to prevent a flood of warnings in some files.
+ */
+static igraph_error_t entity_decode(const char *src, char **dest, igraph_bool_t *warned) {
+    const char *entity_names[] = {
+        "&quot;", "&amp;", "&apos;", "&lt;", "&gt;"
+    };
+
+    const char entity_values[] = {
+        '"', '&', '\'', '<', '>'
+    };
+
+    const int entity_count = sizeof entity_values / sizeof entity_values[0];
+
+    const char *s;
+    char *d;
+    size_t len = strlen(src);
+    *dest = IGRAPH_CALLOC(len+1, char); /* at most as much storage needed as for 'src' */
+    IGRAPH_CHECK_OOM(dest, "Not enough memory to decode string during GML import.");
+
+    for (s = src, d = *dest; *s != '\0';) {
+        if (*s == '&') {
+            int i;
+            for (i=0; i < entity_count; i++) {
+                size_t entity_len = strlen(entity_names[i]);
+                if (!strncasecmp(s, entity_names[i], entity_len)) {
+                    *d++ = entity_values[i];
+                    s += entity_len;
+                    break;
+                }
+            }
+            /* None of the known entities match, report warning and pass through unchanged. */
+            if (i == entity_count) {
+                if (! *warned) {
+                    const int max_entity_name_length = 34;
+                    int j = 0;
+                    while (s[j] != '\0' && s[j] != ';' && j < max_entity_name_length) {
+                        j++;
+                    }
+                    if (s[j] == '\0' || j == max_entity_name_length) {
+                        IGRAPH_WARNING("Unterminated entity or stray & character found, will be returned verbatim.");
+                    } else {
+                        IGRAPH_WARNINGF("One or more unknown entities will be returned verbatim (%.*s).", j+1, s);
+                    }
+                    *warned = 1; /* warn only once */
+                }
+                *d++ = *s++;
+            }
+        } else {
+            *d++ = *s++;
+        }
+    }
+    *d = '\0';
+
+    return IGRAPH_SUCCESS;
+}
 
 static void igraph_i_gml_destroy_attrs(igraph_vector_ptr_t **ptr) {
     igraph_integer_t i;
@@ -275,7 +385,9 @@ static igraph_error_t allocate_attributes(igraph_vector_ptr_t *attrs,
  * \oli Top level attributes except for <code>Version</code> and the
  *      first <code>graph</code> attribute are completely ignored.
  * \oli There is no maximum line length or maximum keyword length.
- * \oli Character entities in strings are not interpreted.
+ * \oli Only the \c quot, \c amp, \c apos, \c lt and \c gt character entities
+ *      are supported. Any other entity is passed through unchanged by the reader
+ *      after issuing a warning, and is expected to be decoded by the user.
  * \oli We allow <code>inf</code>, <code>-inf</code> and <code>nan</code>
  *      (not a number) as a real number. This is case insensitive, so
  *      <code>nan</code>, <code>NaN</code> and <code>NAN</code> are equivalent.
@@ -315,6 +427,7 @@ igraph_error_t igraph_read_graph_gml(igraph_t *graph, FILE *instream) {
     igraph_vector_ptr_t *attrs[3];
     igraph_integer_t edgeptr = 0;
     igraph_i_gml_parsedata_t context;
+    igraph_bool_t entity_warned = 0; /* used to warn at most once about unsupported entities */
 
     attrs[0] = &gattrs; attrs[1] = &vattrs; attrs[2] = &eattrs;
 
@@ -578,7 +691,16 @@ igraph_error_t igraph_read_graph_gml(igraph_t *graph, FILE *instream) {
                 } else if (type == IGRAPH_ATTRIBUTE_STRING) {
                     igraph_strvector_t *v = (igraph_strvector_t *) atrec->value;
                     const char *value = igraph_i_gml_tostring(node, j);
-                    IGRAPH_CHECK(igraph_strvector_set(v, trie_id, value));
+                    if (needs_coding(value)) {
+                        char *value_decoded;
+                        IGRAPH_CHECK(entity_decode(value, &value_decoded, &entity_warned));
+                        IGRAPH_FINALLY(igraph_free, value_decoded);
+                        IGRAPH_CHECK(igraph_strvector_set(v, trie_id, value_decoded));
+                        IGRAPH_FREE(value_decoded);
+                        IGRAPH_FINALLY_CLEAN(1);
+                    } else {
+                        IGRAPH_CHECK(igraph_strvector_set(v, trie_id, value));
+                    }
                 } else {
                     /* Ignored composite attribute */
                 }
@@ -607,7 +729,16 @@ igraph_error_t igraph_read_graph_gml(igraph_t *graph, FILE *instream) {
                     } else if (type == IGRAPH_ATTRIBUTE_STRING) {
                         igraph_strvector_t *v = (igraph_strvector_t *) atrec->value;
                         const char *value = igraph_i_gml_tostring(edge, j);
-                        IGRAPH_CHECK(igraph_strvector_set(v, edgeid, value));
+                        if (needs_coding(value)) {
+                            char *value_decoded;
+                            IGRAPH_CHECK(entity_decode(value, &value_decoded, &entity_warned));
+                            IGRAPH_FINALLY(igraph_free, value_decoded);
+                            IGRAPH_CHECK(igraph_strvector_set(v, edgeid, value_decoded));
+                            IGRAPH_FREE(value_decoded);
+                            IGRAPH_FINALLY_CLEAN(1);
+                        } else {
+                            IGRAPH_CHECK(igraph_strvector_set(v, edgeid, value));
+                        }
                     } else {
                         /* Ignored composite attribute */
                     }
@@ -643,7 +774,16 @@ igraph_error_t igraph_read_graph_gml(igraph_t *graph, FILE *instream) {
             } else if (type == IGRAPH_ATTRIBUTE_STRING) {
                 igraph_strvector_t *v = (igraph_strvector_t *) atrec->value;
                 const char *value = igraph_i_gml_tostring(gtree, i);
-                IGRAPH_CHECK(igraph_strvector_set(v, 0, value));
+                if (needs_coding(value)) {
+                    char *value_decoded;
+                    IGRAPH_CHECK(entity_decode(value, &value_decoded, &entity_warned));
+                    IGRAPH_FINALLY(igraph_free, value_decoded);
+                    IGRAPH_CHECK(igraph_strvector_set(v, 0, value_decoded));
+                    IGRAPH_FREE(value_decoded);
+                    IGRAPH_FINALLY_CLEAN(1);
+                } else {
+                    IGRAPH_CHECK(igraph_strvector_set(v, 0, value));
+                }
             } else {
                 /* Ignored composite attribute */
             }
@@ -762,6 +902,7 @@ static igraph_error_t igraph_i_gml_convert_to_key(const char *orig, char **key) 
  * \param id Either <code>NULL</code> or a numeric vector with the vertex IDs.
  *        See details above.
  * \param creator An optional string to write to the stream in the creator line.
+ *        It must not contain the <code>"</code> character.
  *        If \c NULL, the igraph version with the current date and time is added.
  *        If <code>""</code>, the creator line is omitted. Otherwise, the
  *        supplied string is used verbatim.
@@ -905,7 +1046,16 @@ igraph_error_t igraph_write_graph_gml(const igraph_t *graph, FILE *outstream,
                 const char *s;
                 IGRAPH_CHECK(igraph_i_attribute_get_string_graph_attr(graph, name, &strv));
                 s = igraph_strvector_get(&strv, 0);
-                CHECK(fprintf(outstream, "  %s \"%s\"\n", newname, s));
+                if (needs_coding(s)) {
+                    char *d;
+                    IGRAPH_CHECK(entity_encode(s, &d));
+                    IGRAPH_FINALLY(igraph_free, d);
+                    CHECK(fprintf(outstream, "  %s \"%s\"\n", newname, d));
+                    IGRAPH_FREE(d);
+                    IGRAPH_FINALLY_CLEAN(1);
+                } else {
+                    CHECK(fprintf(outstream, "  %s \"%s\"\n", newname, s));
+                }
             } else if (VECTOR(gtypes)[i] == IGRAPH_ATTRIBUTE_BOOLEAN) {
                 IGRAPH_CHECK(igraph_i_attribute_get_bool_graph_attr(graph, name, &boolv));
                 CHECK(fprintf(outstream, "  %s %d\n", newname, VECTOR(boolv)[0] ? 1 : 0));
@@ -975,7 +1125,16 @@ igraph_error_t igraph_write_graph_gml(const igraph_t *graph, FILE *outstream,
                     IGRAPH_CHECK(igraph_i_attribute_get_string_vertex_attr(graph, name,
                                  igraph_vss_1(i), &strv));
                     s = igraph_strvector_get(&strv, 0);
-                    CHECK(fprintf(outstream, "    %s \"%s\"\n", newname, s));
+                    if (needs_coding(s)) {
+                        char *d;
+                        IGRAPH_CHECK(entity_encode(s, &d));
+                        IGRAPH_FINALLY(igraph_free, d);
+                        CHECK(fprintf(outstream, "    %s \"%s\"\n", newname, d));
+                        IGRAPH_FREE(d);
+                        IGRAPH_FINALLY_CLEAN(1);
+                    } else {
+                        CHECK(fprintf(outstream, "    %s \"%s\"\n", newname, s));
+                    }
                 } else if (type == IGRAPH_ATTRIBUTE_BOOLEAN) {
                     IGRAPH_CHECK(igraph_i_attribute_get_bool_vertex_attr(graph, name,
                                  igraph_vss_1(i), &boolv));
@@ -1038,7 +1197,16 @@ igraph_error_t igraph_write_graph_gml(const igraph_t *graph, FILE *outstream,
                     IGRAPH_CHECK(igraph_i_attribute_get_string_edge_attr(graph, name,
                                  igraph_ess_1(i), &strv));
                     s = igraph_strvector_get(&strv, 0);
-                    CHECK(fprintf(outstream, "    %s \"%s\"\n", newname, s));
+                    if (needs_coding(s)) {
+                        char *d;
+                        IGRAPH_CHECK(entity_encode(s, &d));
+                        IGRAPH_FINALLY(igraph_free, d);
+                        CHECK(fprintf(outstream, "    %s \"%s\"\n", newname, d));
+                        IGRAPH_FREE(d);
+                        IGRAPH_FINALLY_CLEAN(1);
+                    } else {
+                        CHECK(fprintf(outstream, "    %s \"%s\"\n", newname, s));
+                    }
                 } else if (type == IGRAPH_ATTRIBUTE_BOOLEAN) {
                     IGRAPH_CHECK(igraph_i_attribute_get_bool_edge_attr(graph, name,
                                  igraph_ess_1(i), &boolv));

--- a/tests/regression/bug_1814.c
+++ b/tests/regression/bug_1814.c
@@ -26,7 +26,7 @@ void test_igraph_to_undirected(igraph_to_undirected_t mode) {
     igraph_to_undirected(&g, mode, &comb);
     igraph_attribute_combination_destroy(&comb);
 
-    igraph_write_graph_gml(&g, stdout, 0, "");
+    igraph_write_graph_gml(&g, stdout, IGRAPH_WRITE_GML_DEFAULT_SW, 0, "");
 
     igraph_destroy(&g);
 

--- a/tests/unit/gml.c
+++ b/tests/unit/gml.c
@@ -36,7 +36,7 @@ void test_input(const char *filename) {
     printf("===== %s =====\n", filename);
 
     IGRAPH_ASSERT(igraph_read_graph_gml(&graph, ifile) == IGRAPH_SUCCESS);
-    IGRAPH_ASSERT(igraph_write_graph_gml(&graph, stdout, NULL, "igraph") == IGRAPH_SUCCESS);
+    IGRAPH_ASSERT(igraph_write_graph_gml(&graph, stdout, IGRAPH_WRITE_GML_DEFAULT_SW, NULL, "igraph") == IGRAPH_SUCCESS);
     igraph_destroy(&graph);
 
     VERIFY_FINALLY_STACK();

--- a/tests/unit/gml.out
+++ b/tests/unit/gml.out
@@ -38,7 +38,7 @@ graph
   [
     source 2
     target 5
-    label "edge label"
+    label "Tom &amp; Jerry's &quot;friendship&quot;"
     num1 Inf
   ]
 ]

--- a/tests/unit/gml.out
+++ b/tests/unit/gml.out
@@ -63,7 +63,7 @@ graph
   node
   [
     id 2
-    Foo "bar"
+    Foo "bar &amp; baz"
   ]
 ]
 ======================

--- a/tests/unit/graph1.gml
+++ b/tests/unit/graph1.gml
@@ -25,11 +25,11 @@ graph [
     ]
     node [ 
         id 5
-        c [ str "foo" ]
+        c [ str "bar" ]
     ]
     edge [
         source 2 target 5
-        label "edge label"
+        label "Tom &amp; Jerry&apos;s &quot;friendship&quot;"
 # The 'sou_rce' attribute will be ignored by the GML writer as it would conflict with
 # 'source' after stripping the '_' character.
         sou_rce 1.0

--- a/tests/unit/graph2.gml
+++ b/tests/unit/graph2.gml
@@ -6,6 +6,6 @@
 Version 3
 graph [
     directed 2
-    node [ ] node  [ ] node [ Foo "bar" ]
+    node [ ] node  [ ] node [ Foo "bar & baz" ]
     composite [ a 1 ]
 ]


### PR DESCRIPTION
`"` and `&` in string attributes values are now encoded to `&quot;` and `&amp;`, meaning that `"` no longer leads to corrupted (unreadable) GML files.

Decoding support is only added for [the five basic predefined entities](https://en.wikipedia.org/wiki/List_of_XML_and_HTML_character_entity_references#List_of_predefined_entities_in_XML).

Any other character entities or stray `&` characters are passed through unchanged, and left to be handled by the user. A warning is issued (at most once per read operation).

This means that if yEd writes an `&Eacute;` into a GML file, and this file is read in, then written back by igraph, we end up with `&amp;Eacute;` This is not ideal, but it's too complicated to deal with, and brings in a whole range of unpleasant issues, such as dealing with character encodings. What is the encoding of igraph string attribute values? We would need to make a decision about this before we can decode `&Eacute;`. (Yes, the GraphML reader is affected by this as well, and it produces consistent UTF-8: I documented this today.)