### PR TITLE
fix: remove the mode-switching hack from Pajek parser, refs #2400

### DIFF
--- a/src/io/pajek-header.h
+++ b/src/io/pajek-header.h
@@ -41,7 +41,7 @@
 
 typedef struct {
     void *scanner;
-    int eof;
+    igraph_bool_t eof;
     char errmsg[300];
     igraph_error_t igraph_errno;
     igraph_vector_int_t *vector;
@@ -49,7 +49,6 @@ typedef struct {
     igraph_integer_t vcount, vcount2;
     igraph_integer_t actfrom;
     igraph_integer_t actto;
-    int mode; /* 0: general, 1: vertex, 2: edge */
     igraph_trie_t *vertex_attribute_names;
     igraph_vector_ptr_t *vertex_attributes;
     igraph_trie_t *edge_attribute_names;

--- a/src/io/pajek-lexer.l
+++ b/src/io/pajek-lexer.l
@@ -79,78 +79,88 @@ digit [0-9]
 word [^\x00-\x20\x7f*]
 
 %x netline
+%s vert edge
 
 /* Notes:
  *  - Pajek files do not allow empty lines (empty lines should signify the end of the file).
  *  - Unquoted '*' characters may only appear at the start of a line-initial word.
  *  - '*net' is not a valid network line, but earlier igraph versions supported it, so we keep it for now.
- *  - Some Pajek files have parenthesized segments. We skip over these without interpreting them.
+ *  - Some Pajek files have parenthesized segments. These are tokenized as PSTR but not handled at this time.
  */
 
 %%
 <*>{whitespace}+  { }
 ^%[^\n\r\0]*[\n\r]*  { } /* comments */
+
 \*net             { BEGIN(netline); return NETWORKLINE; }
 \*network         { BEGIN(netline); return NETWORKLINE; }
 <netline>{whitespace}([^\n\r\0])* { return NET_TITLE; }
+<netline>[\n\r]+                  { 
+                    BEGIN(INITIAL); return NEWLINE; }
 
-\*vertices        { return VERTICESLINE; }
-\*arcs            { return ARCSLINE; }
-\*edges           { return EDGESLINE; }
-\*arcslist        { return ARCSLISTLINE; }
-\*edgeslist       { return EDGESLISTLINE; }
-\*matrix          { return MATRIXLINE; }
-<*>[\n\r]+        { BEGIN(INITIAL); yyextra->mode=0; return NEWLINE; } /* skip over multiple newlines */
+\*vertices        { BEGIN(vert); return VERTICESLINE; }
+\*arcs            { BEGIN(edge); return ARCSLINE; }
+\*edges           { BEGIN(edge); return EDGESLINE; }
+\*arcslist        { BEGIN(INITIAL); return ARCSLISTLINE; }
+\*edgeslist       { BEGIN(INITIAL);return EDGESLISTLINE; }
+\*matrix          { BEGIN(INITIAL); return MATRIXLINE; }
+[\n\r]+           { return NEWLINE; }
+
 \"[^\"\0]*\"      { return QSTR; }
 \([^\)\0]*\)      { return PSTR; }
-(\+|\-)?{digit}+(\.{digit}+)?([eE](\+|\-)?{digit}+)? {
-                    return NUM; }
 
-x_fact  { if (yyextra->mode==1) { return VP_X_FACT; } else { return ALNUM; } }
-y_fact  { if (yyextra->mode==1) { return VP_Y_FACT; } else { return ALNUM; } }
-ic      { if (yyextra->mode==1) { return VP_IC; } else { return ALNUM; } }
-bc      { if (yyextra->mode==1) { return VP_BC; } else { return ALNUM; } }
-bw      { if (yyextra->mode==1) { return VP_BW; } else { return ALNUM; } }
-phi     { if (yyextra->mode==1) { return VP_PHI; } else { return ALNUM; } }
-r       { if (yyextra->mode==1) { return VP_R; } else { return ALNUM; } }
-q       { if (yyextra->mode==1) { return VP_Q; } else { return ALNUM; } }
-font    { if (yyextra->mode==1) { return VP_FONT; } else { return ALNUM; } }
-url     { if (yyextra->mode==1) { return VP_URL; } else { return ALNUM; } }
+(\+|\-)?{digit}+(\.{digit}+)?([eE](\+|\-)?{digit}+)? { return NUM; }
 
-c       { if (yyextra->mode==2) { return EP_C; } else { return ALNUM; } }
-p       { if (yyextra->mode==2) { return EP_P; } else { return ALNUM; } }
-s       { if (yyextra->mode==2) { return EP_S; } else { return ALNUM; } }
-a       { if (yyextra->mode==2) { return EP_A; } else { return ALNUM; } }
-w       { if (yyextra->mode==2) { return EP_W; } else { return ALNUM; } }
-h1      { if (yyextra->mode==2) { return EP_H1; } else { return ALNUM; } }
-h2      { if (yyextra->mode==2) { return EP_H2; } else { return ALNUM; } }
-a1      { if (yyextra->mode==2) { return EP_A1; } else { return ALNUM; } }
-a2      { if (yyextra->mode==2) { return EP_A2; } else { return ALNUM; } }
-k1      { if (yyextra->mode==2) { return EP_K1; } else { return ALNUM; } }
-k2      { if (yyextra->mode==2) { return EP_K2; } else { return ALNUM; } }
-ap      { if (yyextra->mode==2) { return EP_AP; } else { return ALNUM; } }
-l       { if (yyextra->mode==2) { return EP_L; } else { return ALNUM; } }
-lp      { if (yyextra->mode==2) { return EP_LP; } else { return ALNUM; } }
+<vert>{
+x_fact  { return VP_X_FACT; }
+y_fact  { return VP_Y_FACT; }
+ic      { return VP_IC; }
+bc      { return VP_BC; }
+bw      { return VP_BW; }
+phi     { return VP_PHI; }
+r       { return VP_R; }
+q       { return VP_Q; }
+font    { return VP_FONT; }
+url     { return VP_URL; }
 
-lphi    { if (yyextra->mode==1) { return VP_LPHI; } else
-                             if (yyextra->mode==2) { return EP_LPHI; } else { return ALNUM; } }
-lc      { if (yyextra->mode==1) { return VP_LC; } else
-                             if (yyextra->mode==2) { return EP_LC; } else { return ALNUM; } }
-lr      { if (yyextra->mode==1) { return VP_LR; } else
-                             if (yyextra->mode==2) { return EP_LR; } else { return ALNUM; } }
-la      { if (yyextra->mode==1) { return VP_LA; } else
-                             if (yyextra->mode==2) { return EP_LA; } else { return ALNUM; } }
-size    { if (yyextra->mode==1) { return VP_SIZE; } else
-                             if (yyextra->mode==2) { return EP_SIZE; } else { return ALNUM; } }
-fos     { if (yyextra->mode==1) { return VP_FOS; } else
-                             if (yyextra->mode==2) { return EP_FOS; } else { return ALNUM; } }
+lphi    { return VP_LPHI; }
+lc      { return VP_LC; }
+lr      { return VP_LR; }
+la      { return VP_LA; }
+size    { return VP_SIZE; }
+fos     { return VP_FOS; }
+}
+
+<edge>{
+c       { return EP_C; }
+p       { return EP_P; }
+s       { return EP_S; }
+a       { return EP_A; }
+w       { return EP_W; }
+h1      { return EP_H1; }
+h2      { return EP_H2; }
+a1      { return EP_A1; }
+a2      { return EP_A2; }
+k1      { return EP_K1; }
+k2      { return EP_K2; }
+ap      { return EP_AP; }
+l       { return EP_L; }
+lp      { return EP_LP; }
+
+lphi    { return EP_LPHI; }
+lc      { return EP_LC; }
+lr      { return EP_LR; }
+la      { return EP_LA; }
+size    { return EP_SIZE; }
+fos     { return EP_FOS; }
+}
 
 {word}+           { return ALNUM; }
 
 <<EOF>>           { if (yyextra->eof) {
                        yyterminate();
                     } else {
-                       yyextra->eof=1;
+                       yyextra->eof=true;
                        return NEWLINE;
                     }
                   }

--- a/src/io/pajek-parser.y
+++ b/src/io/pajek-parser.y
@@ -235,7 +235,7 @@ vertexline: NEWLINE |
             } vertexid vertexcoords shape params NEWLINE { }
 ;
 
