### PR TITLE
redirect expected Warnings to <stdout> in examples

### DIFF
--- a/examples/simple/graphml.c
+++ b/examples/simple/graphml.c
@@ -23,11 +23,19 @@
 #include <stdio.h>
 #include <unistd.h>     /* unlink */
 
+void igraph_stdwar_print_warning(const char *reason, const char *file,
+                                 int line) {
+    fprintf(stdout,
+        "STDWAR: Warning at %s:%i : %s\n", file, line, reason);
+}
+
 int main() {
     igraph_t g;
-    igraph_error_handler_t* oldhandler;
+    igraph_error_handler_t* olderrorhandler;
     int result;
     FILE *ifile, *ofile;
+
+    igraph_set_warning_handler(igraph_stdwar_print_warning);
 
     igraph_set_attribute_table(&igraph_cattribute_table);
 
@@ -39,7 +47,7 @@ int main() {
 
     /* GraphML support is an optional feature so we disable the error handler
      * temporarily to handle the case when it is not implemented */
-    oldhandler = igraph_set_error_handler(igraph_error_handler_ignore);
+    olderrorhandler = igraph_set_error_handler(igraph_error_handler_ignore);
     if ((result = igraph_read_graph_graphml(&g, ifile, 0))) {
         /* maybe it is simply disabled at compile-time */
         if (result == IGRAPH_UNIMPLEMENTED) {
@@ -47,7 +55,7 @@ int main() {
         }
         return 1;
     }
-    igraph_set_error_handler(oldhandler);
+    igraph_set_error_handler(olderrorhandler);
 
     fclose(ifile);
 

--- a/examples/simple/graphml.out
+++ b/examples/simple/graphml.out
@@ -1,0 +1,1 @@
+STDWAR: Warning at src/io/graphml.c:938 : Unknown attribute key 'd3' in a <data> tag, ignoring attribute.

--- a/examples/simple/safelocale.c
+++ b/examples/simple/safelocale.c
@@ -2,7 +2,10 @@
 #include <igraph.h>
 
 #include <locale.h>
+#include <string.h>
 #include <stdio.h>
+
+#define LOCNAME "de_DE"
 
 int main() {
     const char *filename = "weighted.gml";
@@ -12,11 +15,13 @@ int main() {
     /* Attempt to set a locale that uses a decimal comma. Locale names
      * differ between platforms, and not all locales are available,
      * so the locale change may not be successful. */
-    const char *locname = setlocale(LC_ALL, "de_DE");
+    const char *locname = setlocale(LC_ALL, LOCNAME);
     struct lconv *lc = localeconv();
-    fprintf(stderr, "setlocale() returned '%s', decimal point is '%s'\n",
-            locname ? locname : "NULL",
-            lc->decimal_point);
+    if ((locname == NULL) || (strcmp(locname, LOCNAME))) {
+        fprintf(stderr, "Warning: setlocale() returned '%s', decimal point is '%s'\n",
+              locname ? locname : "NULL",
+              lc->decimal_point);
+    }
 
     FILE *file = fopen(filename, "r");
     if (! file) {


### PR DESCRIPTION
Description: upstream: examples: reserve stderr for errors
 Some simple examples emit (expected) Warning messages to
 <stderr> (others to <stdout>). As <stderr> is a simple mean
 used by some test machineries to determinate test FAILUREs,
 expected warning message might be instead emitted to <stdout>
 (ideally to a <stdwar>). This patch redirects expected Warnings
 to <stdout> where applicable; it also provides the expected
 outputs. This patch is meant to be submitted to the upstream
 maintainer.
Origin: debian
Author: Jerome Benoit
Last-Update: 2022-08-07