### PR TITLE
Make functions overflow-safe 

### DIFF
--- a/src/constructors/adjacency.c
+++ b/src/constructors/adjacency.c
@@ -908,7 +908,6 @@ static igraph_error_t igraph_i_sparse_adjacency_directed(
 ) {
     igraph_sparsemat_iterator_t it;
     igraph_sparsemat_iterator_init(&it, adjmatrix);
-    igraph_integer_t e = 0;
 
     for (; !igraph_sparsemat_iterator_end(&it); igraph_sparsemat_iterator_next(&it)) {
         igraph_integer_t from = igraph_sparsemat_iterator_row(&it);
@@ -918,11 +917,10 @@ static igraph_error_t igraph_i_sparse_adjacency_directed(
             IGRAPH_CHECK(igraph_i_adjust_loop_edge_count(&multi, loops));
         }
         for (igraph_integer_t count = 0; count < multi; count++) {
-            VECTOR(*edges)[e++] = from;
-            VECTOR(*edges)[e++] = to;
+            IGRAPH_CHECK(igraph_vector_int_push_back(edges, from));
+            IGRAPH_CHECK(igraph_vector_int_push_back(edges, to));
         }
     }
-    igraph_vector_int_resize(edges, e);
     return IGRAPH_SUCCESS;
 }
 
@@ -931,7 +929,6 @@ static igraph_error_t igraph_i_sparse_adjacency_max(
     igraph_loops_t loops
 ) {
     igraph_sparsemat_iterator_t it;
-    igraph_integer_t e = 0;
     igraph_real_t other;
 
     igraph_sparsemat_iterator_init(&it, adjmatrix);
@@ -949,11 +946,10 @@ static igraph_error_t igraph_i_sparse_adjacency_max(
             multi = multi > other ? multi : other;
         }
         for (igraph_integer_t count = 0; count < multi; count++) {
-            VECTOR(*edges)[e++] = from;
-            VECTOR(*edges)[e++] = to;
+            IGRAPH_CHECK(igraph_vector_int_push_back(edges, from));
+            IGRAPH_CHECK(igraph_vector_int_push_back(edges, to));
         }
     }
-    igraph_vector_int_resize(edges, e);
 
     return IGRAPH_SUCCESS;
 }
@@ -963,7 +959,6 @@ static igraph_error_t igraph_i_sparse_adjacency_min(
     igraph_loops_t loops
 ) {
     igraph_sparsemat_iterator_t it;
-    igraph_integer_t e = 0;
     igraph_real_t other;
 
     igraph_sparsemat_iterator_init(&it, adjmatrix);
@@ -981,11 +976,10 @@ static igraph_error_t igraph_i_sparse_adjacency_min(
             multi = multi < other ? multi : other;
         }
         for (igraph_integer_t count = 0; count < multi; count++) {
-            VECTOR(*edges)[e++] = from;
-            VECTOR(*edges)[e++] = to;
+            IGRAPH_CHECK(igraph_vector_int_push_back(edges, from));
+            IGRAPH_CHECK(igraph_vector_int_push_back(edges, to));
         }
     }
-    igraph_vector_int_resize(edges, e);
 
     return IGRAPH_SUCCESS;
 }
@@ -995,7 +989,6 @@ static igraph_error_t igraph_i_sparse_adjacency_upper(
     igraph_loops_t loops
 ) {
     igraph_sparsemat_iterator_t it;
-    igraph_integer_t e = 0;
 
     igraph_sparsemat_iterator_init(&it, adjmatrix);
     for (; !igraph_sparsemat_iterator_end(&it); igraph_sparsemat_iterator_next(&it)) {
@@ -1009,11 +1002,9 @@ static igraph_error_t igraph_i_sparse_adjacency_upper(
             IGRAPH_CHECK(igraph_i_adjust_loop_edge_count(&multi, loops));
         }
         for (igraph_integer_t count = 0; count < multi; count++) {
-            VECTOR(*edges)[e++] = from;
-            VECTOR(*edges)[e++] = to;
+            IGRAPH_CHECK(igraph_vector_int_push_back(edges, from));
+            IGRAPH_CHECK(igraph_vector_int_push_back(edges, to));
         }
-    }
-    igraph_vector_int_resize(edges, e);
 
     return IGRAPH_SUCCESS;
 }
