### PR TITLE
Add target to build documentation in info format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Other
 
  - Reduced memory usage and improved initialization performance for `igraph_strvector_t`.
+ - The documentation is now also generated in Texinfo format.
  - Documentation improvements
 
 ## [0.10.8] - 2023-11-17

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -150,7 +150,7 @@ jobs:
       - script: sudo apt-get update
         displayName: Update package registry
 
-      - script: sudo apt-get install ninja-build xmlto texinfo source-highlight libxml2-utils xsltproc fop -y
+      - script: sudo apt-get install ninja-build xmlto texinfo source-highlight libxml2-utils xsltproc fop docbook2x -y
         displayName: Install dependencies
 
       - task: CMake@1

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -95,6 +95,11 @@ find_program(FOP_COMMAND fop)
 find_program(XMLLINT_COMMAND xmllint)
 find_program(XSLTPROC_COMMAND xsltproc)
 
+# GNU info documentation additionally requires docbook2x and makeinfo
+# (and xmllint as well)
+find_program(DOCBOOK2XTEXI_COMMAND docbook2x-texi)
+find_program(MAKEINFO_COMMAND makeinfo)
+
 if(Python3_FOUND AND SOURCE_HIGHLIGHT_COMMAND)
   set(DOC_BUILD_SUPPORTED TRUE)
 else()
@@ -111,6 +116,12 @@ if(DOC_BUILD_SUPPORTED AND XMLLINT_COMMAND AND XSLTPROC_COMMAND AND FOP_COMMAND)
   set(PDF_DOC_BUILD_SUPPORTED TRUE)
 else()
   set(PDF_DOC_BUILD_SUPPORTED FALSE)
+endif()
+
+if(DOC_BUILD_SUPPORTED AND XMLLINT_COMMAND AND DOCBOOK2XTEXI_COMMAND AND MAKEINFO_COMMAND)
+  set(INFO_DOC_BUILD_SUPPORTED TRUE)
+else()
+  set(INFO_DOC_BUILD_SUPPORTED FALSE)
 endif()
 
 if(DOC_BUILD_SUPPORTED)
@@ -301,8 +312,60 @@ if(DOC_BUILD_SUPPORTED)
     set(PDF_TARGET pdf)
   endif()
 
-  add_custom_target(doc DEPENDS ${HTML_TARGET} ${PDF_TARGET})
+  if(INFO_DOC_BUILD_SUPPORTED)
+    add_custom_command(
+      OUTPUT igraph-docs-with-resolved-includes.xml
+      COMMAND ${XMLLINT_COMMAND}
+      ARGS
+      --xinclude
+      --output igraph-docs-with-resolved-includes-tmp.xml
+      igraph-docs.xml
+      COMMAND ${Python3_EXECUTABLE}
+      ARGS
+      ${CMAKE_SOURCE_DIR}/tools/removeexamples.py
+      igraph-docs-with-resolved-includes-tmp.xml
+      igraph-docs-with-resolved-includes.xml
+      COMMAND ${CMAKE_COMMAND}
+      ARGS
+      -E remove igraph-docs-with-resolved-includes-tmp.xml
+      MAIN_DEPENDENCY igraph-docs.xml
+      # The DEPENDS clause below needs to list both the xmlstamp file and the
+      # target that creates it. The former is needed to make Ninja rebuild the
+      # Info file if the source is modified. The latter is needed to make the
+      # XCode build system happy.
+      DEPENDS ${DOCXML_STAMP} docxml
+      COMMENT "Resolving includes in DocBook XML source"
+    )
+
+    add_custom_command(
+      OUTPUT igraph-docs.texi
+      COMMAND ${DOCBOOK2XTEXI_COMMAND}
+      ARGS
+      --encoding=utf8//TRANSLIT
+      --string-param output-file=igraph-docs
+      --string-param directory-category=Libraries
+      --string-param directory-description="A fast graph library \(C\)"
+      igraph-docs-with-resolved-includes.xml
+      MAIN_DEPENDENCY igraph-docs-with-resolved-includes.xml
+      COMMENT "Converting DocBook XML to GNU Texinfo format"
+    )
+
+    add_custom_command(
+      OUTPUT igraph-docs.info
+      COMMAND ${MAKEINFO_COMMAND}
+      ARGS --no-split igraph-docs.texi
+      MAIN_DEPENDENCY igraph-docs.texi
+      COMMENT "Generating info documentation with GNU Makeinfo"
+    )
+
+    add_custom_target(info DEPENDS igraph-docs.info)
+    set(INFO_TARGET info)
+  endif()
+
+
+  add_custom_target(doc DEPENDS ${HTML_TARGET} ${PDF_TARGET} ${INFO_TARGET})
 endif()
 
 set(HTML_DOC_BUILD_SUPPORTED ${HTML_DOC_BUILD_SUPPORTED} PARENT_SCOPE)
 set(PDF_DOC_BUILD_SUPPORTED ${PDF_DOC_BUILD_SUPPORTED} PARENT_SCOPE)
