### PR TITLE
multiarch support: config headers in a per-architecture location

### DIFF
--- a/etc/cmake/pkgconfig_helpers.cmake
+++ b/etc/cmake/pkgconfig_helpers.cmake
@@ -68,6 +68,11 @@ endif()
 
 join_paths(PKGCONFIG_LIBDIR "\${exec_prefix}" "${CMAKE_INSTALL_LIBDIR}")
 join_paths(PKGCONFIG_INCLUDEDIR "\${prefix}" "${CMAKE_INSTALL_INCLUDEDIR}")
+join_paths(PKGCONFIG_CFLAGS_ONLY_I "-I\${includedir}" "igraph")
+if(CMAKE_LIBRARY_ARCHITECTURE)
+  join_paths(PKGCONFIG_CFLAGS_ONLY_I_ARCH "-I\${includedir}" "${CMAKE_LIBRARY_ARCHITECTURE}" "igraph")
+  set(PKGCONFIG_CFLAGS_ONLY_I "${PKGCONFIG_CFLAGS_ONLY_I_ARCH} ${PKGCONFIG_CFLAGS_ONLY_I}")
+endif()
 configure_file(
   ${PROJECT_SOURCE_DIR}/igraph.pc.in
   ${PROJECT_BINARY_DIR}/igraph.pc

--- a/igraph.pc.in
+++ b/igraph.pc.in
@@ -10,4 +10,4 @@ URL: @PROJECT_HOMEPAGE_URL@
 Libs: -L${libdir} -ligraph
 Libs.private: @PKGCONFIG_LIBS_PRIVATE@
 Requires.private: @PKGCONFIG_REQUIRES_PRIVATE@
-Cflags: -I${includedir}/igraph
+Cflags: @PKGCONFIG_CFLAGS_ONLY_I@

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -425,6 +425,11 @@ use_all_warnings(igraph)
 # GNUInstallDirs be included before generating the pkgconfig file, as it defines
 # CMAKE_INSTALL_LIBDIR and CMAKE_INSTALL_INCLUDEDIR variables.
 include(GNUInstallDirs)
+if(CMAKE_LIBRARY_ARCHITECTURE)
+  set(CMAKE_INSTALL_INCLUDEDIR_ARCHITECTURE "${CMAKE_INSTALL_INCLUDEDIR}/${CMAKE_LIBRARY_ARCHITECTURE}")
+else()
+  set(CMAKE_INSTALL_INCLUDEDIR_ARCHITECTURE "${CMAKE_INSTALL_INCLUDEDIR}")
+endif()
 
 # Generate pkgconfig file
 include(pkgconfig_helpers)
@@ -468,7 +473,7 @@ install(
 )
 install(
   DIRECTORY ${PROJECT_BINARY_DIR}/include/
-  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/igraph
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR_ARCHITECTURE}/igraph
   FILES_MATCHING PATTERN "*.h"
 )
 install(


### PR DESCRIPTION
Description: upstream: fix: multiarch: file-conflict
 This patch installs architecture/built specific C headers
 in a per-architecture location to avoid conflict on multiarch
 systems.
Origin: debian
Author: Jerome Benoit <calculus@rezozer.net>
Last-Update: 2023-07-15