### PR TITLE
Fix docs and behaviour of min/max functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
  - Resolved "ignoring duplicate libraries" warning when building tests with Xcode 15 on macOS.
  - Fixed the handling of duplicate vertex IDs in `igraph_induced_subgraph()`.
+ - `igraph_vector_which_min()` and `igraph_vector_which_max()` no longer allow zero-length input, which makes them consistent with other similar functions, and was the originally intended behaviour. Passing zero-length input is invalid use and currently triggers an assertion failure.
 
 ### Other
 

--- a/src/core/matrix.pmt
+++ b/src/core/matrix.pmt
@@ -1403,6 +1403,7 @@ igraph_error_t FUNCTION(igraph_matrix, div_elements)(TYPE(igraph_matrix) *m1,
  * \brief Smallest element of a matrix.
  *
  * The matrix must be non-empty.
+ *
  * \param m The input matrix.
  * \return The smallest element of \p m, or NaN if any element is NaN.
  *

--- a/src/core/vector.pmt
+++ b/src/core/vector.pmt
@@ -1320,9 +1320,8 @@ void FUNCTION(igraph_vector, resize_min)(TYPE(igraph_vector)*v) {
  * \function igraph_vector_max
  * \brief Largest element of a vector.
  *
- * </para><para>
- * If the size of the vector is zero, an arbitrary number is
- * returned.
+ * The vector must not be empty.
+ *
  * \param v The vector object.
  * \return The maximum element of \p v, or NaN if any element is NaN.
  *
@@ -1358,11 +1357,11 @@ BASE FUNCTION(igraph_vector, max)(const TYPE(igraph_vector)* v) {
  * \function igraph_vector_which_max
  * \brief Gives the index of the maximum element of the vector.
  *
- * </para><para>
  * If the size of the vector is zero, -1 is returned. If the largest
  * element is not unique, then the index of the first is returned.
  * If the vector contains NaN values, the index of the first NaN value
  * is returned.
+ *
  * \param v The vector object.
  * \return The index of the first maximum element.
  *
@@ -1401,7 +1400,8 @@ igraph_integer_t FUNCTION(igraph_vector, which_max)(const TYPE(igraph_vector)* v
  * \function igraph_vector_min
  * \brief Smallest element of a vector.
  *
- * The vector must be non-empty.
+ * The vector must not be empty.
+ *
  * \param v The input vector.
  * \return The smallest element of \p v, or NaN if any element is NaN.
  *
@@ -1438,10 +1438,10 @@ BASE FUNCTION(igraph_vector, min)(const TYPE(igraph_vector)* v) {
  * \function igraph_vector_which_min
  * \brief Index of the smallest element.
  *
- * </para><para>
- * The vector must be non-empty. If the smallest element is not unique,
- * then the index of the first is returned. If the vector contains NaN
- * values, the index of the first NaN value is returned.
+ * If the size of the vector is zero, -1 is returned. If the smallest element
+ * is not unique, then the index of the first is returned. If the vector
+ * contains NaN values, the index of the first NaN value is returned.
+ *
  * \param v The input vector.
  * \return Index of the smallest element.
  *

--- a/src/core/vector.pmt
+++ b/src/core/vector.pmt
@@ -1357,7 +1357,7 @@ BASE FUNCTION(igraph_vector, max)(const TYPE(igraph_vector)* v) {
  * \function igraph_vector_which_max
  * \brief Gives the index of the maximum element of the vector.
  *
- * If the size of the vector is zero, -1 is returned. If the largest
+ * The vector must not be empty. If the largest
  * element is not unique, then the index of the first is returned.
  * If the vector contains NaN values, the index of the first NaN value
  * is returned.
@@ -1368,31 +1368,28 @@ BASE FUNCTION(igraph_vector, max)(const TYPE(igraph_vector)* v) {
  * Time complexity: O(n), n is the size of the vector.
  */
 igraph_integer_t FUNCTION(igraph_vector, which_max)(const TYPE(igraph_vector)* v) {
-    if (!FUNCTION(igraph_vector, empty)(v)) {
-        BASE *max;
-        BASE *ptr;
-        IGRAPH_ASSERT(v != NULL);
-        IGRAPH_ASSERT(v->stor_begin != NULL);
-        IGRAPH_ASSERT(v->stor_begin != v->end);
-        max = ptr = v->stor_begin;
+    BASE *max;
+    BASE *ptr;
+    IGRAPH_ASSERT(v != NULL);
+    IGRAPH_ASSERT(v->stor_begin != NULL);
+    IGRAPH_ASSERT(v->stor_begin != v->end);
+    max = ptr = v->stor_begin;
 #if defined(BASE_IGRAPH_REAL)
-        if (isnan(*ptr)) { return ptr - v->stor_begin; } /* Result is NaN */
+    if (isnan(*ptr)) { return ptr - v->stor_begin; } /* Result is NaN */
+#endif
+    ptr++;
+    while (ptr < v->end) {
+        if (*ptr > *max) {
+            max = ptr;
+        }
+#if defined(BASE_IGRAPH_REAL)
+        else if (isnan(*ptr)) {
+            return ptr - v->stor_begin; /* Result is NaN */
+        }
 #endif
         ptr++;
-        while (ptr < v->end) {
-            if (*ptr > *max) {
-                max = ptr;
-            }
-#if defined(BASE_IGRAPH_REAL)
-            else if (isnan(*ptr)) {
-                return ptr - v->stor_begin; /* Result is NaN */
-            }
-#endif
-            ptr++;
-        }
-        return max - v->stor_begin;
     }
-    return -1;
+    return max - v->stor_begin;
 }
 
 /**
@@ -1438,7 +1435,7 @@ BASE FUNCTION(igraph_vector, min)(const TYPE(igraph_vector)* v) {
  * \function igraph_vector_which_min
  * \brief Index of the smallest element.
  *
- * If the size of the vector is zero, -1 is returned. If the smallest element
+ * The vector must not be empty. If the smallest element
  * is not unique, then the index of the first is returned. If the vector
  * contains NaN values, the index of the first NaN value is returned.
  *
@@ -1448,31 +1445,28 @@ BASE FUNCTION(igraph_vector, min)(const TYPE(igraph_vector)* v) {
  * Time complexity: O(n), the number of elements.
  */
 igraph_integer_t FUNCTION(igraph_vector, which_min)(const TYPE(igraph_vector)* v) {
-    if (!FUNCTION(igraph_vector, empty)(v)) {
-        BASE *min;
-        BASE *ptr;
-        IGRAPH_ASSERT(v != NULL);
-        IGRAPH_ASSERT(v->stor_begin != NULL);
-        IGRAPH_ASSERT(v->stor_begin != v->end);
-        min = ptr = v->stor_begin;
+    BASE *min;
+    BASE *ptr;
+    IGRAPH_ASSERT(v != NULL);
+    IGRAPH_ASSERT(v->stor_begin != NULL);
+    IGRAPH_ASSERT(v->stor_begin != v->end);
+    min = ptr = v->stor_begin;
 #if defined(BASE_IGRAPH_REAL)
-        if (isnan(*ptr)) { return ptr - v->stor_begin; } /* Result is NaN */
+    if (isnan(*ptr)) { return ptr - v->stor_begin; } /* Result is NaN */
+#endif
+    ptr++;
+    while (ptr < v->end) {
+        if (*ptr < *min) {
+            min = ptr;
+        }
+#if defined(BASE_IGRAPH_REAL)
+        else if (isnan(*ptr)) {
+            return ptr - v->stor_begin; /* Result is NaN */
+        }
 #endif
         ptr++;
-        while (ptr < v->end) {
-            if (*ptr < *min) {
-                min = ptr;
-            }
-#if defined(BASE_IGRAPH_REAL)
-            else if (isnan(*ptr)) {
-                return ptr - v->stor_begin; /* Result is NaN */
-            }
-#endif
-            ptr++;
-        }
-        return min - v->stor_begin;
     }
-    return -1;
+    return min - v->stor_begin;
 }
 
 #ifdef __clang__


### PR DESCRIPTION
The smallest/largest element of an empty vector/matrix is not defined.

As I recall, out decision was that vector min/max functions should not be legal to call with empty structures.  This is the assumption I've been following when using these functions.

But looking at the docs, this was not explained well in all cases. I fixed this here.

Looking at the code, this is not always what the functions do. In particular, this is not what `vector_which_min` and `vector_which_max` do. They return `-1` instead. However, `vector_which_minmax` assumes that the vector is not empty, which is inconsistent with the other two.

`matrix_which_min/max/minmax` also seem to assume that the matrix is not empty, even though it calls `vector_which_min/max/minmax`. The return value is nonsensical otherwise.

Since these functions are not exposed to high-level languages, I propose that we forbid empty structures, and put in `IGRAPH_ASSERT`s where necessary.  Reasoning: when C code misuses these functions (due to an oversight), it's better to get an assertion failure which alerts the programmer to their error than to get a bad result.