### PR TITLE
refactor: remove MPI code from DrL

### DIFF
--- a/src/layout/drl/DensityGrid.cpp
+++ b/src/layout/drl/DensityGrid.cpp
@@ -174,11 +174,7 @@ void DensityGrid::Subtract(Node &N) {
     // check to see that we are inside grid
     if ( (x_grid >= GRID_SIZE) || (x_grid < 0) ||
          (y_grid >= GRID_SIZE) || (y_grid < 0) ) {
-#ifdef MUSE_MPI
-        MPI_Abort ( MPI_COMM_WORLD, 1 );
-#else
         throw runtime_error("Exceeded density grid in DrL.");
-#endif
     }
 
     /* Subtract density values */
@@ -216,11 +212,7 @@ void DensityGrid::Add(Node &N) {
     // check to see that we are inside grid
     if ( (x_grid >= GRID_SIZE) || (x_grid < 0) ||
          (y_grid >= GRID_SIZE) || (y_grid < 0) ) {
-#ifdef MUSE_MPI
-        MPI_Abort ( MPI_COMM_WORLD, 1 );
-#else
         throw runtime_error("Exceeded density grid in DrL.");
-#endif
     }
 
     /* Add density values */

--- a/src/layout/drl/DensityGrid.h
+++ b/src/layout/drl/DensityGrid.h
@@ -38,9 +38,6 @@
 
 #include "drl_layout.h"
 #include "drl_Node.h"
-#ifdef MUSE_MPI
-    #include <mpi.h>
-#endif
 
 #include <deque>
 

--- a/src/layout/drl/DensityGrid_3d.cpp
+++ b/src/layout/drl/DensityGrid_3d.cpp
@@ -189,11 +189,7 @@ void DensityGrid::Subtract(Node &N) {
     if ( (x_grid >= GRID_SIZE) || (x_grid < 0) ||
          (y_grid >= GRID_SIZE) || (y_grid < 0) ||
          (z_grid >= GRID_SIZE) || (z_grid < 0) ) {
-#ifdef MUSE_MPI
-        MPI_Abort ( MPI_COMM_WORLD, 1 );
-#else
         throw runtime_error("Exceeded density grid in DrL.");
-#endif
     }
 
     /* Subtract density values */
@@ -236,11 +232,7 @@ void DensityGrid::Add(Node &N) {
     if ( (x_grid >= GRID_SIZE) || (x_grid < 0) ||
          (y_grid >= GRID_SIZE) || (y_grid < 0) ||
          (z_grid >= GRID_SIZE) || (z_grid < 0) ) {
-#ifdef MUSE_MPI
-        MPI_Abort ( MPI_COMM_WORLD, 1 );
-#else
         throw runtime_error("Exceeded density grid in DrL.");
-#endif
     }
 
     /* Add density values */

--- a/src/layout/drl/DensityGrid_3d.h
+++ b/src/layout/drl/DensityGrid_3d.h
@@ -38,9 +38,6 @@
 
 #include "drl_layout_3d.h"
 #include "drl_Node_3d.h"
-#ifdef MUSE_MPI
-    #include <mpi.h>
-#endif
 
 #include <deque>
 

--- a/src/layout/drl/drl_graph.cpp
+++ b/src/layout/drl/drl_graph.cpp
@@ -1260,7 +1260,7 @@ int graph::draw_graph(igraph_matrix_t *res) {
     }
     igraph_integer_t n = positions.size();
     IGRAPH_CHECK(igraph_matrix_resize(res, n, 2));
-    for (size_t i = 0; i < n; i++) {
+    for (igraph_integer_t i = 0; i < n; i++) {
         MATRIX(*res, i, 0) = positions[i].x;
         MATRIX(*res, i, 1) = positions[i].y;
     }

--- a/src/layout/drl/drl_graph.cpp
+++ b/src/layout/drl/drl_graph.cpp
@@ -44,9 +44,6 @@ using namespace std;
 #include "igraph_interface.h"
 #include "igraph_progress.h"
 #include "core/interruption.h"
-#ifdef MUSE_MPI
-    #include <mpi.h>
-#endif
 
 namespace drl {
 
@@ -842,31 +839,10 @@ void graph::update_nodes ( ) {
         get_positions ( node_indices, new_positions );
 
         if ( i < num_nodes ) {
-
-            // advance random sequence according to myid
-            for ( size_t j = 0; j < 2 * myid; j++ ) {
-                RNG_UNIF01();
-            }
-            // rand();
-
             // calculate node energy possibilities
             if ( !(positions[i].fixed && real_fixed) ) {
                 update_node_pos ( i, old_positions, new_positions );
             }
-
-            // advance random sequence for next iteration
-            for ( size_t j = 2 * myid; j < 2 * (node_indices.size() - 1); j++ ) {
-                RNG_UNIF01();
-            }
-            // rand();
-
-        } else {
-            // advance random sequence according to use by
-            // the other processors
-            for ( size_t j = 0; j < 2 * (node_indices.size()); j++ ) {
-                RNG_UNIF01();
-            }
-            //rand();
         }
 
         // check if anything was actually updated (e.g. everything was fixed)
@@ -878,11 +854,6 @@ void graph::update_nodes ( ) {
 
         // update positions across processors (if not all fixed)
         if ( !all_fixed ) {
-#ifdef MUSE_MPI
-            MPI_Allgather ( &new_positions[2 * myid], 2, MPI_FLOAT,
-                            new_positions, 2, MPI_FLOAT, MPI_COMM_WORLD );
-#endif
-
             // update positions (old to new)
             update_density ( node_indices, old_positions, new_positions );
         }
@@ -1251,11 +1222,7 @@ float graph::get_tot_energy ( ) {
     //for ( i = positions.begin(); i != positions.end(); i++ )
     //  tot_energy += i->energy;
 
-#ifdef MUSE_MPI
-    MPI_Reduce ( &my_tot_energy, &tot_energy, 1, MPI_FLOAT, MPI_SUM, 0, MPI_COMM_WORLD );
-#else
     tot_energy = my_tot_energy;
-#endif
 
     return tot_energy;
 

--- a/src/layout/drl/drl_layout.cpp
+++ b/src/layout/drl/drl_layout.cpp
@@ -44,12 +44,6 @@
 // S. Martin
 // 5/6/2005
 
-// C++ library routines
-#include <map>
-#include <vector>
-
-using namespace std;
-
 // layout routines and constants
 #include "drl_layout.h"
 #include "drl_parse.h"

--- a/src/layout/drl/drl_layout.cpp
+++ b/src/layout/drl/drl_layout.cpp
@@ -55,11 +55,6 @@ using namespace std;
 #include "drl_parse.h"
 #include "drl_graph.h"
 
-// MPI
-#ifdef MUSE_MPI
-    #include <mpi.h>
-#endif
-
 using namespace drl;
 #include "igraph_layout.h"
 #include "igraph_random.h"

--- a/src/layout/drl/drl_layout_3d.cpp
+++ b/src/layout/drl/drl_layout_3d.cpp
@@ -44,12 +44,6 @@
 // S. Martin
 // 5/6/2005
 
-// C++ library routines
-#include <map>
-#include <vector>
-
-using namespace std;
-
 // layout routines and constants
 #include "drl_layout_3d.h"
 #include "drl_parse.h"

--- a/src/layout/drl/drl_layout_3d.cpp
+++ b/src/layout/drl/drl_layout_3d.cpp
@@ -55,11 +55,6 @@ using namespace std;
 #include "drl_parse.h"
 #include "drl_graph_3d.h"
 
-// MPI
-#ifdef MUSE_MPI
-    #include <mpi.h>
-#endif
-
 using namespace drl3d;
 #include "igraph_layout.h"
 #include "igraph_random.h"

--- a/src/layout/drl/drl_parse.h
+++ b/src/layout/drl/drl_parse.h
@@ -33,10 +33,6 @@
 // The parse class contains the methods necessary to parse
 // the command line, print help, and do error checking
 
-#ifdef MUSE_MPI
-    #include <mpi.h>
-#endif
-
 #include <string>
 
 namespace drl {


### PR DESCRIPTION
This PR removed parallel MPI code from the DrL layout.

Reasoning:

 - DrL was wastefully calling the RNG without using the result, just to deal with parallelization, which we don't use
 - igraph might use parallelization in the future, but not MPI, so we won't need this code
 - Compilation would have failed if someone accidentally defined `MUSE_MPI`. Unfortunately some packagers insert defines for no good reason (once MacPorts broke igraph by forcibly defining the `DEBUG` macro)
 - This eliminates some minor (harmless) compiler warnings about signed-unsigned comparisons

This PR may change the output for the same random seed through the removal of the RNG calls with unused results.