### PR TITLE
Use correct `arpack_defaults()` default

### DIFF
--- a/interfaces/functions.yaml
+++ b/interfaces/functions.yaml
@@ -647,35 +647,35 @@ igraph_eigenvector_centrality:
         GRAPH graph, OUT VERTEXINDEX vector, OUT REAL value,
         BOOLEAN directed=False, BOOLEAN scale=True,
         EDGEWEIGHTS weights=NULL,
-        INOUT ARPACKOPT options=arpack_defaults
+        INOUT ARPACKOPT options=arpack_defaults()
     DEPS: weights ON graph, vector ON graph
 
 igraph_hub_score:
     PARAMS: |-
         GRAPH graph, OUT VERTEXINDEX vector, OUT REAL value,
         BOOLEAN scale=True, EDGEWEIGHTS weights=NULL,
-        INOUT ARPACKOPT options=arpack_defaults
+        INOUT ARPACKOPT options=arpack_defaults()
     DEPS: weights ON graph, vector ON graph
 
 igraph_authority_score:
     PARAMS: |-
         GRAPH graph, OUT VERTEXINDEX vector, OUT REAL value,
         BOOLEAN scale=True, EDGEWEIGHTS weights=NULL,
-        INOUT ARPACKOPT options=arpack_defaults
+        INOUT ARPACKOPT options=arpack_defaults()
     DEPS: weights ON graph, vector ON graph
 
 igraph_arpack_rssolve:
     # TODO(ntamas): this should probably not be exposed to higher-level
     # interfaces; igraph's goal is not to provide an ARPACK wrapper
     PARAMS: |-
-        ARPACKFUNC fun, EXTRA extra, INOUT ARPACKOPT options=arpack_defaults,
+        ARPACKFUNC fun, EXTRA extra, INOUT ARPACKOPT options=arpack_defaults(),
         INOUT ARPACKSTORAGE storage, OPTIONAL OUT VECTOR values, OPTIONAL OUT MATRIX vectors
 
 igraph_arpack_rnsolve:
     # TODO(ntamas): this should probably not be exposed to higher-level
     # interfaces; igraph's goal is not to provide an ARPACK wrapper
     PARAMS: |-
-        ARPACKFUNC fun, EXTRA extra, INOUT ARPACKOPT options=arpack_defaults,
+        ARPACKFUNC fun, EXTRA extra, INOUT ARPACKOPT options=arpack_defaults(),
         INOUT ARPACKSTORAGE storage, OPTIONAL OUT MATRIX values, OPTIONAL OUT MATRIX vectors
 
 igraph_arpack_unpack_complex:
@@ -765,7 +765,7 @@ igraph_centralization_eigenvector_centrality:
     PARAMS: |-
         GRAPH graph, OUT VECTOR vector, OUT REAL value,
         BOOLEAN directed=False, BOOLEAN scale=True,
-        INOUT ARPACKOPT options=arpack_defaults,
+        INOUT ARPACKOPT options=arpack_defaults(),
         OUT REAL centralization, OUT REAL theoretical_max,
         BOOLEAN normalized=True
 
@@ -1314,7 +1314,7 @@ igraph_community_leading_eigenvector:
         GRAPH graph, EDGEWEIGHTS weights=NULL,
         OUT MATRIX merges, OUT VECTOR membership,
         INTEGER steps=-1,
-        INOUT ARPACKOPT options=arpack_defaults,
+        INOUT ARPACKOPT options=arpack_defaults(),
         OUT REAL modularity, BOOLEAN start=False,
         OUT VECTOR_OR_0 eigenvalues,
         OPTIONAL OUT VECTORLIST eigenvectors,
@@ -1999,7 +1999,7 @@ igraph_adjacency_spectral_embedding:
         EIGENWHICHPOS which=ASE, BOOLEAN scaled=True, OUT MATRIX X,
         OUT MATRIX_OR_0 Y, OUT VECTOR_OR_0 D,
         VECTOR cvec=AsmDefaultCvec,
-        INOUT ARPACKOPT options=igraph.arpack.default
+        INOUT ARPACKOPT options=arpack_defaults()
     DEPS: weights ON graph, cvec ON graph
 
 igraph_laplacian_spectral_embedding:
@@ -2008,7 +2008,7 @@ igraph_laplacian_spectral_embedding:
         EIGENWHICHPOS which=ASE,
         LSETYPE type=Default, BOOLEAN scaled=True, OUT MATRIX X,
         OUT MATRIX_OR_0 Y, OUT VECTOR_OR_0 D,
-        INOUT ARPACKOPT options=igraph.arpack.default
+        INOUT ARPACKOPT options=arpack_defaults()
     DEPS: weights ON graph, type ON graph
 
 #######################################
@@ -2019,7 +2019,7 @@ igraph_eigen_adjacency:
     PARAMS: |-
         GRAPH graph, EIGENALGO algorithm=ARPACK,
         EIGENWHICH which=Default,
-        INOUT ARPACKOPT options=arpack_defaults,
+        INOUT ARPACKOPT options=arpack_defaults(),
         INOUT ARPACKSTORAGE storage, OUT VECTOR values, OUT MATRIX vectors,
         OUT VECTOR_COMPLEX cmplxvalues, OUT MATRIX_COMPLEX cmplxvectors
 


### PR DESCRIPTION
I wonder if the C core is really the right place for this configuration.

This would have to be forward-ported to the main branch too.