### PR TITLE
fix: pass through NaN values when building graph from weighted adjacency matrix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
  - `igraph_community_label_propagation()` is now interruptible.
  - `igraph_is_bipartite()` would on rare occasions return invalid results when the cache was employed.
+ - `igraph_weighted_adjacency()` correctly passes through NaN values with `IGRAPH_ADJ_MAX`, and correctly recognized symmetric adjacency matrices containing NaN values with `IGRAPH_ADJ_UNDIRECTED`.
 
 ### Other
 

--- a/src/constructors/adjacency.c
+++ b/src/constructors/adjacency.c
@@ -512,7 +512,7 @@ static igraph_error_t igraph_i_weighted_adjacency_max(
         for (j = i + 1; j < no_of_nodes; j++) {
             M1 = MATRIX(*adjmatrix, i, j);
             M2 = MATRIX(*adjmatrix, j, i);
-            if (M1 < M2) {
+            if (M1 < M2 || isnan(M2)) {
                 M1 = M2;
             }
             if (M1 != 0.0) {
@@ -531,11 +531,21 @@ static igraph_error_t igraph_i_weighted_adjacency_undirected(
     igraph_vector_t *weights,
     igraph_loops_t loops
 ) {
-    if (!igraph_matrix_is_symmetric(adjmatrix)) {
-        IGRAPH_ERROR(
-            "Adjacency matrix should be symmetric to produce an undirected graph.",
-            IGRAPH_EINVAL
-        );
+    /* We do not use igraph_matrix_is_symmetric() for this check, as we need to
+     * allow symmetric matrices with NaN values. igraph_matrix_is_symmetric()
+     * returns false for these as NaN != NaN. */
+    igraph_integer_t n = igraph_matrix_nrow(adjmatrix);
+    for (igraph_integer_t i=0; i < n; i++) {
+        for (igraph_integer_t j=0; j < i; j++) {
+            igraph_real_t a1 = MATRIX(*adjmatrix, i, j);
+            igraph_real_t a2 = MATRIX(*adjmatrix, j, i);
+            if (a1 != a2 && ! (isnan(a1) && isnan(a2))) {
+                IGRAPH_ERROR(
+                    "Adjacency matrix should be symmetric to produce an undirected graph.",
+                    IGRAPH_EINVAL
+                    );
+            }
+        }
     }
     return igraph_i_weighted_adjacency_max(adjmatrix, edges, weights, loops);
 }
@@ -639,7 +649,7 @@ static igraph_error_t igraph_i_weighted_adjacency_min(
         for (j = i + 1; j < no_of_nodes; j++) {
             M1 = MATRIX(*adjmatrix, i, j);
             M2 = MATRIX(*adjmatrix, j, i);
-            if (M1 > M2) {
+            if (M1 > M2 || isnan(M2)) {
                 M1 = M2;
             }
             if (M1 != 0.0) {

--- a/src/constructors/adjacency.c
+++ b/src/constructors/adjacency.c
@@ -322,7 +322,7 @@ igraph_error_t igraph_adjacency(
 
     /* Some checks */
     if (igraph_matrix_nrow(adjmatrix) != igraph_matrix_ncol(adjmatrix)) {
-        IGRAPH_ERROR("Adjacency matrix is non-square.", IGRAPH_NONSQUARE);
+        IGRAPH_ERROR("Adjacency matrices must be square.", IGRAPH_NONSQUARE);
     }
 
     if (no_of_nodes != 0 && igraph_matrix_min(adjmatrix) < 0) {
@@ -747,7 +747,7 @@ igraph_error_t igraph_weighted_adjacency(
 
     /* Some checks */
     if (igraph_matrix_nrow(adjmatrix) != igraph_matrix_ncol(adjmatrix)) {
-        IGRAPH_ERROR("Non-square matrix", IGRAPH_NONSQUARE);
+        IGRAPH_ERROR("Adjacency matrices must be square.", IGRAPH_NONSQUARE);
     }
 
     IGRAPH_VECTOR_INT_INIT_FINALLY(&edges, 0);

--- a/tests/unit/igraph_weighted_adjacency.c
+++ b/tests/unit/igraph_weighted_adjacency.c
@@ -227,6 +227,86 @@ int main(void) {
     VERIFY_FINALLY_STACK();
 
     {
+        igraph_real_t elem[] = { 0,          1.5,              IGRAPH_INFINITY,
+                                 IGRAPH_NAN, -IGRAPH_INFINITY, -5.2,
+                                 IGRAPH_NAN, 0,                IGRAPH_NAN };
+
+        igraph_real_t elem_sym[] = { 0,               IGRAPH_NAN,       IGRAPH_INFINITY,
+                                     IGRAPH_NAN,      -IGRAPH_INFINITY, 0,
+                                     IGRAPH_INFINITY, 0,                IGRAPH_NAN };
+
+        igraph_matrix_t am;
+        igraph_vector_t weights;
+        igraph_t graph;
+
+        printf("\nTesting NaN and Inf passthrough\n");
+
+        igraph_vector_init(&weights, 0);
+
+        matrix_init_real_row_major(&am, 3, 3, elem);
+
+        printf("\nIGRAPH_ADJ_DIRECTED\n");
+        igraph_weighted_adjacency(&graph, &am, IGRAPH_ADJ_DIRECTED, &weights, IGRAPH_LOOPS_TWICE);
+        print_graph(&graph);
+        print_vector(&weights);
+        igraph_destroy(&graph);
+
+        printf("\nIGRAPH_ADJ_MAX\n");
+        igraph_weighted_adjacency(&graph, &am, IGRAPH_ADJ_MAX, &weights, IGRAPH_LOOPS_TWICE);
+        print_graph(&graph);
+        print_vector(&weights);
+        igraph_destroy(&graph);
+
+        printf("\nIGRAPH_ADJ_MIN\n");
+        igraph_weighted_adjacency(&graph, &am, IGRAPH_ADJ_MIN, &weights, IGRAPH_LOOPS_TWICE);
+        print_graph(&graph);
+        print_vector(&weights);
+        igraph_destroy(&graph);
+
+        printf("\nIGRAPH_ADJ_LOWER\n");
+        igraph_weighted_adjacency(&graph, &am, IGRAPH_ADJ_LOWER, &weights, IGRAPH_LOOPS_TWICE);
+        print_graph(&graph);
+        print_vector(&weights);
+        igraph_destroy(&graph);
+
+        printf("\nIGRAPH_ADJ_UPPER\n");
+        igraph_weighted_adjacency(&graph, &am, IGRAPH_ADJ_UPPER, &weights, IGRAPH_LOOPS_TWICE);
+        print_graph(&graph);
+        print_vector(&weights);
+        igraph_destroy(&graph);
+
+        printf("\nIGRAPH_ADJ_PLUS\n");
+        igraph_weighted_adjacency(&graph, &am, IGRAPH_ADJ_PLUS, &weights, IGRAPH_LOOPS_TWICE);
+        print_graph(&graph);
+        print_vector(&weights);
+        igraph_destroy(&graph);
+
+        /* Must detect that the matrix is not symmetric and throw an error. */
+        CHECK_ERROR(
+            igraph_weighted_adjacency(&graph, &am, IGRAPH_ADJ_UNDIRECTED, &weights, IGRAPH_LOOPS_TWICE),
+            IGRAPH_EINVAL);
+
+        igraph_matrix_destroy(&am);
+
+        matrix_init_real_row_major(&am, 3, 3, elem_sym);
+
+        /* Must detect that the matrix is symmetric (desite the NaNs) and succeed. */
+        printf("\nIGRAPH_ADJ_UNDIRECTED (symmetric)\n");
+        igraph_weighted_adjacency(&graph, &am, IGRAPH_ADJ_UNDIRECTED, &weights, IGRAPH_LOOPS_TWICE);
+        print_graph(&graph);
+        print_vector(&weights);
+        igraph_destroy(&graph);
+
+        igraph_matrix_destroy(&am);
+
+        igraph_vector_destroy(&weights);
+
+        printf("\n");
+    }
+
+    VERIFY_FINALLY_STACK();
+
+    {
         printf("Check handling of non-square matrix error.\n");
         igraph_real_t e[] = {1, 2, 0};
         igraph_matrix_view(&mat, e, 1, 3);

--- a/tests/unit/igraph_weighted_adjacency.out
+++ b/tests/unit/igraph_weighted_adjacency.out
@@ -291,6 +291,92 @@ edges: {
 2 2: 2
 }
 
+
+Testing NaN and Inf passthrough
+
+IGRAPH_ADJ_DIRECTED
+directed: true
+vcount: 3
+edges: {
+0 1
+0 2
+1 0
+1 1
+1 2
+2 0
+2 2
+}
+( 1.5 Inf NaN -Inf -5.2 NaN NaN )
+
+IGRAPH_ADJ_MAX
+directed: false
+vcount: 3
+edges: {
+1 0
+2 0
+1 1
+2 2
+}
+( NaN NaN -Inf NaN )
+
+IGRAPH_ADJ_MIN
+directed: false
+vcount: 3
+edges: {
+1 0
+2 0
+1 1
+2 1
+2 2
+}
+( NaN NaN -Inf -5.2 NaN )
+
+IGRAPH_ADJ_LOWER
+directed: false
+vcount: 3
+edges: {
+1 0
+1 1
+2 0
+2 2
+}
+( NaN -Inf NaN NaN )
+
+IGRAPH_ADJ_UPPER
+directed: false
+vcount: 3
+edges: {
+1 0
+2 0
+1 1
+2 1
+2 2
+}
+( 1.5 Inf -Inf -5.2 NaN )
+
+IGRAPH_ADJ_PLUS
+directed: false
+vcount: 3
+edges: {
+1 0
+2 0
+1 1
+2 1
+2 2
+}
+( NaN NaN -Inf -5.2 NaN )
+
+IGRAPH_ADJ_UNDIRECTED (symmetric)
+directed: false
+vcount: 3
+edges: {
+1 0
+2 0
+1 1
+2 2
+}
+( NaN Inf -Inf NaN )
+
 Check handling of non-square matrix error.
 Check handling of invalid adjacency mode.
 Check error for 0x1 matrix.


### PR DESCRIPTION
Ref #2413 

NaN values are now passed through when building a _weighted_ graph  from an adjacency matrix.

This still needs tests, but I'd like a review now @ntamas.

There were two issues that needed to be addressed:

 - max(NaN, anything) should give NaN with the "max" method
 - Adjacency matrices with NaN in symmetric positions should be treated as symmetric. `igraph_matrix_is_symmetric()` doesn't give `true` for these because `NaN != NaN`. A clean way to change the behaviour of `igraph_matrix_is_symmetric()` would be to [define the `EQ` macro](https://github.com/igraph/igraph/blob/master/src/core/matrix.pmt#L1579) so that it treats NaN as equal to NaN, but this would have further implications which are undesirable. In almost all contexts, we want NaN != NaN. Therefore I re-implemented the symmetry check.

It is interesting to note that some systems, like MATLAB, consider any matrix with NaNs to be non-symmetric. R, however, does accept them as symmetric.

```
> isSymmetric(m)
[1] TRUE
> m<-cbind(c(0,NaN),c(NaN,0))
> isSymmetric(m)
[1] TRUE
> NA==NA
[1] NA
> NaN==NaN
[1] NA
```

It seems safer to me to not change `igraph_matrix_is_symmetric()` in igraph and let it continue rejecting NaNs. This is actually useful in numerical contexts.
