### PR TITLE
Add citation information.

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,57 @@
+# This CITATION.cff file was generated with cffinit.
+# Visit https://bit.ly/cffinit to generate yours today!
+
+cff-version: 1.2.0
+title: igraph
+message: >-
+  If you use igraph, please cite it using the
+  metadata from this file.
+type: software
+authors:
+  - given-names: Gábor
+    family-names: Csárdi
+    orcid: 'https://orcid.org/0000-0001-7098-9676'
+  - given-names: Tamás
+    family-names: Nepusz
+    orcid: 'https://orcid.org/0000-0002-1451-338X'
+  - given-names: Szabolcs
+    family-names: Horvát
+    orcid: 'https://orcid.org/0000-0002-3100-523X'
+  - given-names: Vincent Antonio
+    family-names: Traag
+    orcid: 'https://orcid.org/0000-0003-3170-3879'
+  - given-names: Fabio
+    family-names: Zanini
+    orcid: 'https://orcid.org/0000-0001-7097-8539'
+  - given-names: Daniel
+    family-names: Noom
+identifiers:
+  - type: doi
+    value: 10.5281/zenodo.8094849
+    description: Zenodo
+repository-code: 'https://github.com/igraph/igraph'
+url: 'https://igraph.org'
+abstract: >-
+  igraph is a C library for complex network analysis and
+  graph theory, with emphasis on efficiency, portability and
+  ease of use.
+keywords:
+  - network analysis
+  - graph theory
+license: GPL-2.0-or-later
+version: 0.10.5
+date-released: '2023-06-29'
+preferred-citation:
+  type: article
+  authors:
+    - given-names: Gábor
+      family-names: Csárdi
+      orcid: 'https://orcid.org/0000-0001-7098-9676'
+    - given-names: Tamás
+      family-names: Nepusz
+      orcid: 'https://orcid.org/0000-0002-1451-338X'
+  journal: "InterJournal, Complex Systems"
+  start: 1695 # First page number
+  title: "The igraph software package for complex network research"
+  year: 2006
+  type: article

--- a/README.md
+++ b/README.md
@@ -21,3 +21,11 @@ igraph is a collaborative work of many people from all around the world —
 see the [list of contributors here](./CONTRIBUTORS.md). If you would like
 to contribute yourself, [click here to see how you can
 help](./CONTRIBUTING.md).
+
+Citation
+--------
+
+If use use igraph in your research, please cite
+
+> Csardi, G., & Nepusz, T. (2006). The igraph software package for complex network research. InterJournal, Complex Systems, 1695.
+


### PR DESCRIPTION
I've added citation information now to the README.md file, and I added a `CITATION.cff` file that makes it easier to cite. The 2006 article is in the preferred citation in `CITATION.cff`, so that should be shown by GitHub. 

Additionally, `CITATION.cff` also provides the information from Zenodo. At the moment it really reflects the most recent release, including that particular DOI. Preferablly, we shouldn't have to update this manually of course, but that would be of later concern.

The citation itself is already in the documentation, so that wouldn't need any update. Let me know if this should still require some changes.