### PR TITLE
Work around false-positive GCC warnings when using LTO

### DIFF
--- a/include/igraph_decls.h
+++ b/include/igraph_decls.h
@@ -11,13 +11,6 @@
 /* This is to eliminate gcc warnings about unused parameters */
 #define IGRAPH_UNUSED(x) (void)(x)
 
-/* Include the definition of macros controlling symbol visibility */
-#include "igraph_export.h"
-
-/* Used instead of IGRAPH_EXPORT with functions that need to be tested,
- * but are not part of the public API. */
-#define IGRAPH_PRIVATE_EXPORT IGRAPH_EXPORT
-
 /* The pure function attribute of GCC-compatible compilers indicates
  * that the function does not have side-effects, i.e. it does not
  * modify global memory. This enables additional compiler optimizations
@@ -27,3 +20,29 @@
 #else
 #define IGRAPH_FUNCATTR_PURE
 #endif
+
+/* IGRAPH_ASSUME() provides hints to the compiler about conditions
+ * that are true yet the compiler cannot deduce. Use with great care.
+ * Assuming a condition that is not actually true leads to undefined behaviour. */
+#if defined(__clang__)
+   /* For Clang, see https://clang.llvm.org/docs/LanguageExtensions.html */
+#  if __has_builtin(__builtin_assume)
+#    define IGRAPH_ASSUME(expr) __builtin_assume(expr)
+#  else
+#    define IGRAPH_ASSUME(expr) /* empty */
+#  endif
+#elif defined(__GNUC__) && !defined(__ICC)
+   /* Introduced in GCC 4.5, https://gcc.gnu.org/gcc-4.5/changes.html */
+#  define IGRAPH_ASSUME(expr) do { if (expr) {} else { __builtin_unreachable(); } } while (0)
+#elif defined(_MSC_VER) || defined(__ICC)
+#  define IGRAPH_ASSUME(expr) __assume(expr)
+#else
+#  define IGRAPH_ASSUME(expr) /* empty */
+#endif
+
+/* Include the definition of macros controlling symbol visibility */
+#include "igraph_export.h"
+
+/* Used instead of IGRAPH_EXPORT with functions that need to be tested,
+ * but are not part of the public API. */
+#define IGRAPH_PRIVATE_EXPORT IGRAPH_EXPORT

--- a/src/community/walktrap/walktrap_communities.cpp
+++ b/src/community/walktrap/walktrap_communities.cpp
@@ -396,9 +396,10 @@ Communities::Communities(Graph* graph, int random_walks_length,
     }
 
     H = new Neighbor_heap(G->nb_edges);
+    IGRAPH_ASSUME(G->nb_vertices >= 0); // avoid false-positive GCC warnings
     communities = new Community[2 * G->nb_vertices];
 
-// init the n single vertex communities
+    // init the n single vertex communities
 
     for (int i = 0; i < G->nb_vertices; i++) {
         communities[i].this_community = i;

--- a/src/community/walktrap/walktrap_graph.cpp
+++ b/src/community/walktrap/walktrap_graph.cpp
@@ -149,6 +149,10 @@ igraph_error_t Graph::convert_from_igraph(const igraph_t *graph,
     igraph_integer_t no_of_nodes = igraph_vcount(graph);
     igraph_integer_t no_of_edges = igraph_ecount(graph);
 
+    // Avoid warnings with GCC when compiling with LTO.
+    IGRAPH_ASSUME(no_of_nodes >= 0);
+    IGRAPH_ASSUME(no_of_edges >= 0);
+
     // Refactoring the walktrap code to support larger graphs is pointless
     // as running the algorithm on them would take an impractically long time.
     if (no_of_nodes > INT_MAX || no_of_edges > INT_MAX) {

--- a/src/hrg/hrg_types.cc
+++ b/src/hrg/hrg_types.cc
@@ -144,8 +144,8 @@ int rbtree::returnValue(const int searchKey) const {
 // ******** Return Item Functions ****************************************
 
 int* rbtree::returnArrayOfKeys() const {
-    int* array;
-    array = new int [support];
+    IGRAPH_ASSERT(support >= 0);
+    int* array = new int [support];
     bool flag_go = true;
     int index = 0;
     elementrb *curr;
@@ -2289,6 +2289,7 @@ void dendro::resetDendrograph() {
 graph::graph(const int size, bool predict) :
     predict(predict), n(size), m(0)
 {
+    IGRAPH_ASSERT(n >= 0);
     nodes = new vert [n];
     nodeLink = new edge* [n];
     nodeLinkTail = new edge* [n];
@@ -2557,7 +2558,9 @@ bool graph::setName(const int i, const string &text) {
 interns::interns(const int n) :
     q(n), count(0)
 {
+    IGRAPH_ASSERT(n >= 0);
     edgelist  = new ipair  [q];
+    IGRAPH_ASSUME(q >= 0); // work around false positive GCC warning
     splitlist = new string [q + 1];
     indexLUT  = new int*   [q + 1];
     for (int i = 0; i < (q + 1); i++) {
@@ -2831,8 +2834,8 @@ double splittree::returnValue(const string &searchKey) {
 // a linked list
 
 string* splittree::returnArrayOfKeys() {
-    string* array;
-    array = new string [support];
+    IGRAPH_ASSERT(support >= 0);
+    string* array = new string [support];
     bool flag_go = true;
     int index = 0;
     elementsp *curr;
@@ -3016,6 +3019,7 @@ elementsp* splittree::returnSuccessor(elementsp *z) {
 }
 
 int splittree::returnNodecount() {
+    IGRAPH_ASSERT(support > 0);
     return support;
 }
 


### PR DESCRIPTION
This PR adds an IGRAPH_ASSUME macro and uses it, along with IGRAPH_ASSERT, to work around false-positive GCC warnings when compiling with LTO. See #2309.