### PR TITLE
Add local_scan_neighborhood_ecount tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -729,6 +729,7 @@ Some of the highlights are:
  - `igraph_sparse_adjacency()` and `igraph_sparse_weighted_adjacency()` constructs graphs from (weighted) sparse matrices.
  - `igraph_full_multipartite()` generates full multipartite graphs (a generalization of bipartite graphs to multiple groups).
  - `igraph_turan()` generates Turán graphs.
+ - `igraph_local_scan_subset_ecount()` counts the number of edges in induced sugraphs from a subset of vertices.
 
 ### Removed
 
@@ -862,6 +863,8 @@ Some of the highlights are:
  - The macros `igraph_Calloc`, `igraph_Realloc` and `igraph_Free` have been
    deprecated in favour of `IGRAPH_CALLOC`, `IGRAPH_REALLOC` and `IGRAPH_FREE`
    to simplify the API. The deprecated variants will be removed in 0.11.
+ - `igraph_local_scan_neighborhood_ecount()` is now deprecated in favour of `igraph_local_scan_subset_ecount()`.
+
 
 ### Other
 

--- a/doc/structural.xxml
+++ b/doc/structural.xxml
@@ -76,8 +76,9 @@
 <!-- doxrox-include igraph_local_scan_1_ecount_them -->
 <!-- doxrox-include igraph_local_scan_k_ecount_them -->
 </section>
-<section id="pre-calculated-neighborhoods"><title>Pre-calculated neighborhoods</title>
+<section id="pre-calculated-subsets"><title>Pre-calculated subsets</title>
 <!-- doxrox-include igraph_local_scan_neighborhood_ecount -->
+<!-- doxrox-include igraph_local_scan_subset_ecount -->
 </section>
 </section>
 

--- a/include/igraph_scan.h
+++ b/include/igraph_scan.h
@@ -63,7 +63,10 @@ IGRAPH_EXPORT igraph_error_t igraph_local_scan_neighborhood_ecount(const igraph_
                                                         igraph_vector_t *res,
                                                         const igraph_vector_t *weights,
                                                         const igraph_vector_int_list_t *neighborhoods);
-
+IGRAPH_EXPORT igraph_error_t igraph_local_scan_subset_ecount(const igraph_t *graph,
+                                                        igraph_vector_t *res,
+                                                        const igraph_vector_t *weights,
+                                                        const igraph_vector_int_list_t *neighborhoods);
 __END_DECLS
 
 #endif

--- a/interfaces/functions.yaml
+++ b/interfaces/functions.yaml
@@ -1799,6 +1799,12 @@ igraph_local_scan_neighborhood_ecount:
         VERTEXSET_LIST neighborhoods
     DEPS: weights ON graph
 
+igraph_local_scan_subset_ecount:
+    PARAMS: |-
+        GRAPH graph, OUT VECTOR res, EDGEWEIGHTS weights=NULL,
+        VERTEXSET_LIST subsets
+    DEPS: weights ON graph
+
 igraph_list_triangles:
     PARAMS: GRAPH graph, OUT VERTEXSET res
     DEPS: res ON graph

--- a/src/misc/scan.c
+++ b/src/misc/scan.c
@@ -795,28 +795,26 @@ igraph_error_t igraph_local_scan_k_ecount_them(const igraph_t *us, const igraph_
 
     return IGRAPH_SUCCESS;
 }
-
 /**
- * \function igraph_local_scan_neighborhood_ecount
- * Local scan-statistics with pre-calculated neighborhoods
+ * \function igraph_local_scan_subset_ecount
+ * Local scan-statistics of subgraphs induced by subsets of vertices 
  *
  * Count the number of edges, or sum the edge weights in
- * neighborhoods given as a parameter.
+ * induced subgraphs given as a parameter.
  *
  * \param graph The graph to perform the counting/summing in.
  * \param res Initialized vector, the result is stored here.
  * \param weights Weight vector for weighted graphs, null pointer for
  *        unweighted graphs.
- * \param neighborhoods List of <code>igraph_vector_int_t</code>
- *        objects, the neighborhoods, one for each vertex in the
- *        graph.
+ * \param subsets List of <code>igraph_vector_int_t</code>
+ *        objects, the vertex subsets.
  * \return Error code.
  */
 
