### PR TITLE
refactor!: igraph_vector_swap() and igraph_matrix_swap() no longer return an error code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
  - `igraph_delete_vertices_map()` (formerly called `igraph_delete_vertices_idx()`) and `igraph_induced_subgraph_map()` now use -1 to represent unmapped vertices in the returned forward mapping vector and they do not offset vertex indices by 1 any more. (Note that the inverse map always behaved this way, this change makes the two mappings consistent).
  - `igraph_distances_johnson()` now takes a mode parameter to determine in which direction paths should be followed.
  - `igraph_vector_shuffle()` no longer returns an error code.
+ - `igraph_vector_swap()` no longer returns an error code.
+ - `igraph_matrix_swap()` no longer returns an error code.
  - `igraph_rng_set_default()` now returns a pointer to the previous RNG. Furthermore, this function now only stores a pointer to the `igraph_rng_t` struct passed to it, instead of copying the struct. Thus the `igraph_rng_t` must continue to exist for as long as it is used as the default RNG.
  - `igraph_similarity_jaccard()` and `igraph_similarity_dice()` now take two sets of vertices to create vertex pairs of, instead of one.
 

--- a/include/igraph_matrix_pmt.h
+++ b/include/igraph_matrix_pmt.h
@@ -88,7 +88,7 @@ IGRAPH_EXPORT igraph_error_t FUNCTION(igraph_matrix, rbind)(TYPE(igraph_matrix) 
                                                  const TYPE(igraph_matrix) *from);
 IGRAPH_EXPORT igraph_error_t FUNCTION(igraph_matrix, cbind)(TYPE(igraph_matrix) *to,
                                                  const TYPE(igraph_matrix) *from);
-IGRAPH_EXPORT igraph_error_t FUNCTION(igraph_matrix, swap)(TYPE(igraph_matrix) *m1, TYPE(igraph_matrix) *m2);
+IGRAPH_EXPORT void FUNCTION(igraph_matrix, swap)(TYPE(igraph_matrix) *m1, TYPE(igraph_matrix) *m2);
 
 /*--------------------------*/
 /* Copying rows and columns */

--- a/include/igraph_vector_pmt.h
+++ b/include/igraph_vector_pmt.h
@@ -103,7 +103,7 @@ IGRAPH_EXPORT igraph_error_t FUNCTION(igraph_vector, update)(TYPE(igraph_vector)
                                                   const TYPE(igraph_vector) *from);
 IGRAPH_EXPORT igraph_error_t FUNCTION(igraph_vector, append)(TYPE(igraph_vector) *to,
                                                   const TYPE(igraph_vector) *from);
-IGRAPH_EXPORT igraph_error_t FUNCTION(igraph_vector, swap)(TYPE(igraph_vector) *v1, TYPE(igraph_vector) *v2);
+IGRAPH_EXPORT void FUNCTION(igraph_vector, swap)(TYPE(igraph_vector) *v1, TYPE(igraph_vector) *v2);
 
 /*-----------------------*/
 /* Exchanging elements   */

