### PR TITLE
fix: fix cache initialization when igraph_bool_t size is not 1 bytes

### DIFF
--- a/src/graph/caching.c
+++ b/src/graph/caching.c
@@ -30,7 +30,7 @@
 igraph_error_t igraph_i_property_cache_init(igraph_i_property_cache_t *cache) {
     IGRAPH_STATIC_ASSERT(IGRAPH_PROP_I_SIZE <= 32);
 
-    memset(cache->value, 0, sizeof(cache->value) / sizeof(cache->value[0]));
+    memset(cache->value, 0, sizeof(cache->value));
     cache->known = 0;
     return IGRAPH_SUCCESS;
 }


### PR DESCRIPTION
Looks like this could be serious when `sizeof(igraph_bool_t) != 1`, which is the case in R only. Please double-check @ntamas 

CC @krlmlr 