### PR TITLE
perf: check cache for self-loops / forest during bipartiteness check

### DIFF
--- a/src/misc/bipartite.c
+++ b/src/misc/bipartite.c
@@ -910,6 +910,26 @@ igraph_error_t igraph_is_bipartite(const igraph_t *graph,
     igraph_vector_int_t neis;
     igraph_bool_t bi = true;
 
+    /* Shortcut: Graphs with self-loops are not bipartite. */
+    if (igraph_i_property_cache_has(graph, IGRAPH_PROP_HAS_LOOP) &&
+        igraph_i_property_cache_get_bool(graph, IGRAPH_PROP_HAS_LOOP)) {
+        if (*res) {
+            *res = false;
+        }
+        return IGRAPH_SUCCESS;
+    }
+
+    /* Shortcut: If the type vector is not requested, and the graph is a forest
+     * we can immediately return with the result that the graph is bipartite. */
+    if (! types &&
+        igraph_i_property_cache_has(graph, IGRAPH_PROP_IS_FOREST) &&
+        igraph_i_property_cache_get_bool(graph, IGRAPH_PROP_IS_FOREST)) {
+        if (*res) {
+            *res = true;
+        }
+        return IGRAPH_SUCCESS;
+    }
+
     IGRAPH_VECTOR_CHAR_INIT_FINALLY(&seen, no_of_nodes);
     IGRAPH_DQUEUE_INT_INIT_FINALLY(&Q, 100);
     IGRAPH_VECTOR_INT_INIT_FINALLY(&neis, 0);


### PR DESCRIPTION
Minor optimization for bipartiteness check.