### PR TITLE
Add: Dispersion calculation between pairs of nodes in graphs

### DIFF
--- a/include/igraph.h
+++ b/include/igraph.h
@@ -81,6 +81,7 @@
 #include "igraph_mixing.h"
 #include "igraph_separators.h"
 #include "igraph_cohesive_blocks.h"
+#include "igraph_dispersion.h"
 #include "igraph_eigen.h"
 #include "igraph_hrg.h"
 #include "igraph_threading.h"

--- a/include/igraph_dispersion.h
+++ b/include/igraph_dispersion.h
@@ -1,0 +1,40 @@
+/* -*- mode: C -*-  */
+/*
+   IGraph library.
+   Copyright (C) 2010-2012  Gabor Csardi <csardi.gabor@gmail.com>
+   334 Harvard street, Cambridge, MA 02139 USA
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+   02110-1301 USA
+
+*/
+
+#ifndef IGRAPH_DISPERSION_H
+#define IGRAPH_DISPERSION_H
+
+#include "igraph_decls.h"
+#include "igraph_datatype.h"
+#include "igraph_error.h"
+#include "igraph_vector.h"
+#include "igraph_vector_list.h"
+
+__BEGIN_DECLS
+
+IGRAPH_EXPORT igraph_error_t igraph_dispersion(const igraph_t *graph_u, igraph_integer_t u, igraph_integer_t v);
+igraph_error_t intersection(igraph_vector_int_t u_nbrs, igraph_vector_int_t v_nbrs, igraph_vector_int_t *u_v_nbrs);
+
+__END_DECLS
+
+#endif

--- a/interfaces/functions.yaml
+++ b/interfaces/functions.yaml
@@ -2180,6 +2180,11 @@ igraph_cohesive_blocks:
         OUT GRAPH blockTree
     DEPS: blocks ON graph
 
