### PR TITLE
ci: use windows-2022 runner and compiler with VS 2017

### DIFF
--- a/.azure/build-win.yml
+++ b/.azure/build-win.yml
@@ -73,8 +73,13 @@ steps:
 
   # Notes:
   #  - We call vcvarsall.bat to make sure the compiler (cl.exe) is in the path, and so that we can select the desired MSVC version.
-  #      https://docs.microsoft.com/en-us/cpp/build/building-on-the-command-line?view=msvc-160#vcvarsall-syntax
+  #      https://docs.microsoft.com/en-us/cpp/build/building-on-the-command-line?view=msvc-170#vcvarsall-syntax
   #      This is necessary when not using the Visual Studio CMake generator.
+  #      Location for VS2019: 
+  #        C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat
+  #      Location for VS2022:
+  #        C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat
+  #      See https://en.wikipedia.org/wiki/Microsoft_Visual_C%2B%2B#Internal_version_numbering for setting the value of -vcvars_ver
   #  - Due to this setup, CMake must also be called in the same script instead of using the CMake task
   #  - We must set CXX and CC so that CMake would not accidentally pick up another compiler.
   #  - With the above, we can use the Ninja generator, which enables much faster build times than the VS one due to better parallelization.
@@ -83,7 +88,7 @@ steps:
       md build
       cd build
 
-      call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64 -vcvars_ver=14.0
+      call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64 -vcvars_ver=14.1
 
       set CXX=cl.exe
       set CC=cl.exe

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -130,14 +130,14 @@ jobs:
 
   - job: windows_static
     pool:
-       vmImage: windows-2019
+       vmImage: windows-2022
 
     steps:
       - template: .azure/build-win.yml
 
   - job: windows_shared
     pool:
-       vmImage: windows-2019
+       vmImage: windows-2022
 
     steps:
       - template: .azure/build-win.yml


### PR DESCRIPTION
This PR switches the Windows tests to the windows-2022 (latest) image from the previous windows-2019. This image no longer includes the VS 2015 tools, so we need to switch to VS 2017.

We do not need to make this switch right now, but this PR will stay ready to merge for when we _are_ ready.

Perhaps it'd be best to rebase this for `develop`, meaning that we make the switch for 0.11.