### PR TITLE
feat: igraph_reverse_edges()

### DIFF
--- a/doc/operators.xxml
+++ b/doc/operators.xxml
@@ -29,6 +29,7 @@
 <!-- doxrox-include igraph_linegraph -->
 <!-- doxrox-include igraph_simplify -->
 <!-- doxrox-include igraph_subgraph_edges -->
+<!-- doxrox-include igraph_reverse_edges -->
 </section>
 
 </chapter>

--- a/include/igraph_operators.h
+++ b/include/igraph_operators.h
@@ -81,6 +81,7 @@ IGRAPH_EXPORT int igraph_induced_subgraph(const igraph_t *graph, igraph_t *res,
                                           const igraph_vs_t vids, igraph_subgraph_implementation_t impl);
 IGRAPH_EXPORT int igraph_subgraph_edges(const igraph_t *graph, igraph_t *res,
                                         const igraph_es_t eids, igraph_bool_t delete_vertices);
+IGRAPH_EXPORT int igraph_reverse_edges(igraph_t *graph, const igraph_es_t eids);
 
 __END_DECLS
 

--- a/interfaces/functions.yaml
+++ b/interfaces/functions.yaml
@@ -525,6 +525,10 @@ igraph_subgraph_edges:
     PARAMS: GRAPH graph, OUT GRAPH res, EDGESET eids, BOOLEAN delete_vertices=True
     DEPS: eids ON graph
 
+igraph_reverse_edges:
+    PARAMS: INOUT GRAPH graph, EDGESET eids
+    DEPS: eids ON graph
+
 igraph_average_path_length:
     PARAMS: GRAPH graph, PRIMARY OUT REAL res, OUT REAL unconn_pairs=NULL,
         BOOLEAN directed=True, BOOLEAN unconn=True

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -210,6 +210,7 @@ add_library(
   operators/intersection.c
   operators/misc_internal.c
   operators/permute.c
+  operators/reverse.c
   operators/rewire.c
   operators/rewire_edges.c
   operators/simplify.c

--- a/src/operators/reverse.c
+++ b/src/operators/reverse.c
@@ -1,0 +1,87 @@
+/*
+   IGraph library.
+   Copyright (C) 2022 The igraph development team
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+   02110-1301 USA
+*/
+
+#include "igraph_operators.h"
+
+#include "igraph_constructors.h"
+#include "igraph_conversion.h"
+#include "igraph_datatype.h"
+#include "igraph_error.h"
+#include "igraph_interface.h"
+#include "igraph_iterators.h"
+#include "igraph_vector.h"
+
+#include "graph/attributes.h"
+
+/**
+ * \function igraph_reverse_edges
+ * \brief Reverses some edges of a directed graph.
+ *
+ * This functon reverses some edges of a directed graph. The modification is done in place.
+ * All attributes, as well as the ordering of edges and vertices are preserved.
+ *
+ * \param graph The graph whose edges will be reversed.
+ * \param es    The edges to be reversed.
+ *              Pass <code>igraph_ess_all(IGRAPH_EDGEORDER_ID)</code> to reverse all edges.
+ * \return Error code.
+ */
+int igraph_reverse_edges(igraph_t *graph, const igraph_es_t eids) {
+    long int no_of_edges = igraph_ecount(graph);
+    long int no_of_nodes = igraph_vcount(graph);
+    igraph_vector_t edges;
+    igraph_eit_t eit;
+    igraph_t new_graph;
+
+    /* Nothing to do on undirected graph. */
+    if (! igraph_is_directed(graph)) {
+        return IGRAPH_SUCCESS;
+    }
+
+    /* Convert graph to edge list. */
+    IGRAPH_VECTOR_INIT_FINALLY(&edges, 2*no_of_edges);
+    IGRAPH_CHECK(igraph_get_edgelist(graph, &edges, /* bycol= */ 0));
+
+    /* Reverse the edges. */
+
+    IGRAPH_CHECK(igraph_eit_create(graph, eids, &eit));
+    IGRAPH_FINALLY(igraph_eit_destroy, &eit);
+
+    for (; !IGRAPH_EIT_END(eit); IGRAPH_EIT_NEXT(eit)) {
+        long int eid = IGRAPH_EIT_GET(eit);
+        long int tmp = VECTOR(edges)[2*eid];
+        VECTOR(edges)[2*eid] = VECTOR(edges)[2*eid + 1];
+        VECTOR(edges)[2*eid + 1] = tmp;
+    }
+
+    /* Re-create graph from edge list and transfer attributes. */
+    IGRAPH_CHECK(igraph_create(&new_graph, &edges, no_of_nodes, IGRAPH_DIRECTED));
+    IGRAPH_FINALLY(igraph_destroy, &new_graph);
+
+    IGRAPH_I_ATTRIBUTE_COPY(&new_graph, graph, 1, 1, 1); /* does IGRAPH_CHECK */
+
+    igraph_eit_destroy(&eit);
+    igraph_vector_destroy(&edges);
+    igraph_destroy(graph);
+    IGRAPH_FINALLY_CLEAN(3);
+
+    *graph = new_graph;
+
+    return IGRAPH_SUCCESS;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -457,6 +457,7 @@ add_legacy_tests(
   igraph_induced_subgraph
   igraph_induced_subgraph_map
   igraph_intersection2
+  igraph_reverse_edges
   igraph_rewire_directed_edges
 )
 

--- a/tests/unit/igraph_reverse_edges.c
+++ b/tests/unit/igraph_reverse_edges.c
@@ -1,0 +1,46 @@
+/*
+   IGraph library.
+   Copyright (C) 2022 The igraph development team
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+   02110-1301 USA
+*/
+
+#include "test_utilities.inc"
+
+int main() {
+    igraph_t graph;
+
+    igraph_small(&graph, 0, IGRAPH_DIRECTED,
+                 0,1, 1,2, 2,3, 3,1, 1,4,
+                 -1);
+
+    printf("Original graph:\n");
+    print_graph(&graph);
+
+    printf("Reverse one edge:\n");
+    igraph_reverse_edges(&graph, igraph_ess_1(2));
+    print_graph(&graph);
+
+    printf("Reverse all edges:\n");
+    igraph_reverse_edges(&graph, igraph_ess_all(IGRAPH_EDGEORDER_ID));
+    print_graph(&graph);
+
+    igraph_destroy(&graph);
+
+    VERIFY_FINALLY_STACK();
+
+    return 0;
+}


### PR DESCRIPTION
This is the first part of the plan from here: https://github.com/igraph/igraph/issues/1477#issuecomment-1134579555

It adds a functions to reverse _some_ of the edges. It's for the `master` branch so we could expose the functionality in R/igraph 1.3, but if you don't want a new feature this later in 0.9 we can move it to 0.10. I think this is a low-risk change.

----

My preference is to merge this into 0.9, then in 0.10 I add a fast O(1) path for the case when flipping all edges.