### PR TITLE
fix: permute_vertices() now verifies that the permutation vector is valid

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -457,6 +457,7 @@ add_legacy_tests(
   igraph_induced_subgraph
   igraph_induced_subgraph_map
   igraph_intersection2
+  igraph_permute_vertices
   igraph_reverse_edges
   igraph_rewire_directed_edges
 )

--- a/tests/unit/igraph_permute_vertices.c
+++ b/tests/unit/igraph_permute_vertices.c
@@ -1,0 +1,66 @@
+/*
+   IGraph library.
+   Copyright (C) 2022  The igraph development team <igraph@igraph.org>
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_utilities.inc"
+
+int main() {
+    igraph_t graph, pgraph;
+    igraph_vector_t perm;
+
+    igraph_set_attribute_table(&igraph_cattribute_table);
+
+    igraph_small(&graph, 6, IGRAPH_DIRECTED,
+                 0,1, 1,0, 2,1, 2,2, 5,4, 5,4,
+                 -1);
+
+    printf("Graph before permuting vertices:\n");
+    print_graph(&graph);
+
+    igraph_vector_init_int(&perm, 6,
+                           0, 1, 5, 3, 4, 2);
+
+    igraph_permute_vertices(&graph, &pgraph, &perm);
+
+    printf("\nGraph after permuting vertices:\n");
+    print_graph(&pgraph);
+
+    igraph_destroy(&pgraph);
+
+    /* Now we test invalid input. */
+
+    /* Out-of-range value in permutation */
+    VECTOR(perm)[0] = 7;
+    CHECK_ERROR(igraph_permute_vertices(&graph, &pgraph, &perm), IGRAPH_EINVAL);
+
+    /* Duplicate value in permutation */
+    VECTOR(perm)[0] = 1;
+    CHECK_ERROR(igraph_permute_vertices(&graph, &pgraph, &perm), IGRAPH_EINVAL);
+
+    /* Invalid permutation vector length */
+    VECTOR(perm)[0] = 0;
+    VECTOR(perm)[2] = 2;
+    igraph_vector_resize(&perm, 5);
+    CHECK_ERROR(igraph_permute_vertices(&graph, &pgraph, &perm), IGRAPH_EINVAL);
+
+    igraph_vector_destroy(&perm);
+    igraph_destroy(&graph);
+
+    VERIFY_FINALLY_STACK();
+
+    return 0;
+}

--- a/tests/unit/igraph_permute_vertices.out
+++ b/tests/unit/igraph_permute_vertices.out
@@ -1,0 +1,23 @@
+Graph before permuting vertices:
+directed: true
+vcount: 6
+edges: {
+0 1
+1 0
+2 1
+2 2
+5 4
+5 4
+}
+
+Graph after permuting vertices:
+directed: true
+vcount: 6
+edges: {
+0 1
+1 0
+5 1
+5 5
+2 4
+2 4
+}


### PR DESCRIPTION
This ensures that the permutation vector passed to `permute_vertices()` is valid. Recently I added a check for the vector not containing invalid indices. Now we also check that it does not contain duplicates.

This check is necessary because `permute_vertices()` is accessible from high-level interfaces, and passing in duplicates in the permutation vector will produce garbage output. It's unclear if a crash is possible, or whether it corrupts internal state, but it does provide a loophole to introduce duplicate vertex.

The check is done through a newly added helper function that inverts permutations. This should be useful in the future as we deal with the inconsistent representation of permutations, which is being discussed [here](https://github.com/igraph/igraph/issues/1930#issuecomment-1176079877). Using the terminology from there, `permute_vertices` takes an R2 type input, but it uses `igraph_i_attribute_permute_vertices()` which requires an R1 type input. Converting between R2 and R1 is equivalent to inversion, and the function already had to do this before this refactoring. This PR simply couples validating permutations with inverting them, as doing them together is more efficient: both would use the same algorithm anyway.

Is there a performance cost? Yes, there is. Previously, inversion was only done when an attribute handler was set up. Now it is done even if attributes are not used.  One possible solution would be to introduce an internal, unchecked version of `permute_vertices()`. However, I would leave that for a later time (and for `develop`).

On the topic of performance, the check could be done slightly more efficiently if we allocated `inverse` directly within `igraph_i_invert_permutation()`, as we could exploit that it is already filled with zeros.

I have not yet added tests. I will do that only on `develop` as the tools to easily print graph attributes (and check that they're properly permuted) are only available there.

