### PR TITLE
fix: buffers of type T should be of a size that is a multiple of sizeof(T)

### DIFF
--- a/include/igraph_memory.h
+++ b/include/igraph_memory.h
@@ -35,9 +35,9 @@ __BEGIN_DECLS
 #define IGRAPH_I_ALLOC_CHECK_OVERFLOW(n,t,expr) \
     (t*) (((n) > SIZE_MAX / sizeof(t)) ? NULL : (expr))
 
-#define IGRAPH_CALLOC(n,t)    IGRAPH_I_ALLOC_CHECK_OVERFLOW(n, t, calloc( (n) > 0 ? (size_t)((n)*sizeof(t)) : (size_t)1, 1 ))
-#define IGRAPH_MALLOC(n)      malloc( (n) > 0 ? (size_t)((n)) : (size_t)1 )
-#define IGRAPH_REALLOC(p,n,t) IGRAPH_I_ALLOC_CHECK_OVERFLOW(n, t, realloc((void*)(p), (n) > 0 ? (size_t)((n)*sizeof(t)) : (size_t)1))
+#define IGRAPH_CALLOC(n,t)    IGRAPH_I_ALLOC_CHECK_OVERFLOW(n, t, calloc(sizeof(t) * ((n) > 0 ? (n) : 1), 1))
+#define IGRAPH_MALLOC(n)      malloc( (size_t) ((n) > 0 ? (n) : 1) )
+#define IGRAPH_REALLOC(p,n,t) IGRAPH_I_ALLOC_CHECK_OVERFLOW(n, t, realloc((void*)(p), sizeof(t) * ((n) > 0 ? (n) : 1)))
 #define IGRAPH_FREE(p)        (free( (void *)(p) ), (p) = NULL)
 
 /* These are deprecated and scheduled for removal in 0.11 */


### PR DESCRIPTION
Ensure that `IGRAPH_(C|RE)ALLOC(n, t)` allocates a buffer whose size is a multiple of `sizeof(t)`. 

Specifically, when `n==0`, allocate a buffer of `sizeof(t)` instead of size 1.

This is not really a bugfix, as the current behaviour is not wrong. But some static analysers are unhappy if `foo *` points to a buffer whose size is not a multiple of `sizeof(foo)`. This change will fix a large number of Coverity warnings introduced by #2367.

The disadvantage is that now larger buffers are allocated to work around the zero-allocation issue. However, in practice, most implementations are likely to reserve more than 1 byte with `malloc(1)` anyway. This may not make a practical difference.