--- a/src/core/matrix.pmt
+++ b/src/core/matrix.pmt
@@ -1117,12 +1117,11 @@ igraph_error_t FUNCTION(igraph_matrix, cbind)(TYPE(igraph_matrix) *to,
  * The contents of the two matrices will be swapped.
  * \param m1 The first matrix.
  * \param m2 The second matrix.
- * \return Error code.
  *
  * Time complexity: O(1).
  */
 
-igraph_error_t FUNCTION(igraph_matrix, swap)(TYPE(igraph_matrix) *m1, TYPE(igraph_matrix) *m2) {
+void FUNCTION(igraph_matrix, swap)(TYPE(igraph_matrix) *m1, TYPE(igraph_matrix) *m2) {
     igraph_integer_t tmp;
 
     tmp = m1->nrow;
@@ -1133,9 +1132,7 @@ igraph_error_t FUNCTION(igraph_matrix, swap)(TYPE(igraph_matrix) *m1, TYPE(igrap
     m1->ncol = m2->ncol;
     m2->ncol = tmp;
 
-    IGRAPH_CHECK(FUNCTION(igraph_vector, swap)(&m1->data, &m2->data));
-
-    return IGRAPH_SUCCESS;
+    FUNCTION(igraph_vector, swap)(&m1->data, &m2->data);
 }
 
 /**

--- a/src/core/vector.pmt
+++ b/src/core/vector.pmt
@@ -2567,20 +2567,17 @@ igraph_error_t FUNCTION(igraph_vector, update)(TYPE(igraph_vector) *to,
  *
  * \param v1 The first vector.
  * \param v2 The second vector.
- * \return Error code.
  *
  * Time complexity: O(1).
  */
 
-igraph_error_t FUNCTION(igraph_vector, swap)(TYPE(igraph_vector) *v1, TYPE(igraph_vector) *v2) {
+void FUNCTION(igraph_vector, swap)(TYPE(igraph_vector) *v1, TYPE(igraph_vector) *v2) {
 
     TYPE(igraph_vector) tmp;
 
     tmp = *v1;
     *v1 = *v2;
     *v2 = tmp;
-
-    return IGRAPH_SUCCESS;
 }
 
 /**

--- a/src/internal/utils.c
+++ b/src/internal/utils.c
@@ -84,7 +84,7 @@ igraph_error_t igraph_i_matrix_subset_vertices(
     }
 
     /* This is O(1) time */
-    IGRAPH_CHECK(igraph_matrix_swap(m, &tmp));
+    igraph_matrix_swap(m, &tmp);
 
     igraph_matrix_destroy(&tmp);
     igraph_vit_destroy(&tovit);

--- a/src/misc/cycle_bases.c
+++ b/src/misc/cycle_bases.c
@@ -346,7 +346,7 @@ static igraph_error_t gaussian_elimination(igraph_vector_int_list_t *reduced_mat
                 IGRAPH_FINALLY_CLEAN(2);
                 return IGRAPH_SUCCESS;
             }
-            IGRAPH_CHECK(igraph_vector_int_swap(&work, &tmp));
+            igraph_vector_int_swap(&work, &tmp);
         } else { /* VECTOR(*row)[0] > VECTOR(work)[0] */
             break;
         }

--- a/src/paths/bellman_ford.c
+++ b/src/paths/bellman_ford.c
@@ -580,12 +580,12 @@ igraph_error_t igraph_get_shortest_path_bellman_ford(const igraph_t *graph,
     /* We use the constant time vector_swap() instead of the linear-time vector_update() to move the
        result to the output parameter. */
     if (edges) {
-        IGRAPH_CHECK(igraph_vector_int_swap(edges, igraph_vector_int_list_get_ptr(&edges2, 0)));
+        igraph_vector_int_swap(edges, igraph_vector_int_list_get_ptr(&edges2, 0));
         igraph_vector_int_list_destroy(&edges2);
         IGRAPH_FINALLY_CLEAN(1);
     }
     if (vertices) {
-        IGRAPH_CHECK(igraph_vector_int_swap(vertices, igraph_vector_int_list_get_ptr(&vertices2, 0)));
+        igraph_vector_int_swap(vertices, igraph_vector_int_list_get_ptr(&vertices2, 0));
         igraph_vector_int_list_destroy(&vertices2);
         IGRAPH_FINALLY_CLEAN(1);
     }

--- a/src/paths/dijkstra.c
+++ b/src/paths/dijkstra.c
@@ -690,12 +690,12 @@ igraph_error_t igraph_get_shortest_path_dijkstra(const igraph_t *graph,
     /* We use the constant time vector_swap() instead of the linear-time vector_update() to move the
        result to the output parameter. */
     if (edges) {
-        IGRAPH_CHECK(igraph_vector_int_swap(edges, igraph_vector_int_list_get_ptr(&edges2, 0)));
+        igraph_vector_int_swap(edges, igraph_vector_int_list_get_ptr(&edges2, 0));
         igraph_vector_int_list_destroy(&edges2);
         IGRAPH_FINALLY_CLEAN(1);
     }
     if (vertices) {
-        IGRAPH_CHECK(igraph_vector_int_swap(vertices, igraph_vector_int_list_get_ptr(&vertices2, 0)));
+        igraph_vector_int_swap(vertices, igraph_vector_int_list_get_ptr(&vertices2, 0));
         igraph_vector_int_list_destroy(&vertices2);
         IGRAPH_FINALLY_CLEAN(1);
     }

--- a/src/paths/unweighted.c
+++ b/src/paths/unweighted.c
@@ -601,12 +601,12 @@ igraph_error_t igraph_get_shortest_path(const igraph_t *graph,
     /* We use the constant time vector_swap() instead of the linear-time vector_update() to move the
        result to the output parameter. */
     if (edges) {
-        IGRAPH_CHECK(igraph_vector_int_swap(edges, igraph_vector_int_list_get_ptr(&edges2, 0)));
+        igraph_vector_int_swap(edges, igraph_vector_int_list_get_ptr(&edges2, 0));
         igraph_vector_int_list_destroy(&edges2);
         IGRAPH_FINALLY_CLEAN(1);
     }
     if (vertices) {
-        IGRAPH_CHECK(igraph_vector_int_swap(vertices, igraph_vector_int_list_get_ptr(&vertices2, 0)));
+        igraph_vector_int_swap(vertices, igraph_vector_int_list_get_ptr(&vertices2, 0));
         igraph_vector_int_list_destroy(&vertices2);
         IGRAPH_FINALLY_CLEAN(1);
     }


### PR DESCRIPTION
`igraph_vector_swap()` and `igraph_matrix_swap()` no longer return an error code.

Reasoning: The current implementation can never fail and I do not see ever needing to account for failures. There is a pattern for adding new elements into vector lists or matrix lists that is inconvenient to implement if this function fails. See 55948f90fc783c2ee90d337c2a1a331cf6bb664a for an example.

Suppose we have `igraph_vector_t *v` and we need to insert it into an `igraph_vector_list_t *list` and never use it again. One way is:

```
IGRAPH_CHECK(igraph_vector_list_push_back_copy(list, v));
```

But this is inefficient as it copies the vector.  A faster way is the following:

```
igraph_vector_t *new_v;
IGRAPH_CHECK(igraph_vector_list_push_back_new(list, *new_v));
igraph_vector_swap(v, new_v);
```

If `igraph_vector_swap()` can fail, and we put an `IGRAPH_CHECK` on it, then a failure may cause `list` to be in an inconsistent state (containing an empty vector when it shouldn't). In some situations this is undesirable. This behaviour is conveniently avoided if `igraph_vector_swap()` can never fail, which is currently cannot. So let's make that official and not return an error code.

I expect this change may be controversial, hence the PR.