-vertex: longint { $$=$1; context->mode=1; };
+vertex: longint { $$=$1; };
 
 vertexid: word {
   IGRAPH_YY_CHECK(igraph_i_pajek_add_string_vertex_attribute("id", $1.str, $1.len, context));
@@ -311,27 +311,22 @@ param:
      }
 ;
 
-vpword: VP_FONT { context->mode=3; } vpwordpar {
-         context->mode=1;
-         IGRAPH_YY_CHECK(igraph_i_pajek_add_string_vertex_attribute("font", $3.str, $3.len, context));
+vpword: VP_FONT vpwordpar {
+         IGRAPH_YY_CHECK(igraph_i_pajek_add_string_vertex_attribute("font", $2.str, $2.len, context));
      }
-     | VP_URL { context->mode=3; } vpwordpar {
-         context->mode=1;
-         IGRAPH_YY_CHECK(igraph_i_pajek_add_string_vertex_attribute("url", $3.str, $3.len, context));
+     | VP_URL vpwordpar {
+         IGRAPH_YY_CHECK(igraph_i_pajek_add_string_vertex_attribute("url", $2.str, $2.len, context));
      }
-     | VP_IC { context->mode=3; } vpwordpar {
-         context->mode=1;
-         IGRAPH_YY_CHECK(igraph_i_pajek_add_string_vertex_attribute("color", $3.str, $3.len, context));
+     | VP_IC vpwordpar {
+         IGRAPH_YY_CHECK(igraph_i_pajek_add_string_vertex_attribute("color", $2.str, $2.len, context));
      }
-     | VP_BC { context->mode=3; } vpwordpar {
-         context->mode=1;
+     | VP_BC vpwordpar {
          IGRAPH_YY_CHECK(igraph_i_pajek_add_string_vertex_attribute("framecolor",
-                                                    $3.str, $3.len, context));
+                                                    $2.str, $2.len, context));
      }
-     | VP_LC { context->mode=3; } vpwordpar {
-         context->mode=1;
+     | VP_LC vpwordpar {
          IGRAPH_YY_CHECK(igraph_i_pajek_add_string_vertex_attribute("labelcolor",
-                                                    $3.str, $3.len, context));
+                                                    $2.str, $2.len, context));
      }
 ;
 
@@ -345,8 +340,7 @@ arcs:   ARCSLINE NEWLINE arcsdefs        { context->directed=1; }
 arcsdefs: /* empty */ | arcsdefs arcsline;
 
 arcsline: NEWLINE |
-          arcfrom arcto { context->actedge++;
-                          context->mode=2; } weight edgeparams NEWLINE  {
+          arcfrom arcto { context->actedge++; } weight edgeparams NEWLINE  {
   if ($1 < 1) {
       IGRAPH_YY_ERRORF("Non-positive vertex ID (%" IGRAPH_PRId ") while reading Pajek file.", IGRAPH_EINVAL, $1);
   }
@@ -367,8 +361,7 @@ edges:   EDGESLINE NEWLINE edgesdefs { context->directed=0; }
 edgesdefs: /* empty */ | edgesdefs edgesline;
 
 edgesline: NEWLINE |
-          edgefrom edgeto { context->actedge++;
-                            context->mode=2; } weight edgeparams NEWLINE {
+          edgefrom edgeto { context->actedge++; } weight edgeparams NEWLINE {
   if ($1 < 1) {
       IGRAPH_YY_ERRORF("Non-positive vertex ID (%" IGRAPH_PRId ") while reading Pajek file.", IGRAPH_EINVAL, $1);
   }
@@ -443,29 +436,24 @@ edgeparam:
    }
 ;
 
-epword: EP_A { context->mode=4; } epwordpar {
-      context->mode=2;
-      IGRAPH_YY_CHECK(igraph_i_pajek_add_string_edge_attribute("arrowtype", $3.str, $3.len, context));
+epword: EP_A epwordpar {
+      IGRAPH_YY_CHECK(igraph_i_pajek_add_string_edge_attribute("arrowtype", $2.str, $2.len, context));
     }
-    | EP_P { context->mode=4; } epwordpar {
-      context->mode=2;
-      IGRAPH_YY_CHECK(igraph_i_pajek_add_string_edge_attribute("linepattern", $3.str, $3.len, context));
+    | EP_P epwordpar {
+      IGRAPH_YY_CHECK(igraph_i_pajek_add_string_edge_attribute("linepattern", $2.str, $2.len, context));
     }
-    | EP_L { context->mode=4; } epwordpar {
-      context->mode=2;
-      IGRAPH_YY_CHECK(igraph_i_pajek_add_string_edge_attribute("label", $3.str, $3.len, context));
+    | EP_L epwordpar {
+      IGRAPH_YY_CHECK(igraph_i_pajek_add_string_edge_attribute("label", $2.str, $2.len, context));
     }
-    | EP_LC { context->mode=4; } epwordpar {
-      context->mode=2;
-      IGRAPH_YY_CHECK(igraph_i_pajek_add_string_edge_attribute("labelcolor", $3.str, $3.len, context));
+    | EP_LC epwordpar {
+      IGRAPH_YY_CHECK(igraph_i_pajek_add_string_edge_attribute("labelcolor", $2.str, $2.len, context));
     }
-    | EP_C { context->mode=4; } epwordpar {
-      context->mode=2;
-      IGRAPH_YY_CHECK(igraph_i_pajek_add_string_edge_attribute("color", $3.str, $3.len, context));
+    | EP_C epwordpar {
+      IGRAPH_YY_CHECK(igraph_i_pajek_add_string_edge_attribute("color", $2.str, $2.len, context));
     }
 ;
 
-epwordpar: word { context->mode=2; $$=$1; };
+epwordpar: word { $$=$1; };
 
 arcslist: ARCSLISTLINE NEWLINE arcslistlines { context->directed=1; };
 
@@ -475,7 +463,7 @@ arclistline: NEWLINE | arclistfrom arctolist NEWLINE;
 
 arctolist: /* empty */ | arctolist arclistto;
 
-arclistfrom: longint { context->mode=0; context->actfrom=labs($1)-1; };
+arclistfrom: longint { context->actfrom=labs($1)-1; };
 
 arclistto: longint {
   IGRAPH_YY_CHECK(igraph_vector_int_push_back(context->vector, context->actfrom));
@@ -490,7 +478,7 @@ edgelistline: NEWLINE | edgelistfrom edgetolist NEWLINE;
 
 edgetolist: /* empty */ | edgetolist edgelistto;
 
-edgelistfrom: longint { context->mode=0; context->actfrom=labs($1)-1; };
+edgelistfrom: longint { context->actfrom=labs($1)-1; };
 
 edgelistto: longint {
   IGRAPH_YY_CHECK(igraph_vector_int_push_back(context->vector, context->actfrom));

--- a/src/io/pajek.c
+++ b/src/io/pajek.c
@@ -183,7 +183,6 @@ igraph_error_t igraph_read_graph_pajek(igraph_t *graph, FILE *instream) {
 
     context.directed = false; /* assume undirected until an element implying directedness is encountered */
     context.vector = &edges;
-    context.mode = 0;
     context.vcount = -1;
     context.vertexid = 0;
     context.vertex_attribute_names = &vattrnames;
@@ -191,7 +190,7 @@ igraph_error_t igraph_read_graph_pajek(igraph_t *graph, FILE *instream) {
     context.edge_attribute_names = &eattrnames;
     context.edge_attributes = &eattrs;
     context.actedge = 0;
-    context.eof = 0;
+    context.eof = false;
     context.errmsg[0] = '\0';
     context.igraph_errno = IGRAPH_SUCCESS;
 


### PR DESCRIPTION
Mode switching wasn't functioning properly. Now we accept that vertex/edge property keywords are explicitly allowed and recognized everywhere in their respective sections, and do not attempt to prevent treating them as ALNUM. There is a slight mitigation using flex start conditions: now vertex property keywords are only recognized in the `*vertices` section (everywhere within that section!), and similar for edge property keywords.

See #2400 for more explanation.

This PR _may_ change how some files are handled.