### PR TITLE
feat: add IGRAPH_COMPILE_TIME_WARNING()

### DIFF
--- a/include/igraph_error.h
+++ b/include/igraph_error.h
@@ -64,6 +64,16 @@ __BEGIN_DECLS
 #define IGRAPH_FUNCATTR_PRINTFLIKE(string, first)
 #endif
 
+/* IGRAPH_PREPROCESSOR_WARNING(reason) is a macro that evaluates to nothing
+ * but triggers a preprocessor warning with the given message, if the compiler
+ * supports this functionality.
+ */
+#if defined(__GNUC__)
+#define IGRAPH_PREPROCESSOR_WARNING(reason) _Pragma(IGRAPH_I_STRINGIFY(GCC warning reason))
+#else
+#define IGRAPH_PREPROCESSOR_WARNING(reason) /* empty */
+#endif
+
 /**
  * \section error_handling_basics Error handling basics
  *

--- a/include/igraph_strvector.h
+++ b/include/igraph_strvector.h
@@ -58,7 +58,9 @@ typedef struct s_igraph_strvector {
  *
  * \deprecated-by igraph_strvector_get 0.10.9
  */
-#define STR(sv,i) igraph_strvector_get(&sv, i)
+#define STR(sv,i) \
+    (IGRAPH_PREPROCESSOR_WARNING("STR() is deprecated. Use igraph_strvector_get() instead.") \
+     igraph_strvector_get(&sv, i))
 
 #define IGRAPH_STRVECTOR_NULL { 0,0,0 }
 #define IGRAPH_STRVECTOR_INIT_FINALLY(sv, size) \


### PR DESCRIPTION
Be aware that this is a strange macro. It takes effect as soon as it is evaluated. The following still results in a warning:

```
if (false) { IGRAPH_COMPILE_TIME_WARNING("Boo!"); }
```

Furthermore, it can be used in fairly arbitrary places in code. This is valid:

```
int a = IGRAPH_COMPILE_TIME_WARNING("foo") 123;
```

This is not valid (notice the comma, normally used in expressions):

```
int a = IGRAPH_COMPILE_TIME_WARNING("foo"), 123;
```

Something to note in the GCC docs:

https://gcc.gnu.org/onlinedocs/cpp/Pragmas.html

> The standard is unclear on where a _Pragma operator can appear. The preprocessor does not accept it within a preprocessing conditional directive like ‘#if’. To be safe, you are probably best keeping it out of directives other than ‘#define’, and putting it on a line of its own.

My understanding is that this takes effect at preprocessing time, so we might as well call it `IGRAPH_PREPROC_WARNING`.

I tested the `STR` deprecation with GCC 13 and Clang 15 only.