### PR TITLE
add astar benchmark

### DIFF
--- a/src/paths/astar.c
+++ b/src/paths/astar.c
@@ -123,7 +123,7 @@ igraph_error_t igraph_get_shortest_path_astar(const igraph_t *graph,
         heuristic = null_heuristic;
     }
 
-    if (0 && weights) { /* If there are no weights, they are treated as 1. */
+    if (weights) { /* If there are no weights, they are treated as 1. */
         if (igraph_vector_size(weights) != no_of_edges) {
             IGRAPH_ERRORF("Weight vector length (%" IGRAPH_PRId ") does not match number of edges (%" IGRAPH_PRId ").",
                           IGRAPH_EINVAL, igraph_vector_size(weights), no_of_edges);

--- a/src/paths/astar.c
+++ b/src/paths/astar.c
@@ -123,7 +123,7 @@ igraph_error_t igraph_get_shortest_path_astar(const igraph_t *graph,
         heuristic = null_heuristic;
     }
 
-    if (weights) { /* If there are no weights, they are treated as 1. */
+    if (0 && weights) { /* If there are no weights, they are treated as 1. */
         if (igraph_vector_size(weights) != no_of_edges) {
             IGRAPH_ERRORF("Weight vector length (%" IGRAPH_PRId ") does not match number of edges (%" IGRAPH_PRId ").",
                           IGRAPH_EINVAL, igraph_vector_size(weights), no_of_edges);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -978,6 +978,7 @@ add_benchmarks(
   igraph_random_walk
   igraph_transitivity
   igraph_voronoi
+  error_checking
   inc_vs_adj
 )
 

--- a/tests/benchmarks/error_checking.c
+++ b/tests/benchmarks/error_checking.c
@@ -35,6 +35,7 @@ int main(void) {
     BENCH("vector fill of " TOSTRING(big) " 1s", igraph_vector_fill(&weights, 1));
 
     BENCH("50000000 vertices ring graph astar from 0 to 0, 1x", REPEAT(igraph_get_shortest_path_astar(&graph, NULL, NULL, 0, 0, &weights, IGRAPH_ALL, NULL, NULL), 1));
+    BENCH("50000000 vertices ring graph astar from 0 to " TOSTRING(big) " -1, 1x", REPEAT(igraph_get_shortest_path_astar(&graph, NULL, NULL, 0, big - 1, &weights, IGRAPH_ALL, NULL, NULL), 1));
     igraph_destroy(&graph);
 
     igraph_full(&graph, 10000, IGRAPH_UNDIRECTED, 0);

--- a/tests/benchmarks/error_checking.c
+++ b/tests/benchmarks/error_checking.c
@@ -1,6 +1,12 @@
 #include <igraph.h>
 
 #include "bench.h"
+#include "../../src/core/indheap.h"
+#include "igraph_types.h"
+
+#define STRINGIFY(x) #x
+#define TOSTRING(x) STRINGIFY(x)
+#define big 50000000
 
 int main(void) {
     igraph_t graph;
@@ -8,21 +14,46 @@ int main(void) {
 
     BENCH_INIT();
 
-    /*
-    igraph_full(&graph, 10000, IGRAPH_UNDIRECTED, IGRAPH_NO_LOOPS);
+    igraph_full(&graph, 1, IGRAPH_UNDIRECTED, 0);
     igraph_vector_init(&weights, igraph_ecount(&graph));
-    igraph_vector_fill(&weights, 1);
-    BENCH("singleton graph, with error checking", REPEAT(igraph_get_shortest_path_astar(&graph, NULL, NULL, 0, 0, &weights, IGRAPH_ALL, NULL, NULL), 100));
-
+    BENCH("singleton graph", REPEAT(igraph_get_shortest_path_astar(&graph, NULL, NULL, 0, 0, &weights, IGRAPH_ALL, NULL, NULL), 1));
     igraph_vector_destroy(&weights);
     igraph_destroy(&graph);
-    */
 
-    igraph_ring(&graph, 50000000, IGRAPH_UNDIRECTED, 0, 0);
+    igraph_empty(&graph, big, IGRAPH_UNDIRECTED);
     igraph_vector_init(&weights, igraph_ecount(&graph));
-    igraph_vector_fill(&weights, 1);
-    BENCH("ring graph, with error checking", REPEAT(igraph_get_shortest_path_astar(&graph, NULL, NULL, 0, 0, &weights, IGRAPH_ALL, NULL, NULL), 1));
+    BENCH("graph with " TOSTRING(big) " nodes, no edges", REPEAT(igraph_get_shortest_path_astar(&graph, NULL, NULL, 0, 0, &weights, IGRAPH_ALL, NULL, NULL), 1));
+    igraph_vector_destroy(&weights);
+    igraph_destroy(&graph);
 
+    igraph_ring(&graph, big, IGRAPH_UNDIRECTED, 0, 0);
+    BENCH("vector init of " TOSTRING(big), igraph_vector_init(&weights, igraph_ecount(&graph)));
+    BENCH("vector fill of " TOSTRING(big) " INFINITY", igraph_vector_fill(&weights, IGRAPH_INFINITY));
+    BENCH("vector destroy", igraph_vector_destroy(&weights));
+    igraph_vector_destroy(&weights);
+    igraph_vector_init(&weights, igraph_ecount(&graph));
+    BENCH("vector fill of " TOSTRING(big) " 1s", igraph_vector_fill(&weights, 1));
+
+    BENCH("50000000 vertices ring graph astar from 0 to 0, 1x", REPEAT(igraph_get_shortest_path_astar(&graph, NULL, NULL, 0, 0, &weights, IGRAPH_ALL, NULL, NULL), 1));
+    igraph_destroy(&graph);
+
+    igraph_full(&graph, 10000, IGRAPH_UNDIRECTED, 0);
+    igraph_vector_resize(&weights, igraph_ecount(&graph));
+    igraph_vector_fill(&weights, 1);
+    BENCH("10000 vertices full graph astar from 0 to 0, 1x", REPEAT(igraph_get_shortest_path_astar(&graph, NULL, NULL, 0, 0, &weights, IGRAPH_ALL, NULL, NULL), 1));
+
+    igraph_vector_resize(&weights, big);
+    igraph_vector_fill(&weights, 1);
+    BENCH("vector_min on " TOSTRING(big) " numbers 1x", REPEAT(igraph_vector_min(&weights), 1));
+
+    igraph_2wheap_t Q;
+    BENCH("2wheap init of " TOSTRING(big) ", 1x", igraph_2wheap_init(&Q, big));
+
+    igraph_integer_t *tmp;
+    BENCH("IGRAPH_CALLOC of " TOSTRING(big) " igraph_integer_t, 1x", tmp = IGRAPH_CALLOC(big, igraph_integer_t));
+
+    IGRAPH_FREE(tmp);
+    BENCH("2wheap destroy", igraph_2wheap_destroy(&Q));
     igraph_vector_destroy(&weights);
     igraph_destroy(&graph);
 }

--- a/tests/benchmarks/error_checking.c
+++ b/tests/benchmarks/error_checking.c
@@ -1,0 +1,28 @@
+#include <igraph.h>
+
+#include "bench.h"
+
+int main(void) {
+    igraph_t graph;
+    igraph_vector_t weights;
+
+    BENCH_INIT();
+
+    /*
+    igraph_full(&graph, 10000, IGRAPH_UNDIRECTED, IGRAPH_NO_LOOPS);
+    igraph_vector_init(&weights, igraph_ecount(&graph));
+    igraph_vector_fill(&weights, 1);
+    BENCH("singleton graph, with error checking", REPEAT(igraph_get_shortest_path_astar(&graph, NULL, NULL, 0, 0, &weights, IGRAPH_ALL, NULL, NULL), 100));
+
+    igraph_vector_destroy(&weights);
+    igraph_destroy(&graph);
+    */
+
+    igraph_ring(&graph, 50000000, IGRAPH_UNDIRECTED, 0, 0);
+    igraph_vector_init(&weights, igraph_ecount(&graph));
+    igraph_vector_fill(&weights, 1);
+    BENCH("ring graph, with error checking", REPEAT(igraph_get_shortest_path_astar(&graph, NULL, NULL, 0, 0, &weights, IGRAPH_ALL, NULL, NULL), 1));
+
+    igraph_vector_destroy(&weights);
+    igraph_destroy(&graph);
+}


### PR DESCRIPTION
part of #2300

```
|> Benchmark file: /home/daniel/Documents/igraph/tests/benchmarks/error_checking.c
| singleton graph                                                                      0s      0s      0s
| graph with 50000000 nodes, no edges                                              0.061s   0.01s  0.052s
| vector init of 50000000                                                              0s      0s      0s
| vector fill of 50000000 INFINITY                                                 0.049s  0.006s  0.043s
| vector destroy                                                                   0.001s      0s      0s
| vector fill of 50000000 1s                                                       0.048s  0.006s  0.042s
| 50000000 vertices ring graph astar from 0 to 0, 1x                               0.092s  0.051s  0.041s
| 50000000 vertices ring graph astar from 0 to 50000000 -1, 1x                      4.01s   3.14s  0.865s
| 10000 vertices full graph astar from 0 to 0, 1x                                  0.031s  0.031s      0s
| vector_min on 50000000 numbers 1x                                                0.031s  0.031s      0s
| 2wheap init of 50000000, 1x                                                          0s      0s      0s
| IGRAPH_CALLOC of 50000000 igraph_integer_t, 1x                                       0s      0s      0s
| 2wheap destroy                                                                       0s      0s      0s
```

Added some benchmarks for things that almost take no time, because they did take a significant amount of time with a debug build with sanitizers on.
So for the case where you path length is negligible:
just checking weights (vector_min) takes up almost all the time for the full graph.
error checking + filling the dists vector (which scales with no_of_nodes) takes about 8/9 of the time for the ring graph. I find it difficult to find where the rest of the time goes.
I've also put in the longest path scenario, then the overhead is less than 1/40.