### PR TITLE
remove local_scan_1_sumweights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
  - HRG functions now require a graph with at least 3 vertices; previous versions crashed with smaller graphs.
  - `igraph_arpack_rssolve()` and `igraph_arpack_rnsolve()`, i.e. the ARPACK interface in igraph, are now interruptible. As a result, several other functions that rely on ARPACK (eigenvector centrality, hub and authority scores, etc.) also became interruptible.
  - `igraph_get_shortest_paths_dijkstra()`, `igraph_get_all_shortest_paths_dijkstra()` and `igraph_get_shortest_paths_bellman_ford()` now validate the `from` vertex.
+ - Fixed bugs in `igraph_local_scan_1_ecount()` for weighted undirected graphs which would miscount loops and multi-edges.
 
 ### Deprecated
 

--- a/tests/unit/igraph_local_scan_k_ecount.c
+++ b/tests/unit/igraph_local_scan_k_ecount.c
@@ -63,13 +63,16 @@ int main(void) {
     printf("Same graph, weighted:\n");
     call_and_print(&g_lmu, 1, &weights, IGRAPH_IN);
 
-    printf("Same graph, weighted, but using scan_1_ecount directly:\n");
-    igraph_local_scan_1_ecount(&g_lmu, &result, &weights, IGRAPH_IN);
-
-    call_and_print(&g_lmu, 1, &weights, IGRAPH_IN);
     printf("Checking if calling igraph_local_scan_1_ecount properly redirects:\n");
     igraph_vector_clear(&result);
-    IGRAPH_ASSERT(igraph_local_scan_1_ecount(&g_lmu, &result, NULL, IGRAPH_IN) == IGRAPH_SUCCESS);
+    printf("Directed, IN: ");
+    IGRAPH_ASSERT(igraph_local_scan_1_ecount(&g_lm, &result, NULL, IGRAPH_IN) == IGRAPH_SUCCESS);
+    print_vector(&result);
+    printf("Directed, ALL: ");
+    IGRAPH_ASSERT(igraph_local_scan_1_ecount(&g_lm, &result, NULL, IGRAPH_ALL) == IGRAPH_SUCCESS);
+    print_vector(&result);
+    printf("Undirected, with weights: ");
+    IGRAPH_ASSERT(igraph_local_scan_1_ecount(&g_lmu, &result, &weights, IGRAPH_IN) == IGRAPH_SUCCESS);
     print_vector(&result);
     printf("\n");
 

--- a/tests/unit/igraph_local_scan_k_ecount.out
+++ b/tests/unit/igraph_local_scan_k_ecount.out
@@ -22,11 +22,10 @@ Same graph with loop, k=1, undirected:
 Same graph, weighted:
 ( 0.3 0.2 0.7 1.8 1.1 0 )
 
-Same graph, weighted, but using scan_1_ecount directly:
-( 0.3 0.2 0.7 1.8 1.1 0 )
-
 Checking if calling igraph_local_scan_1_ecount properly redirects:
-( 4 3 3 5 2 0 )
+Directed, IN: ( 2 2 2 3 2 0 )
+Directed, ALL: ( 4 3 3 5 2 0 )
+Undirected, with weights: ( 0.3 0.2 0.7 1.8 1.1 0 )
 
 Same graph, directed, k=2:
 ( 2 4 2 6 5 0 )


### PR DESCRIPTION
igraph_i_local_scan_sumweights was faster than using scan_k_ecount, but incorrect. It didn't count loops on neighbors, it counted loops on the starting vertex twice, and it counted only one of the multiple edges between two neighbors. When counting edge weights this is almost always incorrect because you need some way of combining weights, and not just pick a random one. I didn't really find a way to fix this.

Fixes #2163 