### PR TITLE
igraph_degree_1()

### DIFF
--- a/doc/basicigraph.xxml
+++ b/doc/basicigraph.xxml
@@ -194,6 +194,7 @@ Upper and lower limits of <type>igraph_integer_t</type> and
 <!-- doxrox-include igraph_neighbors -->
 <!-- doxrox-include igraph_incident -->
 <!-- doxrox-include igraph_degree -->
+<!-- doxrox-include igraph_degree_1 -->
 </section>
 
 <section id="adding-and-deleting-vertices-and-edges"><title>Adding and deleting vertices and edges</title>

--- a/include/igraph_interface.h
+++ b/include/igraph_interface.h
@@ -54,6 +54,8 @@ IGRAPH_EXPORT igraph_integer_t igraph_ecount(const igraph_t *graph);
 IGRAPH_EXPORT igraph_error_t igraph_neighbors(const igraph_t *graph, igraph_vector_int_t *neis, igraph_integer_t vid,
                                    igraph_neimode_t mode);
 IGRAPH_EXPORT igraph_bool_t igraph_is_directed(const igraph_t *graph);
+IGRAPH_EXPORT igraph_error_t igraph_degree_1(const igraph_t *graph, igraph_integer_t *deg,
+                                             igraph_integer_t vid, igraph_neimode_t mode, igraph_bool_t loops);
 IGRAPH_EXPORT igraph_error_t igraph_degree(const igraph_t *graph, igraph_vector_int_t *res,
                                 const igraph_vs_t vids, igraph_neimode_t mode,
                                 igraph_bool_t loops);

