### PR TITLE
Simplify vertex_disjoint_paths() and add more tests for it

### DIFF
--- a/src/flow/flow.c
+++ b/src/flow/flow.c
@@ -2287,7 +2287,8 @@ igraph_error_t igraph_edge_disjoint_paths(const igraph_t *graph, igraph_integer_
     igraph_real_t flow;
 
     if (source == target) {
-        IGRAPH_ERROR("Not implemented when the source and target are the same.", IGRAPH_UNIMPLEMENTED);
+        IGRAPH_ERROR("Not implemented when the source and target are the same.",
+                     IGRAPH_UNIMPLEMENTED);
     }
 
     IGRAPH_CHECK(igraph_maxflow_value(graph, &flow, source, target, 0, 0));

--- a/tests/unit/igraph_edge_disjoint_paths.c
+++ b/tests/unit/igraph_edge_disjoint_paths.c
@@ -26,13 +26,26 @@ int main(void) {
     igraph_integer_t value;
 
     igraph_small(&g, 6, IGRAPH_DIRECTED,
-                 0, 1, 0, 2, 1, 2, 1, 3, 2, 4, 3, 4, 3, 5, 4, 5, -1);
+                 0,1, 0,2, 1,2, 1,3, 2,4, 3,4, 3,5, 4,5, 3,3, -1);
 
     igraph_edge_disjoint_paths(&g, &value, 0, 5);
+    IGRAPH_ASSERT(value == 2);
+
+    igraph_edge_disjoint_paths(&g, &value, 0, 3);
+    IGRAPH_ASSERT(value == 1);
+
+    igraph_edge_disjoint_paths(&g, &value, 3, 0);
+    IGRAPH_ASSERT(value == 0);
+
+    igraph_edge_disjoint_paths(&g, &value, 3, 5);
+    IGRAPH_ASSERT(value == 2);
+
+    igraph_to_undirected(&g, IGRAPH_TO_UNDIRECTED_EACH, NULL);
+
+    igraph_edge_disjoint_paths(&g, &value, 4, 3);
+    IGRAPH_ASSERT(value == 3);
 
     igraph_destroy(&g);
-
-    IGRAPH_ASSERT(value == 2);
 
     VERIFY_FINALLY_STACK();
     return 0;

--- a/tests/unit/igraph_vertex_disjoint_paths.c
+++ b/tests/unit/igraph_vertex_disjoint_paths.c
@@ -26,13 +26,27 @@ int main(void) {
     igraph_integer_t value;
 
     igraph_small(&g, 7, IGRAPH_DIRECTED,
-                 0, 1, 0, 2, 1, 2, 1, 3, 2, 4, 3, 4, 3, 5, 4, 5, 0, 5, -1);
+                 0,1, 0,2, 1,2, 1,3, 2,4, 3,4, 3,5, 4,5, 0,5, 3,3, 5,2, 1,3, 3,1,
+                 -1);
 
     igraph_vertex_disjoint_paths(&g, &value, 0, 5);
+    IGRAPH_ASSERT(value == 3);
+
+    igraph_vertex_disjoint_paths(&g, &value, 1, 3);
+    IGRAPH_ASSERT(value == 2);
+
+    igraph_vertex_disjoint_paths(&g, &value, 4, 0);
+    IGRAPH_ASSERT(value == 0);
+
+    igraph_to_undirected(&g, IGRAPH_TO_UNDIRECTED_EACH, NULL);
+
+    igraph_vertex_disjoint_paths(&g, &value, 4, 0);
+    IGRAPH_ASSERT(value == 3);
+
+    igraph_vertex_disjoint_paths(&g, &value, 1, 3);
+    IGRAPH_ASSERT(value == 5);
 
     igraph_destroy(&g);
-
-    IGRAPH_ASSERT(value == 3);
 
     VERIFY_FINALLY_STACK();
     return 0;


### PR DESCRIPTION
UPDATE: This PR was changed to merely add tests and simplify code. It no longer adds support for using the same vertex for source and target.

----

As the title says, vertex/edge disjoint path calculations now support the source=target case. In this case we simply count the number of self-loops.

We do not need to merge this for 0.10.8! It's good to think about this carefully, and whether it makes sense to do this at all. An alternative way to think about this is to say that we have already arrived to the destination before traversing any edge, and in fact traversing the self-loop makes this a cycle and not a path. Thus we can return 1, saying that the only path is the "empty path" (similar to how we return an empty path for the shortest path between a vertex and itself).