### PR TITLE
Including iterations in Leiden algorithm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -719,6 +719,8 @@ Some of the highlights are:
 
  - `igraph_is_mutual()` has an additional parameter which controls whether directed self-loops are considered mutual.
 
+ - `igraph_community_leiden` has an additional parameter to indicate the number of iterations to perform (PR #2177).
+
 ### Added
 
  - A new integer type, `igraph_uint_t` has been added. This is the unsigned pair of `igraph_integer_t` and they are always consistent in size.

--- a/examples/simple/igraph_community_leiden.c
+++ b/examples/simple/igraph_community_leiden.c
@@ -40,17 +40,17 @@ int main() {
                  5, 6, 5, 7, 5, 8, 5, 9, 6, 7, 6, 8, 6, 9, 7, 8, 7, 9, 8, 9,
                  0, 5, -1);
 
-    /* Perform Leiden algorithm using CPM */
+    /* Perform Leiden algorithm using CPM for 1 iteration */
     igraph_vector_int_init(&membership, igraph_vcount(&graph));
-    igraph_community_leiden(&graph, NULL, NULL, 0.05, 0.01, 0, &membership, &nb_clusters, &quality);
+    igraph_community_leiden(&graph, NULL, NULL, 0.05, 0.01, 0, 1, &membership, &nb_clusters, &quality);
 
     printf("Leiden found %" IGRAPH_PRId " clusters using CPM (resolution parameter 0.05), quality is %.4f.\n", nb_clusters, quality);
     printf("Membership: ");
     igraph_vector_int_print(&membership);
     printf("\n");
 
-    /* Start from existing membership to improve it further */
-    igraph_community_leiden(&graph, NULL, NULL, 0.05, 0.01, 1, &membership, &nb_clusters, &quality);
+    /* Start from existing membership for 10 iterations to improve it further */
+    igraph_community_leiden(&graph, NULL, NULL, 0.05, 0.01, 1, 10, &membership, &nb_clusters, &quality);
 
     printf("Iterated Leiden, using CPM (resolution parameter 0.05), quality is %.4f.\n", quality);
     printf("Membership: ");
@@ -65,8 +65,8 @@ int main() {
         VECTOR(weights)[i] = VECTOR(degree)[i];
     }
 
-    /* Perform Leiden algorithm using modularity */
-    igraph_community_leiden(&graph, NULL, &weights, 1.0 / (2 * igraph_ecount(&graph)), 0.01, 0, &membership, &nb_clusters, &quality);
+    /* Perform Leiden algorithm using modularity until stable iteration */
+    igraph_community_leiden(&graph, NULL, &weights, 1.0 / (2 * igraph_ecount(&graph)), 0.01, 0, -1, &membership, &nb_clusters, &quality);
 
     printf("Leiden found %" IGRAPH_PRId " clusters using modularity, quality is %.4f.\n", nb_clusters, quality);
     printf("Membership: ");

--- a/include/igraph_community.h
+++ b/include/igraph_community.h
@@ -231,6 +231,7 @@ IGRAPH_EXPORT igraph_error_t igraph_community_leiden(const igraph_t *graph,
                                           const igraph_real_t resolution_parameter,
                                           const igraph_real_t beta,
                                           const igraph_bool_t start,
+                                          const igraph_integer_t n_iterations,
                                           igraph_vector_int_t *membership,
                                           igraph_integer_t *nb_clusters,
                                           igraph_real_t *quality);

--- a/interfaces/functions.yaml
+++ b/interfaces/functions.yaml
@@ -1601,7 +1601,7 @@ igraph_community_leiden:
     PARAMS: |-
         GRAPH graph, OPTIONAL EDGEWEIGHTS weights,
         OPTIONAL VERTEXWEIGHTS vertex_weights,
-        REAL resolution, REAL beta, BOOLEAN start, INTEGER n_iterations=2, 
+        REAL resolution, REAL beta=0.01, BOOLEAN start, INTEGER n_iterations=2, 
         OPTIONAL INOUT VECTOR_INT membership,
         OUT INTEGER nb_clusters, OUT REAL quality
     DEPS: weights ON graph, vertex_weights ON graph

--- a/interfaces/functions.yaml
+++ b/interfaces/functions.yaml
@@ -1601,7 +1601,7 @@ igraph_community_leiden:
     PARAMS: |-
         GRAPH graph, OPTIONAL EDGEWEIGHTS weights,
         OPTIONAL VERTEXWEIGHTS vertex_weights,
-        REAL resolution, REAL beta, BOOLEAN start, INTEGER n_iterations, 
+        REAL resolution, REAL beta, BOOLEAN start, INTEGER n_iterations=2, 
         OPTIONAL INOUT VECTOR_INT membership,
         OUT INTEGER nb_clusters, OUT REAL quality
     DEPS: weights ON graph, vertex_weights ON graph

--- a/interfaces/functions.yaml
+++ b/interfaces/functions.yaml
@@ -1601,7 +1601,8 @@ igraph_community_leiden:
     PARAMS: |-
         GRAPH graph, OPTIONAL EDGEWEIGHTS weights,
         OPTIONAL VERTEXWEIGHTS vertex_weights,
-        REAL resolution, REAL beta, BOOLEAN start, OPTIONAL INOUT VECTOR_INT membership,
+        REAL resolution, REAL beta, BOOLEAN start, INTEGER n_iterations, 
+        OPTIONAL INOUT VECTOR_INT membership,
         OUT INTEGER nb_clusters, OUT REAL quality
     DEPS: weights ON graph, vertex_weights ON graph
 

--- a/src/community/leiden.c
+++ b/src/community/leiden.c
@@ -971,7 +971,7 @@ static igraph_error_t igraph_i_community_leiden(
  *    optimization will start from a singleton partition.
  * \param n_iterations Iterate the core Leiden algorithm for the indicated number 
  *    of times. If this is a negative number, it will continue iterating until 
- *    an iteration that did not improve the quality.
+ *    an iteration did not change the clustering.
  * \param membership The membership vector. This is both used as the initial
  *    membership from which optimisation starts and is updated in place. It
  *    must hence be properly initialized. When finding clusters from scratch it

--- a/src/community/leiden.c
+++ b/src/community/leiden.c
@@ -1058,8 +1058,9 @@ igraph_error_t igraph_community_leiden(const igraph_t *graph,
             if (itr >= n_iterations)
                 stop = true;
         }
-        else if (prev_quality == *quality)
+        else if (prev_quality == *quality) {
             stop = true;
+        }
 
         prev_quality = *quality;
     }

--- a/src/community/leiden.c
+++ b/src/community/leiden.c
@@ -927,9 +927,12 @@ static igraph_error_t igraph_i_community_leiden(
  * next iteration. At each iteration all clusters are guaranteed to be
  * connected and well-separated. After an iteration in which nothing has
  * changed, all nodes and some parts are guaranteed to be locally optimally
- * assigned. Finally, asymptotically, all subsets of all clusters are
- * guaranteed to be locally optimally assigned. For more details, please see
- * Traag, Waltman &amp; van Eck (2019).
+ * assigned. Note that even if a single iteration did not result in any change,
+ * it is still possible that a subsequent iteration might find some 
+ * improvement. Each iteration explores different subsets of nodes to consider 
+ * for moving from one cluster to another. Finally, asymptotically, all subsets 
+ * of all clusters are guaranteed to be locally optimally assigned. For more 
+ * details, please see Traag, Waltman &amp; van Eck (2019).
  *
  * </para><para>
  * The objective function being optimized is
@@ -962,7 +965,7 @@ static igraph_error_t igraph_i_community_leiden(
  *    optimization will start from a singleton partition.
  * \param n_iterations Iterate the core Leiden algorithm for the indicated number 
  *    of times. If this is a negative number, it will continue iterating until 
- *    the quality no longer changed.
+ *    an iteration that did not improve the quality.
  * \param membership The membership vector. This is both used as the initial
  *    membership from which optimisation starts and is updated in place. It
  *    must hence be properly initialized. When finding clusters from scratch it
@@ -1042,9 +1045,10 @@ igraph_error_t igraph_community_leiden(const igraph_t *graph,
 
     /* Perform actual Leiden algorithm iteratively. We either
      * perform a fixed number of iterations, or we perform
-     * iterations until the quality remains unchanged. Note that
-     * the Leiden algorithm can still change in a subsequent 
-     * iteration. 
+     * iterations until the quality remains unchanged. Even if
+     * a single iteration did not change anything, a subsequent
+     * iteration may still find some improvement. This is because
+     * each iteration explores different subsets of nodes.
      */
     igraph_bool_t stop = n_iterations >= 0 ? n_iterations == 0 : false;
     igraph_integer_t itr = 0;

--- a/src/community/leiden.c
+++ b/src/community/leiden.c
@@ -40,6 +40,7 @@
  *
  * This function considers each node and greedily moves it to a neighboring
  * community that maximizes the improvement in the quality of a partition.
+ * Only moves that strictly improve the quality are considered.
  *
  * The nodes are examined in a queue, and initially all nodes are put in the
  * queue in a random order. Nodes are popped from the queue when they are
@@ -160,6 +161,9 @@ static igraph_error_t igraph_i_community_leiden_fastmovenodes(
         for (i = 0; i < nb_neigh_clusters; i++) {
             c = VECTOR(neighbor_clusters)[i];
             diff = VECTOR(edge_weights_per_cluster)[c] - VECTOR(*node_weights)[v] * VECTOR(cluster_weights)[c] * resolution_parameter;
+            /* Only consider strictly improving moves.
+             * Note that this is important in considering convergence.
+             */
             if (diff > max_diff) {
                 best_cluster = c;
                 max_diff = diff;
@@ -917,15 +921,16 @@ static igraph_error_t igraph_i_community_leiden(
  * from the resolution-limit (see preprint http://arxiv.org/abs/1104.3083).
  *
  * </para><para>
- * The Leiden algorithm consists of three phases: (1) local moving of nodes,
- * (2) refinement of the partition and (3) aggregation of the network based on
- * the refined partition, using the non-refined partition to create an initial
+ * The Leiden algorithm consists of three phases: (1) local moving of nodes, (2)
+ * refinement of the partition and (3) aggregation of the network based on the
+ * refined partition, using the non-refined partition to create an initial
  * partition for the aggregate network. In the local move procedure in the
- * Leiden algorithm, only nodes whose neighborhood has changed are visited. The
- * refinement is done by restarting from a singleton partition within each
- * cluster and gradually merging the subclusters. When aggregating, a single
- * cluster may then be represented by several nodes (which are the subclusters
- * identified in the refinement).
+ * Leiden algorithm, only nodes whose neighborhood has changed are visited. Only
+ * moves that strictly improve the quality function are made. The refinement is
+ * done by restarting from a singleton partition within each cluster and
+ * gradually merging the subclusters. When aggregating, a single cluster may
+ * then be represented by several nodes (which are the subclusters identified in
+ * the refinement).
  *
  * </para><para>
  * The Leiden algorithm provides several guarantees. The Leiden algorithm is
@@ -934,10 +939,10 @@ static igraph_error_t igraph_i_community_leiden(
  * connected and well-separated. After an iteration in which nothing has
  * changed, all nodes and some parts are guaranteed to be locally optimally
  * assigned. Note that even if a single iteration did not result in any change,
- * it is still possible that a subsequent iteration might find some 
- * improvement. Each iteration explores different subsets of nodes to consider 
- * for moving from one cluster to another. Finally, asymptotically, all subsets 
- * of all clusters are guaranteed to be locally optimally assigned. For more 
+ * it is still possible that a subsequent iteration might find some
+ * improvement. Each iteration explores different subsets of nodes to consider
+ * for moving from one cluster to another. Finally, asymptotically, all subsets
+ * of all clusters are guaranteed to be locally optimally assigned. For more
  * details, please see Traag, Waltman &amp; van Eck (2019).
  *
  * </para><para>
@@ -969,8 +974,8 @@ static igraph_error_t igraph_i_community_leiden(
  * \param start Start from membership vector. If this is true, the optimization
  *    will start from the provided membership vector. If this is false, the
  *    optimization will start from a singleton partition.
- * \param n_iterations Iterate the core Leiden algorithm for the indicated number 
- *    of times. If this is a negative number, it will continue iterating until 
+ * \param n_iterations Iterate the core Leiden algorithm for the indicated number
+ *    of times. If this is a negative number, it will continue iterating until
  *    an iteration did not change the clustering.
  * \param membership The membership vector. This is both used as the initial
  *    membership from which optimisation starts and is updated in place. It

--- a/tests/unit/community_indexing.c
+++ b/tests/unit/community_indexing.c
@@ -64,7 +64,7 @@ int main() {
     igraph_community_leading_eigenvector(&graph, NULL, NULL, &membership, igraph_vcount(&graph), NULL, NULL, false, NULL, NULL, NULL, NULL, NULL);
     check(&membership);
 
-    igraph_community_leiden(&graph, NULL, NULL, 1, 0.01, false, &membership, NULL, NULL);
+    igraph_community_leiden(&graph, NULL, NULL, 1, 0.01, 1, false, &membership, NULL, NULL);
     check(&membership);
 
     igraph_community_multilevel(&graph, NULL, 1, &membership, NULL, NULL);

--- a/tests/unit/community_leiden.c
+++ b/tests/unit/community_leiden.c
@@ -34,7 +34,7 @@ void run_leiden_CPM(const igraph_t *graph, const igraph_vector_t *edge_weights, 
     /* Initialize with singleton partition. */
     igraph_vector_int_init(&membership, igraph_vcount(graph));
 
-    igraph_community_leiden(graph, edge_weights, NULL, resolution_parameter, 0.01, 0, &membership, &nb_clusters, &quality);
+    igraph_community_leiden(graph, edge_weights, NULL, resolution_parameter, 0.01, 0, 1, &membership, &nb_clusters, &quality);
 
     printf("Leiden found %" IGRAPH_PRId " clusters using CPM (resolution parameter=%.2f), quality is %.4f.\n", nb_clusters, resolution_parameter, quality);
 
@@ -60,7 +60,7 @@ void run_leiden_modularity(igraph_t *graph, igraph_vector_t *edge_weights) {
     /* Initialize with singleton partition. */
     igraph_vector_int_init(&membership, igraph_vcount(graph));
 
-    igraph_community_leiden(graph, edge_weights, &strength, 1.0 / (2 * m), 0.01, 0, &membership, &nb_clusters, &quality);
+    igraph_community_leiden(graph, edge_weights, &strength, 1.0 / (2 * m), 0.01, 0, 1, &membership, &nb_clusters, &quality);
 
     if (isnan(quality)) {
         printf("Leiden found %" IGRAPH_PRId " clusters using modularity, quality is nan.\n", nb_clusters);

--- a/tests/unit/null_communities.c
+++ b/tests/unit/null_communities.c
@@ -91,7 +91,7 @@ int main() {
     m = 2;
     igraph_vector_int_resize(&membership, 1);
 
-    igraph_community_leiden(&g, NULL, NULL, 1, 0.01, 0, &membership, NULL, &m);
+    igraph_community_leiden(&g, NULL, NULL, 1, 0.01, 0, 1, &membership, NULL, &m);
 
     IGRAPH_ASSERT(igraph_vector_int_size(&membership) == 0);
     IGRAPH_ASSERT(igraph_is_nan(m));


### PR DESCRIPTION
This PR fixes #1423, where it was requested to add iteration to the Leiden algorithm in the C core, instead of having to reimplement it in higher-level languages.