### PR TITLE
fix: pass correct integer type to vararg functions

### DIFF
--- a/examples/simple/igraph_union.c
+++ b/examples/simple/igraph_union.c
@@ -103,7 +103,7 @@ int main(void) {
     igraph_vector_ptr_init(&glist, 10);
     for (i = 0; i < igraph_vector_ptr_size(&glist); i++) {
         VECTOR(glist)[i] = calloc(1, sizeof(igraph_t));
-        igraph_vector_int_init_int_end(&v, -1, i, i + 1, 1, 0, -1);
+        igraph_vector_int_init_int_end(&v, -1, (int) i, (int) i + 1, 1, 0, -1);
         igraph_create(VECTOR(glist)[i], &v, 0, IGRAPH_DIRECTED);
         igraph_vector_int_destroy(&v);
     }
@@ -123,7 +123,7 @@ int main(void) {
     igraph_vector_ptr_init(&glist, 10);
     for (i = 0; i < igraph_vector_ptr_size(&glist); i++) {
         VECTOR(glist)[i] = calloc(1, sizeof(igraph_t));
-        igraph_vector_int_init_int_end(&v, -1, i, i + 1, 1, 0, -1);
+        igraph_vector_int_init_int_end(&v, -1, (int) i, (int) i + 1, 1, 0, -1);
         igraph_create(VECTOR(glist)[i], &v, 0, IGRAPH_UNDIRECTED);
         igraph_vector_int_destroy(&v);
     }

--- a/src/core/matrix.pmt
+++ b/src/core/matrix.pmt
@@ -1862,9 +1862,9 @@ igraph_error_t FUNCTION(igraph_matrix, fprint)(const TYPE(igraph_matrix) *m, FIL
                 fputc(' ', file);
             }
 #ifdef FPRINTFUNC_ALIGNED
-            FPRINTFUNC_ALIGNED(file, VECTOR(column_width)[j], MATRIX(*m, i, j));
+            FPRINTFUNC_ALIGNED(file, (int) VECTOR(column_width)[j], MATRIX(*m, i, j));
 #else
-            fprintf(file, format, VECTOR(column_width)[j], MATRIX(*m, i, j));
+            fprintf(file, format, (int) VECTOR(column_width)[j], MATRIX(*m, i, j));
 #endif
         }
         fprintf(file, "\n");


### PR DESCRIPTION
When building igraph with IGRAPH_INTEGER_SIZE=64 on i686, I noticed that some tests fail with incorrect integer values reported. After a lot of debugging, this turned out to be because some variadic functions expect the arguments to be 'int' (32 bit), but igraph_integer_t (64 bit) was passed as argument.