### PR TITLE
Add igraph_sparse_adjacency

### DIFF
--- a/include/igraph_constants.h
+++ b/include/igraph_constants.h
@@ -60,7 +60,7 @@ typedef enum { IGRAPH_RECIPROCITY_DEFAULT = 0,
              } igraph_reciprocity_t;
 
 typedef enum { IGRAPH_ADJ_DIRECTED = 0,
-               IGRAPH_ADJ_UNDIRECTED = 1, IGRAPH_ADJ_MAX = 1,
+               IGRAPH_ADJ_UNDIRECTED, IGRAPH_ADJ_MAX,
                IGRAPH_ADJ_UPPER, IGRAPH_ADJ_LOWER, IGRAPH_ADJ_MIN,
                IGRAPH_ADJ_PLUS
              } igraph_adjacency_t;

--- a/include/igraph_constants.h
+++ b/include/igraph_constants.h
@@ -60,9 +60,10 @@ typedef enum { IGRAPH_RECIPROCITY_DEFAULT = 0,
              } igraph_reciprocity_t;
 
 typedef enum { IGRAPH_ADJ_DIRECTED = 0,
-               IGRAPH_ADJ_UNDIRECTED, IGRAPH_ADJ_MAX,
+               IGRAPH_ADJ_UNDIRECTED,
                IGRAPH_ADJ_UPPER, IGRAPH_ADJ_LOWER, IGRAPH_ADJ_MIN,
-               IGRAPH_ADJ_PLUS
+               IGRAPH_ADJ_PLUS,
+               IGRAPH_ADJ_MAX,
              } igraph_adjacency_t;
 
 typedef enum { IGRAPH_STAR_OUT = 0, IGRAPH_STAR_IN,

--- a/include/igraph_constructors.h
+++ b/include/igraph_constructors.h
@@ -30,6 +30,7 @@
 #include "igraph_matrix.h"
 #include "igraph_datatype.h"
 #include "igraph_graphicality.h"
+#include "igraph_sparsemat.h"
 
 __BEGIN_DECLS
 
@@ -47,6 +48,7 @@ IGRAPH_EXPORT igraph_error_t igraph_adjacency(
 IGRAPH_EXPORT igraph_error_t igraph_weighted_adjacency(
         igraph_t *graph, const igraph_matrix_t *adjmatrix, igraph_adjacency_t mode,
         igraph_vector_t *weights, igraph_loops_t loops);
+IGRAPH_EXPORT igraph_error_t igraph_sparse_adjacency(igraph_t *graph, igraph_sparsemat_t *adjmatrix, igraph_adjacency_t mode, igraph_loops_t loops);
 IGRAPH_EXPORT igraph_error_t igraph_star(igraph_t *graph, igraph_integer_t n, igraph_star_mode_t mode,
                               igraph_integer_t center);
 IGRAPH_EXPORT igraph_error_t igraph_wheel(igraph_t *graph, igraph_integer_t n, igraph_wheel_mode_t mode,

--- a/include/igraph_constructors.h
+++ b/include/igraph_constructors.h
@@ -49,6 +49,7 @@ IGRAPH_EXPORT igraph_error_t igraph_weighted_adjacency(
         igraph_t *graph, const igraph_matrix_t *adjmatrix, igraph_adjacency_t mode,
         igraph_vector_t *weights, igraph_loops_t loops);
 IGRAPH_EXPORT igraph_error_t igraph_sparse_adjacency(igraph_t *graph, igraph_sparsemat_t *adjmatrix, igraph_adjacency_t mode, igraph_loops_t loops);
+IGRAPH_EXPORT igraph_error_t igraph_sparse_weighted_adjacency(igraph_t *graph, igraph_sparsemat_t *adjmatrix, igraph_adjacency_t mode, igraph_vector_t *weights,igraph_loops_t loops);
 IGRAPH_EXPORT igraph_error_t igraph_star(igraph_t *graph, igraph_integer_t n, igraph_star_mode_t mode,
                               igraph_integer_t center);
 IGRAPH_EXPORT igraph_error_t igraph_wheel(igraph_t *graph, igraph_integer_t n, igraph_wheel_mode_t mode,

--- a/src/constructors/adjacency.c
+++ b/src/constructors/adjacency.c
@@ -1129,6 +1129,18 @@ static igraph_error_t igraph_i_sparse_adjacency_undirected(
     return IGRAPH_SUCCESS;
 }
 
+/**
+ * \ingroup generators
+ * \function igraph_sparse_adjacency
+ * \brief Creates a graph from a sparse adjacency matrix.
+ *
+ * This has the same functionality as \ref igraph_adjacency(), but uses
+ * a column-compressed adjacency matrix.
+ *
+ * Time complexity: O(|E|),
+ * where |E| is the number of edges in the graph.
+ */
+
 igraph_error_t igraph_sparse_adjacency(igraph_t *graph, igraph_sparsemat_t *adjmatrix,
         igraph_adjacency_t mode, igraph_loops_t loops) {
 
@@ -1407,6 +1419,18 @@ static igraph_error_t igraph_i_sparse_weighted_adjacency_directed(
     return IGRAPH_SUCCESS;
 }
 
+/**
+ * \ingroup generators
+ * \function igraph_sparse_weighted_adjacency
+ * \brief Creates a graph from a weighted sparse adjacency matrix.
+ *
+ * This has the same functionality as \ref igraph_weighted_adjacency(), but uses
+ * a column-compressed adjacency matrix.
+ *
+ * Time complexity: O(|E|),
+ * where |E| is the number of edges in the graph.
+ */
+
 
 igraph_error_t igraph_sparse_weighted_adjacency(
     igraph_t *graph, igraph_sparsemat_t *adjmatrix, igraph_adjacency_t mode,
@@ -1418,9 +1442,17 @@ igraph_error_t igraph_sparse_weighted_adjacency(
         no_of_edges *= igraph_sparsemat_max(adjmatrix);
     }
     CS_INT no_of_nodes = adjmatrix->cs->m;
-    /* Some checks */
-    if (igraph_sparsemat_nrow(adjmatrix) != igraph_sparsemat_ncol(adjmatrix)) {
-        IGRAPH_ERROR("Non-square matrix", IGRAPH_NONSQUARE);
+
+    if (!igraph_sparsemat_is_cc(adjmatrix)) {
+        IGRAPH_ERROR("Sparse adjacency matrix should be in column-compressed "
+               "form.", IGRAPH_EINVAL);
+    }
+    if (no_of_nodes != adjmatrix->cs->n) {
+        IGRAPH_ERROR("Adjacency matrix is non-square.", IGRAPH_NONSQUARE);
+    }
+    if (no_of_nodes != 0 && igraph_sparsemat_min(adjmatrix) < 0) {
+        IGRAPH_ERRORF("Edge counts should be non-negative, found %g.", IGRAPH_EINVAL,
+                igraph_sparsemat_min(adjmatrix));
     }
 
     IGRAPH_VECTOR_INT_INIT_FINALLY(&edges, no_of_edges * 2);

--- a/src/constructors/adjacency.c
+++ b/src/constructors/adjacency.c
@@ -908,20 +908,20 @@ static igraph_error_t igraph_i_sparse_adjacency_directed(
     CS_INT *p = adjmatrix->cs->p;
     CS_INT *i = adjmatrix->cs->i;
     CS_INT no_of_edges = adjmatrix->cs->p[adjmatrix->cs->n];
-    igraph_integer_t to = 0;
+    igraph_integer_t from = 0;
     igraph_integer_t e = 0;
     CS_ENTRY *entry = adjmatrix->cs->x;
 
-    for (igraph_integer_t from = 0; p[from] < no_of_edges; from++) {
-        for (; to < p[from + 1]; to++) {
-            igraph_integer_t multi = entry[to];
-            if (from == i[to]) {
+    for (igraph_integer_t to = 0; p[to] < no_of_edges; to++) {
+        for (; from < p[to + 1]; from++) {
+            igraph_integer_t multi = entry[from];
+            if (to == i[from]) {
                 IGRAPH_CHECK(igraph_i_adjust_loop_edge_count(&multi, loops));
             }
             for (igraph_integer_t count = 0; count < multi; count++) {
                 //TODO edge directions are reverse of igraph_sparsemat(), why?
-                VECTOR(*edges)[e++] = i[to];
-                VECTOR(*edges)[e++] = from;
+                VECTOR(*edges)[e++] = i[from];
+                VECTOR(*edges)[e++] = to;
             }
         }
     }
@@ -937,26 +937,26 @@ static igraph_error_t igraph_i_sparse_adjacency_max(
     CS_INT *p = adjmatrix->cs->p;
     CS_INT *i = adjmatrix->cs->i;
     CS_INT no_of_edges = adjmatrix->cs->p[adjmatrix->cs->n];
-    igraph_integer_t to = 0;
+    igraph_integer_t from = 0;
     igraph_integer_t e = 0;
     CS_ENTRY *entry = adjmatrix->cs->x;
 
-    for (igraph_integer_t from = 0; p[from] < no_of_edges; from++) {
-        for (; to < p[from + 1]; to++) {
-            if (from >= i[to]) {
+    for (igraph_integer_t to = 0; p[to] < no_of_edges; to++) {
+        for (; from < p[to + 1]; from++) {
+            if (to >= i[from]) {
                 igraph_real_t other;
                 igraph_vector_int_t x, y;
-                igraph_vector_int_view(&x, &from, 1);
-                igraph_vector_int_view(&y, &i[to], 1);
+                igraph_vector_int_view(&x, &to, 1);
+                igraph_vector_int_view(&y, &i[from], 1);
                 igraph_sparsemat_index(adjmatrix, &x, &y, NULL, &other);
-                igraph_integer_t multi = entry[to] > other ? entry[to] : other;
-                if (from == i[to]) {
+                igraph_integer_t multi = entry[from] > other ? entry[from] : other;
+                if (to == i[from]) {
                     IGRAPH_CHECK(igraph_i_adjust_loop_edge_count(&multi, loops));
                 }
                 for (igraph_integer_t count = 0; count < multi; count++) {
                     //edge directions are reverse of igraph_sparsemat()
-                    VECTOR(*edges)[e++] = i[to];
-                    VECTOR(*edges)[e++] = from;
+                    VECTOR(*edges)[e++] = i[from];
+                    VECTOR(*edges)[e++] = to;
                 }
             }
         }
@@ -973,26 +973,26 @@ static igraph_error_t igraph_i_sparse_adjacency_min(
     CS_INT *p = adjmatrix->cs->p;
     CS_INT *i = adjmatrix->cs->i;
     CS_INT no_of_edges = adjmatrix->cs->p[adjmatrix->cs->n];
-    igraph_integer_t to = 0;
+    igraph_integer_t from = 0;
     igraph_integer_t e = 0;
     CS_ENTRY *entry = adjmatrix->cs->x;
 
-    for (igraph_integer_t from = 0; p[from] < no_of_edges; from++) {
-        for (; to < p[from + 1]; to++) {
-            if (from >= i[to]) {
+    for (igraph_integer_t to = 0; p[to] < no_of_edges; to++) {
+        for (; from < p[to + 1]; from++) {
+            if (to >= i[from]) {
                 igraph_real_t other;
                 igraph_vector_int_t x, y;
-                igraph_vector_int_view(&x, &from, 1);
-                igraph_vector_int_view(&y, &i[to], 1);
+                igraph_vector_int_view(&x, &to, 1);
+                igraph_vector_int_view(&y, &i[from], 1);
                 igraph_sparsemat_index(adjmatrix, &x, &y, NULL, &other);
-                igraph_integer_t multi = entry[to] < other ? entry[to] : other;
-                if (from == i[to]) {
+                igraph_integer_t multi = entry[from] < other ? entry[from] : other;
+                if (to == i[from]) {
                     IGRAPH_CHECK(igraph_i_adjust_loop_edge_count(&multi, loops));
                 }
                 for (igraph_integer_t count = 0; count < multi; count++) {
                     //edge directions are reverse of igraph_sparsemat()
-                    VECTOR(*edges)[e++] = i[to];
-                    VECTOR(*edges)[e++] = from;
+                    VECTOR(*edges)[e++] = i[from];
+                    VECTOR(*edges)[e++] = to;
                 }
             }
         }
@@ -1009,26 +1009,26 @@ static igraph_error_t igraph_i_sparse_adjacency_plus(
     CS_INT *p = adjmatrix->cs->p;
     CS_INT *i = adjmatrix->cs->i;
     CS_INT no_of_edges = adjmatrix->cs->p[adjmatrix->cs->n];
-    igraph_integer_t to = 0;
+    igraph_integer_t from = 0;
     igraph_integer_t e = 0;
     CS_ENTRY *entry = adjmatrix->cs->x;
 
-    for (igraph_integer_t from = 0; p[from] < no_of_edges; from++) {
-        for (; to < p[from + 1]; to++) {
-            if (from >= i[to]) {
+    for (igraph_integer_t to = 0; p[to] < no_of_edges; to++) {
+        for (; from < p[to + 1]; from++) {
+            if (to >= i[from]) {
                 igraph_real_t other;
                 igraph_vector_int_t x, y;
-                igraph_vector_int_view(&x, &from, 1);
+                igraph_vector_int_view(&x, &to, 1);
                 igraph_vector_int_view(&y, i, 1);
                 igraph_sparsemat_index(adjmatrix, &x, &y, NULL, &other);
-                igraph_integer_t multi = entry[to] + other;
-                if (from == i[to]) {
+                igraph_integer_t multi = entry[from] + other;
+                if (to == i[from]) {
                     IGRAPH_CHECK(igraph_i_adjust_loop_edge_count(&multi, loops));
                 }
                 for (igraph_integer_t count = 0; count < multi; count++) {
                     //edge directions are reverse of igraph_sparsemat()
-                    VECTOR(*edges)[e++] = i[to];
-                    VECTOR(*edges)[e++] = from;
+                    VECTOR(*edges)[e++] = i[from];
+                    VECTOR(*edges)[e++] = to;
                 }
             }
         }
@@ -1045,21 +1045,21 @@ static igraph_error_t igraph_i_sparse_adjacency_upper(
     CS_INT *p = adjmatrix->cs->p;
     CS_INT *i = adjmatrix->cs->i;
     CS_INT no_of_edges = adjmatrix->cs->p[adjmatrix->cs->n];
-    igraph_integer_t to = 0;
+    igraph_integer_t from = 0;
     igraph_integer_t e = 0;
     CS_ENTRY *entry = adjmatrix->cs->x;
 
-    for (igraph_integer_t from = 0; p[from] < no_of_edges; from++) {
-        for (; to < p[from + 1]; to++) {
-            if (from >= i[to]) {
-                igraph_integer_t multi = entry[to];
-                if (from == i[to]) {
+    for (igraph_integer_t to = 0; p[to] < no_of_edges; to++) {
+        for (; from < p[to + 1]; from++) {
+            if (to >= i[from]) {
+                igraph_integer_t multi = entry[from];
+                if (to == i[from]) {
                     IGRAPH_CHECK(igraph_i_adjust_loop_edge_count(&multi, loops));
                 }
                 for (igraph_integer_t count = 0; count < multi; count++) {
                     //edge directions are reverse of igraph_sparsemat()
-                    VECTOR(*edges)[e++] = i[to];
-                    VECTOR(*edges)[e++] = from;
+                    VECTOR(*edges)[e++] = i[from];
+                    VECTOR(*edges)[e++] = to;
                 }
             }
         }
@@ -1077,21 +1077,21 @@ static igraph_error_t igraph_i_sparse_adjacency_lower(
     CS_INT *p = adjmatrix->cs->p;
     CS_INT *i = adjmatrix->cs->i;
     CS_INT no_of_edges = adjmatrix->cs->p[adjmatrix->cs->n];
-    igraph_integer_t to = 0;
+    igraph_integer_t from = 0;
     igraph_integer_t e = 0;
     CS_ENTRY *entry = adjmatrix->cs->x;
 
-    for (igraph_integer_t from = 0; p[from] < no_of_edges; from++) {
-        for (; to < p[from + 1]; to++) {
-            if (from <= i[to]) {
-                igraph_integer_t multi = entry[to];
-                if (from == i[to]) {
+    for (igraph_integer_t to = 0; p[to] < no_of_edges; to++) {
+        for (; from < p[to + 1]; from++) {
+            if (to <= i[from]) {
+                igraph_integer_t multi = entry[from];
+                if (to == i[from]) {
                     IGRAPH_CHECK(igraph_i_adjust_loop_edge_count(&multi, loops));
                 }
                 for (igraph_integer_t count = 0; count < multi; count++) {
                     //edge directions are reverse of igraph_sparsemat()
-                    VECTOR(*edges)[e++] = i[to];
-                    VECTOR(*edges)[e++] = from;
+                    VECTOR(*edges)[e++] = i[from];
+                    VECTOR(*edges)[e++] = to;
                 }
             }
         }
@@ -1108,7 +1108,7 @@ static igraph_error_t igraph_i_sparse_adjacency_undirected(
     CS_INT *p = adjmatrix->cs->p;
     CS_INT *i = adjmatrix->cs->i;
     CS_INT no_of_edges = adjmatrix->cs->p[adjmatrix->cs->n];
-    igraph_integer_t to = 0;
+    igraph_integer_t from = 0;
     igraph_integer_t e = 0;
     CS_ENTRY *entry = adjmatrix->cs->x;
 
@@ -1116,16 +1116,16 @@ static igraph_error_t igraph_i_sparse_adjacency_undirected(
         IGRAPH_ERROR("Adjacency matrix should be symmetric for IGRAPH_ADJ_UNDIRECTED.",
                 IGRAPH_EINVAL);
     }
-    for (igraph_integer_t from = 0; p[from] < no_of_edges; from++) {
-        for (; to < p[from + 1]; to++) {
-            if (from >= i[to]) {
-                igraph_integer_t multi = entry[to];
-                if (from == i[to]) {
+    for (igraph_integer_t to = 0; p[to] < no_of_edges; to++) {
+        for (; from < p[to + 1]; from++) {
+            if (to >= i[from]) {
+                igraph_integer_t multi = entry[from];
+                if (to == i[from]) {
                     IGRAPH_CHECK(igraph_i_adjust_loop_edge_count(&multi, loops));
                 }
                 for (igraph_integer_t count = 0; count < multi; count++) {
-                    VECTOR(*edges)[e++] = i[to];
-                    VECTOR(*edges)[e++] = from;
+                    VECTOR(*edges)[e++] = i[from];
+                    VECTOR(*edges)[e++] = to;
                 }
             }
         }
@@ -1201,26 +1201,26 @@ static igraph_error_t igraph_i_sparse_weighted_adjacency_max (
     CS_INT *p = adjmatrix->cs->p;
     CS_INT *i = adjmatrix->cs->i;
     CS_INT no_of_edges = adjmatrix->cs->p[adjmatrix->cs->n];
-    igraph_integer_t to = 0;
+    igraph_integer_t from = 0;
     igraph_integer_t e = 0;
     CS_ENTRY *entry = adjmatrix->cs->x;
 
-    for (igraph_integer_t from = 0; p[from] < no_of_edges; from++) {
-        for (; to < p[from + 1]; to++) {
-            if (from >= i[to]) {
+    for (igraph_integer_t to = 0; p[to] < no_of_edges; to++) {
+        for (; from < p[to + 1]; from++) {
+            if (to >= i[from]) {
                 igraph_real_t other;
                 igraph_vector_int_t x, y;
-                igraph_vector_int_view(&x, &from, 1);
-                igraph_vector_int_view(&y, &i[to], 1);
+                igraph_vector_int_view(&x, &to, 1);
+                igraph_vector_int_view(&y, &i[from], 1);
                 igraph_sparsemat_index(adjmatrix, &x, &y, NULL, &other);
-                igraph_real_t weight = entry[to] > other ? entry[to] : other;
-                if (from == i[to]) {
+                igraph_real_t weight = entry[from] > other ? entry[from] : other;
+                if (to == i[from]) {
                     igraph_i_adjust_loop_edge_weight(&weight, loops);
                 }
                 if (weight != 0) {
                     VECTOR(*weights)[e/2] = weight;
-                    VECTOR(*edges)[e++] = i[to];
-                    VECTOR(*edges)[e++] = from;
+                    VECTOR(*edges)[e++] = i[from];
+                    VECTOR(*edges)[e++] = to;
                 }
             }
         }
@@ -1237,26 +1237,26 @@ static igraph_error_t igraph_i_sparse_weighted_adjacency_min (
     CS_INT *p = adjmatrix->cs->p;
     CS_INT *i = adjmatrix->cs->i;
     CS_INT no_of_edges = adjmatrix->cs->p[adjmatrix->cs->n];
-    igraph_integer_t to = 0;
+    igraph_integer_t from = 0;
     igraph_integer_t e = 0;
     CS_ENTRY *entry = adjmatrix->cs->x;
 
-    for (igraph_integer_t from = 0; p[from] < no_of_edges; from++) {
-        for (; to < p[from + 1]; to++) {
-            if (from >= i[to]) {
+    for (igraph_integer_t to = 0; p[to] < no_of_edges; to++) {
+        for (; from < p[to + 1]; from++) {
+            if (to >= i[from]) {
                 igraph_real_t other;
                 igraph_vector_int_t x, y;
-                igraph_vector_int_view(&x, &from, 1);
-                igraph_vector_int_view(&y, &i[to], 1);
+                igraph_vector_int_view(&x, &to, 1);
+                igraph_vector_int_view(&y, &i[from], 1);
                 igraph_sparsemat_index(adjmatrix, &x, &y, NULL, &other);
-                igraph_real_t weight = entry[to] < other ? entry[to] : other;
-                if (from == i[to]) {
+                igraph_real_t weight = entry[from] < other ? entry[from] : other;
+                if (to == i[from]) {
                     igraph_i_adjust_loop_edge_weight(&weight, loops);
                 }
                 if (weight != 0) {
                     VECTOR(*weights)[e/2] = weight;
-                    VECTOR(*edges)[e++] = i[to];
-                    VECTOR(*edges)[e++] = from;
+                    VECTOR(*edges)[e++] = i[from];
+                    VECTOR(*edges)[e++] = to;
                 }
             }
         }
@@ -1274,29 +1274,29 @@ static igraph_error_t igraph_i_sparse_weighted_adjacency_plus (
     CS_INT *p = adjmatrix->cs->p;
     CS_INT *i = adjmatrix->cs->i;
     CS_INT no_of_edges = adjmatrix->cs->p[adjmatrix->cs->n];
-    igraph_integer_t to = 0;
+    igraph_integer_t from = 0;
     igraph_integer_t e = 0;
     CS_ENTRY *entry = adjmatrix->cs->x;
 
-    for (igraph_integer_t from = 0; p[from] < no_of_edges; from++) {
-        for (; to < p[from + 1]; to++) {
-            if (from >= i[to]) {
-                igraph_real_t weight = entry[to];
-                if (from != i[to]) {
+    for (igraph_integer_t to = 0; p[to] < no_of_edges; to++) {
+        for (; from < p[to + 1]; from++) {
+            if (to >= i[from]) {
+                igraph_real_t weight = entry[from];
+                if (to != i[from]) {
                     igraph_real_t other;
                     igraph_vector_int_t x, y;
-                    igraph_vector_int_view(&x, &from, 1);
-                    igraph_vector_int_view(&y, &i[to], 1);
+                    igraph_vector_int_view(&x, &to, 1);
+                    igraph_vector_int_view(&y, &i[from], 1);
                     igraph_sparsemat_index(adjmatrix, &x, &y, NULL, &other);
                     weight += other;
                 }
-                if (from == i[to]) {
+                if (to == i[from]) {
                     igraph_i_adjust_loop_edge_weight(&weight, loops);
                 }
                 if (weight != 0) {
                     VECTOR(*weights)[e/2] = weight;
-                    VECTOR(*edges)[e++] = i[to];
-                    VECTOR(*edges)[e++] = from;
+                    VECTOR(*edges)[e++] = i[from];
+                    VECTOR(*edges)[e++] = to;
                 }
             }
         }
@@ -1312,7 +1312,7 @@ static igraph_error_t igraph_i_sparse_weighted_adjacency_undirected (
     igraph_vector_t *weights, igraph_loops_t loops
 ) {
     if (!igraph_sparsemat_is_symmetric(adjmatrix)) {
-        IGRAPH_ERROR("Adjacency matrix should be symmetric to produce an undirected graph.",
+        IGRAPH_ERROR("Adjacency matrix should be symmetric from produce an undirected graph.",
                 IGRAPH_EINVAL);
     }
     return igraph_i_sparse_weighted_adjacency_max(adjmatrix, edges, weights, loops);
@@ -1325,21 +1325,21 @@ static igraph_error_t igraph_i_sparse_weighted_adjacency_upper(
     CS_INT *p = adjmatrix->cs->p;
     CS_INT *i = adjmatrix->cs->i;
     CS_INT no_of_edges = adjmatrix->cs->p[adjmatrix->cs->n];
-    igraph_integer_t to = 0;
+    igraph_integer_t from = 0;
     igraph_integer_t e = 0;
     CS_ENTRY *entry = adjmatrix->cs->x;
 
-    for (igraph_integer_t from = 0; p[from] < no_of_edges; from++) {
-        for (; to < p[from + 1]; to++) {
-            if (from >= i[to]) {
-                igraph_real_t weight = entry[to];
-                if (from == i[to]) {
+    for (igraph_integer_t to = 0; p[to] < no_of_edges; to++) {
+        for (; from < p[to + 1]; from++) {
+            if (to >= i[from]) {
+                igraph_real_t weight = entry[from];
+                if (to == i[from]) {
                     igraph_i_adjust_loop_edge_weight(&weight, loops);
                 }
                 if (weight != 0) {
                     VECTOR(*weights)[e/2] = weight;
-                    VECTOR(*edges)[e++] = i[to];
-                    VECTOR(*edges)[e++] = from;
+                    VECTOR(*edges)[e++] = i[from];
+                    VECTOR(*edges)[e++] = to;
                 }
             }
         }
@@ -1357,22 +1357,22 @@ static igraph_error_t igraph_i_sparse_weighted_adjacency_lower(
     CS_INT *p = adjmatrix->cs->p;
     CS_INT *i = adjmatrix->cs->i;
     CS_INT no_of_edges = adjmatrix->cs->p[adjmatrix->cs->n];
-    igraph_integer_t to = 0;
+    igraph_integer_t from = 0;
     igraph_integer_t e = 0;
     CS_ENTRY *entry = adjmatrix->cs->x;
 
-    for (igraph_integer_t from = 0; p[from] < no_of_edges; from++) {
-        for (; to < p[from + 1]; to++) {
-            if (from <= i[to]) {
-                igraph_real_t weight = entry[to];
-                if (from == i[to]) {
+    for (igraph_integer_t to = 0; p[to] < no_of_edges; to++) {
+        for (; from < p[to + 1]; from++) {
+            if (to <= i[from]) {
+                igraph_real_t weight = entry[from];
+                if (to == i[from]) {
                     igraph_i_adjust_loop_edge_weight(&weight, loops);
                 }
 
                 if (weight != 0) {
                     VECTOR(*weights)[e/2] = weight;
-                    VECTOR(*edges)[e++] = i[to];
-                    VECTOR(*edges)[e++] = from;
+                    VECTOR(*edges)[e++] = i[from];
+                    VECTOR(*edges)[e++] = to;
                 }
             }
         }
@@ -1390,20 +1390,20 @@ static igraph_error_t igraph_i_sparse_weighted_adjacency_directed(
     CS_INT *p = adjmatrix->cs->p;
     CS_INT *i = adjmatrix->cs->i;
     CS_INT no_of_edges = adjmatrix->cs->p[adjmatrix->cs->n];
-    igraph_integer_t to = 0;
+    igraph_integer_t from = 0;
     igraph_integer_t e = 0;
     CS_ENTRY *entry = adjmatrix->cs->x;
 
-    for (igraph_integer_t from = 0; p[from] < no_of_edges; from++) {
-        for (; to < p[from + 1]; to++) {
-            igraph_real_t weight = entry[to];
-            if (from == i[to]) {
+    for (igraph_integer_t to = 0; p[to] < no_of_edges; to++) {
+        for (; from < p[to + 1]; from++) {
+            igraph_real_t weight = entry[from];
+            if (to == i[from]) {
                 igraph_i_adjust_loop_edge_weight(&weight, loops);
             }
             if (weight != 0) {
                 VECTOR(*weights)[e/2] = weight;
-                VECTOR(*edges)[e++] = i[to];
-                VECTOR(*edges)[e++] = from;
+                VECTOR(*edges)[e++] = i[from];
+                VECTOR(*edges)[e++] = to;
             }
         }
     }

--- a/src/constructors/adjacency.c
+++ b/src/constructors/adjacency.c
@@ -913,23 +913,20 @@ static igraph_error_t igraph_i_sparse_adjacency_directed(
     igraph_integer_t e = 0;
     CS_ENTRY *entry = adjmatrix->cs->x;
 
-    while (*p < no_of_edges) {
-        while (to < * (p + 1)) {
-            igraph_integer_t multi = *entry;
-            if (from == *i) {
+    while (p[from] < no_of_edges) {
+        while (to < p[from + 1]) {
+            igraph_integer_t multi = entry[to];
+            if (from == i[to]) {
                 IGRAPH_CHECK(igraph_i_adjust_loop_edge_count(&multi, loops));
             }
             for (igraph_integer_t count = 0; count < multi; count++) {
                 //TODO edge directions are reverse of igraph_sparsemat(), why?
-                VECTOR(*edges)[e++] = (*i);
+                VECTOR(*edges)[e++] = i[to];
                 VECTOR(*edges)[e++] = from;
             }
             to++;
-            i++;
-            entry++;
         }
         from++;
-        p++;
     }
     igraph_vector_int_resize(edges, e);
 
@@ -948,30 +945,27 @@ static igraph_error_t igraph_i_sparse_adjacency_max(
     igraph_integer_t e = 0;
     CS_ENTRY *entry = adjmatrix->cs->x;
 
-    while (*p < no_of_edges) {
-        while (to < * (p + 1)) {
-            if (from >= *i) {
+    while (p[from] < no_of_edges) {
+        while (to < p[from + 1]) {
+            if (from >= i[to]) {
                 igraph_real_t other;
                 igraph_vector_int_t x, y;
                 igraph_vector_int_view(&x, &from, 1);
-                igraph_vector_int_view(&y, i, 1);
+                igraph_vector_int_view(&y, &i[to], 1);
                 igraph_sparsemat_index(adjmatrix, &x, &y, NULL, &other);
-                igraph_integer_t multi = *entry > other ? *entry : other;
-                if (from == *i) {
+                igraph_integer_t multi = entry[to] > other ? entry[to] : other;
+                if (from == i[to]) {
                     IGRAPH_CHECK(igraph_i_adjust_loop_edge_count(&multi, loops));
                 }
                 for (igraph_integer_t count = 0; count < multi; count++) {
                     //edge directions are reverse of igraph_sparsemat()
-                    VECTOR(*edges)[e++] = (*i);
+                    VECTOR(*edges)[e++] = i[to];
                     VECTOR(*edges)[e++] = from;
                 }
             }
             to++;
-            i++;
-            entry++;
         }
         from++;
-        p++;
     }
     igraph_vector_int_resize(edges, e);
 
@@ -990,30 +984,27 @@ static igraph_error_t igraph_i_sparse_adjacency_min(
     igraph_integer_t e = 0;
     CS_ENTRY *entry = adjmatrix->cs->x;
 
-    while (*p < no_of_edges) {
-        while (to < * (p + 1)) {
-            if (from >= *i) {
+    while (p[from] < no_of_edges) {
+        while (to < p[from + 1]) {
+            if (from >= i[to]) {
                 igraph_real_t other;
                 igraph_vector_int_t x, y;
                 igraph_vector_int_view(&x, &from, 1);
-                igraph_vector_int_view(&y, i, 1);
+                igraph_vector_int_view(&y, &i[to], 1);
                 igraph_sparsemat_index(adjmatrix, &x, &y, NULL, &other);
-                igraph_integer_t multi = *entry < other ? *entry : other;
-                if (from == *i) {
+                igraph_integer_t multi = entry[to] < other ? entry[to] : other;
+                if (from == i[to]) {
                     IGRAPH_CHECK(igraph_i_adjust_loop_edge_count(&multi, loops));
                 }
                 for (igraph_integer_t count = 0; count < multi; count++) {
                     //edge directions are reverse of igraph_sparsemat()
-                    VECTOR(*edges)[e++] = (*i);
+                    VECTOR(*edges)[e++] = i[to];
                     VECTOR(*edges)[e++] = from;
                 }
             }
             to++;
-            i++;
-            entry++;
         }
         from++;
-        p++;
     }
     igraph_vector_int_resize(edges, e);
 
@@ -1032,30 +1023,27 @@ static igraph_error_t igraph_i_sparse_adjacency_plus(
     igraph_integer_t e = 0;
     CS_ENTRY *entry = adjmatrix->cs->x;
 
-    while (*p < no_of_edges) {
-        while (to < * (p + 1)) {
-            if (from >= *i) {
+    while (p[from] < no_of_edges) {
+        while (to < p[from + 1]) {
+            if (from >= i[to]) {
                 igraph_real_t other;
                 igraph_vector_int_t x, y;
                 igraph_vector_int_view(&x, &from, 1);
                 igraph_vector_int_view(&y, i, 1);
                 igraph_sparsemat_index(adjmatrix, &x, &y, NULL, &other);
-                igraph_integer_t multi = *entry + other;
-                if (from == *i) {
+                igraph_integer_t multi = entry[to] + other;
+                if (from == i[to]) {
                     IGRAPH_CHECK(igraph_i_adjust_loop_edge_count(&multi, loops));
                 }
                 for (igraph_integer_t count = 0; count < multi; count++) {
                     //edge directions are reverse of igraph_sparsemat()
-                    VECTOR(*edges)[e++] = (*i);
+                    VECTOR(*edges)[e++] = i[to];
                     VECTOR(*edges)[e++] = from;
                 }
             }
             to++;
-            i++;
-            entry++;
         }
         from++;
-        p++;
     }
     igraph_vector_int_resize(edges, e);
 
@@ -1074,25 +1062,22 @@ static igraph_error_t igraph_i_sparse_adjacency_upper(
     igraph_integer_t e = 0;
     CS_ENTRY *entry = adjmatrix->cs->x;
 
-    while (*p < no_of_edges) {
-        while (to < * (p + 1)) {
-            if (from >= *i) {
-                igraph_integer_t multi = *entry;
-                if (from == *i) {
+    while (p[from] < no_of_edges) {
+        while (to < p[from + 1]) {
+            if (from >= i[to]) {
+                igraph_integer_t multi = entry[to];
+                if (from == i[to]) {
                     IGRAPH_CHECK(igraph_i_adjust_loop_edge_count(&multi, loops));
                 }
                 for (igraph_integer_t count = 0; count < multi; count++) {
                     //edge directions are reverse of igraph_sparsemat()
-                    VECTOR(*edges)[e++] = (*i);
+                    VECTOR(*edges)[e++] = i[to];
                     VECTOR(*edges)[e++] = from;
                 }
             }
             to++;
-            i++;
-            entry++;
         }
         from++;
-        p++;
     }
     igraph_vector_int_resize(edges, e);
 
@@ -1112,25 +1097,22 @@ static igraph_error_t igraph_i_sparse_adjacency_lower(
     igraph_integer_t e = 0;
     CS_ENTRY *entry = adjmatrix->cs->x;
 
-    while (*p < no_of_edges) {
-        while (to < * (p + 1)) {
-            if (from <= *i) {
-                igraph_integer_t multi = *entry;
-                if (from == *i) {
+    while (p[from] < no_of_edges) {
+        while (to < p[from + 1]) {
+            if (from <= i[to]) {
+                igraph_integer_t multi = entry[to];
+                if (from == i[to]) {
                     IGRAPH_CHECK(igraph_i_adjust_loop_edge_count(&multi, loops));
                 }
                 for (igraph_integer_t count = 0; count < multi; count++) {
                     //edge directions are reverse of igraph_sparsemat()
-                    VECTOR(*edges)[e++] = (*i);
+                    VECTOR(*edges)[e++] = i[to];
                     VECTOR(*edges)[e++] = from;
                 }
             }
             to++;
-            i++;
-            entry++;
         }
         from++;
-        p++;
     }
     igraph_vector_int_resize(edges, e);
 
@@ -1153,24 +1135,21 @@ static igraph_error_t igraph_i_sparse_adjacency_undirected(
         IGRAPH_ERROR("Adjacency matrix should be symmetric for IGRAPH_ADJ_UNDIRECTED.",
                 IGRAPH_EINVAL);
     }
-    while (*p < no_of_edges) {
-        while (to < * (p + 1)) {
-            if (from >= *i) {
-                igraph_integer_t multi = *entry;
-                if (from == *i) {
+    while (p[from] < no_of_edges) {
+        while (to < p[from + 1]) {
+            if (from >= i[to]) {
+                igraph_integer_t multi = entry[to];
+                if (from == i[to]) {
                     IGRAPH_CHECK(igraph_i_adjust_loop_edge_count(&multi, loops));
                 }
                 for (igraph_integer_t count = 0; count < multi; count++) {
-                    VECTOR(*edges)[e++] = (*i);
+                    VECTOR(*edges)[e++] = i[to];
                     VECTOR(*edges)[e++] = from;
                 }
             }
             to++;
-            i++;
-            entry++;
         }
         from++;
-        p++;
     }
     igraph_vector_int_resize(edges, e);
 
@@ -1248,30 +1227,27 @@ static igraph_error_t igraph_i_sparse_weighted_adjacency_max (
     igraph_integer_t e = 0;
     CS_ENTRY *entry = adjmatrix->cs->x;
 
-    while (*p < no_of_edges) {
-        while (to < * (p + 1)) {
-            if (from >= *i) {
+    while (p[from] < no_of_edges) {
+        while (to < p[from + 1]) {
+            if (from >= i[to]) {
                 igraph_real_t other;
                 igraph_vector_int_t x, y;
                 igraph_vector_int_view(&x, &from, 1);
-                igraph_vector_int_view(&y, i, 1);
+                igraph_vector_int_view(&y, &i[to], 1);
                 igraph_sparsemat_index(adjmatrix, &x, &y, NULL, &other);
-                igraph_real_t weight = *entry > other ? *entry : other;
-                if (from == *i) {
+                igraph_real_t weight = entry[to] > other ? entry[to] : other;
+                if (from == i[to]) {
                     igraph_i_adjust_loop_edge_weight(&weight, loops);
                 }
                 if (weight != 0) {
                     VECTOR(*weights)[e/2] = weight;
-                    VECTOR(*edges)[e++] = (*i);
+                    VECTOR(*edges)[e++] = i[to];
                     VECTOR(*edges)[e++] = from;
                 }
             }
             to++;
-            i++;
-            entry++;
         }
         from++;
-        p++;
     }
     igraph_vector_int_resize(edges, e);
     igraph_vector_resize(weights, e/2);
@@ -1290,30 +1266,27 @@ static igraph_error_t igraph_i_sparse_weighted_adjacency_min (
     igraph_integer_t e = 0;
     CS_ENTRY *entry = adjmatrix->cs->x;
 
-    while (*p < no_of_edges) {
-        while (to < * (p + 1)) {
-            if (from >= *i) {
+    while (p[from] < no_of_edges) {
+        while (to < p[from + 1]) {
+            if (from >= i[to]) {
                 igraph_real_t other;
                 igraph_vector_int_t x, y;
                 igraph_vector_int_view(&x, &from, 1);
-                igraph_vector_int_view(&y, i, 1);
+                igraph_vector_int_view(&y, &i[to], 1);
                 igraph_sparsemat_index(adjmatrix, &x, &y, NULL, &other);
-                igraph_real_t weight = *entry < other ? *entry : other;
-                if (from == *i) {
+                igraph_real_t weight = entry[to] < other ? entry[to] : other;
+                if (from == i[to]) {
                     igraph_i_adjust_loop_edge_weight(&weight, loops);
                 }
                 if (weight != 0) {
                     VECTOR(*weights)[e/2] = weight;
-                    VECTOR(*edges)[e++] = (*i);
+                    VECTOR(*edges)[e++] = i[to];
                     VECTOR(*edges)[e++] = from;
                 }
             }
             to++;
-            i++;
-            entry++;
         }
         from++;
-        p++;
     }
     igraph_vector_int_resize(edges, e);
     igraph_vector_resize(weights, e/2);
@@ -1333,33 +1306,30 @@ static igraph_error_t igraph_i_sparse_weighted_adjacency_plus (
     igraph_integer_t e = 0;
     CS_ENTRY *entry = adjmatrix->cs->x;
 
-    while (*p < no_of_edges) {
-        while (to < * (p + 1)) {
-            if (from >= *i) {
-                igraph_real_t weight = *entry;
-                if (from != *i) {
+    while (p[from] < no_of_edges) {
+        while (to < p[from + 1]) {
+            if (from >= i[to]) {
+                igraph_real_t weight = entry[to];
+                if (from != i[to]) {
                     igraph_real_t other;
                     igraph_vector_int_t x, y;
                     igraph_vector_int_view(&x, &from, 1);
-                    igraph_vector_int_view(&y, i, 1);
+                    igraph_vector_int_view(&y, &i[to], 1);
                     igraph_sparsemat_index(adjmatrix, &x, &y, NULL, &other);
                     weight += other;
                 }
-                if (from == *i) {
+                if (from == i[to]) {
                     igraph_i_adjust_loop_edge_weight(&weight, loops);
                 }
                 if (weight != 0) {
                     VECTOR(*weights)[e/2] = weight;
-                    VECTOR(*edges)[e++] = (*i);
+                    VECTOR(*edges)[e++] = i[to];
                     VECTOR(*edges)[e++] = from;
                 }
             }
             to++;
-            i++;
-            entry++;
         }
         from++;
-        p++;
     }
     igraph_vector_int_resize(edges, e);
     igraph_vector_resize(weights, e/2);
@@ -1390,25 +1360,22 @@ static igraph_error_t igraph_i_sparse_weighted_adjacency_upper(
     igraph_integer_t e = 0;
     CS_ENTRY *entry = adjmatrix->cs->x;
 
-    while (*p < no_of_edges) {
-        while (to < * (p + 1)) {
-            if (from >= *i) {
-                igraph_real_t weight = *entry;
-                if (from == *i) {
+    while (p[from] < no_of_edges) {
+        while (to < p[from + 1]) {
+            if (from >= i[to]) {
+                igraph_real_t weight = entry[to];
+                if (from == i[to]) {
                     igraph_i_adjust_loop_edge_weight(&weight, loops);
                 }
                 if (weight != 0) {
                     VECTOR(*weights)[e/2] = weight;
-                    VECTOR(*edges)[e++] = (*i);
+                    VECTOR(*edges)[e++] = i[to];
                     VECTOR(*edges)[e++] = from;
                 }
             }
             to++;
-            i++;
-            entry++;
         }
         from++;
-        p++;
     }
     igraph_vector_int_resize(edges, e);
     igraph_vector_resize(weights, e/2);
@@ -1428,25 +1395,23 @@ static igraph_error_t igraph_i_sparse_weighted_adjacency_lower(
     igraph_integer_t e = 0;
     CS_ENTRY *entry = adjmatrix->cs->x;
 
-    while (*p < no_of_edges) {
-        while (to < * (p + 1)) {
-            if (from <= *i) {
-                igraph_real_t weight = *entry;
-                if (from == *i) {
+    while (p[from] < no_of_edges) {
+        while (to < p[from + 1]) {
+            if (from <= i[to]) {
+                igraph_real_t weight = entry[to];
+                if (from == i[to]) {
                     igraph_i_adjust_loop_edge_weight(&weight, loops);
                 }
+
                 if (weight != 0) {
                     VECTOR(*weights)[e/2] = weight;
-                    VECTOR(*edges)[e++] = (*i);
+                    VECTOR(*edges)[e++] = i[to];
                     VECTOR(*edges)[e++] = from;
                 }
             }
             to++;
-            i++;
-            entry++;
         }
         from++;
-        p++;
     }
     igraph_vector_int_resize(edges, e);
     igraph_vector_resize(weights, e/2);
@@ -1466,23 +1431,20 @@ static igraph_error_t igraph_i_sparse_weighted_adjacency_directed(
     igraph_integer_t e = 0;
     CS_ENTRY *entry = adjmatrix->cs->x;
 
-    while (*p < no_of_edges) {
-        while (to < * (p + 1)) {
-            igraph_real_t weight = *entry;
-            if (from == *i) {
+    while (p[from] < no_of_edges) {
+        while (to < p[from + 1]) {
+            igraph_real_t weight = entry[to];
+            if (from == i[to]) {
                 igraph_i_adjust_loop_edge_weight(&weight, loops);
             }
             if (weight != 0) {
                 VECTOR(*weights)[e/2] = weight;
-                VECTOR(*edges)[e++] = (*i);
+                VECTOR(*edges)[e++] = i[to];
                 VECTOR(*edges)[e++] = from;
             }
             to++;
-            i++;
-            entry++;
         }
         from++;
-        p++;
     }
     igraph_vector_int_resize(edges, e);
     igraph_vector_resize(weights, e/2);

--- a/src/constructors/adjacency.c
+++ b/src/constructors/adjacency.c
@@ -919,7 +919,6 @@ static igraph_error_t igraph_i_sparse_adjacency_directed(
                 IGRAPH_CHECK(igraph_i_adjust_loop_edge_count(&multi, loops));
             }
             for (igraph_integer_t count = 0; count < multi; count++) {
-                //TODO edge directions are reverse of igraph_sparsemat(), why?
                 VECTOR(*edges)[e++] = i[from];
                 VECTOR(*edges)[e++] = to;
             }
@@ -954,7 +953,6 @@ static igraph_error_t igraph_i_sparse_adjacency_max(
                     IGRAPH_CHECK(igraph_i_adjust_loop_edge_count(&multi, loops));
                 }
                 for (igraph_integer_t count = 0; count < multi; count++) {
-                    //edge directions are reverse of igraph_sparsemat()
                     VECTOR(*edges)[e++] = i[from];
                     VECTOR(*edges)[e++] = to;
                 }
@@ -990,7 +988,6 @@ static igraph_error_t igraph_i_sparse_adjacency_min(
                     IGRAPH_CHECK(igraph_i_adjust_loop_edge_count(&multi, loops));
                 }
                 for (igraph_integer_t count = 0; count < multi; count++) {
-                    //edge directions are reverse of igraph_sparsemat()
                     VECTOR(*edges)[e++] = i[from];
                     VECTOR(*edges)[e++] = to;
                 }
@@ -1026,7 +1023,6 @@ static igraph_error_t igraph_i_sparse_adjacency_plus(
                     IGRAPH_CHECK(igraph_i_adjust_loop_edge_count(&multi, loops));
                 }
                 for (igraph_integer_t count = 0; count < multi; count++) {
-                    //edge directions are reverse of igraph_sparsemat()
                     VECTOR(*edges)[e++] = i[from];
                     VECTOR(*edges)[e++] = to;
                 }
@@ -1057,7 +1053,6 @@ static igraph_error_t igraph_i_sparse_adjacency_upper(
                     IGRAPH_CHECK(igraph_i_adjust_loop_edge_count(&multi, loops));
                 }
                 for (igraph_integer_t count = 0; count < multi; count++) {
-                    //edge directions are reverse of igraph_sparsemat()
                     VECTOR(*edges)[e++] = i[from];
                     VECTOR(*edges)[e++] = to;
                 }
@@ -1089,7 +1084,6 @@ static igraph_error_t igraph_i_sparse_adjacency_lower(
                     IGRAPH_CHECK(igraph_i_adjust_loop_edge_count(&multi, loops));
                 }
                 for (igraph_integer_t count = 0; count < multi; count++) {
-                    //edge directions are reverse of igraph_sparsemat()
                     VECTOR(*edges)[e++] = i[from];
                     VECTOR(*edges)[e++] = to;
                 }
@@ -1142,11 +1136,11 @@ igraph_error_t igraph_sparse_adjacency(igraph_t *graph, igraph_sparsemat_t *adjm
     CS_INT no_of_nodes = adjmatrix->cs->m;
     CS_INT no_of_edges = adjmatrix->cs->p[adjmatrix->cs->n];
     if (no_of_edges) {
-        no_of_edges *= igraph_sparsemat_max(adjmatrix) * 2; //TODO maybe find a better maximum?
+        no_of_edges *= igraph_sparsemat_max(adjmatrix);
     }
 
     if (!igraph_sparsemat_is_cc(adjmatrix)) {
-        IGRAPH_ERROR("Sparese adjacency matrix should be in column-compressed "
+        IGRAPH_ERROR("Sparse adjacency matrix should be in column-compressed "
                "form.", IGRAPH_EINVAL);
     }
     if (no_of_nodes != adjmatrix->cs->n) {
@@ -1421,7 +1415,7 @@ igraph_error_t igraph_sparse_weighted_adjacency(
     igraph_vector_int_t edges;
     CS_INT no_of_edges = adjmatrix->cs->p[adjmatrix->cs->n];
     if (no_of_edges) {
-        no_of_edges *= igraph_sparsemat_max(adjmatrix); //TODO maybe find a better maximum?
+        no_of_edges *= igraph_sparsemat_max(adjmatrix);
     }
     CS_INT no_of_nodes = adjmatrix->cs->m;
     /* Some checks */

--- a/src/constructors/adjacency.c
+++ b/src/constructors/adjacency.c
@@ -19,12 +19,16 @@
    02110-1301 USA
 
 */
+#include "igraph_sparsemat.h"
 
 #include "igraph_constructors.h"
 
 #include "igraph_adjlist.h"
 #include "igraph_attributes.h"
 #include "igraph_interface.h"
+
+#include <cs/cs.h> //TODO take a look at how this is done in /src/core/sparsemat.c. i didn't want to copy it all. Maybe we need a separate header?
+#undef cs  /* because otherwise it messes up the name of the 'cs' member in igraph_sparsemat_t */
 
 static igraph_error_t igraph_i_adjacency_directed(
     const igraph_matrix_t *adjmatrix, igraph_vector_int_t *edges,
@@ -226,6 +230,110 @@ static igraph_error_t igraph_i_adjacency_min(
 
     return IGRAPH_SUCCESS;
 }
+
+
+static igraph_error_t igraph_i_sparse_adjacency_directed(
+    igraph_sparsemat_t *adjmatrix, igraph_vector_int_t *edges,
+    igraph_loops_t loops
+) {
+    CS_INT *p = adjmatrix->cs->p;
+    CS_INT *i = adjmatrix->cs->i;
+    CS_INT no_of_edges = adjmatrix->cs->p[adjmatrix->cs->n];
+    igraph_integer_t from = 0;
+    igraph_integer_t to = 0;
+    igraph_integer_t e = 0;
+    CS_ENTRY *entry = adjmatrix->cs->x;
+
+    while (*p < no_of_edges) {
+        while (to < * (p + 1)) {
+            igraph_integer_t multi = *entry;
+            if (from == *i) {
+                if (loops == IGRAPH_NO_LOOPS) {
+                    multi = 0;
+                }
+                if (loops == IGRAPH_LOOPS_TWICE) {
+                    if ((igraph_integer_t)*entry % 2) {
+                        IGRAPH_ERROR("Odd diagonal entry found while IGRAPH_LOOPS_TWICE.",
+                                IGRAPH_EINVAL);
+                    }
+                    multi /= 2;
+                }
+            }
+            for (igraph_integer_t count = 0; count < multi; count++) {
+                //edge directions are reverse of igraph_sparsemat()
+                VECTOR(*edges)[e++] = (*i);
+                VECTOR(*edges)[e++] = from;
+            }
+            to++;
+            i++;
+            entry++;
+        }
+        from++;
+        p++;
+    }
+    igraph_vector_int_resize(edges, e);
+
+    return IGRAPH_SUCCESS;
+}
+
+igraph_error_t igraph_sparse_adjacency(igraph_t *graph, igraph_sparsemat_t *adjmatrix,
+        igraph_adjacency_t mode, igraph_loops_t loops) {
+
+    igraph_vector_int_t edges = IGRAPH_VECTOR_NULL;
+    CS_INT no_of_nodes = adjmatrix->cs->m;
+    CS_INT no_of_edges = adjmatrix->cs->p[adjmatrix->cs->n];
+    if (no_of_edges) {
+        no_of_edges *= igraph_sparsemat_max(adjmatrix) * 2; //TODO maybe find a better maximum?
+    }
+
+    if (!igraph_sparsemat_is_cc(adjmatrix)) {
+        IGRAPH_ERROR("Sparese adjacency matrix should be in column-compressed "
+               "form.", IGRAPH_EINVAL);
+    }
+    if (no_of_nodes != adjmatrix->cs->n) {
+        IGRAPH_ERROR("Adjacency matrix is non-square.", IGRAPH_NONSQUARE);
+    }
+
+    if (no_of_nodes != 0 && igraph_sparsemat_min(adjmatrix) < 0) {
+        IGRAPH_ERRORF("Edge counts should be non-negative, found %g.", IGRAPH_EINVAL,
+                igraph_sparsemat_min(adjmatrix));
+    }
+
+    IGRAPH_VECTOR_INT_INIT_FINALLY(&edges, no_of_edges * 2);
+
+    /* Collect the edges */
+    switch (mode) {
+    case IGRAPH_ADJ_DIRECTED:
+        IGRAPH_CHECK(igraph_i_sparse_adjacency_directed(adjmatrix, &edges, loops));
+        break;
+        /*
+    case IGRAPH_ADJ_MAX:
+        IGRAPH_CHECK(igraph_i_adjacency_max(adjmatrix, &edges, loops));
+        break;
+    case IGRAPH_ADJ_UPPER:
+        IGRAPH_CHECK(igraph_i_adjacency_upper(adjmatrix, &edges, loops));
+        break;
+    case IGRAPH_ADJ_LOWER:
+        IGRAPH_CHECK(igraph_i_adjacency_lower(adjmatrix, &edges, loops));
+        break;
+    case IGRAPH_ADJ_MIN:
+        IGRAPH_CHECK(igraph_i_adjacency_min(adjmatrix, &edges, loops));
+        break;
+    case IGRAPH_ADJ_PLUS:
+        IGRAPH_CHECK(igraph_i_adjacency_directed(adjmatrix, &edges, loops));
+        break;
+        */
+    default:
+        IGRAPH_ERROR("Invalid adjacency mode.", IGRAPH_EINVAL);
+    }
+
+    IGRAPH_CHECK(igraph_create(graph, &edges, no_of_nodes, (mode == IGRAPH_ADJ_DIRECTED)));
+    igraph_vector_int_destroy(&edges);
+    IGRAPH_FINALLY_CLEAN(1);
+
+    return IGRAPH_SUCCESS;
+}
+
 
 /**
  * \ingroup generators

--- a/src/constructors/adjacency.c
+++ b/src/constructors/adjacency.c
@@ -247,404 +247,6 @@ static igraph_error_t igraph_i_adjacency_min(
 }
 
 
-static igraph_error_t igraph_i_sparse_adjacency_directed(
-    igraph_sparsemat_t *adjmatrix, igraph_vector_int_t *edges,
-    igraph_loops_t loops
-) {
-    CS_INT *p = adjmatrix->cs->p;
-    CS_INT *i = adjmatrix->cs->i;
-    CS_INT no_of_edges = adjmatrix->cs->p[adjmatrix->cs->n];
-    igraph_integer_t from = 0;
-    igraph_integer_t to = 0;
-    igraph_integer_t e = 0;
-    CS_ENTRY *entry = adjmatrix->cs->x;
-
-    while (*p < no_of_edges) {
-        while (to < * (p + 1)) {
-            igraph_integer_t multi = *entry;
-            if (from == *i) {
-                if (loops == IGRAPH_NO_LOOPS) {
-                    multi = 0;
-                }
-                if (loops == IGRAPH_LOOPS_TWICE) {
-                    if ((igraph_integer_t)*entry % 2) {
-                        IGRAPH_ERROR("Odd diagonal entry found while IGRAPH_LOOPS_TWICE.",
-                                IGRAPH_EINVAL);
-                    }
-                    multi /= 2;
-                }
-            }
-            for (igraph_integer_t count = 0; count < multi; count++) {
-                //TODO edge directions are reverse of igraph_sparsemat(), why?
-                VECTOR(*edges)[e++] = (*i);
-                VECTOR(*edges)[e++] = from;
-            }
-            to++;
-            i++;
-            entry++;
-        }
-        from++;
-        p++;
-    }
-    igraph_vector_int_resize(edges, e);
-
-    return IGRAPH_SUCCESS;
-}
-
-static igraph_error_t igraph_i_sparse_adjacency_max(
-    igraph_sparsemat_t *adjmatrix, igraph_vector_int_t *edges,
-    igraph_loops_t loops
-) {
-    CS_INT *p = adjmatrix->cs->p;
-    CS_INT *i = adjmatrix->cs->i;
-    CS_INT no_of_edges = adjmatrix->cs->p[adjmatrix->cs->n];
-    igraph_integer_t from = 0;
-    igraph_integer_t to = 0;
-    igraph_integer_t e = 0;
-    CS_ENTRY *entry = adjmatrix->cs->x;
-
-    while (*p < no_of_edges) {
-        while (to < * (p + 1)) {
-            if (from >= *i) {
-                igraph_real_t other;
-                igraph_vector_int_t x, y;
-                igraph_vector_int_view(&x, &from, 1);
-                igraph_vector_int_view(&y, i, 1);
-                igraph_sparsemat_index(adjmatrix, &x, &y, NULL, &other);
-                igraph_integer_t multi = *entry > other ? *entry : other;
-                if (from == *i) {
-                    if (loops == IGRAPH_NO_LOOPS) {
-                        multi = 0;
-                    }
-                    if (loops == IGRAPH_LOOPS_TWICE) {
-                        if ((igraph_integer_t)*entry % 2) {
-                            IGRAPH_ERROR("Odd diagonal entry found while IGRAPH_LOOPS_TWICE.",
-                                    IGRAPH_EINVAL);
-                        }
-                        multi /= 2;
-                    }
-                }
-                for (igraph_integer_t count = 0; count < multi; count++) {
-                    //edge directions are reverse of igraph_sparsemat()
-                    VECTOR(*edges)[e++] = (*i);
-                    VECTOR(*edges)[e++] = from;
-                }
-            }
-            to++;
-            i++;
-            entry++;
-        }
-        from++;
-        p++;
-    }
-    igraph_vector_int_resize(edges, e);
-
-    return IGRAPH_SUCCESS;
-}
-
-static igraph_error_t igraph_i_sparse_adjacency_min(
-    igraph_sparsemat_t *adjmatrix, igraph_vector_int_t *edges,
-    igraph_loops_t loops
-) {
-    CS_INT *p = adjmatrix->cs->p;
-    CS_INT *i = adjmatrix->cs->i;
-    CS_INT no_of_edges = adjmatrix->cs->p[adjmatrix->cs->n];
-    igraph_integer_t from = 0;
-    igraph_integer_t to = 0;
-    igraph_integer_t e = 0;
-    CS_ENTRY *entry = adjmatrix->cs->x;
-
-    while (*p < no_of_edges) {
-        while (to < * (p + 1)) {
-            if (from >= *i) {
-                igraph_real_t other;
-                igraph_vector_int_t x, y;
-                igraph_vector_int_view(&x, &from, 1);
-                igraph_vector_int_view(&y, i, 1);
-                igraph_sparsemat_index(adjmatrix, &x, &y, NULL, &other);
-                igraph_integer_t multi = *entry < other ? *entry : other;
-                if (from == *i) {
-                    if (loops == IGRAPH_NO_LOOPS) {
-                        multi = 0;
-                    }
-                    if (loops == IGRAPH_LOOPS_TWICE) {
-                        if ((igraph_integer_t)*entry % 2) {
-                            IGRAPH_ERROR("Odd diagonal entry found while IGRAPH_LOOPS_TWICE.",
-                                    IGRAPH_EINVAL);
-                        }
-                        multi /= 2;
-                    }
-                }
-                for (igraph_integer_t count = 0; count < multi; count++) {
-                    //edge directions are reverse of igraph_sparsemat()
-                    VECTOR(*edges)[e++] = (*i);
-                    VECTOR(*edges)[e++] = from;
-                }
-            }
-            to++;
-            i++;
-            entry++;
-        }
-        from++;
-        p++;
-    }
-    igraph_vector_int_resize(edges, e);
-
-    return IGRAPH_SUCCESS;
-}
-
-static igraph_error_t igraph_i_sparse_adjacency_plus(
-    igraph_sparsemat_t *adjmatrix, igraph_vector_int_t *edges,
-    igraph_loops_t loops
-) {
-    CS_INT *p = adjmatrix->cs->p;
-    CS_INT *i = adjmatrix->cs->i;
-    CS_INT no_of_edges = adjmatrix->cs->p[adjmatrix->cs->n];
-    igraph_integer_t from = 0;
-    igraph_integer_t to = 0;
-    igraph_integer_t e = 0;
-    CS_ENTRY *entry = adjmatrix->cs->x;
-
-    while (*p < no_of_edges) {
-        while (to < * (p + 1)) {
-            if (from >= *i) {
-                igraph_real_t other;
-                igraph_vector_int_t x, y;
-                igraph_vector_int_view(&x, &from, 1);
-                igraph_vector_int_view(&y, i, 1);
-                igraph_sparsemat_index(adjmatrix, &x, &y, NULL, &other);
-                igraph_integer_t multi = *entry + other;
-                if (from == *i) {
-                    if (loops == IGRAPH_NO_LOOPS) {
-                        multi = 0;
-                    }
-                    if (loops == IGRAPH_LOOPS_TWICE) {
-                        if ((igraph_integer_t)*entry % 2) {
-                            IGRAPH_ERROR("Odd diagonal entry found while IGRAPH_LOOPS_TWICE.",
-                                    IGRAPH_EINVAL);
-                        }
-                        multi /= 2;
-                    }
-                }
-                for (igraph_integer_t count = 0; count < multi; count++) {
-                    //edge directions are reverse of igraph_sparsemat()
-                    VECTOR(*edges)[e++] = (*i);
-                    VECTOR(*edges)[e++] = from;
-                }
-            }
-            to++;
-            i++;
-            entry++;
-        }
-        from++;
-        p++;
-    }
-    igraph_vector_int_resize(edges, e);
-
-    return IGRAPH_SUCCESS;
-}
-
-static igraph_error_t igraph_i_sparse_adjacency_upper(
-    igraph_sparsemat_t *adjmatrix, igraph_vector_int_t *edges,
-    igraph_loops_t loops
-) {
-    CS_INT *p = adjmatrix->cs->p;
-    CS_INT *i = adjmatrix->cs->i;
-    CS_INT no_of_edges = adjmatrix->cs->p[adjmatrix->cs->n];
-    igraph_integer_t from = 0;
-    igraph_integer_t to = 0;
-    igraph_integer_t e = 0;
-    CS_ENTRY *entry = adjmatrix->cs->x;
-
-    while (*p < no_of_edges) {
-        while (to < * (p + 1)) {
-            if (from >= *i) {
-                igraph_integer_t multi = *entry;
-                if (from == *i) {
-                    if (loops == IGRAPH_NO_LOOPS) {
-                        multi = 0;
-                    }
-                    if (loops == IGRAPH_LOOPS_TWICE) {
-                        if ((igraph_integer_t)*entry % 2) {
-                            IGRAPH_ERROR("Odd diagonal entry found while IGRAPH_LOOPS_TWICE.",
-                                    IGRAPH_EINVAL);
-                        }
-                        multi /= 2;
-                    }
-                }
-                for (igraph_integer_t count = 0; count < multi; count++) {
-                    //edge directions are reverse of igraph_sparsemat()
-                    VECTOR(*edges)[e++] = (*i);
-                    VECTOR(*edges)[e++] = from;
-                }
-            }
-            to++;
-            i++;
-            entry++;
-        }
-        from++;
-        p++;
-    }
-    igraph_vector_int_resize(edges, e);
-
-    return IGRAPH_SUCCESS;
-}
-
-
-static igraph_error_t igraph_i_sparse_adjacency_lower(
-    igraph_sparsemat_t *adjmatrix, igraph_vector_int_t *edges,
-    igraph_loops_t loops
-) {
-    CS_INT *p = adjmatrix->cs->p;
-    CS_INT *i = adjmatrix->cs->i;
-    CS_INT no_of_edges = adjmatrix->cs->p[adjmatrix->cs->n];
-    igraph_integer_t from = 0;
-    igraph_integer_t to = 0;
-    igraph_integer_t e = 0;
-    CS_ENTRY *entry = adjmatrix->cs->x;
-
-    while (*p < no_of_edges) {
-        while (to < * (p + 1)) {
-            if (from <= *i) {
-                igraph_integer_t multi = *entry;
-                if (from == *i) {
-                    if (loops == IGRAPH_NO_LOOPS) {
-                        multi = 0;
-                    }
-                    if (loops == IGRAPH_LOOPS_TWICE) {
-                        if ((igraph_integer_t)*entry % 2) {
-                            IGRAPH_ERROR("Odd diagonal entry found while IGRAPH_LOOPS_TWICE.",
-                                    IGRAPH_EINVAL);
-                        }
-                        multi /= 2;
-                    }
-                }
-                for (igraph_integer_t count = 0; count < multi; count++) {
-                    //edge directions are reverse of igraph_sparsemat()
-                    VECTOR(*edges)[e++] = (*i);
-                    VECTOR(*edges)[e++] = from;
-                }
-            }
-            to++;
-            i++;
-            entry++;
-        }
-        from++;
-        p++;
-    }
-    igraph_vector_int_resize(edges, e);
-
-    return IGRAPH_SUCCESS;
-}
-
-static igraph_error_t igraph_i_sparse_adjacency_undirected(
-    igraph_sparsemat_t *adjmatrix, igraph_vector_int_t *edges,
-    igraph_loops_t loops
-) {
-    CS_INT *p = adjmatrix->cs->p;
-    CS_INT *i = adjmatrix->cs->i;
-    CS_INT no_of_edges = adjmatrix->cs->p[adjmatrix->cs->n];
-    igraph_integer_t from = 0;
-    igraph_integer_t to = 0;
-    igraph_integer_t e = 0;
-    CS_ENTRY *entry = adjmatrix->cs->x;
-
-    if (!igraph_sparsemat_is_symmetric(adjmatrix)) {
-        IGRAPH_ERROR("Adjacency matrix should be symmetric for IGRAPH_ADJ_UNDIRECTED.",
-                IGRAPH_EINVAL);
-    }
-    while (*p < no_of_edges) {
-        while (to < * (p + 1)) {
-            if (from >= *i) {
-                igraph_integer_t multi = *entry;
-                if (from == *i) {
-                    if (loops == IGRAPH_NO_LOOPS) {
-                        multi = 0;
-                    }
-                    if (loops == IGRAPH_LOOPS_TWICE) {
-                        if ((igraph_integer_t)*entry % 2) {
-                            IGRAPH_ERROR("Odd diagonal entry found while IGRAPH_LOOPS_TWICE.",
-                                    IGRAPH_EINVAL);
-                        }
-                        multi /= 2;
-                    }
-                }
-                for (igraph_integer_t count = 0; count < multi; count++) {
-                    VECTOR(*edges)[e++] = (*i);
-                    VECTOR(*edges)[e++] = from;
-                }
-            }
-            to++;
-            i++;
-            entry++;
-        }
-        from++;
-        p++;
-    }
-    igraph_vector_int_resize(edges, e);
-
-    return IGRAPH_SUCCESS;
-}
-
-igraph_error_t igraph_sparse_adjacency(igraph_t *graph, igraph_sparsemat_t *adjmatrix,
-        igraph_adjacency_t mode, igraph_loops_t loops) {
-
-    igraph_vector_int_t edges = IGRAPH_VECTOR_NULL;
-    CS_INT no_of_nodes = adjmatrix->cs->m;
-    CS_INT no_of_edges = adjmatrix->cs->p[adjmatrix->cs->n];
-    if (no_of_edges) {
-        no_of_edges *= igraph_sparsemat_max(adjmatrix) * 2; //TODO maybe find a better maximum?
-    }
-
-    if (!igraph_sparsemat_is_cc(adjmatrix)) {
-        IGRAPH_ERROR("Sparese adjacency matrix should be in column-compressed "
-               "form.", IGRAPH_EINVAL);
-    }
-    if (no_of_nodes != adjmatrix->cs->n) {
-        IGRAPH_ERROR("Adjacency matrix is non-square.", IGRAPH_NONSQUARE);
-    }
-
-    if (no_of_nodes != 0 && igraph_sparsemat_min(adjmatrix) < 0) {
-        IGRAPH_ERRORF("Edge counts should be non-negative, found %g.", IGRAPH_EINVAL,
-                igraph_sparsemat_min(adjmatrix));
-    }
-
-    IGRAPH_VECTOR_INT_INIT_FINALLY(&edges, no_of_edges * 2);
-
-    /* Collect the edges */
-    switch (mode) {
-    case IGRAPH_ADJ_DIRECTED:
-        IGRAPH_CHECK(igraph_i_sparse_adjacency_directed(adjmatrix, &edges, loops));
-        break;
-    case IGRAPH_ADJ_MAX:
-        IGRAPH_CHECK(igraph_i_sparse_adjacency_max(adjmatrix, &edges, loops));
-        break;
-    case IGRAPH_ADJ_UNDIRECTED:
-        IGRAPH_CHECK(igraph_i_sparse_adjacency_undirected(adjmatrix, &edges, loops));
-        break;
-    case IGRAPH_ADJ_UPPER:
-        IGRAPH_CHECK(igraph_i_sparse_adjacency_upper(adjmatrix, &edges, loops));
-        break;
-    case IGRAPH_ADJ_LOWER:
-        IGRAPH_CHECK(igraph_i_sparse_adjacency_lower(adjmatrix, &edges, loops));
-        break;
-    case IGRAPH_ADJ_MIN:
-        IGRAPH_CHECK(igraph_i_sparse_adjacency_min(adjmatrix, &edges, loops));
-        break;
-    case IGRAPH_ADJ_PLUS:
-        IGRAPH_CHECK(igraph_i_sparse_adjacency_directed(adjmatrix, &edges, loops));
-        break;
-    default:
-        IGRAPH_ERROR("Invalid adjacency mode.", IGRAPH_EINVAL);
-    }
-
-    IGRAPH_CHECK(igraph_create(graph, &edges, no_of_nodes, (mode == IGRAPH_ADJ_DIRECTED)));
-    igraph_vector_int_destroy(&edges);
-    IGRAPH_FINALLY_CLEAN(1);
-
-    return IGRAPH_SUCCESS;
-}
-
 
 /**
  * \ingroup generators
@@ -823,259 +425,6 @@ static void igraph_i_adjust_loop_edge_weight(igraph_real_t* weight, igraph_loops
         default:
             break;
     }
-}
-static igraph_error_t igraph_i_sparse_weighted_adjacency_max (
-    igraph_sparsemat_t *adjmatrix, igraph_vector_int_t *edges,
-    igraph_vector_t *weights, igraph_loops_t loops
-) {
-    CS_INT *p = adjmatrix->cs->p;
-    CS_INT *i = adjmatrix->cs->i;
-    CS_INT no_of_edges = adjmatrix->cs->p[adjmatrix->cs->n];
-    igraph_integer_t from = 0;
-    igraph_integer_t to = 0;
-    igraph_integer_t e = 0;
-    CS_ENTRY *entry = adjmatrix->cs->x;
-
-    while (*p < no_of_edges) {
-        while (to < * (p + 1)) {
-            if (from >= *i) {
-                igraph_real_t other;
-                igraph_vector_int_t x, y;
-                igraph_vector_int_view(&x, &from, 1);
-                igraph_vector_int_view(&y, i, 1);
-                igraph_sparsemat_index(adjmatrix, &x, &y, NULL, &other);
-                igraph_real_t weight = *entry > other ? *entry : other;
-                if (from == *i) {
-                    igraph_i_adjust_loop_edge_weight(&weight, loops);
-                }
-                if (weight != 0) {
-                    VECTOR(*weights)[e/2] = weight;
-                    VECTOR(*edges)[e++] = (*i);
-                    VECTOR(*edges)[e++] = from;
-                }
-            }
-            to++;
-            i++;
-            entry++;
-        }
-        from++;
-        p++;
-    }
-    igraph_vector_int_resize(edges, e);
-    igraph_vector_resize(weights, e/2);
-
-    return IGRAPH_SUCCESS;
-}
-static igraph_error_t igraph_i_sparse_weighted_adjacency_min (
-    igraph_sparsemat_t *adjmatrix, igraph_vector_int_t *edges,
-    igraph_vector_t *weights, igraph_loops_t loops
-) {
-    CS_INT *p = adjmatrix->cs->p;
-    CS_INT *i = adjmatrix->cs->i;
-    CS_INT no_of_edges = adjmatrix->cs->p[adjmatrix->cs->n];
-    igraph_integer_t from = 0;
-    igraph_integer_t to = 0;
-    igraph_integer_t e = 0;
-    CS_ENTRY *entry = adjmatrix->cs->x;
-
-    while (*p < no_of_edges) {
-        while (to < * (p + 1)) {
-            if (from >= *i) {
-                igraph_real_t other;
-                igraph_vector_int_t x, y;
-                igraph_vector_int_view(&x, &from, 1);
-                igraph_vector_int_view(&y, i, 1);
-                igraph_sparsemat_index(adjmatrix, &x, &y, NULL, &other);
-                igraph_real_t weight = *entry < other ? *entry : other;
-                if (from == *i) {
-                    igraph_i_adjust_loop_edge_weight(&weight, loops);
-                }
-                if (weight != 0) {
-                    VECTOR(*weights)[e/2] = weight;
-                    VECTOR(*edges)[e++] = (*i);
-                    VECTOR(*edges)[e++] = from;
-                }
-            }
-            to++;
-            i++;
-            entry++;
-        }
-        from++;
-        p++;
-    }
-    igraph_vector_int_resize(edges, e);
-    igraph_vector_resize(weights, e/2);
-
-    return IGRAPH_SUCCESS;
-}
-
-static igraph_error_t igraph_i_sparse_weighted_adjacency_plus (
-    igraph_sparsemat_t *adjmatrix, igraph_vector_int_t *edges,
-    igraph_vector_t *weights, igraph_loops_t loops
-) {
-    CS_INT *p = adjmatrix->cs->p;
-    CS_INT *i = adjmatrix->cs->i;
-    CS_INT no_of_edges = adjmatrix->cs->p[adjmatrix->cs->n];
-    igraph_integer_t from = 0;
-    igraph_integer_t to = 0;
-    igraph_integer_t e = 0;
-    CS_ENTRY *entry = adjmatrix->cs->x;
-
-    while (*p < no_of_edges) {
-        while (to < * (p + 1)) {
-            if (from >= *i) {
-                igraph_real_t weight = *entry;
-                if (from != *i) {
-                    igraph_real_t other;
-                    igraph_vector_int_t x, y;
-                    igraph_vector_int_view(&x, &from, 1);
-                    igraph_vector_int_view(&y, i, 1);
-                    igraph_sparsemat_index(adjmatrix, &x, &y, NULL, &other);
-                    weight += other;
-                }
-                if (from == *i) {
-                    igraph_i_adjust_loop_edge_weight(&weight, loops);
-                }
-                if (weight != 0) {
-                    VECTOR(*weights)[e/2] = weight;
-                    VECTOR(*edges)[e++] = (*i);
-                    VECTOR(*edges)[e++] = from;
-                }
-            }
-            to++;
-            i++;
-            entry++;
-        }
-        from++;
-        p++;
-    }
-    igraph_vector_int_resize(edges, e);
-    igraph_vector_resize(weights, e/2);
-
-    return IGRAPH_SUCCESS;
-}
-
-static igraph_error_t igraph_i_sparse_weighted_adjacency_undirected (
-    igraph_sparsemat_t *adjmatrix, igraph_vector_int_t *edges,
-    igraph_vector_t *weights, igraph_loops_t loops
-) {
-    if (!igraph_sparsemat_is_symmetric(adjmatrix)) {
-        IGRAPH_ERROR("Adjacency matrix should be symmetric for IGRAPH_ADJ_UNDIRECTED.",
-                IGRAPH_EINVAL);
-    }
-    return igraph_i_sparse_weighted_adjacency_max(adjmatrix, edges, weights, loops);
-}
-
-static igraph_error_t igraph_i_sparse_weighted_adjacency_upper(
-    igraph_sparsemat_t *adjmatrix, igraph_vector_int_t *edges,
-    igraph_vector_t *weights, igraph_loops_t loops
-) {
-    CS_INT *p = adjmatrix->cs->p;
-    CS_INT *i = adjmatrix->cs->i;
-    CS_INT no_of_edges = adjmatrix->cs->p[adjmatrix->cs->n];
-    igraph_integer_t from = 0;
-    igraph_integer_t to = 0;
-    igraph_integer_t e = 0;
-    CS_ENTRY *entry = adjmatrix->cs->x;
-
-    while (*p < no_of_edges) {
-        while (to < * (p + 1)) {
-            if (from >= *i) {
-                igraph_real_t weight = *entry;
-                if (from == *i) {
-                    igraph_i_adjust_loop_edge_weight(&weight, loops);
-                }
-                if (weight != 0) {
-                    VECTOR(*weights)[e/2] = weight;
-                    VECTOR(*edges)[e++] = (*i);
-                    VECTOR(*edges)[e++] = from;
-                }
-            }
-            to++;
-            i++;
-            entry++;
-        }
-        from++;
-        p++;
-    }
-    igraph_vector_int_resize(edges, e);
-    igraph_vector_resize(weights, e/2);
-
-    return IGRAPH_SUCCESS;
-}
-
-static igraph_error_t igraph_i_sparse_weighted_adjacency_lower(
-    igraph_sparsemat_t *adjmatrix, igraph_vector_int_t *edges,
-    igraph_vector_t *weights, igraph_loops_t loops
-) {
-    CS_INT *p = adjmatrix->cs->p;
-    CS_INT *i = adjmatrix->cs->i;
-    CS_INT no_of_edges = adjmatrix->cs->p[adjmatrix->cs->n];
-    igraph_integer_t from = 0;
-    igraph_integer_t to = 0;
-    igraph_integer_t e = 0;
-    CS_ENTRY *entry = adjmatrix->cs->x;
-
-    while (*p < no_of_edges) {
-        while (to < * (p + 1)) {
-            if (from <= *i) {
-                igraph_real_t weight = *entry;
-                if (from == *i) {
-                    igraph_i_adjust_loop_edge_weight(&weight, loops);
-                }
-                if (weight != 0) {
-                    VECTOR(*weights)[e/2] = weight;
-                    VECTOR(*edges)[e++] = (*i);
-                    VECTOR(*edges)[e++] = from;
-                }
-            }
-            to++;
-            i++;
-            entry++;
-        }
-        from++;
-        p++;
-    }
-    igraph_vector_int_resize(edges, e);
-    igraph_vector_resize(weights, e/2);
-
-    return IGRAPH_SUCCESS;
-}
-
-static igraph_error_t igraph_i_sparse_weighted_adjacency_directed(
-    igraph_sparsemat_t *adjmatrix, igraph_vector_int_t *edges,
-    igraph_vector_t *weights, igraph_loops_t loops
-) {
-    CS_INT *p = adjmatrix->cs->p;
-    CS_INT *i = adjmatrix->cs->i;
-    CS_INT no_of_edges = adjmatrix->cs->p[adjmatrix->cs->n];
-    igraph_integer_t from = 0;
-    igraph_integer_t to = 0;
-    igraph_integer_t e = 0;
-    CS_ENTRY *entry = adjmatrix->cs->x;
-
-    while (*p < no_of_edges) {
-        while (to < * (p + 1)) {
-            igraph_real_t weight = *entry;
-            if (from == *i) {
-                igraph_i_adjust_loop_edge_weight(&weight, loops);
-            }
-            if (weight != 0) {
-                VECTOR(*weights)[e/2] = weight;
-                VECTOR(*edges)[e++] = (*i);
-                VECTOR(*edges)[e++] = from;
-            }
-            to++;
-            i++;
-            entry++;
-        }
-        from++;
-        p++;
-    }
-    igraph_vector_int_resize(edges, e);
-    igraph_vector_resize(weights, e/2);
-
-    return IGRAPH_SUCCESS;
 }
 
 static igraph_error_t igraph_i_weighted_adjacency_directed(
@@ -1449,73 +798,6 @@ igraph_error_t igraph_weighted_adjacency(
     return IGRAPH_SUCCESS;
 }
 
-igraph_error_t igraph_sparse_weighted_adjacency(
-    igraph_t *graph, igraph_sparsemat_t *adjmatrix, igraph_adjacency_t mode,
-    igraph_vector_t *weights, igraph_loops_t loops
-) {
-    igraph_vector_int_t edges;
-    CS_INT no_of_edges = adjmatrix->cs->p[adjmatrix->cs->n];
-    if (no_of_edges) {
-        no_of_edges *= igraph_sparsemat_max(adjmatrix); //TODO maybe find a better maximum?
-    }
-    CS_INT no_of_nodes = adjmatrix->cs->m;
-    /* Some checks */
-    if (igraph_sparsemat_nrow(adjmatrix) != igraph_sparsemat_ncol(adjmatrix)) {
-        IGRAPH_ERROR("Non-square matrix", IGRAPH_NONSQUARE);
-    }
-
-    IGRAPH_VECTOR_INT_INIT_FINALLY(&edges, no_of_edges * 2);
-    igraph_vector_resize(weights, no_of_edges);
-
-    /* Collect the edges */
-    switch (mode) {
-    case IGRAPH_ADJ_DIRECTED:
-        IGRAPH_CHECK(igraph_i_sparse_weighted_adjacency_directed(adjmatrix, &edges,
-                     weights, loops));
-        break;
-    case IGRAPH_ADJ_MAX:
-        IGRAPH_CHECK(igraph_i_sparse_weighted_adjacency_max(adjmatrix, &edges,
-                     weights, loops));
-        break;
-    case IGRAPH_ADJ_UNDIRECTED:
-        IGRAPH_CHECK(igraph_i_sparse_weighted_adjacency_undirected(adjmatrix, &edges,
-                     weights, loops));
-        break;
-    case IGRAPH_ADJ_UPPER:
-        IGRAPH_CHECK(igraph_i_sparse_weighted_adjacency_upper(adjmatrix, &edges,
-                     weights, loops));
-        break;
-    case IGRAPH_ADJ_LOWER:
-        IGRAPH_CHECK(igraph_i_sparse_weighted_adjacency_lower(adjmatrix, &edges,
-                     weights, loops));
-        break;
-    case IGRAPH_ADJ_MIN:
-        IGRAPH_CHECK(igraph_i_sparse_weighted_adjacency_min(adjmatrix, &edges,
-                     weights, loops));
-        break;
-    case IGRAPH_ADJ_PLUS:
-        IGRAPH_CHECK(igraph_i_sparse_weighted_adjacency_plus(adjmatrix, &edges,
-                     weights, loops));
-        break;
-    default:
-        IGRAPH_ERROR("Invalid adjacency mode.", IGRAPH_EINVAL);
-    }
-
-    /* Create graph */
-    IGRAPH_CHECK(igraph_empty(graph, no_of_nodes, (mode == IGRAPH_ADJ_DIRECTED)));
-    IGRAPH_FINALLY(igraph_destroy, graph);
-    if (igraph_vector_int_size(&edges) > 0) {
-        IGRAPH_CHECK(igraph_add_edges(graph, &edges, NULL));
-    }
-    IGRAPH_FINALLY_CLEAN(1);
-
-    /* Cleanup */
-    igraph_vector_int_destroy(&edges);
-    IGRAPH_FINALLY_CLEAN(1);
-
-    return IGRAPH_SUCCESS;
-}
-
 /**
  * \function igraph_adjlist
  * \brief Creates a graph from an adjacency list.
@@ -1613,6 +895,663 @@ igraph_error_t igraph_adjlist(igraph_t *graph, const igraph_adjlist_t *adjlist,
     else
         IGRAPH_CHECK(igraph_create(graph, &edges, no_of_nodes, 1));
 
+    igraph_vector_int_destroy(&edges);
+    IGRAPH_FINALLY_CLEAN(1);
+
+    return IGRAPH_SUCCESS;
+}
+
+static igraph_error_t igraph_i_sparse_adjacency_directed(
+    igraph_sparsemat_t *adjmatrix, igraph_vector_int_t *edges,
+    igraph_loops_t loops
+) {
+    CS_INT *p = adjmatrix->cs->p;
+    CS_INT *i = adjmatrix->cs->i;
+    CS_INT no_of_edges = adjmatrix->cs->p[adjmatrix->cs->n];
+    igraph_integer_t from = 0;
+    igraph_integer_t to = 0;
+    igraph_integer_t e = 0;
+    CS_ENTRY *entry = adjmatrix->cs->x;
+
+    while (*p < no_of_edges) {
+        while (to < * (p + 1)) {
+            igraph_integer_t multi = *entry;
+            if (from == *i) {
+                IGRAPH_CHECK(igraph_i_adjust_loop_edge_count(&multi, loops));
+            }
+            for (igraph_integer_t count = 0; count < multi; count++) {
+                //TODO edge directions are reverse of igraph_sparsemat(), why?
+                VECTOR(*edges)[e++] = (*i);
+                VECTOR(*edges)[e++] = from;
+            }
+            to++;
+            i++;
+            entry++;
+        }
+        from++;
+        p++;
+    }
+    igraph_vector_int_resize(edges, e);
+
+    return IGRAPH_SUCCESS;
+}
+
+static igraph_error_t igraph_i_sparse_adjacency_max(
+    igraph_sparsemat_t *adjmatrix, igraph_vector_int_t *edges,
+    igraph_loops_t loops
+) {
+    CS_INT *p = adjmatrix->cs->p;
+    CS_INT *i = adjmatrix->cs->i;
+    CS_INT no_of_edges = adjmatrix->cs->p[adjmatrix->cs->n];
+    igraph_integer_t from = 0;
+    igraph_integer_t to = 0;
+    igraph_integer_t e = 0;
+    CS_ENTRY *entry = adjmatrix->cs->x;
+
+    while (*p < no_of_edges) {
+        while (to < * (p + 1)) {
+            if (from >= *i) {
+                igraph_real_t other;
+                igraph_vector_int_t x, y;
+                igraph_vector_int_view(&x, &from, 1);
+                igraph_vector_int_view(&y, i, 1);
+                igraph_sparsemat_index(adjmatrix, &x, &y, NULL, &other);
+                igraph_integer_t multi = *entry > other ? *entry : other;
+                if (from == *i) {
+                    IGRAPH_CHECK(igraph_i_adjust_loop_edge_count(&multi, loops));
+                }
+                for (igraph_integer_t count = 0; count < multi; count++) {
+                    //edge directions are reverse of igraph_sparsemat()
+                    VECTOR(*edges)[e++] = (*i);
+                    VECTOR(*edges)[e++] = from;
+                }
+            }
+            to++;
+            i++;
+            entry++;
+        }
+        from++;
+        p++;
+    }
+    igraph_vector_int_resize(edges, e);
+
+    return IGRAPH_SUCCESS;
+}
+
+static igraph_error_t igraph_i_sparse_adjacency_min(
+    igraph_sparsemat_t *adjmatrix, igraph_vector_int_t *edges,
+    igraph_loops_t loops
+) {
+    CS_INT *p = adjmatrix->cs->p;
+    CS_INT *i = adjmatrix->cs->i;
+    CS_INT no_of_edges = adjmatrix->cs->p[adjmatrix->cs->n];
+    igraph_integer_t from = 0;
+    igraph_integer_t to = 0;
+    igraph_integer_t e = 0;
+    CS_ENTRY *entry = adjmatrix->cs->x;
+
+    while (*p < no_of_edges) {
+        while (to < * (p + 1)) {
+            if (from >= *i) {
+                igraph_real_t other;
+                igraph_vector_int_t x, y;
+                igraph_vector_int_view(&x, &from, 1);
+                igraph_vector_int_view(&y, i, 1);
+                igraph_sparsemat_index(adjmatrix, &x, &y, NULL, &other);
+                igraph_integer_t multi = *entry < other ? *entry : other;
+                if (from == *i) {
+                    IGRAPH_CHECK(igraph_i_adjust_loop_edge_count(&multi, loops));
+                }
+                for (igraph_integer_t count = 0; count < multi; count++) {
+                    //edge directions are reverse of igraph_sparsemat()
+                    VECTOR(*edges)[e++] = (*i);
+                    VECTOR(*edges)[e++] = from;
+                }
+            }
+            to++;
+            i++;
+            entry++;
+        }
+        from++;
+        p++;
+    }
+    igraph_vector_int_resize(edges, e);
+
+    return IGRAPH_SUCCESS;
+}
+
+static igraph_error_t igraph_i_sparse_adjacency_plus(
+    igraph_sparsemat_t *adjmatrix, igraph_vector_int_t *edges,
+    igraph_loops_t loops
+) {
+    CS_INT *p = adjmatrix->cs->p;
+    CS_INT *i = adjmatrix->cs->i;
+    CS_INT no_of_edges = adjmatrix->cs->p[adjmatrix->cs->n];
+    igraph_integer_t from = 0;
+    igraph_integer_t to = 0;
+    igraph_integer_t e = 0;
+    CS_ENTRY *entry = adjmatrix->cs->x;
+
+    while (*p < no_of_edges) {
+        while (to < * (p + 1)) {
+            if (from >= *i) {
+                igraph_real_t other;
+                igraph_vector_int_t x, y;
+                igraph_vector_int_view(&x, &from, 1);
+                igraph_vector_int_view(&y, i, 1);
+                igraph_sparsemat_index(adjmatrix, &x, &y, NULL, &other);
+                igraph_integer_t multi = *entry + other;
+                if (from == *i) {
+                    IGRAPH_CHECK(igraph_i_adjust_loop_edge_count(&multi, loops));
+                }
+                for (igraph_integer_t count = 0; count < multi; count++) {
+                    //edge directions are reverse of igraph_sparsemat()
+                    VECTOR(*edges)[e++] = (*i);
+                    VECTOR(*edges)[e++] = from;
+                }
+            }
+            to++;
+            i++;
+            entry++;
+        }
+        from++;
+        p++;
+    }
+    igraph_vector_int_resize(edges, e);
+
+    return IGRAPH_SUCCESS;
+}
+
+static igraph_error_t igraph_i_sparse_adjacency_upper(
+    igraph_sparsemat_t *adjmatrix, igraph_vector_int_t *edges,
+    igraph_loops_t loops
+) {
+    CS_INT *p = adjmatrix->cs->p;
+    CS_INT *i = adjmatrix->cs->i;
+    CS_INT no_of_edges = adjmatrix->cs->p[adjmatrix->cs->n];
+    igraph_integer_t from = 0;
+    igraph_integer_t to = 0;
+    igraph_integer_t e = 0;
+    CS_ENTRY *entry = adjmatrix->cs->x;
+
+    while (*p < no_of_edges) {
+        while (to < * (p + 1)) {
+            if (from >= *i) {
+                igraph_integer_t multi = *entry;
+                if (from == *i) {
+                    IGRAPH_CHECK(igraph_i_adjust_loop_edge_count(&multi, loops));
+                }
+                for (igraph_integer_t count = 0; count < multi; count++) {
+                    //edge directions are reverse of igraph_sparsemat()
+                    VECTOR(*edges)[e++] = (*i);
+                    VECTOR(*edges)[e++] = from;
+                }
+            }
+            to++;
+            i++;
+            entry++;
+        }
+        from++;
+        p++;
+    }
+    igraph_vector_int_resize(edges, e);
+
+    return IGRAPH_SUCCESS;
+}
+
+
+static igraph_error_t igraph_i_sparse_adjacency_lower(
+    igraph_sparsemat_t *adjmatrix, igraph_vector_int_t *edges,
+    igraph_loops_t loops
+) {
+    CS_INT *p = adjmatrix->cs->p;
+    CS_INT *i = adjmatrix->cs->i;
+    CS_INT no_of_edges = adjmatrix->cs->p[adjmatrix->cs->n];
+    igraph_integer_t from = 0;
+    igraph_integer_t to = 0;
+    igraph_integer_t e = 0;
+    CS_ENTRY *entry = adjmatrix->cs->x;
+
+    while (*p < no_of_edges) {
+        while (to < * (p + 1)) {
+            if (from <= *i) {
+                igraph_integer_t multi = *entry;
+                if (from == *i) {
+                    IGRAPH_CHECK(igraph_i_adjust_loop_edge_count(&multi, loops));
+                }
+                for (igraph_integer_t count = 0; count < multi; count++) {
+                    //edge directions are reverse of igraph_sparsemat()
+                    VECTOR(*edges)[e++] = (*i);
+                    VECTOR(*edges)[e++] = from;
+                }
+            }
+            to++;
+            i++;
+            entry++;
+        }
+        from++;
+        p++;
+    }
+    igraph_vector_int_resize(edges, e);
+
+    return IGRAPH_SUCCESS;
+}
+
+static igraph_error_t igraph_i_sparse_adjacency_undirected(
+    igraph_sparsemat_t *adjmatrix, igraph_vector_int_t *edges,
+    igraph_loops_t loops
+) {
+    CS_INT *p = adjmatrix->cs->p;
+    CS_INT *i = adjmatrix->cs->i;
+    CS_INT no_of_edges = adjmatrix->cs->p[adjmatrix->cs->n];
+    igraph_integer_t from = 0;
+    igraph_integer_t to = 0;
+    igraph_integer_t e = 0;
+    CS_ENTRY *entry = adjmatrix->cs->x;
+
+    if (!igraph_sparsemat_is_symmetric(adjmatrix)) {
+        IGRAPH_ERROR("Adjacency matrix should be symmetric for IGRAPH_ADJ_UNDIRECTED.",
+                IGRAPH_EINVAL);
+    }
+    while (*p < no_of_edges) {
+        while (to < * (p + 1)) {
+            if (from >= *i) {
+                igraph_integer_t multi = *entry;
+                if (from == *i) {
+                    IGRAPH_CHECK(igraph_i_adjust_loop_edge_count(&multi, loops));
+                }
+                for (igraph_integer_t count = 0; count < multi; count++) {
+                    VECTOR(*edges)[e++] = (*i);
+                    VECTOR(*edges)[e++] = from;
+                }
+            }
+            to++;
+            i++;
+            entry++;
+        }
+        from++;
+        p++;
+    }
+    igraph_vector_int_resize(edges, e);
+
+    return IGRAPH_SUCCESS;
+}
+
+igraph_error_t igraph_sparse_adjacency(igraph_t *graph, igraph_sparsemat_t *adjmatrix,
+        igraph_adjacency_t mode, igraph_loops_t loops) {
+
+    igraph_vector_int_t edges = IGRAPH_VECTOR_NULL;
+    CS_INT no_of_nodes = adjmatrix->cs->m;
+    CS_INT no_of_edges = adjmatrix->cs->p[adjmatrix->cs->n];
+    if (no_of_edges) {
+        no_of_edges *= igraph_sparsemat_max(adjmatrix) * 2; //TODO maybe find a better maximum?
+    }
+
+    if (!igraph_sparsemat_is_cc(adjmatrix)) {
+        IGRAPH_ERROR("Sparese adjacency matrix should be in column-compressed "
+               "form.", IGRAPH_EINVAL);
+    }
+    if (no_of_nodes != adjmatrix->cs->n) {
+        IGRAPH_ERROR("Adjacency matrix is non-square.", IGRAPH_NONSQUARE);
+    }
+
+    if (no_of_nodes != 0 && igraph_sparsemat_min(adjmatrix) < 0) {
+        IGRAPH_ERRORF("Edge counts should be non-negative, found %g.", IGRAPH_EINVAL,
+                igraph_sparsemat_min(adjmatrix));
+    }
+
+    IGRAPH_VECTOR_INT_INIT_FINALLY(&edges, no_of_edges * 2);
+
+    /* Collect the edges */
+    switch (mode) {
+    case IGRAPH_ADJ_DIRECTED:
+        IGRAPH_CHECK(igraph_i_sparse_adjacency_directed(adjmatrix, &edges, loops));
+        break;
+    case IGRAPH_ADJ_MAX:
+        IGRAPH_CHECK(igraph_i_sparse_adjacency_max(adjmatrix, &edges, loops));
+        break;
+    case IGRAPH_ADJ_UNDIRECTED:
+        IGRAPH_CHECK(igraph_i_sparse_adjacency_undirected(adjmatrix, &edges, loops));
+        break;
+    case IGRAPH_ADJ_UPPER:
+        IGRAPH_CHECK(igraph_i_sparse_adjacency_upper(adjmatrix, &edges, loops));
+        break;
+    case IGRAPH_ADJ_LOWER:
+        IGRAPH_CHECK(igraph_i_sparse_adjacency_lower(adjmatrix, &edges, loops));
+        break;
+    case IGRAPH_ADJ_MIN:
+        IGRAPH_CHECK(igraph_i_sparse_adjacency_min(adjmatrix, &edges, loops));
+        break;
+    case IGRAPH_ADJ_PLUS:
+        IGRAPH_CHECK(igraph_i_sparse_adjacency_directed(adjmatrix, &edges, loops));
+        break;
+    default:
+        IGRAPH_ERROR("Invalid adjacency mode.", IGRAPH_EINVAL);
+    }
+
+    IGRAPH_CHECK(igraph_create(graph, &edges, no_of_nodes, (mode == IGRAPH_ADJ_DIRECTED)));
+    igraph_vector_int_destroy(&edges);
+    IGRAPH_FINALLY_CLEAN(1);
+
+    return IGRAPH_SUCCESS;
+}
+
+static igraph_error_t igraph_i_sparse_weighted_adjacency_max (
+    igraph_sparsemat_t *adjmatrix, igraph_vector_int_t *edges,
+    igraph_vector_t *weights, igraph_loops_t loops
+) {
+    CS_INT *p = adjmatrix->cs->p;
+    CS_INT *i = adjmatrix->cs->i;
+    CS_INT no_of_edges = adjmatrix->cs->p[adjmatrix->cs->n];
+    igraph_integer_t from = 0;
+    igraph_integer_t to = 0;
+    igraph_integer_t e = 0;
+    CS_ENTRY *entry = adjmatrix->cs->x;
+
+    while (*p < no_of_edges) {
+        while (to < * (p + 1)) {
+            if (from >= *i) {
+                igraph_real_t other;
+                igraph_vector_int_t x, y;
+                igraph_vector_int_view(&x, &from, 1);
+                igraph_vector_int_view(&y, i, 1);
+                igraph_sparsemat_index(adjmatrix, &x, &y, NULL, &other);
+                igraph_real_t weight = *entry > other ? *entry : other;
+                if (from == *i) {
+                    igraph_i_adjust_loop_edge_weight(&weight, loops);
+                }
+                if (weight != 0) {
+                    VECTOR(*weights)[e/2] = weight;
+                    VECTOR(*edges)[e++] = (*i);
+                    VECTOR(*edges)[e++] = from;
+                }
+            }
+            to++;
+            i++;
+            entry++;
+        }
+        from++;
+        p++;
+    }
+    igraph_vector_int_resize(edges, e);
+    igraph_vector_resize(weights, e/2);
+
+    return IGRAPH_SUCCESS;
+}
+static igraph_error_t igraph_i_sparse_weighted_adjacency_min (
+    igraph_sparsemat_t *adjmatrix, igraph_vector_int_t *edges,
+    igraph_vector_t *weights, igraph_loops_t loops
+) {
+    CS_INT *p = adjmatrix->cs->p;
+    CS_INT *i = adjmatrix->cs->i;
+    CS_INT no_of_edges = adjmatrix->cs->p[adjmatrix->cs->n];
+    igraph_integer_t from = 0;
+    igraph_integer_t to = 0;
+    igraph_integer_t e = 0;
+    CS_ENTRY *entry = adjmatrix->cs->x;
+
+    while (*p < no_of_edges) {
+        while (to < * (p + 1)) {
+            if (from >= *i) {
+                igraph_real_t other;
+                igraph_vector_int_t x, y;
+                igraph_vector_int_view(&x, &from, 1);
+                igraph_vector_int_view(&y, i, 1);
+                igraph_sparsemat_index(adjmatrix, &x, &y, NULL, &other);
+                igraph_real_t weight = *entry < other ? *entry : other;
+                if (from == *i) {
+                    igraph_i_adjust_loop_edge_weight(&weight, loops);
+                }
+                if (weight != 0) {
+                    VECTOR(*weights)[e/2] = weight;
+                    VECTOR(*edges)[e++] = (*i);
+                    VECTOR(*edges)[e++] = from;
+                }
+            }
+            to++;
+            i++;
+            entry++;
+        }
+        from++;
+        p++;
+    }
+    igraph_vector_int_resize(edges, e);
+    igraph_vector_resize(weights, e/2);
+
+    return IGRAPH_SUCCESS;
+}
+
+static igraph_error_t igraph_i_sparse_weighted_adjacency_plus (
+    igraph_sparsemat_t *adjmatrix, igraph_vector_int_t *edges,
+    igraph_vector_t *weights, igraph_loops_t loops
+) {
+    CS_INT *p = adjmatrix->cs->p;
+    CS_INT *i = adjmatrix->cs->i;
+    CS_INT no_of_edges = adjmatrix->cs->p[adjmatrix->cs->n];
+    igraph_integer_t from = 0;
+    igraph_integer_t to = 0;
+    igraph_integer_t e = 0;
+    CS_ENTRY *entry = adjmatrix->cs->x;
+
+    while (*p < no_of_edges) {
+        while (to < * (p + 1)) {
+            if (from >= *i) {
+                igraph_real_t weight = *entry;
+                if (from != *i) {
+                    igraph_real_t other;
+                    igraph_vector_int_t x, y;
+                    igraph_vector_int_view(&x, &from, 1);
+                    igraph_vector_int_view(&y, i, 1);
+                    igraph_sparsemat_index(adjmatrix, &x, &y, NULL, &other);
+                    weight += other;
+                }
+                if (from == *i) {
+                    igraph_i_adjust_loop_edge_weight(&weight, loops);
+                }
+                if (weight != 0) {
+                    VECTOR(*weights)[e/2] = weight;
+                    VECTOR(*edges)[e++] = (*i);
+                    VECTOR(*edges)[e++] = from;
+                }
+            }
+            to++;
+            i++;
+            entry++;
+        }
+        from++;
+        p++;
+    }
+    igraph_vector_int_resize(edges, e);
+    igraph_vector_resize(weights, e/2);
+
+    return IGRAPH_SUCCESS;
+}
+
+static igraph_error_t igraph_i_sparse_weighted_adjacency_undirected (
+    igraph_sparsemat_t *adjmatrix, igraph_vector_int_t *edges,
+    igraph_vector_t *weights, igraph_loops_t loops
+) {
+    if (!igraph_sparsemat_is_symmetric(adjmatrix)) {
+        IGRAPH_ERROR("Adjacency matrix should be symmetric to produce an undirected graph.",
+                IGRAPH_EINVAL);
+    }
+    return igraph_i_sparse_weighted_adjacency_max(adjmatrix, edges, weights, loops);
+}
+
+static igraph_error_t igraph_i_sparse_weighted_adjacency_upper(
+    igraph_sparsemat_t *adjmatrix, igraph_vector_int_t *edges,
+    igraph_vector_t *weights, igraph_loops_t loops
+) {
+    CS_INT *p = adjmatrix->cs->p;
+    CS_INT *i = adjmatrix->cs->i;
+    CS_INT no_of_edges = adjmatrix->cs->p[adjmatrix->cs->n];
+    igraph_integer_t from = 0;
+    igraph_integer_t to = 0;
+    igraph_integer_t e = 0;
+    CS_ENTRY *entry = adjmatrix->cs->x;
+
+    while (*p < no_of_edges) {
+        while (to < * (p + 1)) {
+            if (from >= *i) {
+                igraph_real_t weight = *entry;
+                if (from == *i) {
+                    igraph_i_adjust_loop_edge_weight(&weight, loops);
+                }
+                if (weight != 0) {
+                    VECTOR(*weights)[e/2] = weight;
+                    VECTOR(*edges)[e++] = (*i);
+                    VECTOR(*edges)[e++] = from;
+                }
+            }
+            to++;
+            i++;
+            entry++;
+        }
+        from++;
+        p++;
+    }
+    igraph_vector_int_resize(edges, e);
+    igraph_vector_resize(weights, e/2);
+
+    return IGRAPH_SUCCESS;
+}
+
+static igraph_error_t igraph_i_sparse_weighted_adjacency_lower(
+    igraph_sparsemat_t *adjmatrix, igraph_vector_int_t *edges,
+    igraph_vector_t *weights, igraph_loops_t loops
+) {
+    CS_INT *p = adjmatrix->cs->p;
+    CS_INT *i = adjmatrix->cs->i;
+    CS_INT no_of_edges = adjmatrix->cs->p[adjmatrix->cs->n];
+    igraph_integer_t from = 0;
+    igraph_integer_t to = 0;
+    igraph_integer_t e = 0;
+    CS_ENTRY *entry = adjmatrix->cs->x;
+
+    while (*p < no_of_edges) {
+        while (to < * (p + 1)) {
+            if (from <= *i) {
+                igraph_real_t weight = *entry;
+                if (from == *i) {
+                    igraph_i_adjust_loop_edge_weight(&weight, loops);
+                }
+                if (weight != 0) {
+                    VECTOR(*weights)[e/2] = weight;
+                    VECTOR(*edges)[e++] = (*i);
+                    VECTOR(*edges)[e++] = from;
+                }
+            }
+            to++;
+            i++;
+            entry++;
+        }
+        from++;
+        p++;
+    }
+    igraph_vector_int_resize(edges, e);
+    igraph_vector_resize(weights, e/2);
+
+    return IGRAPH_SUCCESS;
+}
+
+static igraph_error_t igraph_i_sparse_weighted_adjacency_directed(
+    igraph_sparsemat_t *adjmatrix, igraph_vector_int_t *edges,
+    igraph_vector_t *weights, igraph_loops_t loops
+) {
+    CS_INT *p = adjmatrix->cs->p;
+    CS_INT *i = adjmatrix->cs->i;
+    CS_INT no_of_edges = adjmatrix->cs->p[adjmatrix->cs->n];
+    igraph_integer_t from = 0;
+    igraph_integer_t to = 0;
+    igraph_integer_t e = 0;
+    CS_ENTRY *entry = adjmatrix->cs->x;
+
+    while (*p < no_of_edges) {
+        while (to < * (p + 1)) {
+            igraph_real_t weight = *entry;
+            if (from == *i) {
+                igraph_i_adjust_loop_edge_weight(&weight, loops);
+            }
+            if (weight != 0) {
+                VECTOR(*weights)[e/2] = weight;
+                VECTOR(*edges)[e++] = (*i);
+                VECTOR(*edges)[e++] = from;
+            }
+            to++;
+            i++;
+            entry++;
+        }
+        from++;
+        p++;
+    }
+    igraph_vector_int_resize(edges, e);
+    igraph_vector_resize(weights, e/2);
+
+    return IGRAPH_SUCCESS;
+}
+
+
+igraph_error_t igraph_sparse_weighted_adjacency(
+    igraph_t *graph, igraph_sparsemat_t *adjmatrix, igraph_adjacency_t mode,
+    igraph_vector_t *weights, igraph_loops_t loops
+) {
+    igraph_vector_int_t edges;
+    CS_INT no_of_edges = adjmatrix->cs->p[adjmatrix->cs->n];
+    if (no_of_edges) {
+        no_of_edges *= igraph_sparsemat_max(adjmatrix); //TODO maybe find a better maximum?
+    }
+    CS_INT no_of_nodes = adjmatrix->cs->m;
+    /* Some checks */
+    if (igraph_sparsemat_nrow(adjmatrix) != igraph_sparsemat_ncol(adjmatrix)) {
+        IGRAPH_ERROR("Non-square matrix", IGRAPH_NONSQUARE);
+    }
+
+    IGRAPH_VECTOR_INT_INIT_FINALLY(&edges, no_of_edges * 2);
+    igraph_vector_resize(weights, no_of_edges);
+
+    /* Collect the edges */
+    switch (mode) {
+    case IGRAPH_ADJ_DIRECTED:
+        IGRAPH_CHECK(igraph_i_sparse_weighted_adjacency_directed(adjmatrix, &edges,
+                     weights, loops));
+        break;
+    case IGRAPH_ADJ_MAX:
+        IGRAPH_CHECK(igraph_i_sparse_weighted_adjacency_max(adjmatrix, &edges,
+                     weights, loops));
+        break;
+    case IGRAPH_ADJ_UNDIRECTED:
+        IGRAPH_CHECK(igraph_i_sparse_weighted_adjacency_undirected(adjmatrix, &edges,
+                     weights, loops));
+        break;
+    case IGRAPH_ADJ_UPPER:
+        IGRAPH_CHECK(igraph_i_sparse_weighted_adjacency_upper(adjmatrix, &edges,
+                     weights, loops));
+        break;
+    case IGRAPH_ADJ_LOWER:
+        IGRAPH_CHECK(igraph_i_sparse_weighted_adjacency_lower(adjmatrix, &edges,
+                     weights, loops));
+        break;
+    case IGRAPH_ADJ_MIN:
+        IGRAPH_CHECK(igraph_i_sparse_weighted_adjacency_min(adjmatrix, &edges,
+                     weights, loops));
+        break;
+    case IGRAPH_ADJ_PLUS:
+        IGRAPH_CHECK(igraph_i_sparse_weighted_adjacency_plus(adjmatrix, &edges,
+                     weights, loops));
+        break;
+    default:
+        IGRAPH_ERROR("Invalid adjacency mode.", IGRAPH_EINVAL);
+    }
+
+    /* Create graph */
+    IGRAPH_CHECK(igraph_empty(graph, no_of_nodes, (mode == IGRAPH_ADJ_DIRECTED)));
+    IGRAPH_FINALLY(igraph_destroy, graph);
+    if (igraph_vector_int_size(&edges) > 0) {
+        IGRAPH_CHECK(igraph_add_edges(graph, &edges, NULL));
+    }
+    IGRAPH_FINALLY_CLEAN(1);
+
+    /* Cleanup */
     igraph_vector_int_destroy(&edges);
     IGRAPH_FINALLY_CLEAN(1);
 

--- a/src/constructors/adjacency.c
+++ b/src/constructors/adjacency.c
@@ -140,8 +140,10 @@ static igraph_error_t igraph_i_adjacency_undirected(
     igraph_loops_t loops
 ) {
     if (!igraph_matrix_is_symmetric(adjmatrix)) {
-        IGRAPH_ERROR("Adjacency matrix should be symmetric for IGRAPH_ADJ_UNDIRECTED.",
-                IGRAPH_EINVAL);
+        IGRAPH_ERROR(
+            "Adjacency matrix should be symmetric to produce an undirected graph.",
+            IGRAPH_EINVAL
+        );
     }
     return igraph_i_adjacency_max(adjmatrix, edges, loops);
 }
@@ -536,8 +538,10 @@ static igraph_error_t igraph_i_weighted_adjacency_undirected(
     igraph_loops_t loops
 ) {
     if (!igraph_matrix_is_symmetric(adjmatrix)) {
-        IGRAPH_ERROR("Adjacency matrix should be symmetric for IGRAPH_ADJ_UNDIRECTED.",
-                IGRAPH_EINVAL);
+        IGRAPH_ERROR(
+            "Adjacency matrix should be symmetric to produce an undirected graph.",
+            IGRAPH_EINVAL
+        );
     }
     return igraph_i_weighted_adjacency_max(adjmatrix, edges, weights, loops);
 }
@@ -1049,32 +1053,13 @@ static igraph_error_t igraph_i_sparse_adjacency_undirected(
     igraph_sparsemat_t *adjmatrix, igraph_vector_int_t *edges,
     igraph_loops_t loops
 ) {
-    igraph_sparsemat_iterator_t it;
-    igraph_sparsemat_iterator_init(&it, adjmatrix);
-    igraph_integer_t e = 0;
-
     if (!igraph_sparsemat_is_symmetric(adjmatrix)) {
-        IGRAPH_ERROR("Adjacency matrix should be symmetric for IGRAPH_ADJ_UNDIRECTED.",
-                IGRAPH_EINVAL);
+        IGRAPH_ERROR(
+            "Adjacency matrix should be symmetric to produce an undirected graph.",
+            IGRAPH_EINVAL
+        );
     }
-    for (; !igraph_sparsemat_iterator_end(&it); igraph_sparsemat_iterator_next(&it)) {
-        igraph_integer_t from = igraph_sparsemat_iterator_row(&it);
-        igraph_integer_t to = igraph_sparsemat_iterator_col(&it);
-        if (to < from) {
-            continue;
-        }
-        igraph_integer_t multi = igraph_sparsemat_iterator_get(&it);
-        if (to == from) {
-            IGRAPH_CHECK(igraph_i_adjust_loop_edge_count(&multi, loops));
-        }
-        for (igraph_integer_t count = 0; count < multi; count++) {
-            VECTOR(*edges)[e++] = from;
-            VECTOR(*edges)[e++] = to;
-        }
-    }
-    igraph_vector_int_resize(edges, e);
-
-    return IGRAPH_SUCCESS;
+    return igraph_i_sparse_adjacency_upper(adjmatrix, edges, loops);
 }
 
 /**
@@ -1322,8 +1307,10 @@ static igraph_error_t igraph_i_sparse_weighted_adjacency_undirected (
     igraph_vector_t *weights, igraph_loops_t loops
 ) {
     if (!igraph_sparsemat_is_symmetric(adjmatrix)) {
-        IGRAPH_ERROR("Adjacency matrix should be symmetric from produce an undirected graph.",
-                IGRAPH_EINVAL);
+        IGRAPH_ERROR(
+            "Adjacency matrix should be symmetric to produce an undirected graph.",
+            IGRAPH_EINVAL
+        );
     }
     return igraph_i_sparse_weighted_adjacency_upper(adjmatrix, edges, weights, loops);
 }

--- a/src/constructors/adjacency.c
+++ b/src/constructors/adjacency.c
@@ -908,12 +908,11 @@ static igraph_error_t igraph_i_sparse_adjacency_directed(
     CS_INT *p = adjmatrix->cs->p;
     CS_INT *i = adjmatrix->cs->i;
     CS_INT no_of_edges = adjmatrix->cs->p[adjmatrix->cs->n];
-    igraph_integer_t from = 0;
     igraph_integer_t to = 0;
     igraph_integer_t e = 0;
     CS_ENTRY *entry = adjmatrix->cs->x;
 
-    while (p[from] < no_of_edges) {
+    for (igraph_integer_t from = 0; p[from] < no_of_edges; from++) {
         while (to < p[from + 1]) {
             igraph_integer_t multi = entry[to];
             if (from == i[to]) {
@@ -926,7 +925,6 @@ static igraph_error_t igraph_i_sparse_adjacency_directed(
             }
             to++;
         }
-        from++;
     }
     igraph_vector_int_resize(edges, e);
 
@@ -940,12 +938,11 @@ static igraph_error_t igraph_i_sparse_adjacency_max(
     CS_INT *p = adjmatrix->cs->p;
     CS_INT *i = adjmatrix->cs->i;
     CS_INT no_of_edges = adjmatrix->cs->p[adjmatrix->cs->n];
-    igraph_integer_t from = 0;
     igraph_integer_t to = 0;
     igraph_integer_t e = 0;
     CS_ENTRY *entry = adjmatrix->cs->x;
 
-    while (p[from] < no_of_edges) {
+    for (igraph_integer_t from = 0; p[from] < no_of_edges; from++) {
         while (to < p[from + 1]) {
             if (from >= i[to]) {
                 igraph_real_t other;
@@ -965,7 +962,6 @@ static igraph_error_t igraph_i_sparse_adjacency_max(
             }
             to++;
         }
-        from++;
     }
     igraph_vector_int_resize(edges, e);
 
@@ -979,12 +975,11 @@ static igraph_error_t igraph_i_sparse_adjacency_min(
     CS_INT *p = adjmatrix->cs->p;
     CS_INT *i = adjmatrix->cs->i;
     CS_INT no_of_edges = adjmatrix->cs->p[adjmatrix->cs->n];
-    igraph_integer_t from = 0;
     igraph_integer_t to = 0;
     igraph_integer_t e = 0;
     CS_ENTRY *entry = adjmatrix->cs->x;
 
-    while (p[from] < no_of_edges) {
+    for (igraph_integer_t from = 0; p[from] < no_of_edges; from++) {
         while (to < p[from + 1]) {
             if (from >= i[to]) {
                 igraph_real_t other;
@@ -1004,7 +999,6 @@ static igraph_error_t igraph_i_sparse_adjacency_min(
             }
             to++;
         }
-        from++;
     }
     igraph_vector_int_resize(edges, e);
 
@@ -1018,12 +1012,11 @@ static igraph_error_t igraph_i_sparse_adjacency_plus(
     CS_INT *p = adjmatrix->cs->p;
     CS_INT *i = adjmatrix->cs->i;
     CS_INT no_of_edges = adjmatrix->cs->p[adjmatrix->cs->n];
-    igraph_integer_t from = 0;
     igraph_integer_t to = 0;
     igraph_integer_t e = 0;
     CS_ENTRY *entry = adjmatrix->cs->x;
 
-    while (p[from] < no_of_edges) {
+    for (igraph_integer_t from = 0; p[from] < no_of_edges; from++) {
         while (to < p[from + 1]) {
             if (from >= i[to]) {
                 igraph_real_t other;
@@ -1043,7 +1036,6 @@ static igraph_error_t igraph_i_sparse_adjacency_plus(
             }
             to++;
         }
-        from++;
     }
     igraph_vector_int_resize(edges, e);
 
@@ -1057,12 +1049,11 @@ static igraph_error_t igraph_i_sparse_adjacency_upper(
     CS_INT *p = adjmatrix->cs->p;
     CS_INT *i = adjmatrix->cs->i;
     CS_INT no_of_edges = adjmatrix->cs->p[adjmatrix->cs->n];
-    igraph_integer_t from = 0;
     igraph_integer_t to = 0;
     igraph_integer_t e = 0;
     CS_ENTRY *entry = adjmatrix->cs->x;
 
-    while (p[from] < no_of_edges) {
+    for (igraph_integer_t from = 0; p[from] < no_of_edges; from++) {
         while (to < p[from + 1]) {
             if (from >= i[to]) {
                 igraph_integer_t multi = entry[to];
@@ -1077,7 +1068,6 @@ static igraph_error_t igraph_i_sparse_adjacency_upper(
             }
             to++;
         }
-        from++;
     }
     igraph_vector_int_resize(edges, e);
 
@@ -1092,12 +1082,11 @@ static igraph_error_t igraph_i_sparse_adjacency_lower(
     CS_INT *p = adjmatrix->cs->p;
     CS_INT *i = adjmatrix->cs->i;
     CS_INT no_of_edges = adjmatrix->cs->p[adjmatrix->cs->n];
-    igraph_integer_t from = 0;
     igraph_integer_t to = 0;
     igraph_integer_t e = 0;
     CS_ENTRY *entry = adjmatrix->cs->x;
 
-    while (p[from] < no_of_edges) {
+    for (igraph_integer_t from = 0; p[from] < no_of_edges; from++) {
         while (to < p[from + 1]) {
             if (from <= i[to]) {
                 igraph_integer_t multi = entry[to];
@@ -1112,7 +1101,6 @@ static igraph_error_t igraph_i_sparse_adjacency_lower(
             }
             to++;
         }
-        from++;
     }
     igraph_vector_int_resize(edges, e);
 
@@ -1126,7 +1114,6 @@ static igraph_error_t igraph_i_sparse_adjacency_undirected(
     CS_INT *p = adjmatrix->cs->p;
     CS_INT *i = adjmatrix->cs->i;
     CS_INT no_of_edges = adjmatrix->cs->p[adjmatrix->cs->n];
-    igraph_integer_t from = 0;
     igraph_integer_t to = 0;
     igraph_integer_t e = 0;
     CS_ENTRY *entry = adjmatrix->cs->x;
@@ -1135,7 +1122,7 @@ static igraph_error_t igraph_i_sparse_adjacency_undirected(
         IGRAPH_ERROR("Adjacency matrix should be symmetric for IGRAPH_ADJ_UNDIRECTED.",
                 IGRAPH_EINVAL);
     }
-    while (p[from] < no_of_edges) {
+    for (igraph_integer_t from = 0; p[from] < no_of_edges; from++) {
         while (to < p[from + 1]) {
             if (from >= i[to]) {
                 igraph_integer_t multi = entry[to];
@@ -1149,7 +1136,6 @@ static igraph_error_t igraph_i_sparse_adjacency_undirected(
             }
             to++;
         }
-        from++;
     }
     igraph_vector_int_resize(edges, e);
 
@@ -1222,12 +1208,11 @@ static igraph_error_t igraph_i_sparse_weighted_adjacency_max (
     CS_INT *p = adjmatrix->cs->p;
     CS_INT *i = adjmatrix->cs->i;
     CS_INT no_of_edges = adjmatrix->cs->p[adjmatrix->cs->n];
-    igraph_integer_t from = 0;
     igraph_integer_t to = 0;
     igraph_integer_t e = 0;
     CS_ENTRY *entry = adjmatrix->cs->x;
 
-    while (p[from] < no_of_edges) {
+    for (igraph_integer_t from = 0; p[from] < no_of_edges; from++) {
         while (to < p[from + 1]) {
             if (from >= i[to]) {
                 igraph_real_t other;
@@ -1247,7 +1232,6 @@ static igraph_error_t igraph_i_sparse_weighted_adjacency_max (
             }
             to++;
         }
-        from++;
     }
     igraph_vector_int_resize(edges, e);
     igraph_vector_resize(weights, e/2);
@@ -1261,12 +1245,11 @@ static igraph_error_t igraph_i_sparse_weighted_adjacency_min (
     CS_INT *p = adjmatrix->cs->p;
     CS_INT *i = adjmatrix->cs->i;
     CS_INT no_of_edges = adjmatrix->cs->p[adjmatrix->cs->n];
-    igraph_integer_t from = 0;
     igraph_integer_t to = 0;
     igraph_integer_t e = 0;
     CS_ENTRY *entry = adjmatrix->cs->x;
 
-    while (p[from] < no_of_edges) {
+    for (igraph_integer_t from = 0; p[from] < no_of_edges; from++) {
         while (to < p[from + 1]) {
             if (from >= i[to]) {
                 igraph_real_t other;
@@ -1286,7 +1269,6 @@ static igraph_error_t igraph_i_sparse_weighted_adjacency_min (
             }
             to++;
         }
-        from++;
     }
     igraph_vector_int_resize(edges, e);
     igraph_vector_resize(weights, e/2);
@@ -1301,12 +1283,11 @@ static igraph_error_t igraph_i_sparse_weighted_adjacency_plus (
     CS_INT *p = adjmatrix->cs->p;
     CS_INT *i = adjmatrix->cs->i;
     CS_INT no_of_edges = adjmatrix->cs->p[adjmatrix->cs->n];
-    igraph_integer_t from = 0;
     igraph_integer_t to = 0;
     igraph_integer_t e = 0;
     CS_ENTRY *entry = adjmatrix->cs->x;
 
-    while (p[from] < no_of_edges) {
+    for (igraph_integer_t from = 0; p[from] < no_of_edges; from++) {
         while (to < p[from + 1]) {
             if (from >= i[to]) {
                 igraph_real_t weight = entry[to];
@@ -1329,7 +1310,6 @@ static igraph_error_t igraph_i_sparse_weighted_adjacency_plus (
             }
             to++;
         }
-        from++;
     }
     igraph_vector_int_resize(edges, e);
     igraph_vector_resize(weights, e/2);
@@ -1355,12 +1335,11 @@ static igraph_error_t igraph_i_sparse_weighted_adjacency_upper(
     CS_INT *p = adjmatrix->cs->p;
     CS_INT *i = adjmatrix->cs->i;
     CS_INT no_of_edges = adjmatrix->cs->p[adjmatrix->cs->n];
-    igraph_integer_t from = 0;
     igraph_integer_t to = 0;
     igraph_integer_t e = 0;
     CS_ENTRY *entry = adjmatrix->cs->x;
 
-    while (p[from] < no_of_edges) {
+    for (igraph_integer_t from = 0; p[from] < no_of_edges; from++) {
         while (to < p[from + 1]) {
             if (from >= i[to]) {
                 igraph_real_t weight = entry[to];
@@ -1375,7 +1354,6 @@ static igraph_error_t igraph_i_sparse_weighted_adjacency_upper(
             }
             to++;
         }
-        from++;
     }
     igraph_vector_int_resize(edges, e);
     igraph_vector_resize(weights, e/2);
@@ -1390,12 +1368,11 @@ static igraph_error_t igraph_i_sparse_weighted_adjacency_lower(
     CS_INT *p = adjmatrix->cs->p;
     CS_INT *i = adjmatrix->cs->i;
     CS_INT no_of_edges = adjmatrix->cs->p[adjmatrix->cs->n];
-    igraph_integer_t from = 0;
     igraph_integer_t to = 0;
     igraph_integer_t e = 0;
     CS_ENTRY *entry = adjmatrix->cs->x;
 
-    while (p[from] < no_of_edges) {
+    for (igraph_integer_t from = 0; p[from] < no_of_edges; from++) {
         while (to < p[from + 1]) {
             if (from <= i[to]) {
                 igraph_real_t weight = entry[to];
@@ -1411,7 +1388,6 @@ static igraph_error_t igraph_i_sparse_weighted_adjacency_lower(
             }
             to++;
         }
-        from++;
     }
     igraph_vector_int_resize(edges, e);
     igraph_vector_resize(weights, e/2);
@@ -1426,12 +1402,11 @@ static igraph_error_t igraph_i_sparse_weighted_adjacency_directed(
     CS_INT *p = adjmatrix->cs->p;
     CS_INT *i = adjmatrix->cs->i;
     CS_INT no_of_edges = adjmatrix->cs->p[adjmatrix->cs->n];
-    igraph_integer_t from = 0;
     igraph_integer_t to = 0;
     igraph_integer_t e = 0;
     CS_ENTRY *entry = adjmatrix->cs->x;
 
-    while (p[from] < no_of_edges) {
+    for (igraph_integer_t from = 0; p[from] < no_of_edges; from++) {
         while (to < p[from + 1]) {
             igraph_real_t weight = entry[to];
             if (from == i[to]) {
@@ -1444,7 +1419,6 @@ static igraph_error_t igraph_i_sparse_weighted_adjacency_directed(
             }
             to++;
         }
-        from++;
     }
     igraph_vector_int_resize(edges, e);
     igraph_vector_resize(weights, e/2);

--- a/src/constructors/adjacency.c
+++ b/src/constructors/adjacency.c
@@ -941,14 +941,15 @@ static igraph_error_t igraph_i_sparse_adjacency_max(
             continue;
         }
         igraph_integer_t multi = igraph_sparsemat_iterator_get(&it);
-        igraph_real_t other;
-        igraph_vector_int_t x, y;
-        igraph_vector_int_view(&x, &to, 1);
-        igraph_vector_int_view(&y, &from, 1);
-        igraph_sparsemat_index(adjmatrix, &x, &y, NULL, &other);
-        multi = multi > other ? multi : other;
         if (to == from) {
             IGRAPH_CHECK(igraph_i_adjust_loop_edge_count(&multi, loops));
+        } else {
+            igraph_real_t other;
+            igraph_vector_int_t x, y;
+            igraph_vector_int_view(&x, &to, 1);
+            igraph_vector_int_view(&y, &from, 1);
+            igraph_sparsemat_index(adjmatrix, &x, &y, NULL, &other);
+            multi = multi > other ? multi : other;
         }
         for (igraph_integer_t count = 0; count < multi; count++) {
             VECTOR(*edges)[e++] = from;
@@ -975,14 +976,15 @@ static igraph_error_t igraph_i_sparse_adjacency_min(
             continue;
         }
         igraph_integer_t multi = igraph_sparsemat_iterator_get(&it);
-        igraph_real_t other;
-        igraph_vector_int_t x, y;
-        igraph_vector_int_view(&x, &to, 1);
-        igraph_vector_int_view(&y, &from, 1);
-        igraph_sparsemat_index(adjmatrix, &x, &y, NULL, &other);
-        multi = multi < other ? multi : other;
         if (to == from) {
             IGRAPH_CHECK(igraph_i_adjust_loop_edge_count(&multi, loops));
+        } else {
+            igraph_real_t other;
+            igraph_vector_int_t x, y;
+            igraph_vector_int_view(&x, &to, 1);
+            igraph_vector_int_view(&y, &from, 1);
+            igraph_sparsemat_index(adjmatrix, &x, &y, NULL, &other);
+            multi = multi < other ? multi : other;
         }
         for (igraph_integer_t count = 0; count < multi; count++) {
             VECTOR(*edges)[e++] = from;
@@ -1148,14 +1150,15 @@ static igraph_error_t igraph_i_sparse_weighted_adjacency_max (
             continue;
         }
         igraph_real_t weight = igraph_sparsemat_iterator_get(&it);
-        igraph_real_t other;
-        igraph_vector_int_t x, y;
-        igraph_vector_int_view(&x, &to, 1);
-        igraph_vector_int_view(&y, &from, 1);
-        igraph_sparsemat_index(adjmatrix, &x, &y, NULL, &other);
-        weight = weight > other ? weight : other;
         if (to == from) {
             igraph_i_adjust_loop_edge_weight(&weight, loops);
+        } else {
+            igraph_real_t other;
+            igraph_vector_int_t x, y;
+            igraph_vector_int_view(&x, &to, 1);
+            igraph_vector_int_view(&y, &from, 1);
+            igraph_sparsemat_index(adjmatrix, &x, &y, NULL, &other);
+            weight = weight > other ? weight : other;
         }
         if (weight != 0) {
             VECTOR(*weights)[e/2] = weight;
@@ -1184,14 +1187,15 @@ static igraph_error_t igraph_i_sparse_weighted_adjacency_min (
             continue;
         }
         igraph_real_t weight = igraph_sparsemat_iterator_get(&it);
-        igraph_real_t other;
-        igraph_vector_int_t x, y;
-        igraph_vector_int_view(&x, &to, 1);
-        igraph_vector_int_view(&y, &from, 1);
-        igraph_sparsemat_index(adjmatrix, &x, &y, NULL, &other);
-        weight = weight < other ? weight : other;
         if (to == from) {
             igraph_i_adjust_loop_edge_weight(&weight, loops);
+        } else {
+            igraph_real_t other;
+            igraph_vector_int_t x, y;
+            igraph_vector_int_view(&x, &to, 1);
+            igraph_vector_int_view(&y, &from, 1);
+            igraph_sparsemat_index(adjmatrix, &x, &y, NULL, &other);
+            weight = weight < other ? weight : other;
         }
         if (weight != 0) {
             VECTOR(*weights)[e/2] = weight;
@@ -1220,14 +1224,14 @@ static igraph_error_t igraph_i_sparse_weighted_adjacency_plus (
             continue;
         }
         igraph_real_t weight = igraph_sparsemat_iterator_get(&it);
-        igraph_real_t other;
-        igraph_vector_int_t x, y;
-        igraph_vector_int_view(&x, &to, 1);
-        igraph_vector_int_view(&y, &from, 1);
-        igraph_sparsemat_index(adjmatrix, &x, &y, NULL, &other);
         if (to == from) {
             igraph_i_adjust_loop_edge_weight(&weight, loops);
         } else {
+            igraph_real_t other;
+            igraph_vector_int_t x, y;
+            igraph_vector_int_view(&x, &to, 1);
+            igraph_vector_int_view(&y, &from, 1);
+            igraph_sparsemat_index(adjmatrix, &x, &y, NULL, &other);
             weight += other;
         }
         if (weight != 0) {

--- a/src/constructors/adjacency.c
+++ b/src/constructors/adjacency.c
@@ -913,7 +913,7 @@ static igraph_error_t igraph_i_sparse_adjacency_directed(
     CS_ENTRY *entry = adjmatrix->cs->x;
 
     for (igraph_integer_t from = 0; p[from] < no_of_edges; from++) {
-        while (to < p[from + 1]) {
+        for (; to < p[from + 1]; to++) {
             igraph_integer_t multi = entry[to];
             if (from == i[to]) {
                 IGRAPH_CHECK(igraph_i_adjust_loop_edge_count(&multi, loops));
@@ -923,7 +923,6 @@ static igraph_error_t igraph_i_sparse_adjacency_directed(
                 VECTOR(*edges)[e++] = i[to];
                 VECTOR(*edges)[e++] = from;
             }
-            to++;
         }
     }
     igraph_vector_int_resize(edges, e);
@@ -943,7 +942,7 @@ static igraph_error_t igraph_i_sparse_adjacency_max(
     CS_ENTRY *entry = adjmatrix->cs->x;
 
     for (igraph_integer_t from = 0; p[from] < no_of_edges; from++) {
-        while (to < p[from + 1]) {
+        for (; to < p[from + 1]; to++) {
             if (from >= i[to]) {
                 igraph_real_t other;
                 igraph_vector_int_t x, y;
@@ -960,7 +959,6 @@ static igraph_error_t igraph_i_sparse_adjacency_max(
                     VECTOR(*edges)[e++] = from;
                 }
             }
-            to++;
         }
     }
     igraph_vector_int_resize(edges, e);
@@ -980,7 +978,7 @@ static igraph_error_t igraph_i_sparse_adjacency_min(
     CS_ENTRY *entry = adjmatrix->cs->x;
 
     for (igraph_integer_t from = 0; p[from] < no_of_edges; from++) {
-        while (to < p[from + 1]) {
+        for (; to < p[from + 1]; to++) {
             if (from >= i[to]) {
                 igraph_real_t other;
                 igraph_vector_int_t x, y;
@@ -997,7 +995,6 @@ static igraph_error_t igraph_i_sparse_adjacency_min(
                     VECTOR(*edges)[e++] = from;
                 }
             }
-            to++;
         }
     }
     igraph_vector_int_resize(edges, e);
@@ -1017,7 +1014,7 @@ static igraph_error_t igraph_i_sparse_adjacency_plus(
     CS_ENTRY *entry = adjmatrix->cs->x;
 
     for (igraph_integer_t from = 0; p[from] < no_of_edges; from++) {
-        while (to < p[from + 1]) {
+        for (; to < p[from + 1]; to++) {
             if (from >= i[to]) {
                 igraph_real_t other;
                 igraph_vector_int_t x, y;
@@ -1034,7 +1031,6 @@ static igraph_error_t igraph_i_sparse_adjacency_plus(
                     VECTOR(*edges)[e++] = from;
                 }
             }
-            to++;
         }
     }
     igraph_vector_int_resize(edges, e);
@@ -1054,7 +1050,7 @@ static igraph_error_t igraph_i_sparse_adjacency_upper(
     CS_ENTRY *entry = adjmatrix->cs->x;
 
     for (igraph_integer_t from = 0; p[from] < no_of_edges; from++) {
-        while (to < p[from + 1]) {
+        for (; to < p[from + 1]; to++) {
             if (from >= i[to]) {
                 igraph_integer_t multi = entry[to];
                 if (from == i[to]) {
@@ -1066,7 +1062,6 @@ static igraph_error_t igraph_i_sparse_adjacency_upper(
                     VECTOR(*edges)[e++] = from;
                 }
             }
-            to++;
         }
     }
     igraph_vector_int_resize(edges, e);
@@ -1087,7 +1082,7 @@ static igraph_error_t igraph_i_sparse_adjacency_lower(
     CS_ENTRY *entry = adjmatrix->cs->x;
 
     for (igraph_integer_t from = 0; p[from] < no_of_edges; from++) {
-        while (to < p[from + 1]) {
+        for (; to < p[from + 1]; to++) {
             if (from <= i[to]) {
                 igraph_integer_t multi = entry[to];
                 if (from == i[to]) {
@@ -1099,7 +1094,6 @@ static igraph_error_t igraph_i_sparse_adjacency_lower(
                     VECTOR(*edges)[e++] = from;
                 }
             }
-            to++;
         }
     }
     igraph_vector_int_resize(edges, e);
@@ -1123,7 +1117,7 @@ static igraph_error_t igraph_i_sparse_adjacency_undirected(
                 IGRAPH_EINVAL);
     }
     for (igraph_integer_t from = 0; p[from] < no_of_edges; from++) {
-        while (to < p[from + 1]) {
+        for (; to < p[from + 1]; to++) {
             if (from >= i[to]) {
                 igraph_integer_t multi = entry[to];
                 if (from == i[to]) {
@@ -1134,7 +1128,6 @@ static igraph_error_t igraph_i_sparse_adjacency_undirected(
                     VECTOR(*edges)[e++] = from;
                 }
             }
-            to++;
         }
     }
     igraph_vector_int_resize(edges, e);
@@ -1213,7 +1206,7 @@ static igraph_error_t igraph_i_sparse_weighted_adjacency_max (
     CS_ENTRY *entry = adjmatrix->cs->x;
 
     for (igraph_integer_t from = 0; p[from] < no_of_edges; from++) {
-        while (to < p[from + 1]) {
+        for (; to < p[from + 1]; to++) {
             if (from >= i[to]) {
                 igraph_real_t other;
                 igraph_vector_int_t x, y;
@@ -1230,7 +1223,6 @@ static igraph_error_t igraph_i_sparse_weighted_adjacency_max (
                     VECTOR(*edges)[e++] = from;
                 }
             }
-            to++;
         }
     }
     igraph_vector_int_resize(edges, e);
@@ -1250,7 +1242,7 @@ static igraph_error_t igraph_i_sparse_weighted_adjacency_min (
     CS_ENTRY *entry = adjmatrix->cs->x;
 
     for (igraph_integer_t from = 0; p[from] < no_of_edges; from++) {
-        while (to < p[from + 1]) {
+        for (; to < p[from + 1]; to++) {
             if (from >= i[to]) {
                 igraph_real_t other;
                 igraph_vector_int_t x, y;
@@ -1267,7 +1259,6 @@ static igraph_error_t igraph_i_sparse_weighted_adjacency_min (
                     VECTOR(*edges)[e++] = from;
                 }
             }
-            to++;
         }
     }
     igraph_vector_int_resize(edges, e);
@@ -1288,7 +1279,7 @@ static igraph_error_t igraph_i_sparse_weighted_adjacency_plus (
     CS_ENTRY *entry = adjmatrix->cs->x;
 
     for (igraph_integer_t from = 0; p[from] < no_of_edges; from++) {
-        while (to < p[from + 1]) {
+        for (; to < p[from + 1]; to++) {
             if (from >= i[to]) {
                 igraph_real_t weight = entry[to];
                 if (from != i[to]) {
@@ -1308,7 +1299,6 @@ static igraph_error_t igraph_i_sparse_weighted_adjacency_plus (
                     VECTOR(*edges)[e++] = from;
                 }
             }
-            to++;
         }
     }
     igraph_vector_int_resize(edges, e);
@@ -1340,7 +1330,7 @@ static igraph_error_t igraph_i_sparse_weighted_adjacency_upper(
     CS_ENTRY *entry = adjmatrix->cs->x;
 
     for (igraph_integer_t from = 0; p[from] < no_of_edges; from++) {
-        while (to < p[from + 1]) {
+        for (; to < p[from + 1]; to++) {
             if (from >= i[to]) {
                 igraph_real_t weight = entry[to];
                 if (from == i[to]) {
@@ -1352,7 +1342,6 @@ static igraph_error_t igraph_i_sparse_weighted_adjacency_upper(
                     VECTOR(*edges)[e++] = from;
                 }
             }
-            to++;
         }
     }
     igraph_vector_int_resize(edges, e);
@@ -1373,7 +1362,7 @@ static igraph_error_t igraph_i_sparse_weighted_adjacency_lower(
     CS_ENTRY *entry = adjmatrix->cs->x;
 
     for (igraph_integer_t from = 0; p[from] < no_of_edges; from++) {
-        while (to < p[from + 1]) {
+        for (; to < p[from + 1]; to++) {
             if (from <= i[to]) {
                 igraph_real_t weight = entry[to];
                 if (from == i[to]) {
@@ -1386,7 +1375,6 @@ static igraph_error_t igraph_i_sparse_weighted_adjacency_lower(
                     VECTOR(*edges)[e++] = from;
                 }
             }
-            to++;
         }
     }
     igraph_vector_int_resize(edges, e);
@@ -1407,7 +1395,7 @@ static igraph_error_t igraph_i_sparse_weighted_adjacency_directed(
     CS_ENTRY *entry = adjmatrix->cs->x;
 
     for (igraph_integer_t from = 0; p[from] < no_of_edges; from++) {
-        while (to < p[from + 1]) {
+        for (; to < p[from + 1]; to++) {
             igraph_real_t weight = entry[to];
             if (from == i[to]) {
                 igraph_i_adjust_loop_edge_weight(&weight, loops);
@@ -1417,7 +1405,6 @@ static igraph_error_t igraph_i_sparse_weighted_adjacency_directed(
                 VECTOR(*edges)[e++] = i[to];
                 VECTOR(*edges)[e++] = from;
             }
-            to++;
         }
     }
     igraph_vector_int_resize(edges, e);

--- a/tests/unit/igraph_adjacency.c
+++ b/tests/unit/igraph_adjacency.c
@@ -20,11 +20,29 @@
 
 void print_destroy(igraph_matrix_t *adjmatrix, igraph_adjacency_t mode, igraph_loops_t loops) {
     igraph_t g;
+    igraph_t g_sparse;
+    igraph_sparsemat_t sparse_adjmatrix, sparse_adjmatrix_comp;
+    igraph_bool_t same;
 
     igraph_adjacency(&g, adjmatrix, mode, loops);
+
+    igraph_matrix_as_sparsemat(&sparse_adjmatrix, adjmatrix, 0.0001);
+    igraph_sparsemat_compress(&sparse_adjmatrix, &sparse_adjmatrix_comp);
+    igraph_sparse_adjacency(&g_sparse, &sparse_adjmatrix_comp, mode, loops);
     print_graph_canon(&g);
+
+    igraph_is_same_graph(&g, &g_sparse, &same);
+    if (!same) {
+        printf("Sparse graph differs from non-sparse:\n");
+        print_graph_canon(&g_sparse);
+        exit(1);
+    }
+
     igraph_matrix_destroy(adjmatrix);
+    igraph_sparsemat_destroy(&sparse_adjmatrix);
+    igraph_sparsemat_destroy(&sparse_adjmatrix_comp);
     igraph_destroy(&g);
+    igraph_destroy(&g_sparse);
 }
 
 int main() {

--- a/tests/unit/igraph_adjacency.c
+++ b/tests/unit/igraph_adjacency.c
@@ -45,9 +45,22 @@ void print_destroy(igraph_matrix_t *adjmatrix, igraph_adjacency_t mode, igraph_l
     igraph_destroy(&g_sparse);
 }
 
+void check_error(igraph_matrix_t *adjmatrix, igraph_adjacency_t mode, igraph_loops_t loops, igraph_error_t error) {
+    igraph_t g;
+    igraph_sparsemat_t sparse_adjmatrix, sparse_adjmatrix_comp;
+
+    igraph_matrix_as_sparsemat(&sparse_adjmatrix, adjmatrix, 0.0001);
+    igraph_sparsemat_compress(&sparse_adjmatrix, &sparse_adjmatrix_comp);
+
+    CHECK_ERROR(igraph_adjacency(&g, adjmatrix, mode, loops), error);
+    CHECK_ERROR(igraph_sparse_adjacency(&g, &sparse_adjmatrix_comp, mode, loops), error);
+
+    igraph_sparsemat_destroy(&sparse_adjmatrix);
+    igraph_sparsemat_destroy(&sparse_adjmatrix_comp);
+}
+
 int main() {
     igraph_matrix_t adjmatrix;
-    igraph_t g;
 
     printf("\n0x0 matrix:\n");
     matrix_init_int_row_major(&adjmatrix, 0, 0, NULL);
@@ -205,35 +218,35 @@ int main() {
     {
         int e[] = {1, 2, 0};
         matrix_init_int_row_major(&adjmatrix, 3, 1, e);
-        CHECK_ERROR(igraph_adjacency(&g, &adjmatrix, IGRAPH_ADJ_DIRECTED, IGRAPH_NO_LOOPS), IGRAPH_NONSQUARE);
+        check_error(&adjmatrix, IGRAPH_ADJ_DIRECTED, IGRAPH_NO_LOOPS, IGRAPH_NONSQUARE);
         igraph_matrix_destroy(&adjmatrix);
     }
     printf("\nCheck handling of negative number of edges error.\n");
     {
         int e[] = {1, 2, 0, -3, 0, 4, 0, 5, 6};
         matrix_init_int_row_major(&adjmatrix, 3, 3, e);
-        CHECK_ERROR(igraph_adjacency(&g, &adjmatrix, IGRAPH_ADJ_DIRECTED, IGRAPH_NO_LOOPS), IGRAPH_EINVAL);
+        check_error(&adjmatrix, IGRAPH_ADJ_DIRECTED, IGRAPH_NO_LOOPS, IGRAPH_EINVAL);
         igraph_matrix_destroy(&adjmatrix);
     }
     printf("\nCheck handling of odd number in diagonal.\n");
     {
         int e[] = {1, 2, 0, 3, 0, 4, 0, 5, 6};
         matrix_init_int_row_major(&adjmatrix, 3, 3, e);
-        CHECK_ERROR(igraph_adjacency(&g, &adjmatrix, IGRAPH_ADJ_DIRECTED, IGRAPH_LOOPS_TWICE), IGRAPH_EINVAL);
+        check_error(&adjmatrix, IGRAPH_ADJ_DIRECTED, IGRAPH_LOOPS_TWICE, IGRAPH_EINVAL);
         igraph_matrix_destroy(&adjmatrix);
     }
     printf("\nCheck handling of invalid adjacency mode.\n");
     {
         int e[] = {0, 2, 0, 3, 0, 4, 0, 5, 6};
         matrix_init_int_row_major(&adjmatrix, 3, 3, e);
-        CHECK_ERROR(igraph_adjacency(&g, &adjmatrix, 42, IGRAPH_LOOPS_TWICE), IGRAPH_EINVAL);
+        check_error(&adjmatrix, 42, IGRAPH_LOOPS_TWICE, IGRAPH_EINVAL);
         igraph_matrix_destroy(&adjmatrix);
     }
     printf("\nCheck handling of non-symmetric matrix for IGRAPH_ADJ_UNDIRECTED.\n");
     {
         int e[] = {0, 2, 0, 3, 0, 4, 0, 5, 6};
         matrix_init_int_row_major(&adjmatrix, 3, 3, e);
-        CHECK_ERROR(igraph_adjacency(&g, &adjmatrix, IGRAPH_ADJ_UNDIRECTED, IGRAPH_LOOPS_ONCE), IGRAPH_EINVAL);
+        check_error(&adjmatrix, IGRAPH_ADJ_UNDIRECTED, IGRAPH_LOOPS_ONCE, IGRAPH_EINVAL);
         igraph_matrix_destroy(&adjmatrix);
     }
 

--- a/tests/unit/igraph_adjacency.c
+++ b/tests/unit/igraph_adjacency.c
@@ -92,19 +92,19 @@ int main() {
     }
     printf("\n3x3 matrix, IGRAPH_ADJ_UNDIRECTED, no loops:\n");
     {
-        int e[] = {4, 2, 0, 3, 0, 4, 0, 5, 6};
+        int e[] = {4, 2, 0, 2, 0, 4, 0, 4, 6};
         matrix_init_int_row_major(&adjmatrix, 3, 3, e);
         print_destroy(&adjmatrix, IGRAPH_ADJ_UNDIRECTED, IGRAPH_NO_LOOPS);
     }
     printf("\n3x3 matrix, IGRAPH_ADJ_UNDIRECTED, loops once:\n");
     {
-        int e[] = {4, 2, 0, 3, 0, 4, 0, 5, 6};
+        int e[] = {4, 2, 0, 2, 0, 4, 0, 4, 6};
         matrix_init_int_row_major(&adjmatrix, 3, 3, e);
         print_destroy(&adjmatrix, IGRAPH_ADJ_UNDIRECTED, IGRAPH_LOOPS_ONCE);
     }
     printf("\n3x3 matrix, IGRAPH_ADJ_UNDIRECTED, loops twice:\n");
     {
-        int e[] = {4, 2, 0, 3, 0, 4, 0, 5, 6};
+        int e[] = {4, 2, 0, 2, 0, 4, 0, 4, 6};
         matrix_init_int_row_major(&adjmatrix, 3, 3, e);
         print_destroy(&adjmatrix, IGRAPH_ADJ_UNDIRECTED, IGRAPH_LOOPS_TWICE);
     }
@@ -227,6 +227,13 @@ int main() {
         int e[] = {0, 2, 0, 3, 0, 4, 0, 5, 6};
         matrix_init_int_row_major(&adjmatrix, 3, 3, e);
         CHECK_ERROR(igraph_adjacency(&g, &adjmatrix, 42, IGRAPH_LOOPS_TWICE), IGRAPH_EINVAL);
+        igraph_matrix_destroy(&adjmatrix);
+    }
+    printf("\nCheck handling of non-symmetric matrix for IGRAPH_ADJ_UNDIRECTED.\n");
+    {
+        int e[] = {0, 2, 0, 3, 0, 4, 0, 5, 6};
+        matrix_init_int_row_major(&adjmatrix, 3, 3, e);
+        CHECK_ERROR(igraph_adjacency(&g, &adjmatrix, IGRAPH_ADJ_UNDIRECTED, IGRAPH_LOOPS_ONCE), IGRAPH_EINVAL);
         igraph_matrix_destroy(&adjmatrix);
     }
 

--- a/tests/unit/igraph_adjacency.out
+++ b/tests/unit/igraph_adjacency.out
@@ -106,8 +106,6 @@ vcount: 3
 edges: {
 0 1
 0 1
-0 1
-1 2
 1 2
 1 2
 1 2
@@ -124,8 +122,6 @@ edges: {
 0 0
 0 1
 0 1
-0 1
-1 2
 1 2
 1 2
 1 2
@@ -146,8 +142,6 @@ edges: {
 0 0
 0 1
 0 1
-0 1
-1 2
 1 2
 1 2
 1 2
@@ -455,3 +449,5 @@ Check handling of negative number of edges error.
 Check handling of odd number in diagonal.
 
 Check handling of invalid adjacency mode.
+
+Check handling of non-symmetric matrix for IGRAPH_ADJ_UNDIRECTED.

--- a/tests/unit/igraph_weighted_adjacency.c
+++ b/tests/unit/igraph_weighted_adjacency.c
@@ -25,7 +25,74 @@
 
 #include "test_utilities.h"
 
-void test_single_matrix(const igraph_matrix_t* mat, igraph_adjacency_t mode) {
+//TODO make public?
+igraph_error_t igraph_is_same_graph_weighted(const igraph_t *graph1, const igraph_t *graph2, igraph_bool_t *res, igraph_vector_t *weights1, igraph_vector_t *weights2) {
+    igraph_integer_t nv1 = igraph_vcount(graph1);
+    igraph_integer_t nv2 = igraph_vcount(graph2);
+    igraph_integer_t ne1 = igraph_ecount(graph1);
+    igraph_integer_t ne2 = igraph_ecount(graph2);
+    igraph_integer_t i, eid1, eid2;
+
+    *res = 0; /* Assume that the graphs differ */
+
+    /* Check for same number of vertices/edges */
+    if ((nv1 != nv2) || (ne1 != ne2)) {
+        return IGRAPH_SUCCESS;
+    }
+
+    /* Check for same directedness */
+    if (igraph_is_directed(graph1) != igraph_is_directed(graph2)) {
+        return IGRAPH_SUCCESS;
+    }
+
+    for (i = 0; i < ne1; i++) {
+        eid1 = VECTOR(graph1->ii)[i];
+        eid2 = VECTOR(graph2->ii)[i];
+
+        /* Check they have the same source */
+        if (IGRAPH_FROM(graph1, eid1) != IGRAPH_FROM(graph2, eid2)) {
+            return IGRAPH_SUCCESS;
+        }
+
+        /* Check they have the same target */
+        if (IGRAPH_TO(graph1, eid1) != IGRAPH_TO(graph2, eid2)) {
+            return IGRAPH_SUCCESS;
+        }
+
+        /* Check they have the same weight */
+        if (VECTOR(*weights1)[eid1] != VECTOR(*weights2)[eid2]) {
+            return IGRAPH_SUCCESS;
+        }
+    }
+
+    *res = 1; /* No difference was found, graphs are the same */
+    return IGRAPH_SUCCESS;
+}
+
+void check_sparsemat(igraph_t *g, igraph_adjacency_t mode, igraph_loops_t loops, igraph_matrix_t *adjmatrix, igraph_vector_t *other_weights) {
+    igraph_t g_sparse;
+    igraph_sparsemat_t sparse_adjmatrix, sparse_adjmatrix_comp;
+    igraph_bool_t same;
+    igraph_vector_t weights;
+
+    igraph_vector_init(&weights, 0);
+
+    igraph_matrix_as_sparsemat(&sparse_adjmatrix, adjmatrix, 0.0001);
+    igraph_sparsemat_compress(&sparse_adjmatrix, &sparse_adjmatrix_comp);
+    igraph_sparse_weighted_adjacency(&g_sparse, &sparse_adjmatrix_comp, mode, &weights, loops);
+    igraph_is_same_graph_weighted(g, &g_sparse, &same, other_weights, &weights);
+    if (!same) {
+        printf("Sparse graph differs from non-sparse:\n");
+        print_weighted_graph(&g_sparse, &weights);
+        exit(1);
+    }
+    igraph_sparsemat_destroy(&sparse_adjmatrix);
+    igraph_sparsemat_destroy(&sparse_adjmatrix_comp);
+    igraph_destroy(&g_sparse);
+    igraph_vector_destroy(&weights);
+}
+
+void test_single_matrix(igraph_matrix_t* mat, igraph_adjacency_t mode) {
     igraph_t g;
     igraph_vector_t weights;
 
@@ -33,19 +100,24 @@ void test_single_matrix(const igraph_matrix_t* mat, igraph_adjacency_t mode) {
 
     printf("No loops\n--------\n\n");
     igraph_weighted_adjacency(&g, mat, mode, &weights, IGRAPH_NO_LOOPS);
+
     print_weighted_graph(&g, &weights);
+    check_sparsemat(&g, mode, IGRAPH_NO_LOOPS, mat, &weights);
+
     igraph_destroy(&g);
     printf("\n");
 
     printf("Loops once\n----------\n\n");
     igraph_weighted_adjacency(&g, mat, mode, &weights, IGRAPH_LOOPS_ONCE);
     print_weighted_graph(&g, &weights);
+    check_sparsemat(&g, mode, IGRAPH_LOOPS_ONCE, mat, &weights);
     igraph_destroy(&g);
     printf("\n");
 
     printf("Loops twice\n-----------\n\n");
     igraph_weighted_adjacency(&g, mat, mode, &weights, IGRAPH_LOOPS_TWICE);
     print_weighted_graph(&g, &weights);
+    check_sparsemat(&g, mode, IGRAPH_LOOPS_TWICE, mat, &weights);
     igraph_destroy(&g);
     printf("\n");
 
@@ -56,9 +128,11 @@ void test_single_matrix(const igraph_matrix_t* mat, igraph_adjacency_t mode) {
 
 int main() {
     igraph_matrix_t mat;
+    igraph_matrix_t mat_sym;
     igraph_vector_t weights;
     igraph_t g;
     int m[4][4] = { { 0, 1, 2, 0 }, { 2, 0, 0, 1 }, { 0, 0, 4, 0 }, { 0, 1, 0, 0 } };
+    int m_sym[4][4] = { { 0, 2, 2, 0 }, { 2, 0, 0, 1 }, { 2, 0, 4, 0 }, { 0, 1, 0, 0 } };
     igraph_integer_t i, j;
 
     printf("0x0 matrix\n");
@@ -70,6 +144,10 @@ int main() {
     igraph_matrix_init(&mat, 4, 4);
     for (i = 0; i < 4; i++) for (j = 0; j < 4; j++) {
         MATRIX(mat, i, j) = m[i][j];
+    }
+    igraph_matrix_init(&mat_sym, 4, 4);
+    for (i = 0; i < 4; i++) for (j = 0; j < 4; j++) {
+        MATRIX(mat_sym, i, j) = m_sym[i][j];
     }
 
     /* [ 0 1 2 0 ]
@@ -112,6 +190,14 @@ int main() {
     printf("==============\n\n");
     test_single_matrix(&mat, IGRAPH_ADJ_MAX);
 
+    /* [ 0 2 2 0 ]
+       [ 2 0 0 1 ]
+       [ 2 0 4 0 ]
+       [ 0 1 0 0 ] */
+    printf("IGRAPH_ADJ_UNDIRECTED\n");
+    printf("==============\n\n");
+    test_single_matrix(&mat_sym, IGRAPH_ADJ_UNDIRECTED);
+
     /* [ 0 3 2 0 ]
        [ 3 0 0 2 ]
        [ 2 0 4 0 ]
@@ -121,6 +207,7 @@ int main() {
     test_single_matrix(&mat, IGRAPH_ADJ_PLUS);
 
     igraph_matrix_destroy(&mat);
+    igraph_matrix_destroy(&mat_sym);
 
     VERIFY_FINALLY_STACK();
 

--- a/tests/unit/igraph_weighted_adjacency.out
+++ b/tests/unit/igraph_weighted_adjacency.out
@@ -215,6 +215,44 @@ edges: {
 2 2: 2
 }
 
+IGRAPH_ADJ_UNDIRECTED
+==============
+
+No loops
+--------
+
+directed: false
+vcount: 4
+edges: {
+1 0: 2
+2 0: 2
+3 1: 1
+}
+
+Loops once
+----------
+
+directed: false
+vcount: 4
+edges: {
+1 0: 2
+2 0: 2
+3 1: 1
+2 2: 4
+}
+
+Loops twice
+-----------
+
+directed: false
+vcount: 4
+edges: {
+1 0: 2
+2 0: 2
+3 1: 1
+2 2: 2
+}
+
 IGRAPH_ADJ_PLUS
 ===============
 

--- a/tests/unit/igraph_weighted_adjacency.out
+++ b/tests/unit/igraph_weighted_adjacency.out
@@ -294,3 +294,4 @@ edges: {
 Check handling of non-square matrix error.
 Check handling of invalid adjacency mode.
 Check error for 0x1 matrix.
+Check error for non-symmetric matrix and IGRAPH_ADJ_UNDIRECTED.


### PR DESCRIPTION
includes the weighted counterpart.

Fixes #1838

issues:
- Some functions call igraph_sparsemat_index in the inner loop, and that seems like it will be slow.
- src/core/sparsemat.c defines CS_LONG 1 before including cs/cs.h. Should every source file that includes cs do this? Maybe this should be in igraph_sparsemat.h?