### PR TITLE
Add fast label propagation

### DIFF
--- a/examples/simple/igraph_community_label_propagation.c
+++ b/examples/simple/igraph_community_label_propagation.c
@@ -36,8 +36,8 @@ int main(void) {
     igraph_vector_int_init(&membership, 0);
     igraph_community_label_propagation(
         &graph, &membership, /* mode = */ IGRAPH_ALL,
-        /* weights= */ NULL, /* initial= */ NULL, /* fixed= */ NULL
-        );
+        /* weights= */ NULL, /* initial= */ NULL, /* fixed= */ NULL,
+        IGRAPH_LPA_DOMINANCE);
 
     /* Also calculate the modularity of the partition */
     igraph_modularity(

--- a/include/igraph_community.h
+++ b/include/igraph_community.h
@@ -217,12 +217,28 @@ IGRAPH_EXPORT igraph_error_t igraph_community_fluid_communities(const igraph_t *
                                                      igraph_integer_t no_of_communities,
                                                      igraph_vector_int_t *membership);
 
+/**
+ * \typedef igraph_lpa_variant_t
+ * \brief Label propagation algorithm variants of implementation
+ *
+ * Algorithms to run the label propagation algorithm.
+ * \enumval IGRAPH_LPA_DOMINANCE Check for dominance of all nodes after each iteration
+ * \enumval IGRAPH_LPA_RETENTION Keep current label if among dominant labels, only check if labels changed
+ * \enumval IGRAPH_LPA_FAST Sample from dominant labels, only check neighbors
+ */
+typedef enum {
+    IGRAPH_LPA_DOMINANCE = 0, // Sample from dominant labels, check for dominance after each iteration
+    IGRAPH_LPA_RETENTION = 1, // Keep current label if among dominant labels, only check if labels changed
+    IGRAPH_LPA_FAST = 2       // Sample from dominant labels, only check neighbors
+} igraph_lpa_variant_t;
+
 IGRAPH_EXPORT igraph_error_t igraph_community_label_propagation(const igraph_t *graph,
                                                      igraph_vector_int_t *membership,
                                                      igraph_neimode_t mode,
                                                      const igraph_vector_t *weights,
                                                      const igraph_vector_int_t *initial,
-                                                     const igraph_vector_bool_t *fixed);
+                                                     const igraph_vector_bool_t *fixed,
+                                                     igraph_lpa_variant_t variant);
 
 IGRAPH_EXPORT igraph_error_t igraph_community_multilevel(const igraph_t *graph,
                                               const igraph_vector_t *weights,

--- a/include/igraph_community.h
+++ b/include/igraph_community.h
@@ -217,20 +217,6 @@ IGRAPH_EXPORT igraph_error_t igraph_community_fluid_communities(const igraph_t *
                                                      igraph_integer_t no_of_communities,
                                                      igraph_vector_int_t *membership);
 
-/**
- * \typedef igraph_lpa_variant_t
- * \brief Label propagation algorithm variants of implementation
- *
- * Algorithms to run the label propagation algorithm.
- * \enumval IGRAPH_LPA_DOMINANCE Check for dominance of all nodes after each iteration
- * \enumval IGRAPH_LPA_RETENTION Keep current label if among dominant labels, only check if labels changed
- * \enumval IGRAPH_LPA_FAST Sample from dominant labels, only check neighbors
- */
-typedef enum {
-    IGRAPH_LPA_DOMINANCE = 0, // Sample from dominant labels, check for dominance after each iteration
-    IGRAPH_LPA_RETENTION = 1, // Keep current label if among dominant labels, only check if labels changed
-    IGRAPH_LPA_FAST = 2       // Sample from dominant labels, only check neighbors
-} igraph_lpa_variant_t;
 
 IGRAPH_EXPORT igraph_error_t igraph_community_label_propagation(const igraph_t *graph,
                                                      igraph_vector_int_t *membership,

--- a/include/igraph_constants.h
+++ b/include/igraph_constants.h
@@ -210,6 +210,21 @@ typedef enum { IGRAPH_ROW_MAJOR = 0,
                IGRAPH_COLUMN_MAJOR = 1
              } igraph_matrix_storage_t;
 
+/**
+ * \typedef igraph_lpa_variant_t
+ * \brief Label propagation algorithm variants of implementation
+ *
+ * Algorithms to run the label propagation algorithm.
+ * \enumval IGRAPH_LPA_DOMINANCE Check for dominance of all nodes after each iteration
+ * \enumval IGRAPH_LPA_RETENTION Keep current label if among dominant labels, only check if labels changed
+ * \enumval IGRAPH_LPA_FAST Sample from dominant labels, only check neighbors
+ */
+typedef enum {
+    IGRAPH_LPA_DOMINANCE = 0, // Sample from dominant labels, check for dominance after each iteration
+    IGRAPH_LPA_RETENTION,     // Keep current label if among dominant labels, only check if labels changed
+    IGRAPH_LPA_FAST           // Sample from dominant labels, only check neighbors
+} igraph_lpa_variant_t;
+
 __END_DECLS
 
 #endif

--- a/include/igraph_constants.h
+++ b/include/igraph_constants.h
@@ -214,7 +214,7 @@ typedef enum { IGRAPH_ROW_MAJOR = 0,
  * \typedef igraph_lpa_variant_t
  * \brief Label propagation algorithm variants of implementation
  *
- * Algorithms to run the label propagation algorithm.
+ * Variants to run the label propagation algorithm.
  * \enumval IGRAPH_LPA_DOMINANCE Check for dominance of all nodes after each iteration
  * \enumval IGRAPH_LPA_RETENTION Keep current label if among dominant labels, only check if labels changed
  * \enumval IGRAPH_LPA_FAST Sample from dominant labels, only check neighbors

--- a/interfaces/functions.yaml
+++ b/interfaces/functions.yaml
@@ -1675,6 +1675,7 @@ igraph_community_label_propagation:
         GRAPH graph, OUT VECTOR_INT membership, NEIMODE mode=ALL,
         OPTIONAL EDGE_WEIGHTS weights, OPTIONAL INDEX_VECTOR initial,
         OPTIONAL VECTOR_BOOL fixed
+        IN LPA_VARIANT
     DEPS: weights ON graph
 
 igraph_community_multilevel:

--- a/interfaces/types.yaml
+++ b/interfaces/types.yaml
@@ -492,6 +492,11 @@ WHEEL_MODE:
     CTYPE: igraph_wheel_mode_t
     FLAGS: ENUM
 
+LPA_VARIANT:
+    # Enum that describes how a tree graph should be constructed
+    CTYPE: igraph_lpa_variant_t
+    FLAGS: ENUM
+
 ###############################################################################
 # Switches / flags / bits
 ###############################################################################

--- a/src/community/label_propagation.c
+++ b/src/community/label_propagation.c
@@ -412,9 +412,10 @@ igraph_error_t igraph_i_community_fast_label_propagation(const igraph_t *graph,
  * \brief Community detection based on label propagation.
  *
  * This function implements the label propagation-based community detection
- * algorithm described by Raghavan, Albert and Kumara. This version extends
+ * algorithm described by Raghavan, Albert and Kumara (2007). This version extends
  * the original method by the ability to take edge weights into consideration
- * and also by allowing some labels to be fixed.
+ * and also by allowing some labels to be fixed. In addition, it implements
+ * the fast label propagation alternative introduced by Traag & Šubelj (2023).
  *
  * </para><para>
  * Weights are taken into account as follows: when the new label of node
@@ -435,10 +436,9 @@ igraph_error_t igraph_i_community_fast_label_propagation(const igraph_t *graph,
  * References:
  *
  * </para><para>
- * Raghavan, U.N. and Albert, R. and Kumara, S.:
- * Near linear time algorithm to detect community structures in large-scale networks.
- * Phys Rev E 76, 036106 (2007).
- * https://doi.org/10.1103/PhysRevE.76.036106
+ * Raghavan, U.N. and Albert, R. and Kumara, S.: Near linear time algorithm to
+ * detect community structures in large-scale networks. Phys Rev E 76, 036106
+ * (2007). https://doi.org/10.1103/PhysRevE.76.036106
  *
  * </para><para>
  * Šubelj, L.: Label propagation for clustering. Chapter in "Advances in
@@ -446,6 +446,12 @@ igraph_error_t igraph_i_community_fast_label_propagation(const igraph_t *graph,
  * &amp; A. Ferligoj (Wiley, New York, 2018).
  * https://doi.org/10.1002/9781119483298.ch5
  * https://arxiv.org/abs/1709.05634
+ *
+ * </para><para>
+ * Traag, V. A., & Šubelj, L.: Large network community detection by fast
+ * label propagation. Scientific Reports, 13:1, (2023).
+ * https://doi.org/10.1038/s41598-023-29610-z
+ * https://arxiv.org/abs/2209.13338
  *
  * \param graph The input graph. Note that the algorithm wsa originally
  *    defined for undirected graphs. You are advised to set \p mode to

--- a/src/community/label_propagation.c
+++ b/src/community/label_propagation.c
@@ -26,7 +26,7 @@
 #include "igraph_memory.h"
 #include "igraph_random.h"
 
-int igraph_i_community_label_propagation(const igraph_t *graph,
+igraph_error_t igraph_i_community_label_propagation(const igraph_t *graph,
     igraph_vector_int_t *membership,
     igraph_neimode_t mode,
     const igraph_vector_t *weights,
@@ -193,9 +193,11 @@ int igraph_i_community_label_propagation(const igraph_t *graph,
     igraph_vector_int_destroy(&dominant_labels);
     igraph_vector_destroy(&label_counters);
     IGRAPH_FINALLY_CLEAN(4);
+
+    return IGRAPH_SUCCESS;
 }
 
-int igraph_i_community_fast_label_propagation(const igraph_t *graph,
+igraph_error_t igraph_i_community_fast_label_propagation(const igraph_t *graph,
     igraph_vector_int_t *membership,
     igraph_neimode_t mode,
     const igraph_vector_t *weights,
@@ -358,7 +360,7 @@ int igraph_i_community_fast_label_propagation(const igraph_t *graph,
     igraph_vector_int_destroy(&nonzero_labels);
     IGRAPH_FINALLY_CLEAN(5);
 
-    return 0;
+    return IGRAPH_SUCCESS;
 }
 
 /**
@@ -546,7 +548,7 @@ igraph_error_t igraph_community_label_propagation(const igraph_t *graph,
     switch(lpa_variant)
     {
       case IGRAPH_LPA_FAST:
-        igraph_i_community_fast_label_propagation(graph, membership, mode, weights, fixed_copy);
+        IGRAPH_CHECK(igraph_i_community_fast_label_propagation(graph, membership, mode, weights, fixed_copy));
         break;
 
       case IGRAPH_LPA_RETENTION:
@@ -555,7 +557,7 @@ igraph_error_t igraph_community_label_propagation(const igraph_t *graph,
 
       case IGRAPH_LPA_DOMINANCE:
       default:
-        igraph_i_community_label_propagation(graph, membership, mode, weights, fixed_copy);
+        IGRAPH_CHECK(igraph_i_community_label_propagation(graph, membership, mode, weights, fixed_copy));
     }
 
 

--- a/src/community/label_propagation.c
+++ b/src/community/label_propagation.c
@@ -41,9 +41,9 @@ igraph_error_t igraph_i_community_label_propagation(const igraph_t *graph,
     igraph_bool_t running, control_iteration;
     igraph_vector_t label_counters;
     igraph_vector_int_t dominant_labels, nonzero_labels, node_order;
-    igraph_neimode_t reversed_mode;
+    igraph_neimode_t reverse_mode;
 
-    reversed_mode = IGRAPH_REVERSE_MODE(mode);
+    reverse_mode = IGRAPH_REVERSE_MODE(mode);
 
     /* Create an adjacency/incidence list representation for efficiency.
     * For the unweighted case, the adjacency list is enough. For the
@@ -254,9 +254,9 @@ igraph_error_t igraph_i_community_fast_label_propagation(const igraph_t *graph,
     igraph_vector_int_t dominant_labels, nonzero_labels, node_order;
     igraph_dqueue_t queue;
     igraph_vector_bool_t in_queue;
-    igraph_neimode_t reversed_mode;
+    igraph_neimode_t reverse_mode;
 
-    reversed_mode = IGRAPH_REVERSE_MODE(mode);
+    reverse_mode = IGRAPH_REVERSE_MODE(mode);
 
     if (weights) {
         IGRAPH_CHECK(igraph_inclist_init(graph, &il, reverse_mode, IGRAPH_LOOPS_ONCE));

--- a/src/community/label_propagation.c
+++ b/src/community/label_propagation.c
@@ -178,7 +178,8 @@ igraph_error_t igraph_i_community_label_propagation(const igraph_t *graph,
                 /* If we are using retention, we first check if the current label
                 is among the maximum label. */
                 j = (long)VECTOR(*membership)[v1];
-                if (VECTOR(label_counters)[j] == 0 || /* Label not present in neighbors */
+                if (j < 0 || /* Doesn't have a label yet */
+                    VECTOR(label_counters)[j] == 0 || /* Label not present in neighbors */
                     VECTOR(label_counters)[j] < max_count /* Label not dominant */)
                 {
                     /* Select randomly from the dominant labels */

--- a/src/community/label_propagation.c
+++ b/src/community/label_propagation.c
@@ -75,6 +75,8 @@ int igraph_i_community_label_propagation(const igraph_t *graph,
         IGRAPH_FINALLY(igraph_vector_int_destroy, &node_order);
     }
 
+    RNG_BEGIN();
+
     /* There are two alternating types of iterations, one for changing labels and
     the other one for checking the end condition - every vertex in the graph has
     a label to which the maximum number of its neighbors belongs. If control_iteration
@@ -98,74 +100,73 @@ int igraph_i_community_label_propagation(const igraph_t *graph,
             igraph_vector_int_shuffle(&node_order);
         }
 
-        RNG_BEGIN();
         /* In the prescribed order, loop over the vertices and reassign labels */
         for (i = 0; i < no_of_not_fixed_nodes; i++) {
             v1 = VECTOR(node_order)[i];
 
-      /* Count the weights corresponding to different labels */
-      igraph_vector_int_clear(&dominant_labels);
-      igraph_vector_int_clear(&nonzero_labels);
-      max_count = 0.0;
-      if (weights) {
-        ineis = igraph_inclist_get(&il, v1);
-        num_neis = igraph_vector_int_size(ineis);
-        for (j = 0; j < num_neis; j++) {
-          k = VECTOR(*membership)[IGRAPH_OTHER(graph, VECTOR(*ineis)[j], v1)];
-          if (k < 0) {
-            continue;    /* skip if it has no label yet */
-          }
-          was_zero = (VECTOR(label_counters)[k] == 0);
-          VECTOR(label_counters)[k] += VECTOR(*weights)[VECTOR(*ineis)[j]];
-          if (was_zero && VECTOR(label_counters)[k] != 0) {
-            /* counter just became nonzero */
-            IGRAPH_CHECK(igraph_vector_int_push_back(&nonzero_labels, k));
-          }
-          if (max_count < VECTOR(label_counters)[k]) {
-            max_count = VECTOR(label_counters)[k];
-            IGRAPH_CHECK(igraph_vector_int_resize(&dominant_labels, 1));
-            VECTOR(dominant_labels)[0] = k;
-          } else if (max_count == VECTOR(label_counters)[k]) {
-            IGRAPH_CHECK(igraph_vector_int_push_back(&dominant_labels, k));
-          }
-        }
-      } else {
-        neis = igraph_adjlist_get(&al, v1);
-        num_neis = igraph_vector_int_size(neis);
-        for (j = 0; j < num_neis; j++) {
-          k = VECTOR(*membership)[VECTOR(*neis)[j]];
-          if (k < 0) {
-            continue;    /* skip if it has no label yet */
-          }
-          VECTOR(label_counters)[k]++;
-          if (VECTOR(label_counters)[k] == 1) {
-            /* counter just became nonzero */
-            IGRAPH_CHECK(igraph_vector_int_push_back(&nonzero_labels, k));
-          }
-          if (max_count < VECTOR(label_counters)[k]) {
-            max_count = VECTOR(label_counters)[k];
-            IGRAPH_CHECK(igraph_vector_int_resize(&dominant_labels, 1));
-            VECTOR(dominant_labels)[0] = k;
-          } else if (max_count == VECTOR(label_counters)[k]) {
-            IGRAPH_CHECK(igraph_vector_int_push_back(&dominant_labels, k));
-          }
-        }
-      }
-
-            if (igraph_vector_int_size(&dominant_labels) > 0) {
-                if (control_iteration) {
-                    /* Check if the _current_ label of the node is also dominant */
-                    if (VECTOR(label_counters)[VECTOR(*membership)[v1]] != max_count) {
-                        /* Nope, we need at least one more iteration */
-                        running = true;
-                    }
+            /* Count the weights corresponding to different labels */
+            igraph_vector_int_clear(&dominant_labels);
+            igraph_vector_int_clear(&nonzero_labels);
+            max_count = 0.0;
+            if (weights) {
+                ineis = igraph_inclist_get(&il, v1);
+                num_neis = igraph_vector_int_size(ineis);
+                for (j = 0; j < num_neis; j++) {
+                k = VECTOR(*membership)[IGRAPH_OTHER(graph, VECTOR(*ineis)[j], v1)];
+                if (k < 0) {
+                    continue;    /* skip if it has no label yet */
                 }
-                else {
-                    /* Select randomly from the dominant labels */
-                    k = RNG_INTEGER(0, igraph_vector_int_size(&dominant_labels) - 1);
-                    VECTOR(*membership)[v1] = VECTOR(dominant_labels)[k];
+                was_zero = (VECTOR(label_counters)[k] == 0);
+                VECTOR(label_counters)[k] += VECTOR(*weights)[VECTOR(*ineis)[j]];
+                if (was_zero && VECTOR(label_counters)[k] != 0) {
+                    /* counter just became nonzero */
+                    IGRAPH_CHECK(igraph_vector_int_push_back(&nonzero_labels, k));
+                }
+                if (max_count < VECTOR(label_counters)[k]) {
+                    max_count = VECTOR(label_counters)[k];
+                    IGRAPH_CHECK(igraph_vector_int_resize(&dominant_labels, 1));
+                    VECTOR(dominant_labels)[0] = k;
+                } else if (max_count == VECTOR(label_counters)[k]) {
+                    IGRAPH_CHECK(igraph_vector_int_push_back(&dominant_labels, k));
+                }
+                }
+            } else {
+                neis = igraph_adjlist_get(&al, v1);
+                num_neis = igraph_vector_int_size(neis);
+                for (j = 0; j < num_neis; j++) {
+                k = VECTOR(*membership)[VECTOR(*neis)[j]];
+                if (k < 0) {
+                    continue;    /* skip if it has no label yet */
+                }
+                VECTOR(label_counters)[k]++;
+                if (VECTOR(label_counters)[k] == 1) {
+                    /* counter just became nonzero */
+                    IGRAPH_CHECK(igraph_vector_int_push_back(&nonzero_labels, k));
+                }
+                if (max_count < VECTOR(label_counters)[k]) {
+                    max_count = VECTOR(label_counters)[k];
+                    IGRAPH_CHECK(igraph_vector_int_resize(&dominant_labels, 1));
+                    VECTOR(dominant_labels)[0] = k;
+                } else if (max_count == VECTOR(label_counters)[k]) {
+                    IGRAPH_CHECK(igraph_vector_int_push_back(&dominant_labels, k));
+                }
                 }
             }
+
+                    if (igraph_vector_int_size(&dominant_labels) > 0) {
+                        if (control_iteration) {
+                            /* Check if the _current_ label of the node is also dominant */
+                            if (VECTOR(label_counters)[VECTOR(*membership)[v1]] != max_count) {
+                                /* Nope, we need at least one more iteration */
+                                running = true;
+                            }
+                        }
+                        else {
+                            /* Select randomly from the dominant labels */
+                            k = RNG_INTEGER(0, igraph_vector_int_size(&dominant_labels) - 1);
+                            VECTOR(*membership)[v1] = VECTOR(dominant_labels)[k];
+                        }
+                    }
 
             /* Clear the nonzero elements in label_counters */
             num_neis = igraph_vector_int_size(&nonzero_labels);
@@ -173,11 +174,12 @@ int igraph_i_community_label_propagation(const igraph_t *graph,
                 VECTOR(label_counters)[VECTOR(nonzero_labels)[j]] = 0;
             }
         }
-        RNG_END();
 
         /* Alternating between control iterations and label updating iterations */
         control_iteration = !control_iteration;
     }
+
+    RNG_END();
 
     if (weights) {
         igraph_inclist_destroy(&il);

--- a/src/community/label_propagation.c
+++ b/src/community/label_propagation.c
@@ -26,209 +26,32 @@
 #include "igraph_memory.h"
 #include "igraph_random.h"
 
-/**
- * \ingroup communities
- * \function igraph_community_label_propagation
- * \brief Community detection based on label propagation.
- *
- * This function implements the label propagation-based community detection
- * algorithm described by Raghavan, Albert and Kumara. This version extends
- * the original method by the ability to take edge weights into consideration
- * and also by allowing some labels to be fixed.
- *
- * </para><para>
- * Weights are taken into account as follows: when the new label of node
- * \c i is determined, the algorithm iterates over all edges incident on
- * node \c i and calculate the total weight of edges leading to other
- * nodes with label 0, 1, 2, ..., \c k - 1 (where \c k is the number of possible
- * labels). The new label of node \c i will then be the label whose edges
- * (among the ones incident on node \c i) have the highest total weight.
- *
- * </para><para>
- * For directed graphs, it is important to know that labels can circulate
- * freely only within the strongly connected components of the graph and
- * may propagate in only one direction (or not at all) \em between strongly
- * connected components. You should treat directed edges as directed only
- * if you are aware of the consequences.
- *
- * </para><para>
- * References:
- *
- * </para><para>
- * Raghavan, U.N. and Albert, R. and Kumara, S.:
- * Near linear time algorithm to detect community structures in large-scale networks.
- * Phys Rev E 76, 036106 (2007).
- * https://doi.org/10.1103/PhysRevE.76.036106
- *
- * </para><para>
- * Šubelj, L.: Label propagation for clustering. Chapter in "Advances in
- * Network Clustering and Blockmodeling" edited by P. Doreian, V. Batagelj
- * &amp; A. Ferligoj (Wiley, New York, 2018).
- * https://doi.org/10.1002/9781119483298.ch5
- * https://arxiv.org/abs/1709.05634
- *
- * \param graph The input graph. Note that the algorithm wsa originally
- *    defined for undirected graphs. You are advised to set \p mode to
- *    \c IGRAPH_ALL if you pass a directed graph here to treat it as
- *    undirected.
- * \param membership The membership vector, the result is returned here.
- *    For each vertex it gives the ID of its community (label).
- * \param mode Whether to consider edge directions for the label propagation,
- *    and if so, which direction the labels should propagate. Ignored for
- *    undirected graphs. \c IGRAPH_ALL means to ignore edge directions (even
- *    in directed graphs). \c IGRAPH_OUT means to propagate labels along the
- *    natural direction of the edges. \c IGRAPH_IN means to propagate labels
- *    \em backwards (i.e. from head to tail). It is advised to set this to
- *    \c IGRAPH_ALL unless you are specifically interested in the effect of
- *    edge directions.
- * \param weights The weight vector, it should contain a positive
- *    weight for all the edges.
- * \param initial The initial state. If \c NULL, every vertex will have
- *   a different label at the beginning. Otherwise it must be a vector
- *   with an entry for each vertex. Non-negative values denote different
- *   labels, negative entries denote vertices without labels. Unlabeled
- *   vertices which are not reachable from any labeled ones will remain
- *   unlabeled at the end of the label propagation process, and will be
- *   labeled in an additional step to avoid returning negative values in
- *   \p membership. In undirected graphs, this happens when entire connected
- *   components are unlabeled. Then, each unlabeled component will receive
- *   its own separate label. In directed graphs, the outcome of the
- *   additional labeling should be considered undefined and may change
- *   in the future; please do not rely on it.
- * \param fixed Boolean vector denoting which labels are fixed. Of course
- *   this makes sense only if you provided an initial state, otherwise
- *   this element will be ignored. Note that vertices without labels
- *   cannot be fixed. The fixed status will be ignored for these with a
- *   warning. Also note that label numbers by themselves have no meaning,
- *   and igraph may renumber labels. However, co-membership constraints
- *   will be respected: two vertices can be fixed to be in the same or in
- *   different communities.
- * \param modularity If not a null pointer, then it must be a pointer
- *   to a real number. The modularity score of the detected community
- *   structure is stored here. Note that igraph will calculate the
- *   \em directed modularity if the input graph is directed, even if
- *   you set \p mode to \c IGRAPH_ALL
- * \return Error code.
- *
- * Time complexity: O(m+n)
- *
- * \example examples/simple/igraph_community_label_propagation.c
- */
-igraph_error_t igraph_community_label_propagation(const igraph_t *graph,
-                                       igraph_vector_int_t *membership,
-                                       igraph_neimode_t mode,
-                                       const igraph_vector_t *weights,
-                                       const igraph_vector_int_t *initial,
-                                       const igraph_vector_bool_t *fixed) {
+int igraph_i_community_label_propagation(const igraph_t *graph,
+    igraph_vector_t *membership,
+    igraph_neimode_t mode,
+    const igraph_vector_t *weights,
+    igraph_vector_bool_t *fixed)
+{
     igraph_integer_t no_of_nodes = igraph_vcount(graph);
-    igraph_integer_t no_of_edges = igraph_ecount(graph);
     igraph_integer_t no_of_not_fixed_nodes = no_of_nodes;
     igraph_integer_t i, j, k;
     igraph_adjlist_t al;
     igraph_inclist_t il;
     igraph_bool_t running, control_iteration;
-    igraph_bool_t unlabelled_left;
-    igraph_neimode_t reversed_mode;
-
-    igraph_vector_t label_counters; /* real type, stores weight sums */
+    igraph_vector_t label_counters;
     igraph_vector_int_t dominant_labels, nonzero_labels, node_order;
-
-    /* We make a copy of 'fixed' as a pointer into 'fixed_copy' after casting
-     * away the constness, and promise ourselves that we will make a proper
-     * copy of 'fixed' into 'fixed_copy' as soon as we start mutating it */
-    igraph_vector_bool_t *fixed_copy = (igraph_vector_bool_t *) fixed;
-
-    /* The implementation uses a trick to avoid negative array indexing:
-     * elements of the membership vector are increased by 1 at the start
-     * of the algorithm; this to allow us to denote unlabeled vertices
-     * (if any) by zeroes. The membership vector is shifted back in the end
-     */
-
-    /* Do some initial checks */
-    if (fixed && igraph_vector_bool_size(fixed) != no_of_nodes) {
-        IGRAPH_ERROR("Fixed labeling vector length must agree with number of nodes.", IGRAPH_EINVAL);
-    }
-    if (weights) {
-        if (igraph_vector_size(weights) != no_of_edges) {
-            IGRAPH_ERROR("Length of weight vector must agree with number of edges.", IGRAPH_EINVAL);
-        }
-        if (no_of_edges > 0) {
-            igraph_real_t minweight = igraph_vector_min(weights);
-            if (minweight < 0) {
-                IGRAPH_ERROR("Weights must not be negative.", IGRAPH_EINVAL);
-            }
-            if (isnan(minweight)) {
-                IGRAPH_ERROR("Weights must not be NaN.", IGRAPH_EINVAL);
-            }
-        }
-    }
-    if (fixed && !initial) {
-        IGRAPH_WARNING("Ignoring fixed vertices as no initial labeling given.");
-    }
-
-    IGRAPH_CHECK(igraph_vector_int_resize(membership, no_of_nodes));
-
-    if (initial) {
-        if (igraph_vector_int_size(initial) != no_of_nodes) {
-            IGRAPH_ERROR("Initial labeling vector length must agree with number of nodes.", IGRAPH_EINVAL);
-        }
-        /* Check if the labels used are valid, initialize membership vector */
-        for (i = 0; i < no_of_nodes; i++) {
-            if (VECTOR(*initial)[i] < 0) {
-                VECTOR(*membership)[i] = 0;
-            } else {
-                VECTOR(*membership)[i] = VECTOR(*initial)[i] + 1;
-            }
-        }
-        if (fixed) {
-            for (i = 0; i < no_of_nodes; i++) {
-                if (VECTOR(*fixed)[i]) {
-                    if (VECTOR(*membership)[i] == 0) {
-                        IGRAPH_WARNING("Fixed nodes cannot be unlabeled, ignoring them.");
-
-                        /* We cannot modify 'fixed' because it is const, so we make a copy and
-                         * modify 'fixed_copy' instead */
-                        if (fixed_copy == fixed) {
-                            fixed_copy = IGRAPH_CALLOC(1, igraph_vector_bool_t);
-                            if (fixed_copy == 0) {
-                                IGRAPH_ERROR("Failed to copy 'fixed' vector.", IGRAPH_ENOMEM); /* LCOV_EXCL_LINE */
-                            }
-
-                            IGRAPH_FINALLY(igraph_free, fixed_copy);
-                            IGRAPH_CHECK(igraph_vector_bool_init_copy(fixed_copy, fixed));
-                            IGRAPH_FINALLY(igraph_vector_bool_destroy, fixed_copy);
-                        }
-
-                        VECTOR(*fixed_copy)[i] = false;
-                    } else {
-                        no_of_not_fixed_nodes--;
-                    }
-                }
-            }
-        }
-
-        i = igraph_vector_int_max(membership);
-        if (i > no_of_nodes) {
-            IGRAPH_ERROR("Elements of the initial labeling vector must be between 0 and |V|-1.", IGRAPH_EINVAL);
-        }
-    } else {
-        for (i = 0; i < no_of_nodes; i++) {
-            VECTOR(*membership)[i] = i + 1;
-        }
-    }
+    igraph_neimode_t reversed_mode;
 
     reversed_mode = IGRAPH_REVERSE_MODE(mode);
 
-    /* From this point onwards we use 'fixed_copy' instead of 'fixed' */
-
     /* Create an adjacency/incidence list representation for efficiency.
-     * For the unweighted case, the adjacency list is enough. For the
-     * weighted case, we need the incidence list */
+    * For the unweighted case, the adjacency list is enough. For the
+    * weighted case, we need the incidence list */
     if (weights) {
-        IGRAPH_CHECK(igraph_inclist_init(graph, &il, reversed_mode, IGRAPH_LOOPS_ONCE));
+        IGRAPH_CHECK(igraph_inclist_init(graph, &il, reverse_mode, IGRAPH_LOOPS_ONCE));
         IGRAPH_FINALLY(igraph_inclist_destroy, &il);
     } else {
-        IGRAPH_CHECK(igraph_adjlist_init(graph, &al, reversed_mode, IGRAPH_LOOPS_ONCE, IGRAPH_MULTIPLE));
+        IGRAPH_CHECK(igraph_adjlist_init(graph, &al, reverse_mode, IGRAPH_LOOPS_ONCE, IGRAPH_MULTIPLE));
         IGRAPH_FINALLY(igraph_adjlist_destroy, &al);
     }
 
@@ -239,10 +62,10 @@ igraph_error_t igraph_community_label_propagation(const igraph_t *graph,
     IGRAPH_CHECK(igraph_vector_int_reserve(&dominant_labels, 2));
 
     /* Initialize node ordering vector with only the not fixed nodes */
-    if (fixed_copy) {
+    if (fixed) {
         IGRAPH_VECTOR_INT_INIT_FINALLY(&node_order, no_of_not_fixed_nodes);
         for (i = 0, j = 0; i < no_of_nodes; i++) {
-            if (!VECTOR(*fixed_copy)[i]) {
+            if (!VECTOR(*fixed)[i]) {
                 VECTOR(node_order)[j] = i;
                 j++;
             }
@@ -363,6 +186,205 @@ igraph_error_t igraph_community_label_propagation(const igraph_t *graph,
     }
     IGRAPH_FINALLY_CLEAN(1);
 
+    igraph_vector_int_destroy(&node_order);
+    igraph_vector_int_destroy(&nonzero_labels);
+    igraph_vector_int_destroy(&dominant_labels);
+    igraph_vector_destroy(&label_counters);
+    IGRAPH_FINALLY_CLEAN(4);
+}
+
+
+/**
+ * \ingroup communities
+ * \function igraph_community_label_propagation
+ * \brief Community detection based on label propagation.
+ *
+ * This function implements the label propagation-based community detection
+ * algorithm described by Raghavan, Albert and Kumara. This version extends
+ * the original method by the ability to take edge weights into consideration
+ * and also by allowing some labels to be fixed.
+ *
+ * </para><para>
+ * Weights are taken into account as follows: when the new label of node
+ * \c i is determined, the algorithm iterates over all edges incident on
+ * node \c i and calculate the total weight of edges leading to other
+ * nodes with label 0, 1, 2, ..., \c k - 1 (where \c k is the number of possible
+ * labels). The new label of node \c i will then be the label whose edges
+ * (among the ones incident on node \c i) have the highest total weight.
+ *
+ * </para><para>
+ * For directed graphs, it is important to know that labels can circulate
+ * freely only within the strongly connected components of the graph and
+ * may propagate in only one direction (or not at all) \em between strongly
+ * connected components. You should treat directed edges as directed only
+ * if you are aware of the consequences.
+ *
+ * </para><para>
+ * References:
+ *
+ * </para><para>
+ * Raghavan, U.N. and Albert, R. and Kumara, S.:
+ * Near linear time algorithm to detect community structures in large-scale networks.
+ * Phys Rev E 76, 036106 (2007).
+ * https://doi.org/10.1103/PhysRevE.76.036106
+ *
+ * </para><para>
+ * Šubelj, L.: Label propagation for clustering. Chapter in "Advances in
+ * Network Clustering and Blockmodeling" edited by P. Doreian, V. Batagelj
+ * &amp; A. Ferligoj (Wiley, New York, 2018).
+ * https://doi.org/10.1002/9781119483298.ch5
+ * https://arxiv.org/abs/1709.05634
+ *
+ * \param graph The input graph. Note that the algorithm wsa originally
+ *    defined for undirected graphs. You are advised to set \p mode to
+ *    \c IGRAPH_ALL if you pass a directed graph here to treat it as
+ *    undirected.
+ * \param membership The membership vector, the result is returned here.
+ *    For each vertex it gives the ID of its community (label).
+ * \param mode Whether to consider edge directions for the label propagation,
+ *    and if so, which direction the labels should propagate. Ignored for
+ *    undirected graphs. \c IGRAPH_ALL means to ignore edge directions (even
+ *    in directed graphs). \c IGRAPH_OUT means to propagate labels along the
+ *    natural direction of the edges. \c IGRAPH_IN means to propagate labels
+ *    \em backwards (i.e. from head to tail). It is advised to set this to
+ *    \c IGRAPH_ALL unless you are specifically interested in the effect of
+ *    edge directions.
+ * \param weights The weight vector, it should contain a positive
+ *    weight for all the edges.
+ * \param initial The initial state. If \c NULL, every vertex will have
+ *   a different label at the beginning. Otherwise it must be a vector
+ *   with an entry for each vertex. Non-negative values denote different
+ *   labels, negative entries denote vertices without labels. Unlabeled
+ *   vertices which are not reachable from any labeled ones will remain
+ *   unlabeled at the end of the label propagation process, and will be
+ *   labeled in an additional step to avoid returning negative values in
+ *   \p membership. In undirected graphs, this happens when entire connected
+ *   components are unlabeled. Then, each unlabeled component will receive
+ *   its own separate label. In directed graphs, the outcome of the
+ *   additional labeling should be considered undefined and may change
+ *   in the future; please do not rely on it.
+ * \param fixed Boolean vector denoting which labels are fixed. Of course
+ *   this makes sense only if you provided an initial state, otherwise
+ *   this element will be ignored. Note that vertices without labels
+ *   cannot be fixed. The fixed status will be ignored for these with a
+ *   warning. Also note that label numbers by themselves have no meaning,
+ *   and igraph may renumber labels. However, co-membership constraints
+ *   will be respected: two vertices can be fixed to be in the same or in
+ *   different communities.
+ * \param modularity If not a null pointer, then it must be a pointer
+ *   to a real number. The modularity score of the detected community
+ *   structure is stored here. Note that igraph will calculate the
+ *   \em directed modularity if the input graph is directed, even if
+ *   you set \p mode to \c IGRAPH_ALL
+ * \return Error code.
+ *
+ * Time complexity: O(m+n)
+ *
+ * \example examples/simple/igraph_community_label_propagation.c
+ */
+igraph_error_t igraph_community_label_propagation(const igraph_t *graph,
+                                       igraph_vector_int_t *membership,
+                                       igraph_neimode_t mode,
+                                       const igraph_vector_t *weights,
+                                       const igraph_vector_int_t *initial,
+                                       const igraph_vector_bool_t *fixed) {
+    igraph_integer_t no_of_nodes = igraph_vcount(graph);
+    igraph_integer_t no_of_edges = igraph_ecount(graph);
+    igraph_integer_t no_of_not_fixed_nodes = no_of_nodes;
+    igraph_integer_t i, j, k;
+    igraph_bool_t unlabelled_left;
+
+    igraph_vector_t label_counters; /* real type, stores weight sums */
+
+    /* We make a copy of 'fixed' as a pointer into 'fixed_copy' after casting
+     * away the constness, and promise ourselves that we will make a proper
+     * copy of 'fixed' into 'fixed_copy' as soon as we start mutating it */
+    igraph_vector_bool_t *fixed_copy = (igraph_vector_bool_t *) fixed;
+
+    /* The implementation uses a trick to avoid negative array indexing:
+     * elements of the membership vector are increased by 1 at the start
+     * of the algorithm; this to allow us to denote unlabeled vertices
+     * (if any) by zeroes. The membership vector is shifted back in the end
+     */
+
+    /* Do some initial checks */
+    if (fixed && igraph_vector_bool_size(fixed) != no_of_nodes) {
+        IGRAPH_ERROR("Fixed labeling vector length must agree with number of nodes.", IGRAPH_EINVAL);
+    }
+    if (weights) {
+        if (igraph_vector_size(weights) != no_of_edges) {
+            IGRAPH_ERROR("Length of weight vector must agree with number of edges.", IGRAPH_EINVAL);
+        }
+        if (no_of_edges > 0) {
+            igraph_real_t minweight = igraph_vector_min(weights);
+            if (minweight < 0) {
+                IGRAPH_ERROR("Weights must not be negative.", IGRAPH_EINVAL);
+            }
+            if (isnan(minweight)) {
+                IGRAPH_ERROR("Weights must not be NaN.", IGRAPH_EINVAL);
+            }
+        }
+    }
+    if (fixed && !initial) {
+        IGRAPH_WARNING("Ignoring fixed vertices as no initial labeling given.");
+    }
+
+    IGRAPH_CHECK(igraph_vector_int_resize(membership, no_of_nodes));
+
+    if (initial) {
+        if (igraph_vector_int_size(initial) != no_of_nodes) {
+            IGRAPH_ERROR("Initial labeling vector length must agree with number of nodes.", IGRAPH_EINVAL);
+        }
+        /* Check if the labels used are valid, initialize membership vector */
+        for (i = 0; i < no_of_nodes; i++) {
+            if (VECTOR(*initial)[i] < 0) {
+                VECTOR(*membership)[i] = 0;
+            } else {
+                VECTOR(*membership)[i] = VECTOR(*initial)[i] + 1;
+            }
+        }
+        if (fixed) {
+            for (i = 0; i < no_of_nodes; i++) {
+                if (VECTOR(*fixed)[i]) {
+                    if (VECTOR(*membership)[i] == 0) {
+                        IGRAPH_WARNING("Fixed nodes cannot be unlabeled, ignoring them.");
+
+                        /* We cannot modify 'fixed' because it is const, so we make a copy and
+                         * modify 'fixed_copy' instead */
+                        if (fixed_copy == fixed) {
+                            fixed_copy = IGRAPH_CALLOC(1, igraph_vector_bool_t);
+                            if (fixed_copy == 0) {
+                                IGRAPH_ERROR("Failed to copy 'fixed' vector.", IGRAPH_ENOMEM); /* LCOV_EXCL_LINE */
+                            }
+
+                            IGRAPH_FINALLY(igraph_free, fixed_copy);
+                            IGRAPH_CHECK(igraph_vector_bool_init_copy(fixed_copy, fixed));
+                            IGRAPH_FINALLY(igraph_vector_bool_destroy, fixed_copy);
+                        }
+
+                        VECTOR(*fixed_copy)[i] = false;
+                    } else {
+                        no_of_not_fixed_nodes--;
+                    }
+                }
+            }
+        }
+
+        i = igraph_vector_int_max(membership);
+        if (i > no_of_nodes) {
+            IGRAPH_ERROR("Elements of the initial labeling vector must be between 0 and |V|-1.", IGRAPH_EINVAL);
+        }
+    } else {
+        for (i = 0; i < no_of_nodes; i++) {
+            VECTOR(*membership)[i] = i + 1;
+        }
+    }
+
+    /* From this point onwards we use 'fixed_copy' instead of 'fixed' */
+    IGRAPH_VECTOR_INIT_FINALLY(&label_counters, no_of_nodes + 1);
+
+    igraph_i_community_label_propagation(graph, membership, mode, weights, fixed_copy);
+
     /* Shift back the membership vector, permute labels in increasing order */
     /* We recycle label_counters here :) and use it as an integer vector from now on */
     igraph_vector_fill(&label_counters, -1);
@@ -401,8 +423,21 @@ igraph_error_t igraph_community_label_propagation(const igraph_t *graph,
         igraph_dqueue_int_t q;
         igraph_vector_int_t neis;
 
-        /* In the directed case, the outcome depends on the node ordering, thus we
-         * shuffle nodes one more time. */
+        igraph_vector_int_t &node_order;
+        /* Initialize node ordering vector with only the not fixed nodes */
+        if (fixed) {
+            IGRAPH_VECTOR_INT_INIT_FINALLY(&node_order, no_of_not_fixed_nodes);
+            for (i = 0, j = 0; i < no_of_nodes; i++) {
+                if (!VECTOR(*fixed)[i]) {
+                VECTOR(node_order)[j] = i;
+                j++;
+                }
+            }
+        } else {
+            IGRAPH_CHECK(igraph_vector_init_seq(&node_order, 0, no_of_nodes - 1));
+            IGRAPH_FINALLY(igraph_vector_destroy, &node_order);
+        }
+        /* Shuffle the node ordering vector if we are in the label updating iteration */
         igraph_vector_int_shuffle(&node_order);
 
         IGRAPH_VECTOR_INT_INIT_FINALLY(&neis, 0);
@@ -440,15 +475,12 @@ igraph_error_t igraph_community_label_propagation(const igraph_t *graph,
 
         igraph_vector_int_destroy(&neis);
         igraph_dqueue_int_destroy(&q);
-        IGRAPH_FINALLY_CLEAN(2);
+        igraph_vector_int_destroy(&node_order);
+        IGRAPH_FINALLY_CLEAN(3);
     }
 
-    igraph_vector_int_destroy(&node_order);
     igraph_vector_destroy(&label_counters);
-    igraph_vector_int_destroy(&dominant_labels);
-    igraph_vector_int_destroy(&nonzero_labels);
-    IGRAPH_FINALLY_CLEAN(4);
-
+    IGRAPH_FINALLY_CLEAN(1);
     if (fixed != fixed_copy) {
         igraph_vector_bool_destroy(fixed_copy);
         IGRAPH_FREE(fixed_copy);

--- a/tests/unit/community_indexing.c
+++ b/tests/unit/community_indexing.c
@@ -48,7 +48,7 @@ int main(void) {
     igraph_community_fastgreedy(&graph, NULL, NULL, NULL, &membership);
     check(&membership);
 
-    igraph_community_label_propagation(&graph, &membership, IGRAPH_ALL, NULL, NULL, NULL);
+    igraph_community_label_propagation(&graph, &membership, IGRAPH_ALL, NULL, NULL, NULL, IGRAPH_LPA_DOMINANCE);
     check(&membership);
 
     igraph_community_walktrap(&graph, NULL, 4, NULL, NULL, &membership);

--- a/tests/unit/community_label_propagation.c
+++ b/tests/unit/community_label_propagation.c
@@ -33,19 +33,27 @@ int main(void) {
     igraph_vector_int_t initial;
     igraph_vector_bool_t fixed;
     igraph_integer_t i, j;
+    igraph_lpa_variant_t variant;
 
     /* Simple triangle graph, the output should be always one community */
     igraph_small(&g, 0, IGRAPH_UNDIRECTED, 0,  1,  0,  2,  1,  2, -1);
     igraph_vector_int_init(&membership, 0);
 
-    for (j = 0; j < 100; j++) {
+    for (variant = 0; variant < 3; variant++)
+    {
+      if (variant == IGRAPH_LPA_RETENTION) // Not yet implemented
+        continue;
+
+      for (j = 0; j < 100; j++)
+      {
         /* label propagation is a stochastic method */
         igraph_rng_seed(igraph_rng_default(), j);
 
-        igraph_community_label_propagation(&g, &membership, IGRAPH_ALL, 0, 0, 0);
+        igraph_community_label_propagation(&g, &membership, IGRAPH_ALL, 0, 0, 0, variant);
 
         for (i = 0; i < 3; i++)
-            IGRAPH_ASSERT(VECTOR(membership)[i] == VECTOR(membership)[0]);
+          IGRAPH_ASSERT(VECTOR(membership)[i] == VECTOR(membership)[0]);
+      }
     }
 
     igraph_destroy(&g);
@@ -73,7 +81,8 @@ int main(void) {
                  31, 32, 31, 33, 32, 33,
                  -1);
 
-    igraph_community_label_propagation(&g, &membership, IGRAPH_ALL, 0, 0, 0);
+    igraph_community_label_propagation(&g, &membership, IGRAPH_ALL, 0, 0, 0, IGRAPH_LPA_DOMINANCE);
+    igraph_community_label_propagation(&g, &membership, IGRAPH_ALL, 0, 0, 0, IGRAPH_LPA_FAST);
 
     igraph_destroy(&g);
 
@@ -87,21 +96,27 @@ int main(void) {
     VECTOR(fixed)[3] = 1;
     VECTOR(fixed)[4] = 1;
     VECTOR(fixed)[5] = 1;
-    igraph_community_label_propagation(&g, &membership, IGRAPH_ALL, &weights,
-                                       &initial, &fixed);
-    for (i = 0; i < igraph_vcount(&g); i++)
+
+    for (variant = 0; variant < 3; variant++)
+    {
+      if (variant == IGRAPH_LPA_RETENTION) // Not yet implemented
+        continue;
+
+      igraph_community_label_propagation(&g, &membership, IGRAPH_ALL, &weights,
+                                         &initial, &fixed, variant);
+      for (i = 0; i < igraph_vcount(&g); i++)
         IGRAPH_ASSERT(VECTOR(membership)[i] == (i < 2 ? 0 : 1));
 
-    igraph_community_label_propagation(&g, &membership, IGRAPH_ALL, 0,
-                                       &initial, &fixed);
-    for (i = 0; i < igraph_vcount(&g); i++)
+      igraph_community_label_propagation(&g, &membership, IGRAPH_ALL, 0,
+                                         &initial, &fixed, variant);
+      for (i = 0; i < igraph_vcount(&g); i++)
         IGRAPH_ASSERT(VECTOR(membership)[i] == 0);
-
+    }
     /* Check whether it works with no fixed vertices at all
      * while an initial configuration is given -- see bug
      * #570902 in Launchpad. This is a simple smoke test only. */
     igraph_community_label_propagation(&g, &membership, IGRAPH_ALL, &weights,
-                                       &initial, 0);
+                                       &initial, 0, IGRAPH_LPA_DOMINANCE);
 
     igraph_vector_bool_destroy(&fixed);
     igraph_vector_destroy(&weights);

--- a/tests/unit/community_label_propagation.c
+++ b/tests/unit/community_label_propagation.c
@@ -118,6 +118,38 @@ int main(void) {
     igraph_vector_int_destroy(&initial);
     igraph_destroy(&g);
 
+    /* Test line graph with fixed and initial memberships */
+    igraph_small(&g, 3, IGRAPH_UNDIRECTED, 0,1, 1,2, 2,3, -1);
+
+    igraph_vector_init(&weights, 3);
+    VECTOR(weights)[0] = 2;
+    VECTOR(weights)[1] = 1;
+    VECTOR(weights)[2] = 2;
+
+    igraph_vector_init(&initial, 4);
+    VECTOR(initial)[0] = 0;
+    VECTOR(initial)[1] = -1;
+    VECTOR(initial)[2] = -1;
+    VECTOR(initial)[3] = 1;
+
+    igraph_vector_bool_init(&fixed, 4);
+    VECTOR(fixed)[0] = 1;
+    VECTOR(fixed)[1] = 0;
+    VECTOR(fixed)[2] = 0;
+    VECTOR(fixed)[3] = 1;
+
+    igraph_community_label_propagation(&g, &membership, &weights,
+        &initial, &fixed, NULL, IGRAPH_LPA_DOMINANCE);
+
+    igraph_vector_int_print(&membership);
+    IGRAPH_ASSERT(VECTOR(membership)[0] == 0);
+    IGRAPH_ASSERT(VECTOR(membership)[3] == 1);
+
+    igraph_vector_bool_destroy(&fixed);
+    igraph_vector_destroy(&weights);
+    igraph_vector_int_destroy(&initial);
+    igraph_destroy(&g);
+
     igraph_vector_int_destroy(&membership);
 
     VERIFY_FINALLY_STACK();

--- a/tests/unit/community_label_propagation.c
+++ b/tests/unit/community_label_propagation.c
@@ -126,7 +126,7 @@ int main(void) {
     VECTOR(weights)[1] = 1;
     VECTOR(weights)[2] = 2;
 
-    igraph_vector_init(&initial, 4);
+    igraph_vector_int_init(&initial, 4);
     VECTOR(initial)[0] = 0;
     VECTOR(initial)[1] = -1;
     VECTOR(initial)[2] = -1;
@@ -138,8 +138,8 @@ int main(void) {
     VECTOR(fixed)[2] = 0;
     VECTOR(fixed)[3] = 1;
 
-    igraph_community_label_propagation(&g, &membership, &weights,
-        &initial, &fixed, NULL, IGRAPH_LPA_DOMINANCE);
+    igraph_community_label_propagation(&g, &membership, IGRAPH_ALL, &weights,
+        &initial, &fixed, IGRAPH_LPA_DOMINANCE);
 
     igraph_vector_int_print(&membership);
     IGRAPH_ASSERT(VECTOR(membership)[0] == 0);

--- a/tests/unit/community_label_propagation.c
+++ b/tests/unit/community_label_propagation.c
@@ -41,9 +41,6 @@ int main(void) {
 
     for (variant = 0; variant < 3; variant++)
     {
-      if (variant == IGRAPH_LPA_RETENTION) // Not yet implemented
-        continue;
-
       for (j = 0; j < 100; j++)
       {
         /* label propagation is a stochastic method */
@@ -82,6 +79,7 @@ int main(void) {
                  -1);
 
     igraph_community_label_propagation(&g, &membership, IGRAPH_ALL, 0, 0, 0, IGRAPH_LPA_DOMINANCE);
+    igraph_community_label_propagation(&g, &membership, IGRAPH_ALL, 0, 0, 0, IGRAPH_LPA_RETENTION);
     igraph_community_label_propagation(&g, &membership, IGRAPH_ALL, 0, 0, 0, IGRAPH_LPA_FAST);
 
     igraph_destroy(&g);
@@ -99,9 +97,6 @@ int main(void) {
 
     for (variant = 0; variant < 3; variant++)
     {
-      if (variant == IGRAPH_LPA_RETENTION) // Not yet implemented
-        continue;
-
       igraph_community_label_propagation(&g, &membership, IGRAPH_ALL, &weights,
                                          &initial, &fixed, variant);
       for (i = 0; i < igraph_vcount(&g); i++)

--- a/tests/unit/community_label_propagation2.c
+++ b/tests/unit/community_label_propagation2.c
@@ -40,7 +40,7 @@ int main(void) {
     VECTOR(initial_labels)[2] = -1;
     VECTOR(initial_labels)[3] = -1;
 
-    igraph_community_label_propagation(&graph, &membership, IGRAPH_ALL, NULL, &initial_labels, NULL);
+    igraph_community_label_propagation(&graph, &membership, IGRAPH_ALL, NULL, &initial_labels, NULL, IGRAPH_LPA_DOMINANCE);
     print_vector_int(&membership);
 
     igraph_destroy(&graph);
@@ -61,7 +61,7 @@ int main(void) {
     VECTOR(initial_labels)[6] = -1;
     VECTOR(initial_labels)[7] = -1;
 
-    igraph_community_label_propagation(&graph, &membership, IGRAPH_OUT, NULL, &initial_labels, NULL);
+    igraph_community_label_propagation(&graph, &membership, IGRAPH_OUT, NULL, &initial_labels, NULL, IGRAPH_LPA_DOMINANCE);
     print_vector_int(&membership);
 
     igraph_destroy(&graph);
@@ -72,7 +72,7 @@ int main(void) {
     igraph_vector_int_resize(&initial_labels, igraph_vcount(&graph));
     igraph_vector_int_fill(&initial_labels, -1);
 
-    igraph_community_label_propagation(&graph, &membership, IGRAPH_OUT, NULL, &initial_labels, NULL);
+    igraph_community_label_propagation(&graph, &membership, IGRAPH_OUT, NULL, &initial_labels, NULL, IGRAPH_LPA_DOMINANCE);
     print_vector_int(&membership);
 
     igraph_destroy(&graph);

--- a/tests/unit/community_label_propagation3.c
+++ b/tests/unit/community_label_propagation3.c
@@ -49,7 +49,7 @@ int main(void) {
 
     igraph_vector_int_init(&membership, 0);
 
-    igraph_community_label_propagation(&g, &membership, IGRAPH_OUT, 0, &initial, &fixed);
+    igraph_community_label_propagation(&g, &membership, IGRAPH_OUT, 0, &initial, &fixed, IGRAPH_LPA_DOMINANCE);
 
     for (i = 0; i < igraph_vcount(&g); i++) {
         /* Check that the "fixed" vector has not been changed */

--- a/tests/unit/null_communities.c
+++ b/tests/unit/null_communities.c
@@ -85,7 +85,7 @@ int main(void) {
 
     igraph_vector_int_resize(&membership, 1);
 
-    igraph_community_label_propagation(&g, &membership, IGRAPH_ALL, NULL, NULL, NULL);
+    igraph_community_label_propagation(&g, &membership, IGRAPH_ALL, NULL, NULL, NULL, IGRAPH_LPA_DOMINANCE);
 
     IGRAPH_ASSERT(igraph_vector_int_size(&membership) == 0);
 


### PR DESCRIPTION
This PR adds the fast label propagation algorithm as proposed by @lovre and me in:

Traag, V. A., & Šubelj, L. (2023). Large network community detection by fast label propagation. Scientific Reports, 13(1) https://doi.org/10.1038/s41598-023-29610-z https://arxiv.org/abs/2209.13338

It is a cleaned up version of an earlier branch in https://github.com/vtraag/igraph/tree/feature/flpa, which contains the code we used for the publication. Several changes to the original LPA implementation required a substantial clean-up, most notably the integer transition & cleanup.

In addition to the fast variant, it also contains the implementation of an alternative strategy we labelled "retention" in our paper.

I believe it should be all correct, but I still need to check some things. Everything does compile correctly, but there are some tests that fail. Perhaps it's just a matter of updating the output to the algorithm. But I don't have the time right now to look into this, I'll try to do this asap.