### PR TITLE
make layout_umap interruptible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
  - `igraph_heap_init_array()` did not copy the array data correctly for non-real specializations.
  - Addressed new warnings introduced by Clang 15.
  - `igraph_layout_umap_3d()` now actually uses three dimensions.
+ - `igraph_layout_umap()` and `igraph_layout_umap_3d()` are now interruptible.
 
 ### Removed
 

--- a/src/layout/umap.c
+++ b/src/layout/umap.c
@@ -532,11 +532,8 @@ static igraph_error_t igraph_i_umap_compute_cross_entropy(const igraph_t *graph,
 
 
 /* clip forces to avoid too rapid shifts */
-static igraph_error_t igraph_i_umap_clip_force(igraph_real_t *force, igraph_real_t limit) {
-
+static void igraph_i_umap_clip_force(igraph_real_t *force, igraph_real_t limit) {
     *force  = fmax(fmin(*force, limit), -limit);
-
-    return IGRAPH_SUCCESS;
 }
 
 /*xd is difference in x direction, mu is a weight */

--- a/src/layout/umap.c
+++ b/src/layout/umap.c
@@ -617,8 +617,6 @@ static igraph_error_t igraph_i_umap_apply_forces(
      * not be doing UMAP.
      * */
     igraph_vector_int_t neis, negative_vertices;
-    igraph_integer_t loop_count = 0;
-    igraph_integer_t interrupt_period = 10000;
 
     /* Initialize vectors */
     IGRAPH_VECTOR_INIT_FINALLY(&from_emb, ndim);
@@ -669,10 +667,8 @@ static igraph_error_t igraph_i_umap_apply_forces(
         /* Random other nodes are repelled from one (the first) vertex */
         IGRAPH_CHECK(igraph_random_sample(&negative_vertices, 0, no_of_nodes - 2, n_random_vertices));
         for (igraph_integer_t j = 0; j < n_random_vertices; j++) {
-            loop_count++;
-            if (loop_count % interrupt_period == 0) {
-                IGRAPH_ALLOW_INTERRUPTION();
-            }
+            IGRAPH_ALLOW_INTERRUPTION();
+
             /* Get random neighbor */
             to = VECTOR(negative_vertices)[j];
             /* obviously you cannot repel yourself */

--- a/src/layout/umap.c
+++ b/src/layout/umap.c
@@ -26,6 +26,7 @@
 #include "igraph_random.h"
 
 #include "layout/layout_internal.h"
+#include "core/interruption.h"
 
 #include <math.h>
 
@@ -616,6 +617,8 @@ static igraph_error_t igraph_i_umap_apply_forces(
      * not be doing UMAP.
      * */
     igraph_vector_int_t neis, negative_vertices;
+    igraph_integer_t loop_count = 0;
+    igraph_integer_t interrupt_period = 10000;
 
     /* Initialize vectors */
     IGRAPH_VECTOR_INIT_FINALLY(&from_emb, ndim);
@@ -666,6 +669,10 @@ static igraph_error_t igraph_i_umap_apply_forces(
         /* Random other nodes are repelled from one (the first) vertex */
         IGRAPH_CHECK(igraph_random_sample(&negative_vertices, 0, no_of_nodes - 2, n_random_vertices));
         for (igraph_integer_t j = 0; j < n_random_vertices; j++) {
+            loop_count++;
+            if (loop_count % interrupt_period == 0) {
+                IGRAPH_ALLOW_INTERRUPTION();
+            }
             /* Get random neighbor */
             to = VECTOR(negative_vertices)[j];
             /* obviously you cannot repel yourself */

--- a/src/layout/umap.c
+++ b/src/layout/umap.c
@@ -532,8 +532,8 @@ static igraph_error_t igraph_i_umap_compute_cross_entropy(const igraph_t *graph,
 
 
 /* clip forces to avoid too rapid shifts */
-static void igraph_i_umap_clip_force(igraph_real_t *force, igraph_real_t limit) {
-    *force  = fmax(fmin(*force, limit), -limit);
+static igraph_real_t igraph_i_umap_clip_force(igraph_real_t force, igraph_real_t limit) {
+    return fmax(fmin(force, limit), -limit);
 }
 
 /*xd is difference in x direction, mu is a weight */
@@ -557,7 +557,7 @@ static igraph_error_t igraph_i_umap_attract(
     for (igraph_integer_t d = 0; d != ndim; d++) {
         VECTOR(*forces)[d] = force * VECTOR(*delta)[d];
         /* clip force to avoid too rapid change */
-        igraph_i_umap_clip_force(&(VECTOR(*forces)[d]), 3);
+        VECTOR(*forces)[d] = igraph_i_umap_clip_force(VECTOR(*forces)[d], 3);
 
 #ifdef UMAP_DEBUG
         printf("force attractive: delta[%d] = %g, forces[%d] = %g\n", d, VECTOR(*delta)[d], d, VECTOR(*forces)[d]);
@@ -589,7 +589,7 @@ static igraph_error_t igraph_i_umap_repel(
         VECTOR(*forces)[d] = force * VECTOR(*delta)[d];
 
         /* clip force to avoid too rapid change */
-        igraph_i_umap_clip_force(&(VECTOR(*forces)[d]), 3);
+        VECTOR(*forces)[d] = igraph_i_umap_clip_force(VECTOR(*forces)[d], 3);
 
 #ifdef UMAP_DEBUG
         printf("force repulsive: delta[%d] = %g, forces[%d] = %g\n", d, VECTOR(*delta)[d], d, VECTOR(*forces)[d]);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -945,6 +945,7 @@ add_benchmarks(
   igraph_coloring
   igraph_decompose
   igraph_distances
+  igraph_layout_umap
   igraph_maximal_cliques
   igraph_neighborhood
   igraph_pagerank

--- a/tests/benchmarks/igraph_layout_umap.c
+++ b/tests/benchmarks/igraph_layout_umap.c
@@ -45,7 +45,7 @@ int main(void) {
 
 #undef EPOCHS
 #undef REP
-#define EPOCHS 5
+#define EPOCHS 60
 #define REP 1
 #define VCOUNT 10000
 #define DENS 0.001
@@ -59,7 +59,7 @@ int main(void) {
     }
     RNG_END();
 
-    BENCH("Larger graph, epochs: " TOSTR(EPOCHS) ", repetitions: " TOSTR(REP) ", vertices: " TOSTR(VCOUNT) ", density: " TOSTR(DENS), REPEAT(igraph_layout_umap(&graph, &layout, 0, &distances, 0.01, EPOCHS, 0.8) , REP);
+    BENCH("Larger graph, epochs: " TOSTR(EPOCHS) ", repetitions: " TOSTR(REP) ", vertices: " TOSTR(VCOUNT) ", density: " TOSTR(DENS), REPEAT(igraph_layout_umap(&graph, &layout, 0, &distances, 0.01, EPOCHS, 0.05) , REP);
     );
 
 

--- a/tests/benchmarks/igraph_layout_umap.c
+++ b/tests/benchmarks/igraph_layout_umap.c
@@ -1,0 +1,70 @@
+
+#include <igraph.h>
+
+#include "bench.h"
+
+#define TOSTR1(x) #x
+#define TOSTR(x) TOSTR1(x)
+
+int main(void) {
+    igraph_t graph;
+    igraph_vector_t distances;
+    igraph_matrix_t layout;
+
+    igraph_rng_seed(igraph_rng_default(), 42);
+    BENCH_INIT();
+
+    igraph_matrix_init(&layout, 0, 0);
+
+
+    igraph_small(&graph, 12, IGRAPH_UNDIRECTED,
+            0,1, 0,2, 0,3, 1,2, 1,3, 2,3,
+            3,4, 4,5, 5,6,
+            6,7, 7,8, 6,8, 7,9, 6,9, 8,9, 7,10, 8,10, 9,10, 10,11, 9,11, 8,11, 7,11,
+            -1);
+    igraph_vector_init_real(&distances,
+            igraph_ecount(&graph),
+            0.1, 0.09, 0.12, 0.09, 0.1, 0.1,
+            0.9, 0.9, 0.9,
+            0.2, 0.1, 0.1, 0.1, 0.1, 0.1, 0.08, 0.05, 0.1, 0.08, 0.12, 0.09, 0.11
+            );
+
+#define EPOCHS 5000
+#define REP 40
+
+    BENCH("Small graph, epochs: " TOSTR(EPOCHS) ", repetitions: " TOSTR(REP), REPEAT(igraph_layout_umap(&graph, &layout, 0, &distances, 0.01, EPOCHS, 0.8) , REP);
+    );
+
+#undef EPOCHS
+#undef REP
+#define EPOCHS 500
+#define REP 400
+
+    BENCH("Small graph, epochs: " TOSTR(EPOCHS) ", repetitions: " TOSTR(REP), REPEAT(igraph_layout_umap(&graph, &layout, 0, &distances, 0.01, EPOCHS, 0.8) , REP);
+    );
+
+#undef EPOCHS
+#undef REP
+#define EPOCHS 5
+#define REP 1
+#define VCOUNT 10000
+#define DENS 0.001
+
+    igraph_destroy(&graph);
+    igraph_erdos_renyi_game_gnp(&graph, VCOUNT, DENS, IGRAPH_DIRECTED, IGRAPH_NO_LOOPS);
+    igraph_vector_resize(&distances, igraph_ecount(&graph));
+    RNG_BEGIN();
+    for (igraph_integer_t i=0; i < igraph_ecount(&graph); i++) {
+        VECTOR(distances)[i] = RNG_UNIF(0.05, 0.15);
+    }
+    RNG_END();
+
+    BENCH("Larger graph, epochs: " TOSTR(EPOCHS) ", repetitions: " TOSTR(REP) ", vertices: " TOSTR(VCOUNT) ", density: " TOSTR(DENS), REPEAT(igraph_layout_umap(&graph, &layout, 0, &distances, 0.01, EPOCHS, 0.8) , REP);
+    );
+
+
+    igraph_matrix_destroy(&layout);
+    igraph_destroy(&graph);
+    igraph_vector_destroy(&distances);
+    return 0;
+}

--- a/tests/benchmarks/igraph_layout_umap.c
+++ b/tests/benchmarks/igraph_layout_umap.c
@@ -31,8 +31,9 @@ int main(void) {
 
 #define EPOCHS 5000
 #define REP 40
+#define SAMP_PROB 0.8
 
-    BENCH("Small graph, epochs: " TOSTR(EPOCHS) ", repetitions: " TOSTR(REP), REPEAT(igraph_layout_umap(&graph, &layout, 0, &distances, 0.01, EPOCHS, 0.8) , REP);
+    BENCH("Small graph, epochs: " TOSTR(EPOCHS) ", repetitions: " TOSTR(REP) ", sampling prob: " TOSTR(SAMP_PROB), REPEAT(igraph_layout_umap(&graph, &layout, 0, &distances, 0.01, EPOCHS, SAMP_PROB) , REP);
     );
 
 #undef EPOCHS
@@ -40,11 +41,13 @@ int main(void) {
 #define EPOCHS 500
 #define REP 400
 
-    BENCH("Small graph, epochs: " TOSTR(EPOCHS) ", repetitions: " TOSTR(REP), REPEAT(igraph_layout_umap(&graph, &layout, 0, &distances, 0.01, EPOCHS, 0.8) , REP);
+    BENCH("Small graph, epochs: " TOSTR(EPOCHS) ", repetitions: " TOSTR(REP) ", sampling prob: " TOSTR(SAMP_PROB), REPEAT(igraph_layout_umap(&graph, &layout, 0, &distances, 0.01, EPOCHS, SAMP_PROB) , REP);
     );
 
 #undef EPOCHS
 #undef REP
+#undef SAMP_PROB
+#define SAMP_PROB 0.05
 #define EPOCHS 60
 #define REP 1
 #define VCOUNT 10000
@@ -59,7 +62,7 @@ int main(void) {
     }
     RNG_END();
 
-    BENCH("Larger graph, epochs: " TOSTR(EPOCHS) ", repetitions: " TOSTR(REP) ", vertices: " TOSTR(VCOUNT) ", density: " TOSTR(DENS), REPEAT(igraph_layout_umap(&graph, &layout, 0, &distances, 0.01, EPOCHS, 0.05) , REP);
+    BENCH("Larger graph, epochs: " TOSTR(EPOCHS) ", repetitions: " TOSTR(REP) ", sampling prob: " TOSTR(SAMP_PROB), REPEAT(igraph_layout_umap(&graph, &layout, 0, &distances, 0.01, EPOCHS, SAMP_PROB) , REP);
     );
 
 


### PR DESCRIPTION
Fixes #2211

I use an interrupt period of 10000 loops over neighbor repulsions. The counter is not static, so will be reset every epoch. This makes sure interruptions are allowed at least once every epoch (if there are any nodes).

I did not test this, and the `10000` is pretty random. Any suggestions on timing this better are welcome.