### PR TITLE
feat: igraph_matrix_subset_vertices()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Changed
 
  - The `test` build target now only _runs_ the unit tests, but it does not _build_ them. In order to both build and run tests, use the `check` target, which continues to behave as before (PR #2291).
+ - The experimental function `igraph_distances_floyd_warshall()` now has `from` and `to` parameters for choosing source and target vertices.
  - The experimental function `igraph_distances_floyd_warshall()` now has an additional `method` parameter to select a specific algorithm. A faster "Tree" variant of the Floyd-Warshall algorithm is now available (#2267, thanks to @rfulekjames).
 
 ### Fixed

--- a/include/igraph_paths.h
+++ b/include/igraph_paths.h
@@ -117,6 +117,8 @@ IGRAPH_EXPORT igraph_error_t igraph_distances_johnson(const igraph_t *graph,
                                                 const igraph_vector_t *weights);
 IGRAPH_EXPORT igraph_error_t igraph_distances_floyd_warshall(const igraph_t *graph,
                                                              igraph_matrix_t *res,
+                                                             igraph_vs_t from,
+                                                             igraph_vs_t to,
                                                              const igraph_vector_t *weights,
                                                              igraph_neimode_t mode,
                                                              igraph_floyd_warshall_algorithm_t method);

--- a/interfaces/functions.yaml
+++ b/interfaces/functions.yaml
@@ -559,7 +559,9 @@ igraph_distances_johnson:
 
 igraph_distances_floyd_warshall:
     PARAMS: |-
-        GRAPH graph, OUT MATRIX res, EDGEWEIGHTS weights=NULL, NEIMODE mode=OUT, FWALGORITHM method
+        GRAPH graph, OUT MATRIX res, VERTEX_SELECTOR from=ALL,
+        VERTEX_SELECTOR to=ALL, EDGEWEIGHTS weights=NULL, NEIMODE mode=OUT,
+        FWALGORITHM method
     DEPS: weights ON graph
 
 igraph_voronoi:

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -303,6 +303,7 @@ add_library(
   internal/lsap.c
   internal/qsort_r.c
   internal/qsort.c
+  internal/utils.c
   internal/zeroin.c
 
   version.c

--- a/src/core/matrix.c
+++ b/src/core/matrix.c
@@ -21,8 +21,8 @@
 
 */
 
-#include "igraph_types.h"
 #include "igraph_matrix.h"
+#include "igraph_types.h"
 
 #define BASE_IGRAPH_REAL
 #include "igraph_pmt.h"

--- a/src/internal/utils.c
+++ b/src/internal/utils.c
@@ -1,0 +1,95 @@
+/*
+   IGraph library.
+   Copyright (C) 2023  The igraph development team <igraph@igraph.org>
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "igraph_interface.h"
+
+#include "internal/utils.h"
+
+/**
+ * \function igraph_i_matrix_subset_vertices
+ * \brief Subsets a matrix whose rows/columns correspond to graph vertices.
+ *
+ * This is a convenience function to subset a matrix computed from a graph.
+ * It takes a matrix whose rows and columns correspond to the vertices
+ * of a graph, and subsets it in-place to retain only some of the vertices.
+ *
+ * \param m A square matrix with the same number of rows/columns as the vertex
+ *    count of \p graph. It will be modified in-place, deleting rows \em not present
+ *    in \p from and columns \em not present in \p to.
+ * \param graph The corresponding graph. <code>m[u,v]</code> is assumed to contain
+ *    a value associated with vertices \c u and \c v of \p graph, e.g. the graph
+ *    distance between them, their similarity, etc.
+ * \param from Vertex set, these rows of the matrix will be retained.
+ * \param to Vertex set, these columns of the matrix will be retained.
+ * \return Error code.
+ *
+ * Time complexity:
+ * O(1) when taking all vertices,
+ * O(|from|*|to|) otherwise where |from| and |to| denote the size
+ * of the source and target vertex sets.
+ */
+igraph_error_t igraph_i_matrix_subset_vertices(
+        igraph_matrix_t *m,
+        const igraph_t *graph,
+        igraph_vs_t from,
+        igraph_vs_t to) {
+
+    /* Assertion: the size of 'm' agrees with 'graph': */
+
+    igraph_integer_t no_of_nodes = igraph_vcount(graph);
+    igraph_integer_t ncol = igraph_matrix_ncol(m);
+    igraph_integer_t nrow = igraph_matrix_ncol(m);
+
+    IGRAPH_ASSERT(nrow == no_of_nodes && nrow == ncol);
+
+    /* When taking all vertices, nothing needs to be done: */
+
+    if (igraph_vs_is_all(&from) && igraph_vs_is_all(&to)) {
+        return IGRAPH_SUCCESS;
+    }
+
+    /* Otherwise, allocate a temporary matrix to copy the data into: */
+
+    igraph_vit_t fromvit, tovit;
+    igraph_matrix_t tmp;
+
+    IGRAPH_CHECK(igraph_vit_create(graph, from, &fromvit));
+    IGRAPH_FINALLY(igraph_vit_destroy, &fromvit);
+
+    IGRAPH_CHECK(igraph_vit_create(graph, to, &tovit));
+    IGRAPH_FINALLY(igraph_vit_destroy, &tovit);
+
+    IGRAPH_MATRIX_INIT_FINALLY(&tmp, IGRAPH_VIT_SIZE(fromvit), IGRAPH_VIT_SIZE(tovit));
+
+    for (igraph_integer_t j=0; ! IGRAPH_VIT_END(tovit); IGRAPH_VIT_NEXT(tovit), j++) {
+        igraph_integer_t i;
+        for (IGRAPH_VIT_RESET(fromvit), i=0; ! IGRAPH_VIT_END(fromvit); IGRAPH_VIT_NEXT(fromvit), i++) {
+            MATRIX(tmp, i, j) = MATRIX(*m, IGRAPH_VIT_GET(fromvit), IGRAPH_VIT_GET(tovit));
+        }
+    }
+
+    /* This is O(1) time */
+    IGRAPH_CHECK(igraph_matrix_swap(m, &tmp));
+
+    igraph_matrix_destroy(&tmp);
+    igraph_vit_destroy(&tovit);
+    igraph_vit_destroy(&fromvit);
+    IGRAPH_FINALLY_CLEAN(3);
+
+    return IGRAPH_SUCCESS;
+}

--- a/src/internal/utils.c
+++ b/src/internal/utils.c
@@ -53,7 +53,7 @@ igraph_error_t igraph_i_matrix_subset_vertices(
 
     igraph_integer_t no_of_nodes = igraph_vcount(graph);
     igraph_integer_t ncol = igraph_matrix_ncol(m);
-    igraph_integer_t nrow = igraph_matrix_ncol(m);
+    igraph_integer_t nrow = igraph_matrix_nrow(m);
 
     IGRAPH_ASSERT(nrow == no_of_nodes && nrow == ncol);
 

--- a/src/internal/utils.h
+++ b/src/internal/utils.h
@@ -1,0 +1,32 @@
+/*
+   IGraph library.
+   Copyright (C) 2008-2021  The igraph development team <igraph@igraph.org>
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef IGRAPH_INTERNAL_UTILS_H
+#define IGRAPH_INTERNAL_UTILS_H
+
+#include "igraph_datatype.h"
+#include "igraph_iterators.h"
+#include "igraph_matrix.h"
+
+igraph_error_t igraph_i_matrix_subset_vertices(
+        igraph_matrix_t *m,
+        const igraph_t *graph,
+        igraph_vs_t from,
+        igraph_vs_t to);
+
+#endif /* IGRAPH_INTERNAL_UTILS_H */

--- a/src/paths/floyd_warshall.c
+++ b/src/paths/floyd_warshall.c
@@ -21,6 +21,7 @@
 #include "igraph_stack.h"
 
 #include "core/interruption.h"
+#include "internal/utils.h"
 
 static igraph_error_t igraph_distances_floyd_warshall_original(
         const igraph_t *graph, igraph_matrix_t *res,
@@ -216,6 +217,12 @@ static igraph_error_t igraph_distances_floyd_warshall_tree(
  * running times for most instances. See the reference below for more information.
  *
  * </para><para>
+ * Note that internally this function always computes the distance matrix
+ * for all pairs of vertices. The \p from and \p to parameters only serve
+ * to subset this matrix, but do not affect the time or memory taken by the
+ * calculation.
+ *
+ * </para><para>
  * Reference:
  *
  * </para><para>
@@ -226,6 +233,8 @@ static igraph_error_t igraph_distances_floyd_warshall_tree(
  *
  * \param graph The graph object.
  * \param res An intialized matrix, the distances will be stored here.
+ * \param from The source vertices.
+ * \param to The target vertices.
  * \param weights The edge weights. If \c NULL, all weights are assumed to be 1.
  *   Negative weights are allowed, but the graph must not contain negative cycles.
  * \param mode The type of shortest paths to be use for the
@@ -263,9 +272,10 @@ static igraph_error_t igraph_distances_floyd_warshall_tree(
  * Here |V| denotes the number of vertices and |E| is the number of edges.
  */
 igraph_error_t igraph_distances_floyd_warshall(
-    const igraph_t *graph, igraph_matrix_t *res,
-    const igraph_vector_t *weights, igraph_neimode_t mode,
-    const igraph_floyd_warshall_algorithm_t method) {
+        const igraph_t *graph, igraph_matrix_t *res,
+        igraph_vs_t from, igraph_vs_t to,
+        const igraph_vector_t *weights, igraph_neimode_t mode,
+        const igraph_floyd_warshall_algorithm_t method) {
 
     igraph_integer_t no_of_nodes = igraph_vcount(graph);
     igraph_integer_t no_of_edges = igraph_ecount(graph);
@@ -346,5 +356,8 @@ igraph_error_t igraph_distances_floyd_warshall(
     default:
         IGRAPH_ERROR("Invalid method.", IGRAPH_EINVAL);
     }
+
+    IGRAPH_CHECK(igraph_i_matrix_subset_vertices(res, graph, from, to));
+
     return IGRAPH_SUCCESS;
 }

--- a/tests/benchmarks/igraph_distances.c
+++ b/tests/benchmarks/igraph_distances.c
@@ -38,16 +38,16 @@ int main(void) {
           REPEAT(igraph_distances_dijkstra(&g, &res, igraph_vss_all(), igraph_vss_all(), &weights, IGRAPH_OUT), REP)
     );
     BENCH(" 3 vcount=" TOSTR(VCOUNT) ", p=" TOSTR(DENS) ", Unweighted Floyd-Warshall, " TOSTR(REP) "x",
-          REPEAT(igraph_distances_floyd_warshall(&g, &res, NULL, IGRAPH_OUT, IGRAPH_FLOYD_WARSHALL_ORIGINAL), REP)
+          REPEAT(igraph_distances_floyd_warshall(&g, &res, igraph_vss_all(), igraph_vss_all(), NULL, IGRAPH_OUT, IGRAPH_FLOYD_WARSHALL_ORIGINAL), REP)
     );
     BENCH(" 4 vcount=" TOSTR(VCOUNT) ", p=" TOSTR(DENS) ", Unweighted Floyd-Warshall-tree-speedup, " TOSTR(REP) "x",
-          REPEAT(igraph_distances_floyd_warshall(&g, &res, NULL, IGRAPH_OUT, IGRAPH_FLOYD_WARSHALL_TREE), REP)
+          REPEAT(igraph_distances_floyd_warshall(&g, &res, igraph_vss_all(), igraph_vss_all(), NULL, IGRAPH_OUT, IGRAPH_FLOYD_WARSHALL_TREE), REP)
     );
     BENCH(" 5 vcount=" TOSTR(VCOUNT) ", p=" TOSTR(DENS) ", Floyd-Warshall, " TOSTR(REP) "x",
-          REPEAT(igraph_distances_floyd_warshall(&g, &res, &weights, IGRAPH_OUT, IGRAPH_FLOYD_WARSHALL_ORIGINAL), REP)
+          REPEAT(igraph_distances_floyd_warshall(&g, &res, igraph_vss_all(), igraph_vss_all(), &weights, IGRAPH_OUT, IGRAPH_FLOYD_WARSHALL_ORIGINAL), REP)
     );
     BENCH(" 6 vcount=" TOSTR(VCOUNT) ", p=" TOSTR(DENS) ", Floyd-Warshall-tree-speedup, " TOSTR(REP) "x",
-          REPEAT(igraph_distances_floyd_warshall(&g, &res, &weights, IGRAPH_OUT, IGRAPH_FLOYD_WARSHALL_TREE), REP)
+          REPEAT(igraph_distances_floyd_warshall(&g, &res, igraph_vss_all(), igraph_vss_all(), &weights, IGRAPH_OUT, IGRAPH_FLOYD_WARSHALL_TREE), REP)
     );
 
     RNG_BEGIN();
@@ -66,10 +66,10 @@ int main(void) {
           REPEAT(igraph_distances_johnson(&g, &res, igraph_vss_all(), igraph_vss_all(), &weights), REP)
     );
     BENCH(" 9 vcount=" TOSTR(VCOUNT) ", p=" TOSTR(DENS) ", Floyd-Warshall (negative), " TOSTR(REP) "x",
-          REPEAT(igraph_distances_floyd_warshall(&g, &res, &weights, IGRAPH_OUT, IGRAPH_FLOYD_WARSHALL_ORIGINAL), REP)
+          REPEAT(igraph_distances_floyd_warshall(&g, &res, igraph_vss_all(), igraph_vss_all(), &weights, IGRAPH_OUT, IGRAPH_FLOYD_WARSHALL_ORIGINAL), REP)
     );
     BENCH(" 10 vcount=" TOSTR(VCOUNT) ", p=" TOSTR(DENS) ", Floyd-Warshall-tree-speedup (negative), " TOSTR(REP) "x",
-          REPEAT(igraph_distances_floyd_warshall(&g, &res, &weights, IGRAPH_OUT, IGRAPH_FLOYD_WARSHALL_TREE), REP)
+          REPEAT(igraph_distances_floyd_warshall(&g, &res, igraph_vss_all(), igraph_vss_all(), &weights, IGRAPH_OUT, IGRAPH_FLOYD_WARSHALL_TREE), REP)
     );
 
     igraph_destroy(&g);
@@ -101,16 +101,16 @@ int main(void) {
           REPEAT(igraph_distances_dijkstra(&g, &res, igraph_vss_all(), igraph_vss_all(), &weights, IGRAPH_OUT), REP)
     );
     BENCH(" 3 vcount=" TOSTR(VCOUNT) ", p=" TOSTR(DENS) ", Unweighted Floyd-Warshall, " TOSTR(REP) "x",
-          REPEAT(igraph_distances_floyd_warshall(&g, &res, NULL, IGRAPH_OUT, IGRAPH_FLOYD_WARSHALL_ORIGINAL), REP)
+          REPEAT(igraph_distances_floyd_warshall(&g, &res, igraph_vss_all(), igraph_vss_all(), NULL, IGRAPH_OUT, IGRAPH_FLOYD_WARSHALL_ORIGINAL), REP)
     );
     BENCH(" 4 vcount=" TOSTR(VCOUNT) ", p=" TOSTR(DENS) ", Unweighted Floyd-Warshall-tree-speedup, " TOSTR(REP) "x",
-          REPEAT(igraph_distances_floyd_warshall(&g, &res, NULL, IGRAPH_OUT, IGRAPH_FLOYD_WARSHALL_TREE), REP)
+          REPEAT(igraph_distances_floyd_warshall(&g, &res, igraph_vss_all(), igraph_vss_all(), NULL, IGRAPH_OUT, IGRAPH_FLOYD_WARSHALL_TREE), REP)
     );
     BENCH(" 5 vcount=" TOSTR(VCOUNT) ", p=" TOSTR(DENS) ", Floyd-Warshall, " TOSTR(REP) "x",
-          REPEAT(igraph_distances_floyd_warshall(&g, &res, &weights, IGRAPH_OUT, IGRAPH_FLOYD_WARSHALL_ORIGINAL), REP)
+          REPEAT(igraph_distances_floyd_warshall(&g, &res, igraph_vss_all(), igraph_vss_all(), &weights, IGRAPH_OUT, IGRAPH_FLOYD_WARSHALL_ORIGINAL), REP)
     );
     BENCH(" 6 vcount=" TOSTR(VCOUNT) ", p=" TOSTR(DENS) ", Floyd-Warshall-tree-speedup, " TOSTR(REP) "x",
-          REPEAT(igraph_distances_floyd_warshall(&g, &res, &weights, IGRAPH_OUT, IGRAPH_FLOYD_WARSHALL_TREE), REP)
+          REPEAT(igraph_distances_floyd_warshall(&g, &res, igraph_vss_all(), igraph_vss_all(), &weights, IGRAPH_OUT, IGRAPH_FLOYD_WARSHALL_TREE), REP)
     );
 
     RNG_BEGIN();
@@ -129,10 +129,10 @@ int main(void) {
           REPEAT(igraph_distances_johnson(&g, &res, igraph_vss_all(), igraph_vss_all(), &weights), REP)
     );
     BENCH(" 9 vcount=" TOSTR(VCOUNT) ", p=" TOSTR(DENS) ", Floyd-Warshall (negative), " TOSTR(REP) "x",
-          REPEAT(igraph_distances_floyd_warshall(&g, &res, &weights, IGRAPH_OUT, IGRAPH_FLOYD_WARSHALL_ORIGINAL), REP)
+          REPEAT(igraph_distances_floyd_warshall(&g, &res, igraph_vss_all(), igraph_vss_all(), &weights, IGRAPH_OUT, IGRAPH_FLOYD_WARSHALL_ORIGINAL), REP)
     );
     BENCH(" 10 vcount=" TOSTR(VCOUNT) ", p=" TOSTR(DENS) ", Floyd-Warshall-tree-speedup (negative), " TOSTR(REP) "x",
-          REPEAT(igraph_distances_floyd_warshall(&g, &res, &weights, IGRAPH_OUT, IGRAPH_FLOYD_WARSHALL_TREE), REP)
+          REPEAT(igraph_distances_floyd_warshall(&g, &res, igraph_vss_all(), igraph_vss_all(), &weights, IGRAPH_OUT, IGRAPH_FLOYD_WARSHALL_TREE), REP)
     );
 
     igraph_destroy(&g);
@@ -164,16 +164,16 @@ int main(void) {
           REPEAT(igraph_distances_dijkstra(&g, &res, igraph_vss_all(), igraph_vss_all(), &weights, IGRAPH_OUT), REP)
     );
     BENCH(" 3 vcount=" TOSTR(VCOUNT) ", p=" TOSTR(DENS) ", Unweighted Floyd-Warshall, " TOSTR(REP) "x",
-          REPEAT(igraph_distances_floyd_warshall(&g, &res, NULL, IGRAPH_OUT, IGRAPH_FLOYD_WARSHALL_ORIGINAL), REP)
+          REPEAT(igraph_distances_floyd_warshall(&g, &res, igraph_vss_all(), igraph_vss_all(), NULL, IGRAPH_OUT, IGRAPH_FLOYD_WARSHALL_ORIGINAL), REP)
     );
     BENCH(" 4 vcount=" TOSTR(VCOUNT) ", p=" TOSTR(DENS) ", Unweighted Floyd-Warshall-tree-speedup, " TOSTR(REP) "x",
-          REPEAT(igraph_distances_floyd_warshall(&g, &res, NULL, IGRAPH_OUT, IGRAPH_FLOYD_WARSHALL_TREE), REP)
+          REPEAT(igraph_distances_floyd_warshall(&g, &res, igraph_vss_all(), igraph_vss_all(), NULL, IGRAPH_OUT, IGRAPH_FLOYD_WARSHALL_TREE), REP)
     );
     BENCH(" 5 vcount=" TOSTR(VCOUNT) ", p=" TOSTR(DENS) ", Floyd-Warshall, " TOSTR(REP) "x",
-          REPEAT(igraph_distances_floyd_warshall(&g, &res, &weights, IGRAPH_OUT, IGRAPH_FLOYD_WARSHALL_ORIGINAL), REP)
+          REPEAT(igraph_distances_floyd_warshall(&g, &res, igraph_vss_all(), igraph_vss_all(), &weights, IGRAPH_OUT, IGRAPH_FLOYD_WARSHALL_ORIGINAL), REP)
     );
     BENCH(" 6 vcount=" TOSTR(VCOUNT) ", p=" TOSTR(DENS) ", Floyd-Warshall-tree-speedup, " TOSTR(REP) "x",
-          REPEAT(igraph_distances_floyd_warshall(&g, &res, &weights, IGRAPH_OUT, IGRAPH_FLOYD_WARSHALL_TREE), REP)
+          REPEAT(igraph_distances_floyd_warshall(&g, &res, igraph_vss_all(), igraph_vss_all(), &weights, IGRAPH_OUT, IGRAPH_FLOYD_WARSHALL_TREE), REP)
     );
 
     RNG_BEGIN();
@@ -192,10 +192,10 @@ int main(void) {
           REPEAT(igraph_distances_johnson(&g, &res, igraph_vss_all(), igraph_vss_all(), &weights), REP)
     );
     BENCH(" 9 vcount=" TOSTR(VCOUNT) ", p=" TOSTR(DENS) ", Floyd-Warshall (negative), " TOSTR(REP) "x",
-          REPEAT(igraph_distances_floyd_warshall(&g, &res, &weights, IGRAPH_OUT, IGRAPH_FLOYD_WARSHALL_ORIGINAL), REP)
+          REPEAT(igraph_distances_floyd_warshall(&g, &res, igraph_vss_all(), igraph_vss_all(), &weights, IGRAPH_OUT, IGRAPH_FLOYD_WARSHALL_ORIGINAL), REP)
     );
     BENCH(" 10 vcount=" TOSTR(VCOUNT) ", p=" TOSTR(DENS) ", Floyd-Warshall-tree-speedup (negative), " TOSTR(REP) "x",
-          REPEAT(igraph_distances_floyd_warshall(&g, &res, &weights, IGRAPH_OUT, IGRAPH_FLOYD_WARSHALL_TREE), REP)
+          REPEAT(igraph_distances_floyd_warshall(&g, &res, igraph_vss_all(), igraph_vss_all(), &weights, IGRAPH_OUT, IGRAPH_FLOYD_WARSHALL_TREE), REP)
     );
 
     igraph_destroy(&g);

--- a/tests/unit/igraph_distances_floyd_warshall.c
+++ b/tests/unit/igraph_distances_floyd_warshall.c
@@ -29,13 +29,13 @@ int main(void) {
 
     printf("Null graph\n");
     igraph_empty(&g, 0, IGRAPH_UNDIRECTED);
-    igraph_distances_floyd_warshall(&g, &d, NULL, IGRAPH_OUT, IGRAPH_FLOYD_WARSHALL_ORIGINAL);
+    igraph_distances_floyd_warshall(&g, &d, igraph_vss_all(), igraph_vss_all(), NULL, IGRAPH_OUT, IGRAPH_FLOYD_WARSHALL_ORIGINAL);
     print_matrix(&d);
     igraph_destroy(&g);
 
     printf("\nSingleton graph\n");
     igraph_empty(&g, 1, IGRAPH_UNDIRECTED);
-    igraph_distances_floyd_warshall(&g, &d, NULL, IGRAPH_OUT, IGRAPH_FLOYD_WARSHALL_ORIGINAL);
+    igraph_distances_floyd_warshall(&g, &d, igraph_vss_all(), igraph_vss_all(), NULL, IGRAPH_OUT, IGRAPH_FLOYD_WARSHALL_ORIGINAL);
     print_matrix(&d);
     igraph_destroy(&g);
 
@@ -44,21 +44,21 @@ int main(void) {
                  -1);
 
     printf("\nUnweighted directed\n");
-    igraph_distances_floyd_warshall(&g, &d, NULL, IGRAPH_OUT, IGRAPH_FLOYD_WARSHALL_ORIGINAL);
+    igraph_distances_floyd_warshall(&g, &d, igraph_vss_all(), igraph_vss_all(), NULL, IGRAPH_OUT, IGRAPH_FLOYD_WARSHALL_ORIGINAL);
     print_matrix(&d);
 
     igraph_distances(&g, &d2, igraph_vss_all(), igraph_vss_all(), IGRAPH_OUT);
     IGRAPH_ASSERT(igraph_matrix_all_e(&d, &d2));
 
     printf("\nUnweighted directed, 'in' mode\n");
-    igraph_distances_floyd_warshall(&g, &d, NULL, IGRAPH_IN, IGRAPH_FLOYD_WARSHALL_ORIGINAL);
+    igraph_distances_floyd_warshall(&g, &d, igraph_vss_all(), igraph_vss_all(), NULL, IGRAPH_IN, IGRAPH_FLOYD_WARSHALL_ORIGINAL);
     print_matrix(&d);
 
     igraph_distances(&g, &d2, igraph_vss_all(), igraph_vss_all(), IGRAPH_IN);
     IGRAPH_ASSERT(igraph_matrix_all_e(&d, &d2));
 
     printf("\nUnweighted undirected\n");
-    igraph_distances_floyd_warshall(&g, &d, NULL, IGRAPH_ALL, IGRAPH_FLOYD_WARSHALL_ORIGINAL);
+    igraph_distances_floyd_warshall(&g, &d, igraph_vss_all(), igraph_vss_all(), NULL, IGRAPH_ALL, IGRAPH_FLOYD_WARSHALL_ORIGINAL);
     print_matrix(&d);
 
     igraph_distances(&g, &d2, igraph_vss_all(), igraph_vss_all(), IGRAPH_ALL);
@@ -68,14 +68,14 @@ int main(void) {
                            2, 1, 5, 1, 2, 6, 8, 3, 3, 2, 3);
 
     printf("\nWeighted directed\n");
-    igraph_distances_floyd_warshall(&g, &d, &weights, IGRAPH_OUT, IGRAPH_FLOYD_WARSHALL_ORIGINAL);
+    igraph_distances_floyd_warshall(&g, &d, igraph_vss_all(), igraph_vss_all(), &weights, IGRAPH_OUT, IGRAPH_FLOYD_WARSHALL_ORIGINAL);
     print_matrix(&d);
 
     igraph_distances_bellman_ford(&g, &d2, igraph_vss_all(), igraph_vss_all(), &weights, IGRAPH_OUT);
     IGRAPH_ASSERT(igraph_matrix_all_e(&d, &d2));
 
     printf("\nWeighted undirected\n");
-    igraph_distances_floyd_warshall(&g, &d, &weights, IGRAPH_ALL, IGRAPH_FLOYD_WARSHALL_ORIGINAL);
+    igraph_distances_floyd_warshall(&g, &d, igraph_vss_all(), igraph_vss_all(), &weights, IGRAPH_ALL, IGRAPH_FLOYD_WARSHALL_ORIGINAL);
     print_matrix(&d);
 
     igraph_distances_bellman_ford(&g, &d2, igraph_vss_all(), igraph_vss_all(), &weights, IGRAPH_ALL);
@@ -83,7 +83,7 @@ int main(void) {
 
     VECTOR(weights)[1] = -2;
     printf("\nNegative weight, directed\n");
-    igraph_distances_floyd_warshall(&g, &d, &weights, IGRAPH_OUT, IGRAPH_FLOYD_WARSHALL_ORIGINAL);
+    igraph_distances_floyd_warshall(&g, &d, igraph_vss_all(), igraph_vss_all(), &weights, IGRAPH_OUT, IGRAPH_FLOYD_WARSHALL_ORIGINAL);
     print_matrix(&d);
 
     igraph_distances_bellman_ford(&g, &d2, igraph_vss_all(), igraph_vss_all(), &weights, IGRAPH_OUT);
@@ -92,20 +92,20 @@ int main(void) {
     /* Check bad inputs */
 
     /* Negative weight edge in undirected graph */
-    CHECK_ERROR(igraph_distances_floyd_warshall(&g, &d, &weights, IGRAPH_ALL, IGRAPH_FLOYD_WARSHALL_ORIGINAL), IGRAPH_ENEGLOOP);
+    CHECK_ERROR(igraph_distances_floyd_warshall(&g, &d, igraph_vss_all(), igraph_vss_all(), &weights, IGRAPH_ALL, IGRAPH_FLOYD_WARSHALL_ORIGINAL), IGRAPH_ENEGLOOP);
 
     /* Negative cycle in directed graph */
     VECTOR(weights)[1] = -10;
-    CHECK_ERROR(igraph_distances_floyd_warshall(&g, &d, &weights, IGRAPH_OUT, IGRAPH_FLOYD_WARSHALL_ORIGINAL), IGRAPH_ENEGLOOP);
+    CHECK_ERROR(igraph_distances_floyd_warshall(&g, &d, igraph_vss_all(), igraph_vss_all(), &weights, IGRAPH_OUT, IGRAPH_FLOYD_WARSHALL_ORIGINAL), IGRAPH_ENEGLOOP);
 
     /* Negative self-loop in directed graph */
     VECTOR(weights)[1] = 1;
     VECTOR(weights)[10] = -1;
-    CHECK_ERROR(igraph_distances_floyd_warshall(&g, &d, &weights, IGRAPH_OUT, IGRAPH_FLOYD_WARSHALL_ORIGINAL), IGRAPH_ENEGLOOP);
+    CHECK_ERROR(igraph_distances_floyd_warshall(&g, &d, igraph_vss_all(), igraph_vss_all(), &weights, IGRAPH_OUT, IGRAPH_FLOYD_WARSHALL_ORIGINAL), IGRAPH_ENEGLOOP);
 
     /* NaN weight */
     VECTOR(weights)[1] = IGRAPH_NAN;
-    CHECK_ERROR(igraph_distances_floyd_warshall(&g, &d, &weights, IGRAPH_OUT, IGRAPH_FLOYD_WARSHALL_ORIGINAL), IGRAPH_EINVAL);
+    CHECK_ERROR(igraph_distances_floyd_warshall(&g, &d, igraph_vss_all(), igraph_vss_all(), &weights, IGRAPH_OUT, IGRAPH_FLOYD_WARSHALL_ORIGINAL), IGRAPH_EINVAL);
 
     igraph_vector_destroy(&weights);
 

--- a/tests/unit/igraph_distances_floyd_warshall_speedup.c
+++ b/tests/unit/igraph_distances_floyd_warshall_speedup.c
@@ -29,13 +29,13 @@ int main(void) {
 
     printf("Null graph\n");
     igraph_empty(&g, 0, IGRAPH_UNDIRECTED);
-    igraph_distances_floyd_warshall(&g, &d, NULL, IGRAPH_OUT, IGRAPH_FLOYD_WARSHALL_TREE);
+    igraph_distances_floyd_warshall(&g, &d, igraph_vss_all(), igraph_vss_all(), NULL, IGRAPH_OUT, IGRAPH_FLOYD_WARSHALL_TREE);
     print_matrix(&d);
     igraph_destroy(&g);
 
     printf("\nSingleton graph\n");
     igraph_empty(&g, 1, IGRAPH_UNDIRECTED);
-    igraph_distances_floyd_warshall(&g, &d, NULL, IGRAPH_OUT, IGRAPH_FLOYD_WARSHALL_TREE);
+    igraph_distances_floyd_warshall(&g, &d, igraph_vss_all(), igraph_vss_all(), NULL, IGRAPH_OUT, IGRAPH_FLOYD_WARSHALL_TREE);
     print_matrix(&d);
     igraph_destroy(&g);
 
@@ -44,21 +44,21 @@ int main(void) {
                  -1);
 
     printf("\nUnweighted directed\n");
-    igraph_distances_floyd_warshall(&g, &d, NULL, IGRAPH_OUT, IGRAPH_FLOYD_WARSHALL_TREE);
+    igraph_distances_floyd_warshall(&g, &d, igraph_vss_all(), igraph_vss_all(), NULL, IGRAPH_OUT, IGRAPH_FLOYD_WARSHALL_TREE);
     print_matrix(&d);
 
     igraph_distances(&g, &d2, igraph_vss_all(), igraph_vss_all(), IGRAPH_OUT);
     IGRAPH_ASSERT(igraph_matrix_all_e(&d, &d2));
 
     printf("\nUnweighted directed, 'in' mode\n");
-    igraph_distances_floyd_warshall(&g, &d, NULL, IGRAPH_IN, IGRAPH_FLOYD_WARSHALL_TREE);
+    igraph_distances_floyd_warshall(&g, &d, igraph_vss_all(), igraph_vss_all(), NULL, IGRAPH_IN, IGRAPH_FLOYD_WARSHALL_TREE);
     print_matrix(&d);
 
     igraph_distances(&g, &d2, igraph_vss_all(), igraph_vss_all(), IGRAPH_IN);
     IGRAPH_ASSERT(igraph_matrix_all_e(&d, &d2));
 
     printf("\nUnweighted undirected\n");
-    igraph_distances_floyd_warshall(&g, &d, NULL, IGRAPH_ALL, IGRAPH_FLOYD_WARSHALL_TREE);
+    igraph_distances_floyd_warshall(&g, &d, igraph_vss_all(), igraph_vss_all(), NULL, IGRAPH_ALL, IGRAPH_FLOYD_WARSHALL_TREE);
     print_matrix(&d);
 
     igraph_distances(&g, &d2, igraph_vss_all(), igraph_vss_all(), IGRAPH_ALL);
@@ -68,14 +68,14 @@ int main(void) {
                            2, 1, 5, 1, 2, 6, 8, 3, 3, 2, 3);
 
     printf("\nWeighted directed\n");
-    igraph_distances_floyd_warshall(&g, &d, &weights, IGRAPH_OUT, IGRAPH_FLOYD_WARSHALL_TREE);
+    igraph_distances_floyd_warshall(&g, &d, igraph_vss_all(), igraph_vss_all(), &weights, IGRAPH_OUT, IGRAPH_FLOYD_WARSHALL_TREE);
     print_matrix(&d);
 
     igraph_distances_bellman_ford(&g, &d2, igraph_vss_all(), igraph_vss_all(), &weights, IGRAPH_OUT);
     IGRAPH_ASSERT(igraph_matrix_all_e(&d, &d2));
 
     printf("\nWeighted undirected\n");
-    igraph_distances_floyd_warshall(&g, &d, &weights, IGRAPH_ALL, IGRAPH_FLOYD_WARSHALL_TREE);
+    igraph_distances_floyd_warshall(&g, &d, igraph_vss_all(), igraph_vss_all(), &weights, IGRAPH_ALL, IGRAPH_FLOYD_WARSHALL_TREE);
     print_matrix(&d);
 
     igraph_distances_bellman_ford(&g, &d2, igraph_vss_all(), igraph_vss_all(), &weights, IGRAPH_ALL);
@@ -83,7 +83,7 @@ int main(void) {
 
     VECTOR(weights)[1] = -2;
     printf("\nNegative weight, directed\n");
-    igraph_distances_floyd_warshall(&g, &d, &weights, IGRAPH_OUT, IGRAPH_FLOYD_WARSHALL_TREE);
+    igraph_distances_floyd_warshall(&g, &d, igraph_vss_all(), igraph_vss_all(), &weights, IGRAPH_OUT, IGRAPH_FLOYD_WARSHALL_TREE);
     print_matrix(&d);
 
     igraph_distances_bellman_ford(&g, &d2, igraph_vss_all(), igraph_vss_all(), &weights, IGRAPH_OUT);
@@ -92,25 +92,25 @@ int main(void) {
     /* Check bad inputs */
 
     /* Negative weight edge in undirected graph */
-    CHECK_ERROR(igraph_distances_floyd_warshall(&g, &d, &weights, IGRAPH_ALL, IGRAPH_FLOYD_WARSHALL_TREE), IGRAPH_ENEGLOOP);
+    CHECK_ERROR(igraph_distances_floyd_warshall(&g, &d, igraph_vss_all(), igraph_vss_all(), &weights, IGRAPH_ALL, IGRAPH_FLOYD_WARSHALL_TREE), IGRAPH_ENEGLOOP);
 
     /* Negative cycle in directed graph */
     VECTOR(weights)[1] = -10;
-    CHECK_ERROR(igraph_distances_floyd_warshall(&g, &d, &weights, IGRAPH_OUT, IGRAPH_FLOYD_WARSHALL_TREE), IGRAPH_ENEGLOOP);
+    CHECK_ERROR(igraph_distances_floyd_warshall(&g, &d, igraph_vss_all(), igraph_vss_all(), &weights, IGRAPH_OUT, IGRAPH_FLOYD_WARSHALL_TREE), IGRAPH_ENEGLOOP);
 
     /* Negative self-loop in directed graph */
     VECTOR(weights)[1] = 1;
     VECTOR(weights)[10] = -1;
-    CHECK_ERROR(igraph_distances_floyd_warshall(&g, &d, &weights, IGRAPH_OUT, IGRAPH_FLOYD_WARSHALL_TREE), IGRAPH_ENEGLOOP);
+    CHECK_ERROR(igraph_distances_floyd_warshall(&g, &d, igraph_vss_all(), igraph_vss_all(), &weights, IGRAPH_OUT, IGRAPH_FLOYD_WARSHALL_TREE), IGRAPH_ENEGLOOP);
 
     /* NaN weight */
     VECTOR(weights)[1] = IGRAPH_NAN;
-    CHECK_ERROR(igraph_distances_floyd_warshall(&g, &d, &weights, IGRAPH_OUT, IGRAPH_FLOYD_WARSHALL_TREE), IGRAPH_EINVAL);
+    CHECK_ERROR(igraph_distances_floyd_warshall(&g, &d, igraph_vss_all(), igraph_vss_all(), &weights, IGRAPH_OUT, IGRAPH_FLOYD_WARSHALL_TREE), IGRAPH_EINVAL);
     igraph_destroy(&g);
 
     /* Unweighted directed - larger graph */
     igraph_erdos_renyi_game_gnp(&g, 100, 0.1, IGRAPH_DIRECTED, IGRAPH_NO_LOOPS);
-    igraph_distances_floyd_warshall(&g, &d, NULL, IGRAPH_OUT, IGRAPH_FLOYD_WARSHALL_TREE);
+    igraph_distances_floyd_warshall(&g, &d, igraph_vss_all(), igraph_vss_all(), NULL, IGRAPH_OUT, IGRAPH_FLOYD_WARSHALL_TREE);
     igraph_distances_dijkstra(&g, &d2, igraph_vss_all(), igraph_vss_all(), NULL, IGRAPH_OUT);
     IGRAPH_ASSERT(igraph_matrix_all_e(&d, &d2));
 


### PR DESCRIPTION
@ntamas Have a look before I continue.

I find it a bit unpleasant that now `igraph_matrix.h` needs to include all headers that defined `igraph_t` and `igraph_vs_t`.

Once we're happy with the general approach, I'll add another function for vectors, and will start using this in Floyd-Warshall.