-igraph_error_t igraph_local_scan_neighborhood_ecount(const igraph_t *graph,
+igraph_error_t igraph_local_scan_subset_ecount(const igraph_t *graph,
         igraph_vector_t *res,
         const igraph_vector_t *weights,
-        const igraph_vector_int_list_t *neighborhoods) {
+        const igraph_vector_int_list_t *subsets) {
 
     igraph_integer_t node, no_of_nodes = igraph_vcount(graph);
     igraph_inclist_t incs;
@@ -825,10 +823,6 @@ igraph_error_t igraph_local_scan_neighborhood_ecount(const igraph_t *graph,
 
     if (weights && igraph_vector_size(weights) != igraph_ecount(graph)) {
         IGRAPH_ERROR("Invalid weight vector length in local scan", IGRAPH_EINVAL);
-    }
-    if (igraph_vector_int_list_size(neighborhoods) != no_of_nodes) {
-        IGRAPH_ERROR("Invalid neighborhood list length in local scan",
-                     IGRAPH_EINVAL);
     }
 
     IGRAPH_VECTOR_INT_INIT_FINALLY(&marked, no_of_nodes);
@@ -874,4 +868,41 @@ igraph_error_t igraph_local_scan_neighborhood_ecount(const igraph_t *graph,
     IGRAPH_FINALLY_CLEAN(2);
 
     return IGRAPH_SUCCESS;
+}
+
+/**
+ * \function igraph_local_scan_neighborhood_ecount
+ * Local scan-statistics with pre-calculated neighborhoods
+ *
+ * Count the number of edges, or sum the edge weights in
+ * neighborhoods given as a parameter.
+ *
+ * \deprecated-by igraph_local_scan_subset_ecount 0.10.0
+ *
+ * \param graph The graph to perform the counting/summing in.
+ * \param res Initialized vector, the result is stored here.
+ * \param weights Weight vector for weighted graphs, null pointer for
+ *        unweighted graphs.
+ * \param neighborhoods List of <code>igraph_vector_int_t</code>
+ *        objects, the neighborhoods, one for each vertex in the
+ *        graph.
+ * \return Error code.
+ */
+
+igraph_error_t igraph_local_scan_neighborhood_ecount(const igraph_t *graph,
+        igraph_vector_t *res,
+        const igraph_vector_t *weights,
+        const igraph_vector_int_list_t *neighborhoods) {
+
+    igraph_integer_t node, no_of_nodes = igraph_vcount(graph);
+    igraph_inclist_t incs;
+    igraph_vector_int_t marked;
+    igraph_bool_t directed = igraph_is_directed(graph);
+
+    if (igraph_vector_int_list_size(neighborhoods) != no_of_nodes) {
+        IGRAPH_ERROR("Invalid neighborhood list length in local scan",
+                     IGRAPH_EINVAL);
+    }
+
+    return igraph_local_scan_subset_ecount(graph, res, weights, neighborhood);
 }

--- a/src/misc/scan.c
+++ b/src/misc/scan.c
@@ -834,7 +834,7 @@ igraph_error_t igraph_local_scan_subset_ecount(const igraph_t *graph,
     }
     IGRAPH_FINALLY(igraph_inclist_destroy, &incs);
 
-    IGRAPH_CHECK(igraph_vector_resize(res, no_of_nodes));
+    IGRAPH_CHECK(igraph_vector_resize(res, no_of_subsets));
     igraph_vector_null(res);
 
     for (subset = 0; subset < no_of_subsets; subset++) {

--- a/src/misc/scan.c
+++ b/src/misc/scan.c
@@ -883,7 +883,7 @@ igraph_error_t igraph_local_scan_subset_ecount(const igraph_t *graph,
  * \param res Initialized vector, the result is stored here.
  * \param weights Weight vector for weighted graphs, null pointer for
  *        unweighted graphs.
- * \param neighborhoods List of <code>igraph_vector_int_t</code>
+ * \param neighborhoods List of \type igraph_vector_int_t
  *        objects, the neighborhoods, one for each vertex in the
  *        graph.
  * \return Error code.

--- a/src/misc/scan.c
+++ b/src/misc/scan.c
@@ -806,7 +806,7 @@ igraph_error_t igraph_local_scan_k_ecount_them(const igraph_t *us, const igraph_
  * \param res Initialized vector, the result is stored here.
  * \param weights Weight vector for weighted graphs, null pointer for
  *        unweighted graphs.
- * \param subsets List of <code>igraph_vector_int_t</code>
+ * \param subsets List of \type igraph_vector_int_t
  *        objects, the vertex subsets.
  * \return Error code.
  */

--- a/src/misc/scan.c
+++ b/src/misc/scan.c
@@ -827,11 +827,7 @@ igraph_error_t igraph_local_scan_subset_ecount(const igraph_t *graph,
     }
 
     IGRAPH_VECTOR_INT_INIT_FINALLY(&marked, no_of_nodes);
-    if (directed) {
-        IGRAPH_CHECK(igraph_inclist_init(graph, &incs, IGRAPH_OUT, IGRAPH_LOOPS_ONCE));
-    } else {
-        IGRAPH_CHECK(igraph_inclist_init(graph, &incs, IGRAPH_OUT, IGRAPH_LOOPS_TWICE));
-    }
+    IGRAPH_CHECK(igraph_inclist_init(graph, &incs, IGRAPH_OUT, IGRAPH_LOOPS_TWICE));
     IGRAPH_FINALLY(igraph_inclist_destroy, &incs);
 
     IGRAPH_CHECK(igraph_vector_resize(res, no_of_subsets));

--- a/src/misc/scan.c
+++ b/src/misc/scan.c
@@ -797,7 +797,7 @@ igraph_error_t igraph_local_scan_k_ecount_them(const igraph_t *us, const igraph_
 }
 /**
  * \function igraph_local_scan_subset_ecount
- * Local scan-statistics of subgraphs induced by subsets of vertices 
+ * \brief Local scan-statistics of subgraphs induced by subsets of vertices.
  *
  * Count the number of edges, or sum the edge weights in
  * induced subgraphs from vertices given as a parameter.

--- a/src/misc/scan.c
+++ b/src/misc/scan.c
@@ -823,7 +823,7 @@ igraph_error_t igraph_local_scan_subset_ecount(const igraph_t *graph,
     igraph_bool_t directed = igraph_is_directed(graph);
 
     if (weights && igraph_vector_size(weights) != igraph_ecount(graph)) {
-        IGRAPH_ERROR("Invalid weight vector length in local scan", IGRAPH_EINVAL);
+        IGRAPH_ERROR("Invalid weight vector length in local scan.", IGRAPH_EINVAL);
     }
 
     IGRAPH_VECTOR_INT_INIT_FINALLY(&marked, no_of_nodes);
@@ -843,7 +843,7 @@ igraph_error_t igraph_local_scan_subset_ecount(const igraph_t *graph,
         for (i = 0; i < neilen; i++) {
             igraph_integer_t vertex = VECTOR(*nei)[i];
             if (vertex < 0 || vertex >= no_of_nodes) {
-                IGRAPH_ERROR("Invalid vertex ID in neighborhood list in local scan",
+                IGRAPH_ERROR("Invalid vertex ID in neighborhood list in local scan.",
                              IGRAPH_EINVAL);
             }
             VECTOR(marked)[vertex] = subset + 1;
@@ -901,7 +901,7 @@ igraph_error_t igraph_local_scan_neighborhood_ecount(const igraph_t *graph,
     igraph_integer_t no_of_nodes = igraph_vcount(graph);
 
     if (igraph_vector_int_list_size(neighborhoods) != no_of_nodes) {
-        IGRAPH_ERROR("Invalid neighborhood list length in local scan",
+        IGRAPH_ERROR("Invalid neighborhood list length in local scan.",
                      IGRAPH_EINVAL);
     }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -310,7 +310,7 @@ add_legacy_tests(
   igraph_list_triangles
   igraph_local_scan_k_ecount
   igraph_local_scan_k_ecount_them
-  igraph_local_scan_neighborhood_ecount
+  igraph_local_scan_subset_ecount
   igraph_local_transitivity
   igraph_neighborhood
   igraph_neighborhood_graphs

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -310,6 +310,7 @@ add_legacy_tests(
   igraph_list_triangles
   igraph_local_scan_k_ecount
   igraph_local_scan_k_ecount_them
+  igraph_local_scan_neighborhood_ecount
   igraph_local_transitivity
   igraph_neighborhood
   igraph_neighborhood_graphs

--- a/tests/unit/igraph_local_scan_neighborhood_ecount.c
+++ b/tests/unit/igraph_local_scan_neighborhood_ecount.c
@@ -1,0 +1,81 @@
+/* IGraph library.
+   Copyright (C) 2021  The igraph development team <igraph@igraph.org>
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include <igraph.h>
+#include "test_utilities.h"
+
+void call_and_print(igraph_t *graph, igraph_vector_t *weights, igraph_vector_int_list_t *neighborhoods) {
+    igraph_vector_t result;
+    igraph_vector_init(&result, 0);
+    IGRAPH_ASSERT(igraph_local_scan_neighborhood_ecount(graph, &result, weights, neighborhoods) == IGRAPH_SUCCESS);
+    print_vector(&result);
+    igraph_vector_destroy(&result);
+    printf("\n");
+}
+
+
+int main() {
+    igraph_t g_0, g_1, g_lmu, g_lm;
+    igraph_vector_t weights, result;
+    igraph_vector_int_list_t neighborhoods;
+    igraph_vector_int_t n1;
+
+    igraph_vector_init_real(&weights, 8, -0.1, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6);
+    igraph_vector_init(&result, 0);
+    igraph_small(&g_0, 0, 0, -1);
+    igraph_small(&g_1, 1, 0, -1);
+    igraph_small(&g_lm, 6, 1, 0,1, 0,2, 1,1, 1,3, 2,0, 2,3, 3,4, 3,4, -1);
+    igraph_small(&g_lmu, 6, 0, 0,1, 0,2, 1,1, 1,3, 2,0, 2,3, 3,4, 3,4, -1); //undirected
+
+    igraph_vector_int_list_init(&neighborhoods, 0);
+
+
+    printf("No vertices:\n");
+    call_and_print(&g_0, NULL, &neighborhoods);
+
+    printf("one vertex, empty neighborhood:\n");
+    igraph_vector_int_init(&n1, 0);
+    igraph_vector_int_list_push_back(&neighborhoods, &n1);
+    call_and_print(&g_1, NULL, &neighborhoods);
+
+    printf("Graph with unconnected vertices, loops and multiple edges, empty neighborhoods:\n");
+    for (int i = 0; i < 5; i ++) {
+        igraph_vector_int_init_int(&n1, 0);
+        igraph_vector_int_list_push_back(&neighborhoods, &n1);
+    }
+    call_and_print(&g_lm, NULL, &neighborhoods);
+    igraph_vector_int_list_clear(&neighborhoods);
+
+    printf("Graph with unconnected vertices, loops and multiple edges, all the same neighborhood:\n");
+    for (int i = 0; i < 6; i ++) {
+        igraph_vector_int_init_int(&n1, 3, 0, 1, 2);
+        igraph_vector_int_list_push_back(&neighborhoods, &n1);
+    }
+    call_and_print(&g_lm, NULL, &neighborhoods);
+    igraph_vector_int_list_destroy(&neighborhoods);
+
+    igraph_destroy(&g_0);
+    igraph_destroy(&g_1);
+    igraph_destroy(&g_lm);
+    igraph_destroy(&g_lmu);
+    igraph_vector_destroy(&weights);
+    igraph_vector_destroy(&result);
+    igraph_vector_int_list_destroy(&neighborhoods);
+
+    VERIFY_FINALLY_STACK();
+    return 0;
+}

--- a/tests/unit/igraph_local_scan_subset_ecount.c
+++ b/tests/unit/igraph_local_scan_subset_ecount.c
@@ -83,7 +83,6 @@ int main() {
     igraph_vector_int_list_clear(&subsets);
 
     printf("Same graph, whole graph as subset:\n");
-    igraph_vector_int_list_resize(&subsets, 0);
     igraph_vector_int_init_int(&n1, 6, 0, 1, 2, 3, 4, 5);
     igraph_vector_int_list_push_back(&subsets, &n1);
     call_and_print(&g_lmu, NULL, &subsets);

--- a/tests/unit/igraph_local_scan_subset_ecount.out
+++ b/tests/unit/igraph_local_scan_subset_ecount.out
@@ -1,0 +1,24 @@
+No vertices:
+( )
+
+one vertex, empty subset:
+( 0 )
+
+Graph with unconnected vertices, loops and multiple edges, empty subsets:
+( 0 0 0 0 0 0 )
+
+Same graph, every vertex as a subset:
+( 0 1 0 0 0 0 )
+
+Same graph, every vertex and next one as a subset:
+( 2 1 1 2 0 0 )
+
+Same situation, but with weights:
+( 0 0.1 0.4 1.1 0 0 )
+
+Same situation, no weights, but undirected graph:
+( 2 1 1 2 0 0 )
+
+Same graph, whole graph as subset:
+( 8 )
+


### PR DESCRIPTION
part of #1592

Right now I get inconsistent results. When I use a neighborhood of vertices {0,1,2} while looking at vertex 3, I get the count of edges in the subgraph induced by {0,1,2,3}. But when I look at an empty neighborhood at vertex 1, the loop at vertex 1 isn't counted. 

Also, is this used? The documentation is not too elaborate, but the R documentation for local scan (https://igraph.org/r/doc/local_scan.html) says about the neighborhoods parameter:

> In theory this could be useful if the same graph.us graph is used for multiple graph.them arguments. Then the neighborhoods can be calculated on graph.us and used with multiple graphs. In practice, this is currently slower than simply using graph.them multiple times.
