### PR TITLE
fix: propagate -DIGRAPH_STATIC usage requirement

### DIFF
--- a/etc/cmake/benchmark_helpers.cmake
+++ b/etc/cmake/benchmark_helpers.cmake
@@ -8,11 +8,6 @@ function(add_benchmark NAME NAMESPACE)
   add_dependencies(build_benchmarks ${TARGET_NAME})
   target_link_libraries(${TARGET_NAME} PRIVATE igraph)
 
-  if (NOT BUILD_SHARED_LIBS)
-    # Add a compiler definition required to compile igraph in static mode
-    target_compile_definitions(${TARGET_NAME} PRIVATE IGRAPH_STATIC)
-  endif()
-
   # Some benchmarks include plfit_sampling.h from plfit. The following ensures
   # that the correct version is included, depending on whether plfit is vendored
   target_include_directories(

--- a/etc/cmake/test_helpers.cmake
+++ b/etc/cmake/test_helpers.cmake
@@ -19,11 +19,6 @@ function(add_legacy_test FOLDER NAME NAMESPACE)
   endif()
   target_link_libraries(${TARGET_NAME} PRIVATE igraph)
 
-  if (NOT BUILD_SHARED_LIBS)
-    # Add a compiler definition required to compile igraph in static mode
-    target_compile_definitions(${TARGET_NAME} PRIVATE IGRAPH_STATIC)
-  endif()
-
   # Some tests depend on internal igraph headers so we also have to add src/
   # to the include path even though it's not part of the public API
   target_include_directories(

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -409,7 +409,7 @@ target_link_libraries(
 )
 
 if (NOT BUILD_SHARED_LIBS)
-  target_compile_definitions(igraph PRIVATE IGRAPH_STATIC)
+  target_compile_definitions(igraph PUBLIC IGRAPH_STATIC)
 else()
   target_compile_definitions(igraph PRIVATE igraph_EXPORTS)
 endif()


### PR DESCRIPTION
This should ensure that CMake-based projects that use igraph through ` target_link_libraries()` automatically have `-DIGRAPH_STATIC` if igraph was compiled into a static lib. Thus we can remove the explicit definition of this symbols from tests/benchmarks.

I don't quite remember _if_ we still need this and _why_ we need this, so asking for a review.