### PR TITLE
Fix unused-but-set-parameter warning

### DIFF
--- a/src/cliques/maximal_cliques.c
+++ b/src/cliques/maximal_cliques.c
@@ -308,7 +308,7 @@ static igraph_error_t igraph_i_maximal_cliques_up(
         VECTOR(*PX)[vvpos - 1] = tmp;
         VECTOR(*pos)[vv] = XS + 1;
         VECTOR(*pos)[tmp] = vvpos;
-        PE++; XS++;
+        XS++;
     }
 
     return IGRAPH_SUCCESS;


### PR DESCRIPTION
PE is otherwise unused (and is marked as such) so modifying its value serves no purpose, and also triggers -Wunused-but-set-parameter. Remote the unnecessary postincrement.