### PR TITLE
Fix compiler error with libxml2 2.12 and clang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
  - More robust error handling in HRG code.
  - Fixed infinite loop in `igraph_hrg_sample_many()`.
+ - Compatibility with libxml2 version 2.12 and above.
 
 ### Other
 

--- a/src/io/graphml.c
+++ b/src/io/graphml.c
@@ -344,7 +344,11 @@ static void igraph_i_graphml_parser_state_set_error_from_varargs(
 }
 
 static void igraph_i_graphml_parser_state_set_error_from_xmlerror(
+#if LIBXML_VERSION >= 21200
+    struct igraph_i_graphml_parser_state *state, const xmlError *error
+#else
     struct igraph_i_graphml_parser_state *state, const xmlErrorPtr error
+#endif
 ) {
     const size_t max_error_message_length = 4096;
 
@@ -1530,7 +1534,11 @@ static void igraph_i_libxml_generic_error_handler(void* ctx, const char* msg, ..
     va_end(args);
 }
 
+#if LIBXML_VERSION >= 21200
+static void igraph_i_libxml_structured_error_handler(void* ctx, const xmlError *error) {
+#else
 static void igraph_i_libxml_structured_error_handler(void* ctx, xmlErrorPtr error) {
+#endif
     struct igraph_i_graphml_parser_state* state = (struct igraph_i_graphml_parser_state*) ctx;
     igraph_i_graphml_parser_state_set_error_from_xmlerror(state, error);
 }


### PR DESCRIPTION

    This commit fixes the following compiler error.

    graphml.c:1613:39: error: incompatible function pointer types passing
    'void (*)(void *, xmlErrorPtr)' (aka 'void (*)(void *, struct _xmlError *)') to
    parameter of type 'xmlStructuredErrorFunc' (aka 'void (*)(void *, const struct _xmlError *)')
     [-Wincompatible-function-pointer-types]
     1613 |     xmlSetStructuredErrorFunc(&state, &igraph_i_libxml_structured_error_handler);
          |                                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    libxml2/libxml/xmlerror.h:898:29: note: passing argument to parameter 'handler' here
      898 |                                  xmlStructuredErrorFunc handler);
          |                                                         ^

    According to the libxml2 changelog, this is due to a change in version 2.12:
    https://download.gnome.org/sources/libxml2/2.12/libxml2-2.12.0.news