+set(INFO_DOC_BUILD_SUPPORTED ${INFO_DOC_BUILD_SUPPORTED} PARENT_SCOPE)

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -98,7 +98,7 @@ find_program(XSLTPROC_COMMAND xsltproc)
 # GNU Texinfo documentation additionally requires the docbook2X package,
 # makeinfo (and xmllint as well). The docbook2texi command from docbook2X
 # is renamed to docbook2x-texi by many Linux distros to avoid conflict with
-# the a command of the same name from the incompatible docbook-tools package.
+# a command of the same name from the incompatible docbook-tools package.
 # We look for both command names, and prefer docbook2x-texi if found.
 # At the moment we do not validate that docbook2texi is from docbook2X
 # instead of docbook-tools. Such validation will be possible with CMake >= 3.25.

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -95,9 +95,14 @@ find_program(FOP_COMMAND fop)
 find_program(XMLLINT_COMMAND xmllint)
 find_program(XSLTPROC_COMMAND xsltproc)
 
-# GNU info documentation additionally requires docbook2x and makeinfo
-# (and xmllint as well)
-find_program(DOCBOOK2XTEXI_COMMAND docbook2x-texi)
+# GNU Texinfo documentation additionally requires the docbook2X package,
+# makeinfo (and xmllint as well). The docbook2texi command from docbook2X
+# is renamed to docbook2x-texi by many Linux distros to avoid conflict with
+# the a command of the same name from the incompatible docbook-tools package.
+# We look for both command names, and prefer docbook2x-texi if found.
+# At the moment we do not validate that docbook2texi is from docbook2X
+# instead of docbook-tools. Such validation will be possible with CMake >= 3.25.
+find_program(DOCBOOK2XTEXI_COMMAND NAMES docbook2x-texi docbook2texi)
 find_program(MAKEINFO_COMMAND makeinfo)
 
 if(Python3_FOUND AND SOURCE_HIGHLIGHT_COMMAND)

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -341,7 +341,7 @@ if(DOC_BUILD_SUPPORTED)
       OUTPUT igraph-docs.texi
       COMMAND ${DOCBOOK2XTEXI_COMMAND}
       ARGS
-      --encoding=utf8//TRANSLIT
+      --encoding=utf-8//TRANSLIT
       --string-param output-file=igraph-docs
       --string-param directory-category=Libraries
       --string-param directory-description="A fast graph library \(C\)"

--- a/doc/installation.xml
+++ b/doc/installation.xml
@@ -471,8 +471,8 @@ $ cmake --build . --target html
     Building the HTML documentation requires Python 3, <literal>xmlto</literal>
     and <literal>source-highlight</literal>. Building the PDF documentation also
     requires <literal>xsltproc</literal>, <literal>xmllint</literal> and
-    <literal>fop</literal>. Building the Info documentation also requires
-    <literal>docbook2x</literal>, <literal>xmllint</literal> and
+    <literal>fop</literal>. Building the Texinfo documentation also requires
+    the docbook2X package, <literal>xmllint</literal> and
     <literal>makeinfo</literal>.
   </para>
 </section>

--- a/doc/installation.xml
+++ b/doc/installation.xml
@@ -459,18 +459,21 @@ pacman -S \
     directory.
   </para>
   <para>