--- a/src/graph/type_indexededgelist.c
+++ b/src/graph/type_indexededgelist.c
@@ -1094,6 +1094,67 @@ igraph_bool_t igraph_is_directed(const igraph_t *graph) {
 
 /**
  * \ingroup interface
+ * \function igraph_degree_1
+ * \brief The degree of of a single vertex in the graph.
+ *
+ * This function calculates the in-, out- or total degree of a single vertex.
+ * For a single vertex, it is more efficient than calling \ref igraph_degree().
+ *
+ * \param graph The graph.
+ * \param deg Pointer to the integer where the computed degree will be stored.
+ * \param vid The vertex for which the degree will be calculated.
+ * \param mode Defines the type of the degree for directed graphs. Valid modes are:
+ *        \c IGRAPH_OUT, out-degree;
+ *        \c IGRAPH_IN, in-degree;
+ *        \c IGRAPH_ALL, total degree (sum of the in- and out-degree).
+ *        This parameter is ignored for undirected graphs.
+ * \param loops Boolean, gives whether the self-loops should be
+ *        counted.
+ * \return Error code.
+ *
+ * \sa \ref igraph_degree() to compute the degree of several vertices at once.
+ *
+ * Time complexity: O(1) if \p loops is \c true, and
+ * O(d) otherwise, where d is the degree.
+ */
+igraph_error_t igraph_degree_1(const igraph_t *graph, igraph_integer_t *deg,
+                               igraph_integer_t vid, igraph_neimode_t mode, igraph_bool_t loops) {
+
+    if (!igraph_is_directed(graph)) {
+        mode = IGRAPH_ALL;
+    }
+
+    *deg = 0;
+    if (mode & IGRAPH_OUT) {
+        *deg += (VECTOR(graph->os)[vid + 1] - VECTOR(graph->os)[vid]);
+    }
+    if (mode & IGRAPH_IN) {
+        *deg += (VECTOR(graph->is)[vid + 1] - VECTOR(graph->is)[vid]);
+    }
+    if (! loops) {
+        /* When loops should not be counted, we remove their contribution from the
+         * previously computed degree. */
+        if (mode & IGRAPH_OUT) {
+            for (igraph_integer_t i = VECTOR(graph->os)[vid]; i < VECTOR(graph->os)[vid + 1]; i++) {
+                if (VECTOR(graph->to)[ VECTOR(graph->oi)[i] ] == vid) {
+                    *deg -= 1;
+                }
+            }
+        }
+        if (mode & IGRAPH_IN) {
+            for (igraph_integer_t i = VECTOR(graph->is)[vid]; i < VECTOR(graph->is)[vid + 1]; i++) {
+                if (VECTOR(graph->from)[ VECTOR(graph->ii)[i] ] == vid) {
+                    *deg -= 1;
+                }
+            }
+        }
+    }
+
+    return IGRAPH_SUCCESS;
+}
+
+/**
+ * \ingroup interface
  * \function igraph_degree
  * \brief The degree of some vertices in a graph.
  *
@@ -1129,7 +1190,8 @@ igraph_bool_t igraph_is_directed(const igraph_t *graph) {
  * d is their (average) degree.
  *
  * \sa \ref igraph_strength() for the version that takes into account
- * edge weights.
+ * edge weights; \ref igraph_degree_1() to efficiently compute the
+ * degree of a single vertex.
  *
  * \example examples/simple/igraph_degree.c
  */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -944,6 +944,7 @@ add_benchmarks(
   igraph_closeness_weighted
   igraph_coloring
   igraph_decompose
+  igraph_degree
   igraph_distances
   igraph_maximal_cliques
   igraph_neighborhood

--- a/tests/benchmarks/igraph_degree.c
+++ b/tests/benchmarks/igraph_degree.c
@@ -1,0 +1,106 @@
+
+#include <igraph.h>
+
+#include "bench.h"
+
+#define TOSTR1(x) #x
+#define TOSTR(x) TOSTR1(x)
+
+/* Calls igraph_degree_1() separately for each vertex. */
+void deg1(const igraph_t *g, igraph_vector_int_t *res, igraph_neimode_t mode, igraph_bool_t loops) {
+    igraph_integer_t n = igraph_vcount(g);
+    igraph_vector_int_resize(res, n);
+    for (igraph_integer_t i=0; i < n; i++) {
+        igraph_degree_1(g, &VECTOR(*res)[i], i, mode, loops);
+    }
+}
+
+/* Calls igraph_degree() separately for each vertex, pre-allocates work vector. */
+void degv(const igraph_t *g, igraph_vector_int_t *res, igraph_neimode_t mode, igraph_bool_t loops) {
+    igraph_integer_t n = igraph_vcount(g);
+    igraph_vector_int_t work;
+
+    igraph_vector_int_resize(res, n);
+    igraph_vector_int_init(&work, 1);
+    for (igraph_integer_t i=0; i < n; i++) {
+        igraph_degree(g, &work, igraph_vss_1(i), mode, loops);
+    }
+    igraph_vector_int_destroy(&work);
+}
+
+/* Calls igraph_degree() separately for each vertex, allocates a new work vector each time. */
+void degv2(const igraph_t *g, igraph_vector_int_t *res, igraph_neimode_t mode, igraph_bool_t loops) {
+    igraph_integer_t n = igraph_vcount(g);
+
+    for (igraph_integer_t i=0; i < n; i++) {
+        igraph_vector_int_t work;
+        igraph_vector_int_init(&work, 1);
+        igraph_degree(g, &work, igraph_vss_1(i), mode, loops);
+        igraph_vector_int_destroy(&work);
+    }
+}
+
+int main(void) {
+    igraph_t g;
+    igraph_vector_int_t degs;
+
+    igraph_rng_seed(igraph_rng_default(), 137);
+    BENCH_INIT();
+
+    igraph_barabasi_game(&g, 100000, 1, 10, NULL, true, 0, IGRAPH_UNDIRECTED, IGRAPH_BARABASI_PSUMTREE_MULTIPLE, NULL);
+    igraph_vector_int_init(&degs, igraph_vcount(&g));
+
+#define REP 1000
+
+    printf("Count loops, O(1) per degree, fast methods only.\n");
+
+    BENCH(" 1 igraph_degree(), preferential attachment n=100000, m=10, " TOSTR(REP) "x",
+          REPEAT(igraph_degree(&g, &degs, igraph_vss_all(), IGRAPH_ALL, IGRAPH_LOOPS), REP);
+    );
+    BENCH(" 2 deg1(), preferential attachment n=100000, m=10, " TOSTR(REP) "x",
+          REPEAT(deg1(&g, &degs, IGRAPH_ALL, IGRAPH_LOOPS), REP);
+    );
+
+#undef REP
+
+#define REP 100
+
+    printf("\nCount loops, O(1) per degree.\n");
+
+    BENCH(" 1 igraph_degree(), preferential attachment n=100000, m=10, " TOSTR(REP) "x",
+          REPEAT(igraph_degree(&g, &degs, igraph_vss_all(), IGRAPH_ALL, IGRAPH_LOOPS), REP);
+    );
+    BENCH(" 2 deg1(), preferential attachment n=100000, m=10, " TOSTR(REP) "x",
+          REPEAT(deg1(&g, &degs, IGRAPH_ALL, IGRAPH_LOOPS), REP);
+    );
+    BENCH(" 3 degv(), preferential attachment n=100000, m=10, " TOSTR(REP) "x",
+          REPEAT(degv(&g, &degs, IGRAPH_ALL, IGRAPH_LOOPS), REP);
+    );
+    BENCH(" 4 degv2(), preferential attachment n=100000, m=10, " TOSTR(REP) "x",
+          REPEAT(degv2(&g, &degs, IGRAPH_ALL, IGRAPH_LOOPS), REP);
+    );
+
+#undef REP
+
+#define REP 100
+
+    printf("\nDo not count loops, O(d) per degree.\n");
+
+    BENCH(" 1 igraph_degree(), preferential attachment n=100000, m=10, " TOSTR(REP) "x",
+          REPEAT(igraph_degree(&g, &degs, igraph_vss_all(), IGRAPH_ALL, IGRAPH_NO_LOOPS), REP);
+    );
+    BENCH(" 2 deg1(), preferential attachment n=100000, m=10, " TOSTR(REP) "x",
+          REPEAT(deg1(&g, &degs, IGRAPH_ALL, IGRAPH_NO_LOOPS), REP);
+    );
+    BENCH(" 3 degv(), preferential attachment n=100000, m=10, " TOSTR(REP) "x",
+          REPEAT(degv(&g, &degs, IGRAPH_ALL, IGRAPH_NO_LOOPS), REP);
+    );
+    BENCH(" 4 degv2(), preferential attachment n=100000, m=10, " TOSTR(REP) "x",
+          REPEAT(degv2(&g, &degs, IGRAPH_ALL, IGRAPH_NO_LOOPS), REP);
+    );
+
+    igraph_vector_int_destroy(&degs);
+    igraph_destroy(&g);
+
+    return 0;
+}

--- a/tests/unit/igraph_degree.c
+++ b/tests/unit/igraph_degree.c
@@ -18,26 +18,85 @@
 #include <igraph.h>
 #include "test_utilities.h"
 
+void all_degs(const igraph_t *g, igraph_vector_int_t *res, igraph_neimode_t mode, igraph_bool_t loops) {
+    igraph_integer_t n = igraph_vcount(g);
+    igraph_vector_int_resize(res, n);
+    for (igraph_integer_t i=0; i < n; i++) {
+        igraph_degree_1(g, &VECTOR(*res)[i], i, mode, loops);
+    }
+}
+
 int main(void) {
-    igraph_vector_int_t v, seq;
+    igraph_vector_int_t v, v2, seq;
     igraph_t g;
 
     igraph_vector_int_init(&seq, 3);
     igraph_vector_int_init(&v, 0);
+    igraph_vector_int_init(&v2, 0);
     VECTOR(seq)[0] = 2;
     VECTOR(seq)[1] = 0;
     VECTOR(seq)[2] = 2;
 
-    igraph_small(&g, 4, IGRAPH_UNDIRECTED, 0,1, 1,2, 2,3, 2,2, -1);
+    igraph_small(&g, 4, IGRAPH_DIRECTED, 0,1, 1,2, 2,3, 2,2, 3,2, 2,3, -1);
+
+    igraph_vector_int_clear(&v);
+    igraph_vector_int_clear(&v2);
+    printf("out,    loops: ");
+    igraph_degree(&g, &v, igraph_vss_all(), IGRAPH_OUT, IGRAPH_LOOPS);
+    print_vector_int(&v);
+    all_degs(&g, &v2, IGRAPH_OUT, IGRAPH_LOOPS);
+    IGRAPH_ASSERT(igraph_vector_int_all_e(&v, &v2));
+
+    igraph_vector_int_clear(&v);
+    igraph_vector_int_clear(&v2);
+    printf(" in,    loops: ");
+    igraph_degree(&g, &v, igraph_vss_all(), IGRAPH_IN, IGRAPH_LOOPS);
+    print_vector_int(&v);
+    all_degs(&g, &v2, IGRAPH_IN, IGRAPH_LOOPS);
+    IGRAPH_ASSERT(igraph_vector_int_all_e(&v, &v2));
+
+    igraph_vector_int_clear(&v);
+    igraph_vector_int_clear(&v2);
+    printf("all,    loops: ");
+    igraph_degree(&g, &v, igraph_vss_all(), IGRAPH_ALL, IGRAPH_LOOPS);
+    print_vector_int(&v);
+    all_degs(&g, &v2, IGRAPH_ALL, IGRAPH_LOOPS);
+    IGRAPH_ASSERT(igraph_vector_int_all_e(&v, &v2));
+
+    igraph_vector_int_clear(&v);
+    igraph_vector_int_clear(&v2);
+    printf("out, no loops: ");
+    igraph_degree(&g, &v, igraph_vss_all(), IGRAPH_OUT, IGRAPH_NO_LOOPS);
+    print_vector_int(&v);
+    all_degs(&g, &v2, IGRAPH_OUT, IGRAPH_NO_LOOPS);
+    IGRAPH_ASSERT(igraph_vector_int_all_e(&v, &v2));
+
+    igraph_vector_int_clear(&v);
+    igraph_vector_int_clear(&v2);
+    printf(" in, no loops: ");
+    igraph_degree(&g, &v, igraph_vss_all(), IGRAPH_IN, IGRAPH_NO_LOOPS);
+    print_vector_int(&v);
+    all_degs(&g, &v2, IGRAPH_IN, IGRAPH_NO_LOOPS);
+    IGRAPH_ASSERT(igraph_vector_int_all_e(&v, &v2));
+
+    igraph_vector_int_clear(&v);
+    igraph_vector_int_clear(&v2);
+    printf("all, no loops: ");
+    igraph_degree(&g, &v, igraph_vss_all(), IGRAPH_ALL, IGRAPH_NO_LOOPS);
+    print_vector_int(&v);
+    all_degs(&g, &v2, IGRAPH_ALL, IGRAPH_NO_LOOPS);
+    IGRAPH_ASSERT(igraph_vector_int_all_e(&v, &v2));
+
     /* Invalid mode */
     CHECK_ERROR(igraph_degree(&g, &v, igraph_vss_vector(&seq), (igraph_neimode_t)0,
                         IGRAPH_LOOPS), IGRAPH_EINVMODE);
 
-    VECTOR(seq)[0] = 4;
     /* Vertex does not exist */
+    VECTOR(seq)[0] = 4;
     CHECK_ERROR(igraph_degree(&g, &v, igraph_vss_vector(&seq), IGRAPH_ALL, IGRAPH_LOOPS), IGRAPH_EINVVID);
 
     igraph_destroy(&g);
+    igraph_vector_int_destroy(&v2);
     igraph_vector_int_destroy(&v);
     igraph_vector_int_destroy(&seq);
 

--- a/tests/unit/igraph_degree.out
+++ b/tests/unit/igraph_degree.out
@@ -1,0 +1,6 @@
+out,    loops: ( 1 1 3 1 )
+ in,    loops: ( 0 1 3 2 )
+all,    loops: ( 1 2 6 3 )
+out, no loops: ( 1 1 2 1 )
+ in, no loops: ( 0 1 2 2 )
+all, no loops: ( 1 2 4 3 )


### PR DESCRIPTION
In #2215 we discussed that it would be useful to have a function that computes the degree of a single vertex. Finally I decided that adding such a function should be in a separate PR, with its performance impact investigated separately.

Benchmark results are the following:

macOS on an M1 Mac Mini / LTO=OFF, shared library build
Apple clang version 14.0.0 (clang-1400.0.29.102)

```
|> Benchmark file: /Users/szhorvat/Repos/igraph-main/igraph/tests/benchmarks/igraph_degree.c
Count loops, O(1) per degree, fast methods only.
|  1 igraph_degree(), preferential attachment n=100000, m=10, 1000x                0.445s  0.445s      0s
|  2 deg1(), preferential attachment n=100000, m=10, 1000x                         0.188s  0.188s      0s

Count loops, O(1) per degree.
|  1 igraph_degree(), preferential attachment n=100000, m=10, 100x                 0.045s  0.044s      0s
|  2 deg1(), preferential attachment n=100000, m=10, 100x                          0.019s  0.019s      0s
|  3 degv(), preferential attachment n=100000, m=10, 100x                          0.202s  0.202s      0s
|  4 degv2(), preferential attachment n=100000, m=10, 100x                         0.468s  0.467s      0s

Do not count loops, O(d) per degree.
|  1 igraph_degree(), preferential attachment n=100000, m=10, 100x                  0.22s   0.22s      0s
|  2 deg1(), preferential attachment n=100000, m=10, 100x                          0.229s  0.229s      0s
|  3 degv(), preferential attachment n=100000, m=10, 100x                          0.422s  0.422s  0.001s
|  4 degv2(), preferential attachment n=100000, m=10, 100x                         0.711s   0.71s  0.001s
```

macOS on an M1 Mac Mini / LTO=ON, shared library build
Apple clang version 14.0.0 (clang-1400.0.29.102)

```
|> Benchmark file: /Users/szhorvat/Repos/igraph-main/igraph/tests/benchmarks/igraph_degree.c
Count loops, O(1) per degree, fast methods only.
|  1 igraph_degree(), preferential attachment n=100000, m=10, 1000x                0.445s  0.445s      0s
|  2 deg1(), preferential attachment n=100000, m=10, 1000x                         0.188s  0.188s      0s

Count loops, O(1) per degree.
|  1 igraph_degree(), preferential attachment n=100000, m=10, 100x                 0.045s  0.044s      0s
|  2 deg1(), preferential attachment n=100000, m=10, 100x                          0.019s  0.019s      0s
|  3 degv(), preferential attachment n=100000, m=10, 100x                          0.168s  0.168s      0s
|  4 degv2(), preferential attachment n=100000, m=10, 100x                         0.434s  0.433s      0s

Do not count loops, O(d) per degree.
|  1 igraph_degree(), preferential attachment n=100000, m=10, 100x                 0.218s  0.218s      0s
|  2 deg1(), preferential attachment n=100000, m=10, 100x                          0.225s  0.224s      0s
|  3 degv(), preferential attachment n=100000, m=10, 100x                          0.382s  0.382s      0s
|  4 degv2(), preferential attachment n=100000, m=10, 100x                         0.664s  0.664s  0.001s
```

macOS 10.14, Intel MacBook Pro / LTO=ON, shared build
Apple clang version 11.0.0 (clang-1100.0.33.17)

```
|> Benchmark file: /Users/szhorvat/Repos/igraph-main/igraph/tests/benchmarks/igraph_degree.c
Count loops, O(1) per degree, fast methods only.
|  1 igraph_degree(), preferential attachment n=100000, m=10, 1000x                0.319s  0.318s      0s
|  2 deg1(), preferential attachment n=100000, m=10, 1000x                         0.326s  0.326s      0s

Count loops, O(1) per degree.
|  1 igraph_degree(), preferential attachment n=100000, m=10, 100x                  0.03s   0.03s      0s
|  2 deg1(), preferential attachment n=100000, m=10, 100x                           0.03s   0.03s      0s
|  3 degv(), preferential attachment n=100000, m=10, 100x                          0.254s  0.254s      0s
|  4 degv2(), preferential attachment n=100000, m=10, 100x                         0.973s  0.972s  0.001s

Do not count loops, O(d) per degree.
|  1 igraph_degree(), preferential attachment n=100000, m=10, 100x                 0.833s  0.832s  0.001s
|  2 deg1(), preferential attachment n=100000, m=10, 100x                           1.03s   1.02s  0.001s
|  3 degv(), preferential attachment n=100000, m=10, 100x                           1.28s   1.28s  0.001s
|  4 degv2(), preferential attachment n=100000, m=10, 100x                           1.9s   1.89s  0.002s
```

I did the benchmark on the Arm Mac just before opening this PR because my laptop is not very stable for benchmarking, and I wanted to check how great a slowdown we will see from using `igraph_degree_1()` in a loop vs `igraph_degree()` to compute _all_ degrees. But as you can see, _very strangely_, `igraph_degree()` ends of being _slower_ than `igraph_degree_1()` even though it shouldn't be. Can you double-check this on your machine @ntamas ? Can you perhaps try as well on Linux @vtraag ? I do not have a Linux machine that I can use for benchmarking at the moment (shared machine is used by others).

See here for the meaning of the four benchmark lines:

https://github.com/igraph/igraph/blob/10da91961b964a6a39b47cb85150627120e23956/tests/benchmarks/igraph_degree.c#L9-L32