### PR TITLE
Refactor widest path implementation

### DIFF
--- a/src/paths/widest_paths.c
+++ b/src/paths/widest_paths.c
@@ -408,12 +408,15 @@ igraph_error_t igraph_get_widest_path(const igraph_t *graph,
  * \brief Widths of widest paths between vertices.
  *
  * This function implements a modified Floyd-Warshall algorithm,
- * to find the widest path widths from a set of source vertices to
- * all other target vertices.
+ * to find the widest path widths between a set of source and target
+ * vertices. It is primarily useful for all-pairs path widths in very dense
+ * graphs, as its running time is manily determined by the vertex count,
+ * and is not sensitive to the graph density. In sparse graphs, other methods
+ * such as the Dijkstra algorithm, will perform better.
  *
  * </para><para>
- * Note that this function always computes the path width matrix for
- * all pairs of vertices. The \p from and \p to parameters only serve
+ * Note that internally this function always computes the path width matrix
+ * for all pairs of vertices. The \p from and \p to parameters only serve
  * to subset this matrix, but do not affect the time taken by the
  * calculation.
  *

--- a/src/paths/widest_paths.c
+++ b/src/paths/widest_paths.c
@@ -648,8 +648,6 @@ igraph_error_t igraph_widest_path_widths_dijkstra(const igraph_t *graph,
     igraph_integer_t no_of_from, no_of_to;
     igraph_lazy_inclist_t inclist;
     igraph_integer_t i, j;
-    igraph_real_t my_posinfinity = IGRAPH_POSINFINITY;
-    igraph_real_t my_neginfinity = IGRAPH_NEGINFINITY;
     igraph_bool_t all_to;
     igraph_vector_int_t indexv;
 
@@ -695,7 +693,7 @@ igraph_error_t igraph_widest_path_widths_dijkstra(const igraph_t *graph,
     }
 
     IGRAPH_CHECK(igraph_matrix_resize(res, no_of_from, no_of_to));
-    igraph_matrix_fill(res, my_neginfinity);
+    igraph_matrix_fill(res, IGRAPH_NEGINFINITY);
 
     for (IGRAPH_VIT_RESET(fromvit), i = 0;
          !IGRAPH_VIT_END(fromvit);
@@ -704,7 +702,7 @@ igraph_error_t igraph_widest_path_widths_dijkstra(const igraph_t *graph,
         igraph_integer_t reached = 0;
         igraph_integer_t source = IGRAPH_VIT_GET(fromvit);
         igraph_2wheap_clear(&Q);
-        igraph_2wheap_push_with_index(&Q, source, my_posinfinity);
+        igraph_2wheap_push_with_index(&Q, source, IGRAPH_POSINFINITY);
 
         while (!igraph_2wheap_empty(&Q)) {
             igraph_integer_t maxnei = igraph_2wheap_max_index(&Q);
@@ -738,7 +736,7 @@ igraph_error_t igraph_widest_path_widths_dijkstra(const igraph_t *graph,
                 igraph_real_t altwidth = maxwidth < edgewidth ? maxwidth : edgewidth;
                 igraph_bool_t active = igraph_2wheap_has_active(&Q, tto);
                 igraph_bool_t has = igraph_2wheap_has_elem(&Q, tto);
-                igraph_real_t curwidth = active ? igraph_2wheap_get(&Q, tto) : my_posinfinity;
+                igraph_real_t curwidth = active ? igraph_2wheap_get(&Q, tto) : IGRAPH_POSINFINITY;
                 if (!has) {
                     /* This is the first time assigning a width to this vertex */
                     IGRAPH_CHECK(igraph_2wheap_push_with_index(&Q, tto, altwidth));

--- a/tests/unit/igraph_widest_paths.c
+++ b/tests/unit/igraph_widest_paths.c
@@ -251,8 +251,8 @@ int main(void) {
 
     igraph_matrix_init(&res1, n, n);
     igraph_matrix_init(&res2, n, n);
-    igraph_vs_range(&from, 0, n);
-    igraph_vs_range(&to, 0, n);
+    igraph_vs_all(&from);
+    igraph_vs_all(&to);
 
     init_vertices_and_edges(n, &vertices, &edges, &parents, &inbound_edges, &vertices2, &edges2);
 
@@ -302,8 +302,8 @@ int main(void) {
 
     igraph_matrix_init(&res1, n, n);
     igraph_matrix_init(&res2, n, n);
-    igraph_vs_range(&from, 0, n);
-    igraph_vs_range(&to, 0, n);
+    igraph_vs_all(&from);
+    igraph_vs_all(&to);
 
     init_vertices_and_edges(n, &vertices, &edges, &parents, &inbound_edges, &vertices2, &edges2);
     run_widest_paths(&g, &w, &res1, &res2, &from, &to, IGRAPH_OUT);
@@ -447,8 +447,8 @@ int main(void) {
 
     igraph_matrix_init(&res1, n, n);
     igraph_matrix_init(&res2, n, n);
-    igraph_vs_range(&from, 0, n);
-    igraph_vs_range(&to, 0, n);
+    igraph_vs_all(&from);
+    igraph_vs_all(&to);
 
     init_vertices_and_edges(n, &vertices, &edges, &parents, &inbound_edges, &vertices2, &edges2);
     run_widest_paths(&g, &w, &res1, &res2, &from, &to, IGRAPH_OUT);
@@ -527,8 +527,8 @@ int main(void) {
 
     igraph_matrix_init(&res1, n, n);
     igraph_matrix_init(&res2, n, n);
-    igraph_vs_range(&from, 0, n);
-    igraph_vs_range(&to, 0, n);
+    igraph_vs_all(&from);
+    igraph_vs_all(&to);
 
     init_vertices_and_edges(n, &vertices, &edges, &parents, &inbound_edges, &vertices2, &edges2);
 


### PR DESCRIPTION
 - [x] Clarify docs
 - [x] Simplify and speed up Floyd-Warshall: (1) makes no sense to use _lazy_ inclist (2) no need to use any inclist to construct the adj. mat., just iterate through edges (3) iterate through matrices in column-major order for better performance
 - [x] Avoid using an extra matrix when computing all-pairs results in Floyd-Warshall
 - [x] Do not copy infinities into separate variables