-    To build the documentation for the development version, simply build
-    the <literal>html</literal> or <literal>pdf</literal> targets for the
-    HTML and PDF versions of the documentation, respectively.
+    To build the documentation for the development version, simply build the
+    <literal>html</literal>, <literal>pdf</literal> or <literal>info</literal>
+    targets for the HTML, PDF and Info versions of the documentation,
+    respectively.
   </para>
 <programlisting>
 $ cmake --build . --target html
 </programlisting>
   <para>
     Building the HTML documentation requires Python 3, <literal>xmlto</literal>
-    and <literal>source-highlight</literal>. Building the PDF documentation
-    also requires <literal>xsltproc</literal>, <literal>xmllint</literal>
-    and <literal>fop</literal>.
+    and <literal>source-highlight</literal>. Building the PDF documentation also
+    requires <literal>xsltproc</literal>, <literal>xmllint</literal> and
+    <literal>fop</literal>. Building the Info documentation also requires
+    <literal>docbook2x</literal>, <literal>xmllint</literal> and
+    <literal>makeinfo</literal>.
   </para>
 </section>
 

--- a/etc/cmake/cpack_install_script.cmake
+++ b/etc/cmake/cpack_install_script.cmake
@@ -79,4 +79,9 @@ if(CPACK_SOURCE_INSTALLED_DIRECTORIES)
         "${CPACK_PACKAGE_DIRECTORY}/doc/html"
         DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/doc"
     )
+    file(
+        INSTALL
+        "${CPACK_PACKAGE_DIRECTORY}/doc/igraph-docs.info"
+        DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/doc"
+    )
 endif()

--- a/etc/cmake/packaging.cmake
+++ b/etc/cmake/packaging.cmake
@@ -4,7 +4,7 @@ set(CPACK_PACKAGE_VENDOR "The igraph development team")
 
 set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_SOURCE_DIR}/COPYING")
 
-if(TARGET html)
+if(TARGET html AND TARGET info)
   # Alias "dist" to "package_source"
   add_custom_target(dist
     COMMAND "${CMAKE_COMMAND}"
@@ -14,13 +14,13 @@ if(TARGET html)
     USES_TERMINAL
   )
 
-  # We want to include the HTML docs in the source package so add a dependency
-  add_dependencies(dist html)
+  # Add dependencies to "dist"
+  add_dependencies(dist html info)
 else()
   add_custom_target(dist
     COMMAND "${CMAKE_COMMAND}" -E false
     COMMENT
-      "Cannot build source tarball since the HTML documentation was not built."
+      "Cannot build source tarball since the HTML or the Texinfo documentation was not built."
     VERBATIM
     USES_TERMINAL
   )

--- a/etc/cmake/summary.cmake
+++ b/etc/cmake/summary.cmake
@@ -86,6 +86,7 @@ message(STATUS " ")
 message(STATUS "--------[ Documentation ]-------")
 print_bool("HTML" HTML_DOC_BUILD_SUPPORTED)
 print_bool("PDF" PDF_DOC_BUILD_SUPPORTED)
+print_bool("INFO" INFO_DOC_BUILD_SUPPORTED)
 message(STATUS " ")
 
 set(MISSING_DEPENDENCIES)


### PR DESCRIPTION
Hello,

First of all, thank you for this very useful library.

I spend quite a lot of time perusing the documentation in PDF format, and I
thought it would be nice to have the possibility to read it in GNU Info format
as well.

Since you build the documentation in Docbook format in the first place, it is
quite trivial.

This PR adds an extra Cmake target to build the documentation in Info format,
and reuses parts of the commands used to build the PDF docs.

This target has two new dependencies :
- docbook2x, which provides the command docbook2x-texi, to convert from Docbook
  to texi.
- texinfo, which provides the command makeinfo, to build info from texi.

I have documented this new target and its dependencies.

I have also added it to the cmake summary.

This should require little to no effort on your part to maintain, and I can be
pinged to deal with any issues that might arise.

Thank you in advance for your time.

Best,

Aymeric Agon-Rambosson, a happy user of your library