### PR TITLE
Add failing test: deleting edge with attribute

### DIFF
--- a/tests/unit/igraph_delete_edges.c
+++ b/tests/unit/igraph_delete_edges.c
@@ -47,6 +47,14 @@ int main(void) {
         return 7;
     }
 
+    /* no error test, deleting edges with attributes */
+    igraph_set_attribute_table(&igraph_cattribute_table);
+    igraph_cattribute_EAN_set(&g, "test", 2, 9);
+    igraph_delete_edges(&g, igraph_ess_1(1)); // CHECK_NO_ERROR
+    if (igraph_ecount(&g) != 2) {
+        return 9;
+    }
+
     igraph_es_destroy(&es);
     igraph_destroy(&g);
 


### PR DESCRIPTION
This is rather a bug report, or a question of what I am doing wrong I guess: if the graph has edge attributes, the `igraph_delete_edges` results in a segfault.

I might update this PR with a fix in case I can figure out what the issue is.
The current understanding is this:
In `type_indexededgelist.c`, the `igraph_delete_edges` function calls "only" `igraph_i_attribute_permute_edges`, which in turn has the comment `If they are _not_ the same, it is assumed that the new graph has no edge attributes yet`, which is not applicable here.