+igraph_dispersion:
+    PARAMS: |-
+        GRAPH graph, U source node, V target node
+    DEPS: disperson value ON pairwise vertices
+
 #######################################
 # K-Cores
 #######################################

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -143,6 +143,7 @@ add_library(
   centrality/eigenvector.c
   centrality/hub_authority.c
   centrality/pagerank.c
+  centrality/dispersion.c
   centrality/truss.cpp
   centrality/prpack.cpp
 

--- a/src/centrality/dispersion.c
+++ b/src/centrality/dispersion.c
@@ -1,0 +1,80 @@
+#include "igraph_dispersion.h"
+
+#include "igraph_adjlist.h"
+#include "igraph_interface.h"
+#include "igraph_progress.h"
+#include "igraph_dqueue.h"
+
+#include "core/indheap.h"
+#include "core/interruption.h"
+
+
+igraph_error_t igraph_dispersion(const igraph_t *graph_u, igraph_integer_t u, igraph_integer_t v) {
+    // Get the neighbors of u
+    igraph_vector_int_t u_nbrs;
+    igraph_vector_int_init(&u_nbrs, 0);
+    igraph_neighbors(graph_u, &u_nbrs, u, IGRAPH_ALL);
+
+    // Get the neighbors of v
+    igraph_vector_int_t v_nbrs;
+    igraph_vector_int_init(&v_nbrs, 0);
+    igraph_neighbors(graph_u, &v_nbrs, v, IGRAPH_ALL);
+
+    // Get the common neighbors of u and v
+    igraph_vector_int_t u_v_nbrs;
+    igraph_vector_int_init(&u_v_nbrs, 0);
+    intersection(u_nbrs, v_nbrs, &u_v_nbrs);
+
+    // Traverse all possible ties of connections that u and b share
+    igraph_integer_t i, j, k, s, t, neighbors_size = igraph_vector_int_size(&u_v_nbrs);
+    igraph_integer_t dispersion_val = 0;
+    for (i = 0; i < neighbors_size - 1; i++) {
+        // Get neighbor of s that are in G_u
+        s = VECTOR(u_v_nbrs)[i];
+        igraph_vector_int_t s_nbrs;
+        igraph_vector_int_init(&s_nbrs, 0);
+        igraph_neighbors(graph_u, &s_nbrs, s, IGRAPH_ALL);
+        igraph_vector_int_t u_s_nbrs;
+        igraph_vector_int_init(&u_s_nbrs, 0);
+        intersection(u_nbrs, s_nbrs, &u_s_nbrs);
+        for (j = i + 1; j < neighbors_size; j++) {
+            t = VECTOR(u_v_nbrs)[j];
+            // Determine if s and t are directly connected
+            if (igraph_vector_int_contains(&u_s_nbrs, t)) {
+                continue;
+            }
+            // Determine if the path from s to t is 2
+            igraph_vector_int_t t_nbrs;
+            igraph_vector_int_init(&t_nbrs, 0);
+            igraph_neighbors(graph_u, &t_nbrs, t, IGRAPH_ALL);
+            // Determine if s and t share a connection
+            for (k = 0; k < igraph_vector_int_size(&u_s_nbrs); k++) {
+                // Skip u and v
+                if (VECTOR(u_s_nbrs)[k] == u || VECTOR(u_s_nbrs)[k] == v) continue;
+                if (igraph_vector_int_contains(&t_nbrs, VECTOR(u_s_nbrs)[k])) {
+                    break;
+                }
+            }
+            if (k == igraph_vector_int_size(&u_s_nbrs)) dispersion_val++;
+        }
+    }
+    return dispersion_val;
+}
+
+igraph_error_t intersection(igraph_vector_int_t u_nbrs, igraph_vector_int_t v_nbrs, igraph_vector_int_t *u_v_nbrs) {
+    igraph_integer_t u_nbrs_num, v_nbrs_num, i, j, pos = 0;
+    u_nbrs_num = igraph_vector_int_size(&u_nbrs);
+    v_nbrs_num = igraph_vector_int_size(&v_nbrs);
+    IGRAPH_CHECK(igraph_vector_int_resize(u_v_nbrs, u_nbrs_num));
+    for (i = 0; i < u_nbrs_num; i++) {
+        for (j = 0; j < v_nbrs_num; j++) {
+            if (VECTOR(u_nbrs)[i] == VECTOR(v_nbrs)[j]) {
+                VECTOR(*u_v_nbrs)[pos++] = VECTOR(u_nbrs)[i];
+            }
+        }
+    }
+    IGRAPH_CHECK(igraph_vector_int_resize(u_v_nbrs, pos));
+    return 0;
+}
+
+

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -311,6 +311,7 @@ add_legacy_tests(
   igraph_eccentricity_dijkstra
   igraph_edge_betweenness
   igraph_edge_betweenness_subset
+  igraph_dispersion
   igraph_feedback_arc_set_undirected
   igraph_get_all_simple_paths
   igraph_get_all_shortest_paths_dijkstra

--- a/tests/unit/igraph_dispersion.c
+++ b/tests/unit/igraph_dispersion.c
@@ -1,0 +1,31 @@
+#include <igraph.h>
+#include "test_utilities.h"
+
+
+int main(void) {
+
+    igraph_t g;
+
+    printf("The graph from for dispersion test:\n");
+    igraph_small(&g, 12, IGRAPH_UNDIRECTED,
+                 0, 1, 0, 2,
+                 1, 2, 1, 3, 1, 4, 1, 5,
+                 2, 3, 2, 5, 2, 7,
+                 3, 5,
+                 4, 5,
+                 5, 7,
+                 7, 9, 7, 10,
+                 8, 9, 8, 10,
+                 9, 10,
+                 11, 0, 11, 1, 11, 2, 11, 3, 11, 4, 11, 5, 11, 6, 11, 7, 11, 8, 11, 9, 11, 10,
+                 -1);
+
+    IGRAPH_ASSERT(igraph_dispersion(&g, 11, 7) == 4);
+    IGRAPH_ASSERT(igraph_dispersion(&g, 11, 1) == 1);
+
+    igraph_destroy(&g);
+
+    VERIFY_FINALLY_STACK();
+
+    return 0;
+}


### PR DESCRIPTION
Original issue: Add dispersion calculation between pairs of nodes in graphs #2430

This PR is a fairly straightforward implementation of Dispersion (calculation between pairs of nodes in graphs), following what is implemented in Python Networkx (https://networkx.org/documentation/stable/reference/algorithms/generated/networkx.algorithms.centrality.dispersion.html). However, I only implemented the case where both u and v nodes are specified. I did not implement for when only u or neither u or v is specified. Additionally, I did not implement the normalization in this PR as I wanted to keep it simple. (These were all implemented in the Networkx implementation).

I tested by checking that this implementation will return the same results for the graph shown in [1] as the unit tests in the Networkx implementation. I also tested each of the function and components directly with the graph shown in [1].

This is my first time submitting a PR to igraph so please let me know if I need to change or add anything in this PR.

[1] Romantic Partnerships and the Dispersion of Social Ties:
        A Network Analysis of Relationship Status on Facebook.
        Lars Backstrom, Jon Kleinberg.
        https://arxiv.org/pdf/1310.6753v1.pdf