@@ -1023,7 +1014,6 @@ static igraph_error_t igraph_i_sparse_adjacency_lower(
     igraph_loops_t loops
 ) {
     igraph_sparsemat_iterator_t it;
-    igraph_integer_t e = 0;
 
     igraph_sparsemat_iterator_init(&it, adjmatrix);
     for (; !igraph_sparsemat_iterator_end(&it); igraph_sparsemat_iterator_next(&it)) {
@@ -1037,11 +1027,10 @@ static igraph_error_t igraph_i_sparse_adjacency_lower(
             IGRAPH_CHECK(igraph_i_adjust_loop_edge_count(&multi, loops));
         }
         for (igraph_integer_t count = 0; count < multi; count++) {
-            VECTOR(*edges)[e++] = from;
-            VECTOR(*edges)[e++] = to;
+            IGRAPH_CHECK(igraph_vector_int_push_back(edges, from));
+            IGRAPH_CHECK(igraph_vector_int_push_back(edges, to));
         }
     }
-    igraph_vector_int_resize(edges, e);
     return IGRAPH_SUCCESS;
 }
 
@@ -1075,10 +1064,6 @@ igraph_error_t igraph_sparse_adjacency(igraph_t *graph, igraph_sparsemat_t *adjm
 
     igraph_vector_int_t edges = IGRAPH_VECTOR_NULL;
     igraph_integer_t no_of_nodes = igraph_sparsemat_nrow(adjmatrix);
-    igraph_integer_t no_of_edges = igraph_sparsemat_count_nonzero(adjmatrix);
-    if (no_of_edges) {
-        no_of_edges *= igraph_sparsemat_max(adjmatrix);
-    }
 
     if (!igraph_sparsemat_is_cc(adjmatrix)) {
         IGRAPH_ERROR("Sparse adjacency matrix should be in column-compressed "
@@ -1093,7 +1078,7 @@ igraph_error_t igraph_sparse_adjacency(igraph_t *graph, igraph_sparsemat_t *adjm
                 igraph_sparsemat_min(adjmatrix));
     }
 
-    IGRAPH_VECTOR_INT_INIT_FINALLY(&edges, no_of_edges * 2);
+    IGRAPH_VECTOR_INT_INIT_FINALLY(&edges, 0);
 
     /* Collect the edges */
     switch (mode) {

--- a/src/constructors/adjacency.c
+++ b/src/constructors/adjacency.c
@@ -1005,6 +1005,7 @@ static igraph_error_t igraph_i_sparse_adjacency_upper(
             IGRAPH_CHECK(igraph_vector_int_push_back(edges, from));
             IGRAPH_CHECK(igraph_vector_int_push_back(edges, to));
         }
+    }
 
     return IGRAPH_SUCCESS;
 }

--- a/src/flow/st-cuts.c
+++ b/src/flow/st-cuts.c
@@ -88,14 +88,13 @@ igraph_error_t igraph_even_tarjan_reduction(const igraph_t *graph, igraph_t *gra
     igraph_integer_t no_of_edges = igraph_ecount(graph);
 
     igraph_integer_t new_no_of_nodes;
-    igraph_integer_t new_no_of_edges;
+    igraph_integer_t new_no_of_edges = no_of_edges * 2;
 
     igraph_vector_int_t edges;
     igraph_integer_t edgeptr = 0, capptr = 0;
     igraph_integer_t i;
 
     IGRAPH_SAFE_MULT(no_of_nodes, 2, &new_no_of_nodes);
-    IGRAPH_SAFE_MULT(no_of_edges, 2, &new_no_of_edges);
     IGRAPH_SAFE_ADD(new_no_of_edges, no_of_nodes, &new_no_of_edges);
 
     /* To ensure the size of the edges vector will not overflow. */

--- a/src/misc/conversion.c
+++ b/src/misc/conversion.c
@@ -33,6 +33,7 @@
 
 #include "core/fixed_vectorlist.h"
 #include "graph/attributes.h"
+#include "math/safe_intop.h"
 
 /**
  * \ingroup conversion
@@ -465,12 +466,13 @@ igraph_error_t igraph_to_directed(igraph_t *graph,
         igraph_t newgraph;
         igraph_vector_int_t edges;
         igraph_vector_int_t index;
-        igraph_integer_t size = no_of_edges * 4;
+        igraph_integer_t size;
         igraph_integer_t i;
+        IGRAPH_SAFE_MULT(no_of_edges, 4, &size);
         IGRAPH_VECTOR_INT_INIT_FINALLY(&edges, 0);
         IGRAPH_CHECK(igraph_vector_int_reserve(&edges, size));
         IGRAPH_CHECK(igraph_get_edgelist(graph, &edges, 0));
-        IGRAPH_CHECK(igraph_vector_int_resize(&edges, no_of_edges * 4));
+        IGRAPH_CHECK(igraph_vector_int_resize(&edges, size));
         IGRAPH_VECTOR_INT_INIT_FINALLY(&index, no_of_edges * 2);
         for (i = 0; i < no_of_edges; i++) {
             VECTOR(edges)[no_of_edges * 2 + i * 2]  = VECTOR(edges)[i * 2 + 1];

--- a/src/paths/johnson.c
+++ b/src/paths/johnson.c
@@ -26,6 +26,7 @@
 #include "igraph_conversion.h"
 #include "igraph_interface.h"
 
+#include "math/safe_intop.h"
 /**
  * \function igraph_distances_johnson
  * \brief Weighted shortest path lengths between vertices, using Johnson's algorithm.
@@ -80,6 +81,7 @@ igraph_error_t igraph_distances_johnson(const igraph_t *graph,
     igraph_integer_t i, ptr;
     igraph_integer_t nr, nc;
     igraph_vit_t fromvit;
+    igraph_integer_t no_edges_reserved;
 
     /* If no weights, then we can just run the unweighted version */
     if (!weights) {
@@ -122,10 +124,13 @@ igraph_error_t igraph_distances_johnson(const igraph_t *graph,
     IGRAPH_CHECK(igraph_empty(&newgraph, no_of_nodes + 1, igraph_is_directed(graph)));
     IGRAPH_FINALLY(igraph_destroy, &newgraph);
 
+    IGRAPH_SAFE_MULT(no_of_nodes, 2, &no_edges_reserved);
+    IGRAPH_SAFE_ADD(no_edges_reserved, no_of_edges * 2, &no_edges_reserved);
+
     /* Add a new node to the graph, plus edges from it to all the others. */
-    IGRAPH_VECTOR_INT_INIT_FINALLY(&edges, no_of_edges * 2 + no_of_nodes * 2);
+    IGRAPH_VECTOR_INT_INIT_FINALLY(&edges, no_edges_reserved);
     igraph_get_edgelist(graph, &edges, /*bycol=*/ 0); /* reserved */
-    igraph_vector_int_resize(&edges, no_of_edges * 2 + no_of_nodes * 2); /* reserved */
+    igraph_vector_int_resize(&edges, no_edges_reserved); /* reserved */
     for (i = 0, ptr = no_of_edges * 2; i < no_of_nodes; i++) {
         VECTOR(edges)[ptr++] = no_of_nodes;
         VECTOR(edges)[ptr++] = i;

--- a/src/properties/spectral.c
+++ b/src/properties/spectral.c
@@ -25,6 +25,8 @@
 #include "igraph_structural.h"
 #include "igraph_interface.h"
 
+#include "math/safe_intop.h"
+
 #include <math.h>
 
 static igraph_error_t igraph_i_laplacian_validate_weights(
@@ -259,7 +261,13 @@ igraph_error_t igraph_get_laplacian_sparse(
     igraph_bool_t directed = igraph_is_directed(graph);
     igraph_vector_t degree;
     igraph_integer_t i;
-    igraph_integer_t nz = directed ? no_of_edges + no_of_nodes : no_of_edges * 2 + no_of_nodes;
+    igraph_integer_t nz;
+   
+    if (directed) {
+        IGRAPH_SAFE_ADD(no_of_edges, no_of_nodes, &nz);
+    } else {
+        IGRAPH_SAFE_ADD(no_of_edges * 2, no_of_nodes, &nz);
+    }
 
     IGRAPH_ASSERT(sparseres != NULL);
 


### PR DESCRIPTION
Fixes part of #51
#2097 handles random generators

I just did a grep for "no_of_edges \* 2", and even_tarjan_reduction was the first. 
