### PR TITLE
Control whether self-loops are considered mutual

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -695,6 +695,8 @@ Some of the highlights are:
 
  - `igraph_matrix_minmax()`, `igraph_matrix_which_minmax()`, `igraph_matrix_which_min()` and `igraph_matrix_which_max()` no longer return an error code. The return type is now `void`. These functions never fail.
 
+ - `igraph_is_mutual()` has an additional parameter which controls whether directed self-loops are considered mutual.
+
 ### Added
 
  - A new integer type, `igraph_uint_t` has been added. This is the unsigned pair of `igraph_integer_t` and they are always consistent in size.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -734,6 +734,7 @@ Some of the highlights are:
  - `igraph_sparse_adjacency()` and `igraph_sparse_weighted_adjacency()` constructs graphs from (weighted) sparse matrices.
  - `igraph_full_multipartite()` generates full multipartite graphs (a generalization of bipartite graphs to multiple groups).
  - `igraph_turan()` generates Turán graphs.
+ - `igraph_has_mutual()` checks if a directed graph has any mutual edges.
 
 ### Removed
 

--- a/include/igraph_datatype.h
+++ b/include/igraph_datatype.h
@@ -48,7 +48,7 @@ typedef enum {
      * with edges (a, b) and (b, a), and false for a directed graph with
      * edges (a, b) and (a, b) again. Self-loops (a, a) are not considered
      * reciprocal. */
-    IGRAPH_PROP_HAS_RECIPROCAL,
+    IGRAPH_PROP_HAS_MUTUAL,
 
     /* Stores whether the graph is weakly connected. */
     IGRAPH_PROP_IS_WEAKLY_CONNECTED,

--- a/include/igraph_structural.h
+++ b/include/igraph_structural.h
@@ -55,7 +55,7 @@ IGRAPH_EXPORT igraph_error_t igraph_is_loop(const igraph_t *graph, igraph_vector
 IGRAPH_EXPORT igraph_error_t igraph_is_multiple(const igraph_t *graph, igraph_vector_bool_t *res,
                                      igraph_es_t es);
 IGRAPH_EXPORT igraph_error_t igraph_is_mutual(const igraph_t *graph, igraph_vector_bool_t *res, igraph_es_t es, igraph_bool_t loops);
-IGRAPH_EXPORT igraph_error_t igraph_has_mutual(const igraph_t *graph, igraph_bool_t loops, igraph_bool_t *res);
+IGRAPH_EXPORT igraph_error_t igraph_has_mutual(const igraph_t *graph, igraph_bool_t *res, igraph_bool_t loops);
 IGRAPH_EXPORT igraph_error_t igraph_is_simple(const igraph_t *graph, igraph_bool_t *res);
 IGRAPH_EXPORT igraph_error_t igraph_is_tree(const igraph_t *graph, igraph_bool_t *res, igraph_integer_t *root, igraph_neimode_t mode);
 IGRAPH_EXPORT igraph_error_t igraph_is_acyclic(const igraph_t *graph, igraph_bool_t *res);

--- a/include/igraph_structural.h
+++ b/include/igraph_structural.h
@@ -56,6 +56,7 @@ IGRAPH_EXPORT igraph_error_t igraph_is_loop(const igraph_t *graph, igraph_vector
 IGRAPH_EXPORT igraph_error_t igraph_is_multiple(const igraph_t *graph, igraph_vector_bool_t *res,
                                      igraph_es_t es);
 IGRAPH_EXPORT igraph_error_t igraph_is_mutual(const igraph_t *graph, igraph_vector_bool_t *res, igraph_es_t es, igraph_bool_t loops);
+IGRAPH_EXPORT igraph_error_t igraph_has_mutual(const igraph_t *graph, igraph_bool_t loops, igraph_bool_t *res);
 IGRAPH_EXPORT igraph_error_t igraph_is_simple(const igraph_t *graph, igraph_bool_t *res);
 IGRAPH_EXPORT igraph_error_t igraph_is_tree(const igraph_t *graph, igraph_bool_t *res, igraph_integer_t *root, igraph_neimode_t mode);
 IGRAPH_EXPORT igraph_error_t igraph_is_acyclic(const igraph_t *graph, igraph_bool_t *res);

--- a/include/igraph_structural.h
+++ b/include/igraph_structural.h
@@ -55,7 +55,7 @@ IGRAPH_EXPORT igraph_error_t igraph_is_loop(const igraph_t *graph, igraph_vector
                                  igraph_es_t es);
 IGRAPH_EXPORT igraph_error_t igraph_is_multiple(const igraph_t *graph, igraph_vector_bool_t *res,
                                      igraph_es_t es);
-IGRAPH_EXPORT igraph_error_t igraph_is_mutual(const igraph_t *graph, igraph_vector_bool_t *res, igraph_es_t es);
+IGRAPH_EXPORT igraph_error_t igraph_is_mutual(const igraph_t *graph, igraph_vector_bool_t *res, igraph_es_t es, igraph_bool_t loops);
 IGRAPH_EXPORT igraph_error_t igraph_is_simple(const igraph_t *graph, igraph_bool_t *res);
 IGRAPH_EXPORT igraph_error_t igraph_is_tree(const igraph_t *graph, igraph_bool_t *res, igraph_integer_t *root, igraph_neimode_t mode);
 IGRAPH_EXPORT igraph_error_t igraph_is_acyclic(const igraph_t *graph, igraph_bool_t *res);

--- a/interfaces/functions.yaml
+++ b/interfaces/functions.yaml
@@ -865,7 +865,7 @@ igraph_unfold_tree:
         OPTIONAL OUT INDEX_VECTOR vertex_index
 
 igraph_is_mutual:
-    PARAMS: GRAPH graph, OUT VECTOR_BOOL res, EDGESET es=ALL
+    PARAMS: GRAPH graph, OUT VECTOR_BOOL res, EDGESET es=ALL, BOOLEAN loops=True
     DEPS: es ON graph
 
 igraph_maximum_cardinality_search:

--- a/interfaces/functions.yaml
+++ b/interfaces/functions.yaml
@@ -868,6 +868,9 @@ igraph_is_mutual:
     PARAMS: GRAPH graph, OUT VECTOR_BOOL res, EDGESET es=ALL, BOOLEAN loops=True
     DEPS: es ON graph
 
+igraph_has_mutual:
+    PARAMS: GRAPH graph, BOOLEAN loops=True, OUT BOOLEAN res
+
 igraph_maximum_cardinality_search:
     PARAMS: GRAPH graph, OPTIONAL OUT INDEX_VECTOR alpha, OPTIONAL OUT VERTEX_INDICES alpham1
     DEPS: alpham1 ON graph

--- a/interfaces/functions.yaml
+++ b/interfaces/functions.yaml
@@ -869,7 +869,7 @@ igraph_is_mutual:
     DEPS: es ON graph
 
 igraph_has_mutual:
-    PARAMS: GRAPH graph, BOOLEAN loops=True, OUT BOOLEAN res
+    PARAMS: GRAPH graph, OUT BOOLEAN res, BOOLEAN loops=True
 
 igraph_maximum_cardinality_search:
     PARAMS: GRAPH graph, OPTIONAL OUT INDEX_VECTOR alpha, OPTIONAL OUT VERTEX_INDICES alpham1

--- a/src/graph/type_indexededgelist.c
+++ b/src/graph/type_indexededgelist.c
@@ -340,7 +340,7 @@ igraph_error_t igraph_add_edges(igraph_t *graph, const igraph_vector_int_t *edge
      * false.
      *
      * Also, adding one or more edges does not change HAS_LOOP, HAS_MULTI and
-     * HAS_RECIPROCAL if they were already true.
+     * HAS_MUTUAL if they were already true.
      */
     igraph_i_property_cache_invalidate_conditionally(
         graph,
@@ -352,7 +352,7 @@ igraph_error_t igraph_add_edges(igraph_t *graph, const igraph_vector_int_t *edge
         (1 << IGRAPH_PROP_IS_STRONGLY_CONNECTED) |
         (1 << IGRAPH_PROP_HAS_LOOP) |
         (1 << IGRAPH_PROP_HAS_MULTI) |
-        (1 << IGRAPH_PROP_HAS_RECIPROCAL)
+        (1 << IGRAPH_PROP_HAS_MUTUAL)
     );
 
     return IGRAPH_SUCCESS;
@@ -431,7 +431,7 @@ igraph_error_t igraph_add_vertices(igraph_t *graph, igraph_integer_t nv, void *a
      *
      * - IGRAPH_PROP_HAS_LOOP
      * - IGRAPH_PROP_HAS_MULTI
-     * - IGRAPH_PROP_HAS_RECIPROCAL
+     * - IGRAPH_PROP_HAS_MUTUAL
      * - IGRAPH_PROP_IS_DAG (adding a node does not create/destroy cycles)
      * - IGRAPH_PROP_IS_FOREST (same)
      *
@@ -449,7 +449,7 @@ igraph_error_t igraph_add_vertices(igraph_t *graph, igraph_integer_t nv, void *a
         /* keep_always = */
         (1 << IGRAPH_PROP_HAS_LOOP) |
         (1 << IGRAPH_PROP_HAS_MULTI) |
-        (1 << IGRAPH_PROP_HAS_RECIPROCAL) |
+        (1 << IGRAPH_PROP_HAS_MUTUAL) |
         (1 << IGRAPH_PROP_IS_DAG) |
         (1 << IGRAPH_PROP_IS_FOREST),
         /* keep_when_false = */
@@ -591,7 +591,7 @@ igraph_error_t igraph_delete_edges(igraph_t *graph, igraph_es_t edges) {
         /* keep_when_false = */
         (1 << IGRAPH_PROP_HAS_LOOP) |
         (1 << IGRAPH_PROP_HAS_MULTI) |
-        (1 << IGRAPH_PROP_HAS_RECIPROCAL) |
+        (1 << IGRAPH_PROP_HAS_MUTUAL) |
         (1 << IGRAPH_PROP_IS_STRONGLY_CONNECTED) |
         (1 << IGRAPH_PROP_IS_WEAKLY_CONNECTED),
         /* keep_when_true = */
@@ -800,7 +800,7 @@ igraph_error_t igraph_delete_vertices_idx(
         /* keep_when_false = */
         (1 << IGRAPH_PROP_HAS_LOOP) |
         (1 << IGRAPH_PROP_HAS_MULTI) |
-        (1 << IGRAPH_PROP_HAS_RECIPROCAL),
+        (1 << IGRAPH_PROP_HAS_MUTUAL),
         /* keep_when_true = */
         (1 << IGRAPH_PROP_IS_DAG) |
         (1 << IGRAPH_PROP_IS_FOREST)

--- a/src/properties/multiplicity.c
+++ b/src/properties/multiplicity.c
@@ -393,14 +393,14 @@ igraph_error_t igraph_is_mutual(const igraph_t *graph, igraph_vector_bool_t *res
  * mutual.
  *
  * \param graph The input graph.
+ * \param res Pointer to a boolean, the result will be stored here.
  * \param loops Boolean, whether to consider directed self-loops
  *        to be mutual.
- * \param res Pointer to a boolean, the result will be stored here.
  * \return Error code.
  *
  * Time complexity: O(|E| log(d)) where d is the maximum in-degree.
  */
-igraph_error_t igraph_has_mutual(const igraph_t *graph, igraph_bool_t loops, igraph_bool_t *res) {
+igraph_error_t igraph_has_mutual(const igraph_t *graph, igraph_bool_t *res, igraph_bool_t loops) {
     igraph_integer_t no_of_edges = igraph_ecount(graph);
     igraph_lazy_adjlist_t adjlist;
 

--- a/src/properties/multiplicity.c
+++ b/src/properties/multiplicity.c
@@ -274,7 +274,9 @@ igraph_error_t igraph_count_multiple(const igraph_t *graph, igraph_vector_int_t 
  * \function igraph_is_mutual
  * \brief Check whether some edges of a directed graph are mutual.
  *
- * An (A,B) edge is mutual if the graph contains the (B,A) edge too.
+ * An (A,B) non-loop directed edge is mutual if the graph contains
+ * the (B,A) edge too. Whether directed self-loops are considered mutual
+ * is controlled by the \p loops parameter.
  *
  * </para><para>
  * An undirected graph only has mutual edges, by definition.
@@ -284,14 +286,13 @@ igraph_error_t igraph_count_multiple(const igraph_t *graph, igraph_vector_int_t 
  * (A,B) edges and one (B,A) edge, then all three are considered to be
  * mutual.
  *
- * </para><para>
- * Self-loops are always mutual.
- *
  * \param graph The input graph.
  * \param res Pointer to an initialized vector, the result is stored
  *        here.
  * \param es The sequence of edges to check. Supply
  *        \ref igraph_ess_all() to check all edges.
+ * \param loops Boolean, whether to consider directed self-loops
+ *        to be mutual.
  * \return Error code.
  *
  * Time complexity: O(n log(d)), n is the number of edges supplied, d
@@ -299,7 +300,7 @@ igraph_error_t igraph_count_multiple(const igraph_t *graph, igraph_vector_int_t 
  * supplied edges. An upper limit of the time complexity is O(n log(|E|)),
  * |E| is the number of edges in the graph.
  */
-igraph_error_t igraph_is_mutual(const igraph_t *graph, igraph_vector_bool_t *res, igraph_es_t es) {
+igraph_error_t igraph_is_mutual(const igraph_t *graph, igraph_vector_bool_t *res, igraph_es_t es, igraph_bool_t loops) {
 
     igraph_eit_t eit;
     igraph_lazy_adjlist_t adjlist;
@@ -326,6 +327,11 @@ igraph_error_t igraph_is_mutual(const igraph_t *graph, igraph_vector_bool_t *res
         igraph_integer_t edge = IGRAPH_EIT_GET(eit);
         igraph_integer_t from = IGRAPH_FROM(graph, edge);
         igraph_integer_t to = IGRAPH_TO(graph, edge);
+
+        if (from == to) {
+            VECTOR(*res)[i] = loops;
+            continue; /* no need to do binsearch for self-loops */
+        }
 
         /* Check whether there is a to->from edge, search for from in the
            out-list of to */

--- a/src/properties/multiplicity.c
+++ b/src/properties/multiplicity.c
@@ -411,8 +411,8 @@ igraph_error_t igraph_has_mutual(const igraph_t *graph, igraph_bool_t *res, igra
         return IGRAPH_SUCCESS;
     }
 
-    if (igraph_i_property_cache_has(graph, IGRAPH_PROP_HAS_RECIPROCAL)) {
-        if (igraph_i_property_cache_get_bool(graph, IGRAPH_PROP_HAS_RECIPROCAL)) {
+    if (igraph_i_property_cache_has(graph, IGRAPH_PROP_HAS_MUTUAL)) {
+        if (igraph_i_property_cache_get_bool(graph, IGRAPH_PROP_HAS_MUTUAL)) {
             /* we know that the graph has at least one mutual non-loop edge
              * (because the cache only stores non-loop edges) */
             *res = 1;
@@ -458,7 +458,7 @@ igraph_error_t igraph_has_mutual(const igraph_t *graph, igraph_bool_t *res, igra
 
     /* cache the result if loops are not treated as mutual */
     if (!loops) {
-        igraph_i_property_cache_set_bool(graph, IGRAPH_PROP_HAS_RECIPROCAL, *res);
+        igraph_i_property_cache_set_bool(graph, IGRAPH_PROP_HAS_MUTUAL, *res);
     }
 
     return IGRAPH_SUCCESS;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -299,6 +299,7 @@ add_legacy_tests(
   igraph_get_shortest_path_bellman_ford
   igraph_get_shortest_paths_bellman_ford
   igraph_graph_center
+  igraph_has_mutual
   igraph_is_bipartite
   igraph_is_connected
   igraph_is_chordal

--- a/tests/unit/igraph_has_mutual.c
+++ b/tests/unit/igraph_has_mutual.c
@@ -24,55 +24,55 @@ int main() {
 
     /* undirected null graph */
     igraph_empty(&graph, 0, IGRAPH_UNDIRECTED);
-    igraph_has_mutual(&graph, IGRAPH_LOOPS, &has_mutual);
+    igraph_has_mutual(&graph, &has_mutual, IGRAPH_LOOPS);
     IGRAPH_ASSERT(! has_mutual);
     igraph_destroy(&graph);
 
     /* undirected edgeless graph */
     igraph_empty(&graph, 3, IGRAPH_UNDIRECTED);
-    igraph_has_mutual(&graph, IGRAPH_LOOPS, &has_mutual);
+    igraph_has_mutual(&graph, &has_mutual, IGRAPH_LOOPS);
     IGRAPH_ASSERT(! has_mutual);
     igraph_destroy(&graph);
 
     /* directed null graph */
     igraph_empty(&graph, 0, IGRAPH_DIRECTED);
-    igraph_has_mutual(&graph, IGRAPH_LOOPS, &has_mutual);
+    igraph_has_mutual(&graph, &has_mutual, IGRAPH_LOOPS);
     IGRAPH_ASSERT(! has_mutual);
     igraph_destroy(&graph);
 
     /* directed edgeless graph */
     igraph_empty(&graph, 3, IGRAPH_DIRECTED);
-    igraph_has_mutual(&graph, IGRAPH_LOOPS, &has_mutual);
+    igraph_has_mutual(&graph, &has_mutual, IGRAPH_LOOPS);
     IGRAPH_ASSERT(! has_mutual);
     igraph_destroy(&graph);
 
     /* undirected with edges */
     igraph_small(&graph, 1, IGRAPH_UNDIRECTED, 0,1, -1);
-    igraph_has_mutual(&graph, IGRAPH_LOOPS, &has_mutual);
+    igraph_has_mutual(&graph, &has_mutual, IGRAPH_LOOPS);
     IGRAPH_ASSERT(has_mutual);
     igraph_destroy(&graph);
 
     /* directed with no mutual */
     igraph_small(&graph, 0, IGRAPH_DIRECTED, 0,1, 1,2, -1);
-    igraph_has_mutual(&graph, IGRAPH_LOOPS, &has_mutual);
+    igraph_has_mutual(&graph, &has_mutual, IGRAPH_LOOPS);
     IGRAPH_ASSERT(! has_mutual);
     igraph_destroy(&graph);
 
     /* directed with mutual */
     igraph_small(&graph, 0, IGRAPH_DIRECTED, 0,1, 1,0, -1);
-    igraph_has_mutual(&graph, IGRAPH_LOOPS, &has_mutual);
+    igraph_has_mutual(&graph, &has_mutual, IGRAPH_LOOPS);
     IGRAPH_ASSERT(has_mutual);
     igraph_destroy(&graph);
 
     /* directed with loops, loops considered mutual */
     igraph_small(&graph, 0, IGRAPH_DIRECTED, 0,1, 0,1, 1,1, 1,2, -1);
-    igraph_has_mutual(&graph, IGRAPH_LOOPS, &has_mutual);
+    igraph_has_mutual(&graph, &has_mutual, IGRAPH_LOOPS);
     IGRAPH_ASSERT(has_mutual);
     igraph_destroy(&graph);
 
     /* directed with loops, loops not considered mutual */
     igraph_small(&graph, 0, IGRAPH_DIRECTED, 0,1, 0,1, 1,1, 1,2, -1);
-    igraph_has_mutual(&graph, IGRAPH_NO_LOOPS, &has_mutual);
+    igraph_has_mutual(&graph, &has_mutual, IGRAPH_NO_LOOPS);
     IGRAPH_ASSERT(!has_mutual);
     igraph_destroy(&graph);
 

--- a/tests/unit/igraph_has_mutual.c
+++ b/tests/unit/igraph_has_mutual.c
@@ -1,0 +1,82 @@
+/*
+   IGraph library.
+   Copyright (C) 2022  The igraph development team <igraph@igraph.org>
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_utilities.h"
+
+int main() {
+    igraph_t graph;
+    igraph_bool_t has_mutual;
+
+    /* undirected null graph */
+    igraph_empty(&graph, 0, IGRAPH_UNDIRECTED);
+    igraph_has_mutual(&graph, IGRAPH_LOOPS, &has_mutual);
+    IGRAPH_ASSERT(! has_mutual);
+    igraph_destroy(&graph);
+
+    /* undirected edgeless graph */
+    igraph_empty(&graph, 3, IGRAPH_UNDIRECTED);
+    igraph_has_mutual(&graph, IGRAPH_LOOPS, &has_mutual);
+    IGRAPH_ASSERT(! has_mutual);
+    igraph_destroy(&graph);
+
+    /* directed null graph */
+    igraph_empty(&graph, 0, IGRAPH_DIRECTED);
+    igraph_has_mutual(&graph, IGRAPH_LOOPS, &has_mutual);
+    IGRAPH_ASSERT(! has_mutual);
+    igraph_destroy(&graph);
+
+    /* directed edgeless graph */
+    igraph_empty(&graph, 3, IGRAPH_DIRECTED);
+    igraph_has_mutual(&graph, IGRAPH_LOOPS, &has_mutual);
+    IGRAPH_ASSERT(! has_mutual);
+    igraph_destroy(&graph);
+
+    /* undirected with edges */
+    igraph_small(&graph, 1, IGRAPH_UNDIRECTED, 0,1, -1);
+    igraph_has_mutual(&graph, IGRAPH_LOOPS, &has_mutual);
+    IGRAPH_ASSERT(has_mutual);
+    igraph_destroy(&graph);
+
+    /* directed with no mutual */
+    igraph_small(&graph, 0, IGRAPH_DIRECTED, 0,1, 1,2, -1);
+    igraph_has_mutual(&graph, IGRAPH_LOOPS, &has_mutual);
+    IGRAPH_ASSERT(! has_mutual);
+    igraph_destroy(&graph);
+
+    /* directed with mutual */
+    igraph_small(&graph, 0, IGRAPH_DIRECTED, 0,1, 1,0, -1);
+    igraph_has_mutual(&graph, IGRAPH_LOOPS, &has_mutual);
+    IGRAPH_ASSERT(has_mutual);
+    igraph_destroy(&graph);
+
+    /* directed with loops, loops considered mutual */
+    igraph_small(&graph, 0, IGRAPH_DIRECTED, 0,1, 0,1, 1,1, 1,2, -1);
+    igraph_has_mutual(&graph, IGRAPH_LOOPS, &has_mutual);
+    IGRAPH_ASSERT(has_mutual);
+    igraph_destroy(&graph);
+
+    /* directed with loops, loops not considered mutual */
+    igraph_small(&graph, 0, IGRAPH_DIRECTED, 0,1, 0,1, 1,1, 1,2, -1);
+    igraph_has_mutual(&graph, IGRAPH_NO_LOOPS, &has_mutual);
+    IGRAPH_ASSERT(!has_mutual);
+    igraph_destroy(&graph);
+
+    VERIFY_FINALLY_STACK();
+
+    return 0;
+}

--- a/tests/unit/igraph_is_mutual.c
+++ b/tests/unit/igraph_is_mutual.c
@@ -19,10 +19,10 @@
 #include <igraph.h>
 #include "test_utilities.h"
 
-void call_and_print(igraph_t *graph, igraph_es_t es) {
+void call_and_print(igraph_t *graph, igraph_es_t es, igraph_bool_t loops) {
     igraph_vector_bool_t result;
     igraph_vector_bool_init(&result, 0);
-    igraph_is_mutual(graph, &result, es, 1);
+    igraph_is_mutual(graph, &result, es, loops);
     igraph_vector_bool_print(&result);
     printf("\n");
     igraph_vector_bool_destroy(&result);
@@ -40,16 +40,19 @@ int main() {
     igraph_small(&g_lmu, 6, 0, 0,1, 0,2, 1,1, 1,3, 2,0, 2,0, 2,3, 3,4, 3,4, -1);
 
     printf("No vertices:\n");
-    call_and_print(&g_0, igraph_ess_all(IGRAPH_EDGEORDER_ID));
+    call_and_print(&g_0, igraph_ess_all(IGRAPH_EDGEORDER_ID), IGRAPH_LOOPS);
 
-    printf("Graph with loops and multiple edges:\n");
-    call_and_print(&g_lm, igraph_ess_all(IGRAPH_EDGEORDER_ID));
+    printf("Graph with loops and multiple edges, loops considered:\n");
+    call_and_print(&g_lm, igraph_ess_all(IGRAPH_EDGEORDER_ID), IGRAPH_LOOPS);
+
+    printf("Graph with loops and multiple edges, loops not considered:\n");
+    call_and_print(&g_lm, igraph_ess_all(IGRAPH_EDGEORDER_ID), IGRAPH_NO_LOOPS);
 
     printf("Same graph, selecting edge 4:\n");
-    call_and_print(&g_lm, igraph_ess_1(4));
+    call_and_print(&g_lm, igraph_ess_1(4), IGRAPH_LOOPS);
 
     printf("Same graph, but undirected:\n");
-    call_and_print(&g_lmu, igraph_ess_all(IGRAPH_EDGEORDER_ID));
+    call_and_print(&g_lmu, igraph_ess_all(IGRAPH_EDGEORDER_ID), IGRAPH_LOOPS);
 
     VERIFY_FINALLY_STACK();
 

--- a/tests/unit/igraph_is_mutual.c
+++ b/tests/unit/igraph_is_mutual.c
@@ -22,7 +22,7 @@
 void call_and_print(igraph_t *graph, igraph_es_t es) {
     igraph_vector_bool_t result;
     igraph_vector_bool_init(&result, 0);
-    IGRAPH_ASSERT(igraph_is_mutual(graph, &result, es) == IGRAPH_SUCCESS);
+    igraph_is_mutual(graph, &result, es, 1);
     igraph_vector_bool_print(&result);
     printf("\n");
     igraph_vector_bool_destroy(&result);
@@ -52,10 +52,9 @@ int main() {
     call_and_print(&g_lmu, igraph_ess_all(IGRAPH_EDGEORDER_ID));
 
     VERIFY_FINALLY_STACK();
-    igraph_set_error_handler(igraph_error_handler_ignore);
 
     printf("Edge out of range.\n");
-    IGRAPH_ASSERT(igraph_is_mutual(&g_lm, &result, igraph_ess_1(100)) == IGRAPH_EINVAL);
+    CHECK_ERROR(igraph_is_mutual(&g_lm, &result, igraph_ess_1(100), 1), IGRAPH_EINVAL);
 
     igraph_destroy(&g_0);
     igraph_destroy(&g_lm);

--- a/tests/unit/igraph_is_mutual.out
+++ b/tests/unit/igraph_is_mutual.out
@@ -1,8 +1,11 @@
 No vertices:
 
 
-Graph with loops and multiple edges:
+Graph with loops and multiple edges, loops considered:
 0 1 1 0 1 1 0 0 0
+
+Graph with loops and multiple edges, loops not considered:
+0 1 0 0 1 1 0 0 0
 
 Same graph, selecting edge 4:
 1

--- a/tests/unit/prop_caching.c
+++ b/tests/unit/prop_caching.c
@@ -23,6 +23,14 @@
  * without a cache should be tested in other unit tests, not here.
  */
 
+igraph_error_t has_mutual_nonloop_edge(const igraph_t* graph, igraph_bool_t* result) {
+    return igraph_has_mutual(graph, result, /* loops = */ 0);
+}
+
+igraph_error_t has_mutual_edge(const igraph_t* graph, igraph_bool_t* result) {
+    return igraph_has_mutual(graph, result, /* loops = */ 1);
+}
+
 igraph_error_t is_weakly_connected(const igraph_t* graph, igraph_bool_t* result) {
     return igraph_is_connected(graph, result, IGRAPH_WEAK);
 }
@@ -55,6 +63,8 @@ void validate_properties(const igraph_t* graph) {
     CHECK(is_forest);
     CHECK(is_weakly_connected);
     CHECK(is_strongly_connected);
+    CHECK(has_mutual_edge);
+    CHECK(has_mutual_nonloop_edge);
 }
 
 void test_basic_operations(igraph_t* graph) {


### PR DESCRIPTION
Currently, `igraph_is_mutual()` considers all directed self-loops to be mutual with the reasoning that edge (A, B) is mutual if edge (B, A) is present as well. I think this is a bit naive and does not fit practical use-cases well.

Let's think about conversion between directed and undirected graphs. A "mutual edge _pair_" is the directed equivalent of an undirected edge. We went to great lengths to ensure that even undirected self-loops are interpreted as the equivalent of not one, but _two_ directed loops. We called this "counting loops twice" in undirected graphs.  This is inconsistent with counting a single directed self-loop as "mutual".

Another way to think about it is that a directed graph with no mutual edges is one that can be obtained from a multi-edge-free undirected graph by assigning a direction to each edge. Again, this would mean that a single directed self-loop does not fit the idea of a "mutual edge" well.

Finally, a practically useful application for checking for mutual edges is to verify if converting a multi-edge-free directed graph to undirected (by ignoring edge directions) would keep the graph multi-edge-free. Again, this does not fit with interpreting directed self-loops as mutual.

I believe this makes a good case that _not_ treating self-loops are "mutual" is more useful than the current behaviour. At least it's application-dependent which behaviour one may want.

This PR adds an option to control how directed self-loops are treated. In high-level interfaces the default will be as before. In C, having this option forces users to think about the special case of loops, and avoids surprises due to misunderstandings (we don't want surprised in C, right?). So it's a win no every front. It has the added benefit that the `HAS_RECIPROCAL` property can be hooked up to this function in the caching PR. 

----

**Update:** A `has_mutual` function is now also added. Since we have a corresponding cached property, it makes sense to have a function to hook it up to. With `loops=false` this function is now usable to check whether ignoring edge directions in a directed graph effectively creates undirected multi-edges.