### PR TITLE
WIP: Change IGRAPH_BOOL_TYPE to int

### DIFF
--- a/include/igraph_config.h.in
+++ b/include/igraph_config.h.in
@@ -48,7 +48,7 @@ __BEGIN_DECLS
  * Any other use-case of overriding igraph's bool type is completely
  * unsupported.
  */
-#define IGRAPH_BOOL_TYPE bool
+#define IGRAPH_BOOL_TYPE int
 
 __END_DECLS
 


### PR DESCRIPTION
This is a test to see if we can successfully change the definition of the `IGRAPH_BOOL_TYPE` macro. This seems necessary for the R package.

Do not merge.