### PR TITLE
Perf/set cache bipartiteness check

### DIFF
--- a/src/misc/bipartite.c
+++ b/src/misc/bipartite.c
@@ -970,6 +970,12 @@ igraph_error_t igraph_is_bipartite(const igraph_t *graph,
     igraph_dqueue_int_destroy(&Q);
     IGRAPH_FINALLY_CLEAN(2);
 
+    /* Set the cache: A graph that is not bipartite has
+     * an odd-length cycle, therefore it cannot be a forest. */
+    if (! bi) {
+        igraph_i_property_cache_set_bool(graph, IGRAPH_PROP_IS_FOREST, false);
+    }
+
     if (res) {
         *res = bi;
     }

--- a/tests/unit/igraph_is_bipartite.c
+++ b/tests/unit/igraph_is_bipartite.c
@@ -6,7 +6,7 @@
 int main(void) {
 
     igraph_t graph;
-    igraph_bool_t bipartite;
+    igraph_bool_t bipartite, acyclic, has_loop;
     igraph_vector_bool_t types;
 
     igraph_vector_bool_init(&types, 5);
@@ -25,6 +25,21 @@ int main(void) {
     IGRAPH_ASSERT(igraph_vector_bool_size(&types) == igraph_vcount(&graph));
     igraph_destroy(&graph);
 
+    /* Singleton with self-loop */
+    igraph_small(&graph, 1, IGRAPH_UNDIRECTED,
+                 0, 0,
+                 -1);
+    igraph_is_bipartite(&graph, &bipartite, &types);
+    IGRAPH_ASSERT(! bipartite);
+    IGRAPH_ASSERT(igraph_vector_bool_size(&types) == igraph_vcount(&graph));
+
+    /* Test cache usage */
+    igraph_has_loop(&graph, &has_loop);
+    igraph_is_bipartite(&graph, &bipartite, NULL);
+    IGRAPH_ASSERT(! bipartite);
+
+    igraph_destroy(&graph);
+
     /* Directed path */
     igraph_small(&graph, 0, IGRAPH_DIRECTED,
                  0,1, 1,2,
@@ -34,12 +49,23 @@ int main(void) {
     IGRAPH_ASSERT(bipartite);
     IGRAPH_ASSERT(igraph_vector_bool_size(&types) == igraph_vcount(&graph));
 
+    /* Test cache usage */
+    igraph_is_forest(&graph, &acyclic, NULL, IGRAPH_ALL);
+    igraph_is_bipartite(&graph, &bipartite, NULL);
+    IGRAPH_ASSERT(bipartite);
+
     /* Odd directed cycle */
     igraph_add_edge(&graph, 2, 0);
+    igraph_invalidate_cache(&graph);
 
     igraph_is_bipartite(&graph, &bipartite, &types);
     IGRAPH_ASSERT(! bipartite);
     IGRAPH_ASSERT(igraph_vector_bool_size(&types) == igraph_vcount(&graph));
+
+    /* Test cache usage */
+    igraph_is_forest(&graph, &acyclic, NULL, IGRAPH_ALL);
+    igraph_is_bipartite(&graph, &bipartite, NULL);
+    IGRAPH_ASSERT(! bipartite);
 
     igraph_destroy(&graph);
 


### PR DESCRIPTION
A bit riskier, since this sets the cache, but in this case I think it's fine. No issues with null graph / singleton graph.