### PR TITLE
More aggressive tree/forest caching and forest caching bug fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [master]
 
+### Fixed
+
+ - When `igraph_is_forest()` tested for a directed in- or out-forest, and the test result was negative, it would incorrectly cache that the graph was not an undirected forest either.
+
 ## [0.10.9] - 2024-02-02
 
 ### Added

--- a/src/connectivity/components.c
+++ b/src/connectivity/components.c
@@ -730,6 +730,7 @@ static igraph_error_t igraph_i_decompose_weak(const igraph_t *graph,
             /* invmap = */ 0, /* map_is_prepared = */ 1
         ));
         IGRAPH_FINALLY(igraph_destroy, &newg);
+        igraph_i_property_cache_set_bool(&newg, IGRAPH_PROP_IS_WEAKLY_CONNECTED, true);
         IGRAPH_CHECK(igraph_graph_list_push_back(components, &newg));
         IGRAPH_FINALLY_CLEAN(1);  /* ownership of newg now taken by 'components' */
         resco++;
@@ -937,6 +938,8 @@ static igraph_error_t igraph_i_decompose_strong(const igraph_t *graph,
             /* invmap = */ 0, /* map_is_prepared = */ 1
         ));
         IGRAPH_FINALLY(igraph_destroy, &newg);
+        igraph_i_property_cache_set_bool(&newg, IGRAPH_PROP_IS_WEAKLY_CONNECTED, true);
+        igraph_i_property_cache_set_bool(&newg, IGRAPH_PROP_IS_STRONGLY_CONNECTED, true);
         IGRAPH_CHECK(igraph_graph_list_push_back(components, &newg));
         IGRAPH_FINALLY_CLEAN(1);  /* ownership of newg now taken by 'components' */
 

--- a/tests/unit/igraph_has_mutual.c
+++ b/tests/unit/igraph_has_mutual.c
@@ -26,54 +26,63 @@ int main(void) {
     igraph_empty(&graph, 0, IGRAPH_UNDIRECTED);
     igraph_has_mutual(&graph, &has_mutual, IGRAPH_LOOPS);
     IGRAPH_ASSERT(! has_mutual);
+    cache_consistency_checks(&graph);
     igraph_destroy(&graph);
 
     /* undirected edgeless graph */
     igraph_empty(&graph, 3, IGRAPH_UNDIRECTED);
     igraph_has_mutual(&graph, &has_mutual, IGRAPH_LOOPS);
     IGRAPH_ASSERT(! has_mutual);
+    cache_consistency_checks(&graph);
     igraph_destroy(&graph);
 
     /* directed null graph */
     igraph_empty(&graph, 0, IGRAPH_DIRECTED);
     igraph_has_mutual(&graph, &has_mutual, IGRAPH_LOOPS);
     IGRAPH_ASSERT(! has_mutual);
+    cache_consistency_checks(&graph);
     igraph_destroy(&graph);
 
     /* directed edgeless graph */
     igraph_empty(&graph, 3, IGRAPH_DIRECTED);
     igraph_has_mutual(&graph, &has_mutual, IGRAPH_LOOPS);
     IGRAPH_ASSERT(! has_mutual);
+    cache_consistency_checks(&graph);
     igraph_destroy(&graph);
 
     /* undirected with edges */
     igraph_small(&graph, 1, IGRAPH_UNDIRECTED, 0,1, -1);
     igraph_has_mutual(&graph, &has_mutual, IGRAPH_LOOPS);
     IGRAPH_ASSERT(has_mutual);
+    cache_consistency_checks(&graph);
     igraph_destroy(&graph);
 
     /* directed with no mutual */
     igraph_small(&graph, 0, IGRAPH_DIRECTED, 0,1, 1,2, -1);
     igraph_has_mutual(&graph, &has_mutual, IGRAPH_LOOPS);
     IGRAPH_ASSERT(! has_mutual);
+    cache_consistency_checks(&graph);
     igraph_destroy(&graph);
 
     /* directed with mutual */
     igraph_small(&graph, 0, IGRAPH_DIRECTED, 0,1, 1,0, -1);
     igraph_has_mutual(&graph, &has_mutual, IGRAPH_LOOPS);
     IGRAPH_ASSERT(has_mutual);
+    cache_consistency_checks(&graph);
     igraph_destroy(&graph);
 
     /* directed with loops, loops considered mutual */
     igraph_small(&graph, 0, IGRAPH_DIRECTED, 0,1, 0,1, 1,1, 1,2, -1);
     igraph_has_mutual(&graph, &has_mutual, IGRAPH_LOOPS);
     IGRAPH_ASSERT(has_mutual);
+    cache_consistency_checks(&graph);
     igraph_destroy(&graph);
 
     /* directed with loops, loops not considered mutual */
     igraph_small(&graph, 0, IGRAPH_DIRECTED, 0,1, 0,1, 1,1, 1,2, -1);
     igraph_has_mutual(&graph, &has_mutual, IGRAPH_NO_LOOPS);
     IGRAPH_ASSERT(!has_mutual);
+    cache_consistency_checks(&graph);
     igraph_destroy(&graph);
 
     VERIFY_FINALLY_STACK();

--- a/tests/unit/igraph_is_acyclic.c
+++ b/tests/unit/igraph_is_acyclic.c
@@ -28,24 +28,28 @@ int main(void) {
     igraph_empty(&graph, 0, IGRAPH_DIRECTED);
     igraph_is_acyclic(&graph, &acyclic);
     IGRAPH_ASSERT(acyclic);
+    cache_consistency_checks(&graph);
     igraph_destroy(&graph);
 
     /* Null graph undirected */
     igraph_empty(&graph, 0, IGRAPH_UNDIRECTED);
     igraph_is_acyclic(&graph, &acyclic);
     IGRAPH_ASSERT(acyclic);
+    cache_consistency_checks(&graph);
     igraph_destroy(&graph);
 
     /* Singleton graph directed */
     igraph_empty(&graph, 1, IGRAPH_DIRECTED);
     igraph_is_acyclic(&graph, &acyclic);
     IGRAPH_ASSERT(acyclic);
+    cache_consistency_checks(&graph);
     igraph_destroy(&graph);
 
     /* Singleton graph undirected */
     igraph_empty(&graph, 1, IGRAPH_UNDIRECTED);
     igraph_is_acyclic(&graph, &acyclic);
     IGRAPH_ASSERT(acyclic);
+    cache_consistency_checks(&graph);
     igraph_destroy(&graph);
 
     /* Directed cyclic */
@@ -54,6 +58,7 @@ int main(void) {
         -1);
     igraph_is_acyclic(&graph, &acyclic);
     IGRAPH_ASSERT(!acyclic);
+    cache_consistency_checks(&graph);
     igraph_destroy(&graph);
 
     /* Directed acyclic */
@@ -62,6 +67,7 @@ int main(void) {
         -1);
     igraph_is_acyclic(&graph, &acyclic);
     IGRAPH_ASSERT(acyclic);
+    cache_consistency_checks(&graph);
     igraph_destroy(&graph);
 
     /* Undirected cyclic */
@@ -70,6 +76,7 @@ int main(void) {
         -1);
     igraph_is_acyclic(&graph, &acyclic);
     IGRAPH_ASSERT(! acyclic);
+    cache_consistency_checks(&graph);
     igraph_destroy(&graph);
 
     /* Undirected acyclic */
@@ -78,6 +85,7 @@ int main(void) {
         -1);
     igraph_is_acyclic(&graph, &acyclic);
     IGRAPH_ASSERT(acyclic);
+    cache_consistency_checks(&graph);
     igraph_destroy(&graph);
 
     /* Self loop directed */
@@ -86,6 +94,7 @@ int main(void) {
         -1);
     igraph_is_acyclic(&graph, &acyclic);
     IGRAPH_ASSERT(! acyclic);
+    cache_consistency_checks(&graph);
     igraph_destroy(&graph);
 
     /* Self loop undirected */
@@ -94,6 +103,7 @@ int main(void) {
         -1);
     igraph_is_acyclic(&graph, &acyclic);
     IGRAPH_ASSERT(! acyclic);
+    cache_consistency_checks(&graph);
     igraph_destroy(&graph);
 
     /* Directed acyclic graph which would be cyclic if undirected */
@@ -102,10 +112,10 @@ int main(void) {
         -1);
     igraph_is_acyclic(&graph, &acyclic);
     IGRAPH_ASSERT(acyclic);
+    cache_consistency_checks(&graph);
     igraph_destroy(&graph);
 
     VERIFY_FINALLY_STACK();
 
     return 0;
-
 }

--- a/tests/unit/igraph_is_biconnected.c
+++ b/tests/unit/igraph_is_biconnected.c
@@ -27,16 +27,19 @@ int main(void) {
     igraph_empty(&g, 0, IGRAPH_UNDIRECTED);
     igraph_is_biconnected(&g, &result);
     IGRAPH_ASSERT(!result);
+    cache_consistency_checks(&g);
     igraph_destroy(&g);
 
     igraph_empty(&g, 1, IGRAPH_UNDIRECTED);
     igraph_is_biconnected(&g, &result);
     IGRAPH_ASSERT(!result);
+    cache_consistency_checks(&g);
     igraph_destroy(&g);
 
     igraph_empty(&g, 2, IGRAPH_UNDIRECTED);
     igraph_is_biconnected(&g, &result);
     IGRAPH_ASSERT(!result);
+    cache_consistency_checks(&g);
     igraph_destroy(&g);
 
     igraph_small(&g, 2, IGRAPH_UNDIRECTED,
@@ -44,6 +47,7 @@ int main(void) {
                  -1);
     igraph_is_biconnected(&g, &result);
     IGRAPH_ASSERT(result);
+    cache_consistency_checks(&g);
     igraph_destroy(&g);
 
     igraph_small(&g, 6, IGRAPH_UNDIRECTED,
@@ -52,6 +56,7 @@ int main(void) {
                  -1);
     igraph_is_biconnected(&g, &result);
     IGRAPH_ASSERT(!result);
+    cache_consistency_checks(&g);
     igraph_destroy(&g);
 
     igraph_ring(&g, 10, IGRAPH_UNDIRECTED, 0, 1);
@@ -64,6 +69,7 @@ int main(void) {
                  -1);
     igraph_is_biconnected(&g, &result);
     IGRAPH_ASSERT(!result);
+    cache_consistency_checks(&g);
     igraph_destroy(&g);
 
     igraph_small(&g, 5, IGRAPH_UNDIRECTED,
@@ -71,6 +77,7 @@ int main(void) {
                  -1);
     igraph_is_biconnected(&g, &result);
     IGRAPH_ASSERT(result);
+    cache_consistency_checks(&g);
     igraph_destroy(&g);
 
     igraph_small(&g, 7, IGRAPH_UNDIRECTED,
@@ -78,6 +85,7 @@ int main(void) {
                  -1);
     igraph_is_biconnected(&g, &result);
     IGRAPH_ASSERT(!result);
+    cache_consistency_checks(&g);
     igraph_destroy(&g);
 
     /* Two disjoint cycles */
@@ -86,6 +94,7 @@ int main(void) {
                  -1);
     igraph_is_biconnected(&g, &result);
     IGRAPH_ASSERT(!result);
+    cache_consistency_checks(&g);
     igraph_destroy(&g);
 
     /* Cycle + isolated vertex */
@@ -94,6 +103,7 @@ int main(void) {
                  -1);
     igraph_is_biconnected(&g, &result);
     IGRAPH_ASSERT(!result);
+    cache_consistency_checks(&g);
     igraph_destroy(&g);
 
     /* Special case: the root is an articulation point */
@@ -102,6 +112,7 @@ int main(void) {
                  -1);
     igraph_is_biconnected(&g, &result);
     IGRAPH_ASSERT(!result);
+    cache_consistency_checks(&g);
     igraph_destroy(&g);
 
     VERIFY_FINALLY_STACK();
@@ -120,6 +131,7 @@ int main(void) {
     IGRAPH_ASSERT(result);
     igraph_is_acyclic(&g, &acyclic);
     IGRAPH_ASSERT(acyclic);
+    cache_consistency_checks(&g);
 
     igraph_invalidate_cache(&g);
 
@@ -127,9 +139,11 @@ int main(void) {
     IGRAPH_ASSERT(acyclic);
     igraph_is_biconnected(&g, &result);
     IGRAPH_ASSERT(result);
+    cache_consistency_checks(&g);
 
     igraph_destroy(&g);
 
+    VERIFY_FINALLY_STACK();
 
     return 0;
 }

--- a/tests/unit/igraph_is_bipartite.c
+++ b/tests/unit/igraph_is_bipartite.c
@@ -16,6 +16,7 @@ int main(void) {
     igraph_is_bipartite(&graph, &bipartite, &types);
     IGRAPH_ASSERT(bipartite);
     IGRAPH_ASSERT(igraph_vector_bool_size(&types) == igraph_vcount(&graph));
+    cache_consistency_checks(&graph);
     igraph_destroy(&graph);
 
     /* Singleton graph */
@@ -23,6 +24,7 @@ int main(void) {
     igraph_is_bipartite(&graph, &bipartite, &types);
     IGRAPH_ASSERT(bipartite);
     IGRAPH_ASSERT(igraph_vector_bool_size(&types) == igraph_vcount(&graph));
+    cache_consistency_checks(&graph);
     igraph_destroy(&graph);
 
     /* Singleton with self-loop */
@@ -32,11 +34,13 @@ int main(void) {
     igraph_is_bipartite(&graph, &bipartite, &types);
     IGRAPH_ASSERT(! bipartite);
     IGRAPH_ASSERT(igraph_vector_bool_size(&types) == igraph_vcount(&graph));
+    cache_consistency_checks(&graph);
 
     /* Test cache usage */
     igraph_has_loop(&graph, &has_loop);
     igraph_is_bipartite(&graph, &bipartite, NULL);
     IGRAPH_ASSERT(! bipartite);
+    cache_consistency_checks(&graph);
 
     igraph_destroy(&graph);
 
@@ -48,11 +52,13 @@ int main(void) {
     igraph_is_bipartite(&graph, &bipartite, &types);
     IGRAPH_ASSERT(bipartite);
     IGRAPH_ASSERT(igraph_vector_bool_size(&types) == igraph_vcount(&graph));
+    cache_consistency_checks(&graph);
 
     /* Test cache usage */
     igraph_is_forest(&graph, &acyclic, NULL, IGRAPH_ALL);
     igraph_is_bipartite(&graph, &bipartite, NULL);
     IGRAPH_ASSERT(bipartite);
+    cache_consistency_checks(&graph);
 
     /* Odd directed cycle */
     igraph_add_edge(&graph, 2, 0);
@@ -61,11 +67,13 @@ int main(void) {
     igraph_is_bipartite(&graph, &bipartite, &types);
     IGRAPH_ASSERT(! bipartite);
     IGRAPH_ASSERT(igraph_vector_bool_size(&types) == igraph_vcount(&graph));
+    cache_consistency_checks(&graph);
 
     /* Test cache usage */
     igraph_is_forest(&graph, &acyclic, NULL, IGRAPH_ALL);
     igraph_is_bipartite(&graph, &bipartite, NULL);
     IGRAPH_ASSERT(! bipartite);
+    cache_consistency_checks(&graph);
 
     igraph_destroy(&graph);
 

--- a/tests/unit/igraph_is_connected.c
+++ b/tests/unit/igraph_is_connected.c
@@ -32,6 +32,7 @@ int main(void) {
 
     igraph_is_connected(&graph, &conn, IGRAPH_STRONG);
     IGRAPH_ASSERT(! conn);
+    cache_consistency_checks(&graph);
 
     igraph_destroy(&graph);
 
@@ -43,6 +44,7 @@ int main(void) {
 
     igraph_is_connected(&graph, &conn, IGRAPH_STRONG);
     IGRAPH_ASSERT(conn);
+    cache_consistency_checks(&graph);
 
     igraph_destroy(&graph);
 
@@ -55,6 +57,7 @@ int main(void) {
 
     igraph_is_connected(&graph, &conn, IGRAPH_STRONG);
     IGRAPH_ASSERT(! conn);
+    cache_consistency_checks(&graph);
 
     igraph_destroy(&graph);
 
@@ -67,6 +70,7 @@ int main(void) {
 
     igraph_is_connected(&graph, &conn, IGRAPH_STRONG);
     IGRAPH_ASSERT(! conn);
+    cache_consistency_checks(&graph);
 
     igraph_destroy(&graph);
 
@@ -80,6 +84,7 @@ int main(void) {
 
     igraph_is_connected(&graph, &conn, IGRAPH_STRONG);
     IGRAPH_ASSERT(! conn);
+    cache_consistency_checks(&graph);
 
     igraph_destroy(&graph);
 
@@ -93,6 +98,7 @@ int main(void) {
 
     igraph_is_connected(&graph, &conn, IGRAPH_STRONG);
     IGRAPH_ASSERT(conn);
+    cache_consistency_checks(&graph);
 
     igraph_destroy(&graph);
 

--- a/tests/unit/igraph_is_dag.c
+++ b/tests/unit/igraph_is_dag.c
@@ -28,6 +28,7 @@ int main(void) {
         igraph_empty(&graph, n, IGRAPH_DIRECTED);
         igraph_is_dag(&graph, &is_dag);
         IGRAPH_ASSERT(is_dag);
+        cache_consistency_checks(&graph);
         igraph_destroy(&graph);
     }
 
@@ -36,6 +37,7 @@ int main(void) {
         igraph_empty(&graph, n, IGRAPH_UNDIRECTED);
         igraph_is_dag(&graph, &is_dag);
         IGRAPH_ASSERT(!is_dag);
+        cache_consistency_checks(&graph);
         igraph_destroy(&graph);
     }
 
@@ -45,6 +47,7 @@ int main(void) {
                  -1);
     igraph_is_dag(&graph, &is_dag);
     IGRAPH_ASSERT(is_dag);
+    cache_consistency_checks(&graph);
     igraph_destroy(&graph);
 
     // reciprocal edges -- not a DAG
@@ -53,6 +56,7 @@ int main(void) {
                  -1);
     igraph_is_dag(&graph, &is_dag);
     IGRAPH_ASSERT(! is_dag);
+    cache_consistency_checks(&graph);
     igraph_destroy(&graph);
 
     // 4-cycle -- not a DAG
@@ -61,6 +65,7 @@ int main(void) {
                  -1);
     igraph_is_dag(&graph, &is_dag);
     IGRAPH_ASSERT(!is_dag);
+    cache_consistency_checks(&graph);
     igraph_destroy(&graph);
 
     // 4-cycle with outgoing edge -- not a DAG
@@ -69,6 +74,7 @@ int main(void) {
                  -1);
     igraph_is_dag(&graph, &is_dag);
     IGRAPH_ASSERT(!is_dag);
+    cache_consistency_checks(&graph);
     igraph_destroy(&graph);
 
     // 4-cycle with incoming edge -- not a DAG
@@ -77,6 +83,7 @@ int main(void) {
                  -1);
     igraph_is_dag(&graph, &is_dag);
     IGRAPH_ASSERT(!is_dag);
+    cache_consistency_checks(&graph);
     igraph_destroy(&graph);
 
     // X shape, DAG
@@ -85,6 +92,7 @@ int main(void) {
                  -1);
     igraph_is_dag(&graph, &is_dag);
     IGRAPH_ASSERT(is_dag);
+    cache_consistency_checks(&graph);
     igraph_destroy(&graph);
 
     // self-loop present, not a DAG
@@ -93,6 +101,7 @@ int main(void) {
                  -1);
     igraph_is_dag(&graph, &is_dag);
     IGRAPH_ASSERT(!is_dag);
+    cache_consistency_checks(&graph);
     igraph_destroy(&graph);
 
     // singleton with self-loop
@@ -101,24 +110,28 @@ int main(void) {
                  -1);
     igraph_is_dag(&graph, &is_dag);
     IGRAPH_ASSERT(!is_dag);
+    cache_consistency_checks(&graph);
     igraph_destroy(&graph);
 
     // out-tree
     igraph_kary_tree(&graph, 6, 2, IGRAPH_TREE_OUT);
     igraph_is_dag(&graph, &is_dag);
     IGRAPH_ASSERT(is_dag);
+    cache_consistency_checks(&graph);
     igraph_destroy(&graph);
 
     // in-tree
     igraph_kary_tree(&graph, 6, 2, IGRAPH_TREE_IN);
     igraph_is_dag(&graph, &is_dag);
     IGRAPH_ASSERT(is_dag);
+    cache_consistency_checks(&graph);
     igraph_destroy(&graph);
 
     // undirected -- not a DAG
     igraph_kary_tree(&graph, 6, 2, IGRAPH_TREE_UNDIRECTED);
     igraph_is_dag(&graph, &is_dag);
     IGRAPH_ASSERT(!is_dag);
+    cache_consistency_checks(&graph);
     igraph_destroy(&graph);
 
     VERIFY_FINALLY_STACK();

--- a/tests/unit/igraph_is_forest.c
+++ b/tests/unit/igraph_is_forest.c
@@ -125,8 +125,21 @@ int main(void) {
     mode=IGRAPH_ALL;
     res=0;
     check_output(&graph, &res, mode);
-
     igraph_destroy(&graph);
+
+    /* Cache testing */
+
+    /* 1 <- 0 -> 2 <- 3 */
+    igraph_small(&graph, 0, IGRAPH_DIRECTED,
+                 0,1, 0,2, 3,2, -1);
+    /* This must not cache that the graph is not a forest,
+     * as we are only checking the directed case: */
+    igraph_is_forest(&graph, &res, NULL, IGRAPH_OUT);
+    IGRAPH_ASSERT(!res);
+    igraph_is_forest(&graph, &res, NULL, IGRAPH_ALL);
+    IGRAPH_ASSERT(res);
+    igraph_destroy(&graph);
+
     VERIFY_FINALLY_STACK();
 
     return 0;

--- a/tests/unit/igraph_is_forest.c
+++ b/tests/unit/igraph_is_forest.c
@@ -34,6 +34,7 @@ void check_output(const igraph_t *graph, igraph_bool_t *res, igraph_neimode_t mo
         printf("Not a forest.\n");
     }
     IGRAPH_ASSERT(*res == result);
+    cache_consistency_checks(graph);
     igraph_vector_int_destroy(&roots);
     printf("\n");
 }
@@ -138,6 +139,7 @@ int main(void) {
     IGRAPH_ASSERT(!res);
     igraph_is_forest(&graph, &res, NULL, IGRAPH_ALL);
     IGRAPH_ASSERT(res);
+    cache_consistency_checks(&graph);
     igraph_destroy(&graph);
 
     VERIFY_FINALLY_STACK();

--- a/tests/unit/igraph_is_mutual.c
+++ b/tests/unit/igraph_is_mutual.c
@@ -26,6 +26,7 @@ void call_and_print(igraph_t *graph, igraph_es_t es, igraph_bool_t loops) {
     igraph_vector_bool_print(&result);
     printf("\n");
     igraph_vector_bool_destroy(&result);
+    cache_consistency_checks(graph);
 }
 
 

--- a/tests/unit/igraph_is_tree.c
+++ b/tests/unit/igraph_is_tree.c
@@ -13,6 +13,7 @@ int main(void) {
 
     igraph_is_tree(&g, &res, &root, IGRAPH_ALL);
     IGRAPH_ASSERT(! res);
+    cache_consistency_checks(&g);
 
     igraph_destroy(&g);
 
@@ -23,6 +24,7 @@ int main(void) {
     igraph_is_tree(&g, &res, &root, IGRAPH_ALL);
     IGRAPH_ASSERT(res);
     IGRAPH_ASSERT(root == 0);
+    cache_consistency_checks(&g);
 
     igraph_destroy(&g);
 
@@ -32,6 +34,7 @@ int main(void) {
 
     igraph_is_tree(&g, &res, &root, IGRAPH_ALL);
     IGRAPH_ASSERT(! res);
+    cache_consistency_checks(&g);
 
     igraph_destroy(&g);
 
@@ -41,6 +44,7 @@ int main(void) {
 
     igraph_is_tree(&g, &res, &root, IGRAPH_ALL);
     IGRAPH_ASSERT(! res);
+    cache_consistency_checks(&g);
 
     igraph_destroy(&g);
 
@@ -53,6 +57,7 @@ int main(void) {
 
     igraph_is_tree(&g, &res, &root, IGRAPH_ALL);
     IGRAPH_ASSERT(! res);
+    cache_consistency_checks(&g);
 
     igraph_destroy(&g);
 
@@ -64,6 +69,7 @@ int main(void) {
     igraph_is_tree(&g, &res, &root, IGRAPH_ALL);
     IGRAPH_ASSERT(res);
     IGRAPH_ASSERT(root == 0);
+    cache_consistency_checks(&g);
 
     igraph_destroy(&g);
 
@@ -78,11 +84,13 @@ int main(void) {
 
     igraph_is_tree(&g, &res, &root, IGRAPH_IN);
     IGRAPH_ASSERT(! res);
+    cache_consistency_checks(&g);
 
     root = -1;
     igraph_is_tree(&g, &res, &root, IGRAPH_ALL);
     IGRAPH_ASSERT(res);
     IGRAPH_ASSERT(root == 0);
+    cache_consistency_checks(&g);
 
     igraph_destroy(&g);
 
@@ -94,14 +102,17 @@ int main(void) {
     igraph_is_tree(&g, &res, &root, IGRAPH_IN);
     IGRAPH_ASSERT(res);
     IGRAPH_ASSERT(root == 3);
+    cache_consistency_checks(&g);
 
     igraph_is_tree(&g, &res, &root, IGRAPH_OUT);
     IGRAPH_ASSERT(! res);
+    cache_consistency_checks(&g);
 
     root = -1;
     igraph_is_tree(&g, &res, &root, IGRAPH_ALL);
     IGRAPH_ASSERT(res);
     IGRAPH_ASSERT(root == 0);
+    cache_consistency_checks(&g);
 
     igraph_destroy(&g);
 
@@ -113,12 +124,15 @@ int main(void) {
     igraph_is_tree(&g, &res, &root, IGRAPH_ALL);
     IGRAPH_ASSERT(res);
     IGRAPH_ASSERT(root == 0);
+    cache_consistency_checks(&g);
 
     igraph_is_tree(&g, &res, &root, IGRAPH_IN);
     IGRAPH_ASSERT(! res);
+    cache_consistency_checks(&g);
 
     igraph_is_tree(&g, &res, &root, IGRAPH_OUT);
     IGRAPH_ASSERT(! res);
+    cache_consistency_checks(&g);
 
     igraph_destroy(&g);
 
@@ -131,6 +145,7 @@ int main(void) {
 
     igraph_is_tree(&g, &res, &root, IGRAPH_ALL);
     IGRAPH_ASSERT(! res);
+    cache_consistency_checks(&g);
 
     igraph_destroy(&g);
 

--- a/tests/unit/prop_caching.c
+++ b/tests/unit/prop_caching.c
@@ -83,6 +83,7 @@ void validate_properties(const igraph_t* graph) {
     CHECK(is_strongly_connected);
     CHECK(has_mutual_edge);
     CHECK(has_mutual_nonloop_edge);
+    cache_consistency_checks(graph);
 }
 
 void test_basic_operations(igraph_t* graph) {

--- a/tests/unit/test_utilities.h
+++ b/tests/unit/test_utilities.h
@@ -167,4 +167,7 @@ void record_last_warning(const char *reason, const char *file, int line);
             free(expect_warning_ctx.observed); \
         } \
     } while (0)
+
+void cache_consistency_checks(const igraph_t *graph);
+
 #endif /* TEST_UTILITIES_H */


### PR DESCRIPTION
This PR adds more aggressive cache use for `is_tree()` and `is_forest()` and also fixes a bug in how `is_forest()` set the cache. See the added test (which failed previously) as well as the commit messages.

Since cache use bugs can be high-consequence, I need _two_ very careful reviews on this please.

EDIT: Also added some consistency checks for cached properties as well as caching for `igraph_decompose()`.