### PR TITLE
Fix `is_separator()` on disconnected graphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,11 @@
  - `igraph_disjoint_union()` and `igraph_disjoint_union_many()` now check for overflow.
  - `igraph_read_graph_graphml()` now correctly compares attribute values with certain expected values, meaning that prefixes of valid values of `attr.type` are not accepted any more.
  - Empty IDs are not allowed any more in `<key>` tags of GraphML files as this is a violation of the GraphML specification.
+ - `igraph_is_separator()` and `igraph_is_minimal_separator()` now work correctly with disconnected graphs.
 
 ### Other
 
+ - The performance of `igraph_is_minimal_separator()` was improved.
  - Documentation improvements.
 
 ## [0.10.10] - 2024-02-13

--- a/examples/simple/igraph_is_separator.c
+++ b/examples/simple/igraph_is_separator.c
@@ -50,7 +50,6 @@ int main(void) {
     if (result) {
         FAIL("All non-central vertices of star graph failed.", 5);
     }
-    igraph_destroy(&graph);
 
     /* Same graph, all vertices */
     igraph_is_separator(&graph, igraph_vss_range(0, 10), &result);

--- a/src/connectivity/separators.c
+++ b/src/connectivity/separators.c
@@ -34,97 +34,269 @@
 
 #include "core/interruption.h"
 
-static igraph_error_t igraph_i_is_separator(const igraph_t *graph,
-                                 igraph_vit_t *vit,
-                                 igraph_integer_t except,
-                                 igraph_bool_t *res,
-                                 igraph_vector_bool_t *removed,
-                                 igraph_dqueue_int_t *Q,
-                                 igraph_vector_int_t *neis,
-                                 igraph_integer_t no_of_nodes) {
 
-    igraph_integer_t start = 0;
+/**
+ * \function igraph_i_is_separator
+ *
+ * Checks if vertex set \c S is a separator. Optionally, also checks if it
+ * is a _minimal_ separator.
+ *
+ * \param graph The graph, edge directions are ignored.
+ * \param S Candidate vertex set.
+ * \param is_separator Pointer to boolean, is S a separator?
+ * \param is_minimal If not \c NULL, it is also checked whether the separator
+ *    is minimal. This takes additional time.  If S is not a separator, this is
+ *    set to false
+ */
+static igraph_error_t igraph_i_is_separator(
+    const igraph_t *graph,
+    igraph_vs_t S,
+    igraph_bool_t *is_separator,
+    igraph_bool_t *is_minimal
+) {
 
-    if (IGRAPH_VIT_SIZE(*vit) >= no_of_nodes - 1) {
-        /* Just need to check that we really have at least n-1 vertices in it */
-        igraph_vector_bool_t hit;
-        igraph_integer_t nohit = 0;
-        IGRAPH_CHECK(igraph_vector_bool_init(&hit, no_of_nodes));
-        IGRAPH_FINALLY(igraph_vector_bool_destroy, &hit);
-        for (IGRAPH_VIT_RESET(*vit);
-             !IGRAPH_VIT_END(*vit);
-             IGRAPH_VIT_NEXT(*vit)) {
-            igraph_integer_t v = IGRAPH_VIT_GET(*vit);
-            if (!VECTOR(hit)[v]) {
-                nohit++;
-                VECTOR(hit)[v] = true;
+    const igraph_integer_t vcount = igraph_vcount(graph);
+
+    /* mark[v] means:
+     *
+     * bit 0: Was v visited?
+     * bit 1: Is v in S?
+     * bit 2: Used to keep track of which vertices were reachable in S
+     *        from its neighbourhood in the minimal separator test.
+     */
+    igraph_vector_char_t mark;
+
+    igraph_vector_int_t neis;
+    igraph_dqueue_int_t Q;
+    igraph_vit_t vit;
+    igraph_integer_t S_size = 0, S_visited_count = 0;
+
+    IGRAPH_CHECK(igraph_vit_create(graph, S, &vit));
+    IGRAPH_FINALLY(igraph_vit_destroy, &vit);
+
+    IGRAPH_VECTOR_CHAR_INIT_FINALLY(&mark, vcount);
+    IGRAPH_VECTOR_INT_INIT_FINALLY(&neis, 10);
+    IGRAPH_DQUEUE_INT_INIT_FINALLY(&Q, 100);
+
+#define VISITED(x) (VECTOR(mark)[x] & 1) /* Was x visited? */
+#define SET_VISITED(x) (VECTOR(mark)[x] |= 1) /* Mark x as visited. */
+#define IN_S(x) (VECTOR(mark)[x] & 2) /* Is x in S? */
+#define SET_IN_S(x) (VECTOR(mark)[x] |= 2) /* Mark x as being in S. */
+
+    /* Mark and count vertices in S, taking care not to double-count
+     * when duplicate vertices were passed in. */
+    for (; ! IGRAPH_VIT_END(vit); IGRAPH_VIT_NEXT(vit)) {
+        const igraph_integer_t u = IGRAPH_VIT_GET(vit);
+        if (! IN_S(u)) {
+            SET_IN_S(u);
+            S_size++;
+        }
+    }
+
+    /* If S contains more than |V| - 2 vertices, it is not a separator. */
+    if (S_size > vcount-2) {
+        *is_separator = false;
+        goto done;
+    }
+
+    /* Assume that S is not a separator until proven otherwise. */
+    *is_separator = false;
+
+    for (IGRAPH_VIT_RESET(vit); ! IGRAPH_VIT_END(vit); IGRAPH_VIT_NEXT(vit)) {
+
+        const igraph_integer_t u = IGRAPH_VIT_GET(vit);
+        if (VISITED(u)) {
+            continue;
+        }
+
+        /* For the sake of the following discussion, and counting of degrees,
+         * let us consider each undirected edge as a pair of directed ones.
+         */
+
+        /* We start at a vertex in S, and traverse the graph with the following
+         * restriction:
+         *
+         * Once we exited S through an edge, we may not exit through
+         * any other edge again (but we may re-enter S). With this traversal,
+         * we can determine: once we find ourselves outside of S, are there
+         * any vertices which we can only reach by passing through S again?
+         *
+         * Theorem: The visited vertices in S constitute a separating set if and
+         * only if when the traversal is complete, some of them still have
+         * untraversed out-edges.
+         *
+         * Note that this refers only to the subset of S visited during this
+         * traversal, not the rest of S. If there are remaining vertices in S,
+         * they may constitute a separating set as well. We cannot conclude that
+         * S is NOT a separator until all its vertices have been considered, hence
+         * the outer for-loop.
+         */
+
+        /* Sum of in-degrees of visited vertices in S. */
+        igraph_integer_t degsum = 0;
+
+        /* Number of in-edges of vertices in S that were traversed. */
+        igraph_integer_t edgecount = 0;
+
+        /* Have we already traversed an edge leaving S? */
+        igraph_bool_t exited = false;
+
+        IGRAPH_CHECK(igraph_dqueue_int_push(&Q, u));
+
+        while (! igraph_dqueue_int_empty(&Q)) {
+            const igraph_integer_t v = igraph_dqueue_int_pop(&Q);
+            if (VISITED(v)) {
+                continue;
+            }
+
+            SET_VISITED(v);
+            IGRAPH_CHECK(igraph_neighbors(graph, &neis, v, IGRAPH_ALL));
+
+            const igraph_integer_t dv = igraph_vector_int_size(&neis);
+
+            if (IN_S(v)) {
+                degsum += dv;
+                S_visited_count++;
+            }
+
+            for (igraph_integer_t i=0; i < dv; i++) {
+                const igraph_integer_t w = VECTOR(neis)[i];
+
+                /* Decide whether to traverse the v -> w edge. */
+                if (!exited || !IN_S(v) || IN_S(w)) {
+                    if (IN_S(w)) {
+                        edgecount++;
+                    }
+
+                    if (!VISITED(w)) {
+                        IGRAPH_CHECK(igraph_dqueue_int_push(&Q, w));
+                    }
+
+                    if (!exited && IN_S(v) && !IN_S(w)) {
+                        exited = true;
+                    }
+                }
             }
         }
-        igraph_vector_bool_destroy(&hit);
-        IGRAPH_FINALLY_CLEAN(1);
-        if (nohit >= no_of_nodes - 1) {
-            *res = false;
-            return IGRAPH_SUCCESS;
+
+        /* If some incident edges of visited vertices in S are
+         * still untraversed, then S is a separator. We are done. */
+        if (degsum > edgecount) {
+            *is_separator = true;
+            break;
         }
     }
 
-    /* Remove the given vertices from the graph, do a breadth-first
-       search and check the number of components */
+done:
 
-    if (except < 0) {
-        for (IGRAPH_VIT_RESET(*vit);
-             !IGRAPH_VIT_END(*vit);
-             IGRAPH_VIT_NEXT(*vit)) {
-            VECTOR(*removed)[ IGRAPH_VIT_GET(*vit) ] = true;
+    /* Optionally, check if S is also a _minimal_ separator. */
+    if (is_minimal != NULL) {
+        /* Be optimistic, and assume that if S was found to be a separator,
+         * it is a minimal separator. */
+        *is_minimal = *is_separator;
+
+        /* If S was proven to be a separator before visiting all of its
+         * vertices, it is not minimal. We are done. */
+        if (*is_minimal && S_visited_count < S_size) {
+            *is_minimal = false;
         }
-    } else {
-        /* There is an exception */
-        igraph_integer_t i;
-        for (i = 0, IGRAPH_VIT_RESET(*vit);
-             i < except;
-             i++, IGRAPH_VIT_NEXT(*vit)) {
-            VECTOR(*removed)[ IGRAPH_VIT_GET(*vit) ] = true;
-        }
-        for (IGRAPH_VIT_NEXT(*vit);
-             !IGRAPH_VIT_END(*vit);
-             IGRAPH_VIT_NEXT(*vit)) {
-            VECTOR(*removed)[ IGRAPH_VIT_GET(*vit) ] = true;
-        }
-    }
 
-    /* Look for the first node that is not removed */
-    while (start < no_of_nodes && VECTOR(*removed)[start]) {
-        start++;
-    }
+        /* The subset of S with untraversed out-edges forms a separator.
+         * Therefore, if S contains vertices with no untraversed out-edges,
+         * S is not minimal.
+         *
+         * Suppose it doesn't contain any.
+         *
+         * Then for S to be minimal, each of its vertices should be reachable
+         * from any vertex in the unvisited neighbourhood of S. In order to
+         * separate a vertex in this neighbourhood, we need to cut precisely
+         * those vertices in S which are reachable from it.
+         *
+         * The check below verifies BOTH of the above conditions by traversing
+         * the graph from each unvisited neighbour of S with the constraint
+         * of never entering S.
+         */
+        if (*is_minimal) {
+            igraph_vector_int_t Sneis;
+            IGRAPH_VECTOR_INT_INIT_FINALLY(&Sneis, 10);
 
-    if (start == no_of_nodes) {
-        IGRAPH_ERROR("All vertices are included in the separator",
-                     IGRAPH_EINVAL);
-    }
+            /* If the 2nd bit of mark[v] is the same as 'bit', it indicates
+             * that v in S was reached in the current testing round.
+             * We flip 'bit' between testing rounds, assuming that the previous
+             * round reached all of S. */
+            igraph_bool_t bit = true;
 
-    IGRAPH_CHECK(igraph_dqueue_int_push(Q, start));
-    VECTOR(*removed)[start] = true;
-    while (!igraph_dqueue_int_empty(Q)) {
-        igraph_integer_t node = igraph_dqueue_int_pop(Q);
-        igraph_integer_t j, n;
-        IGRAPH_CHECK(igraph_neighbors(graph, neis, node, IGRAPH_ALL));
-        n = igraph_vector_int_size(neis);
-        for (j = 0; j < n; j++) {
-            igraph_integer_t nei = VECTOR(*neis)[j];
-            if (!VECTOR(*removed)[nei]) {
-                IGRAPH_CHECK(igraph_dqueue_int_push(Q, nei));
-                VECTOR(*removed)[nei] = true;
+#define REACHED(x) (!(VECTOR(mark)[x] & 4) == !bit) /* Was x in S reached already? */
+#define FLIP_REACHED(x) (VECTOR(mark)[x] ^= 4) /* Flip the reachability status of x in S. */
+
+            for (IGRAPH_VIT_RESET(vit); !IGRAPH_VIT_END(vit); IGRAPH_VIT_NEXT(vit)) {
+                const igraph_integer_t u = IGRAPH_VIT_GET(vit);
+                IGRAPH_CHECK(igraph_neighbors(graph, &Sneis, u, IGRAPH_ALL));
+                const igraph_integer_t du = igraph_vector_int_size(&Sneis);
+                for (igraph_integer_t i=0; i < du; i++) {
+
+                    igraph_integer_t v = VECTOR(Sneis)[i];
+                    if (VISITED(v)) {
+                        continue;
+                    }
+
+                    /* How many vertices in S were reachable from u? */
+                    igraph_integer_t S_reached = 0;
+                    IGRAPH_CHECK(igraph_dqueue_int_push(&Q, v));
+                    while (! igraph_dqueue_int_empty(&Q)) {
+                        v = igraph_dqueue_int_pop(&Q);
+                        if (VISITED(v)) {
+                            continue;
+                        }
+
+                        SET_VISITED(v);
+                        IGRAPH_CHECK(igraph_neighbors(graph, &neis, v, IGRAPH_ALL));
+
+                        const igraph_integer_t dv = igraph_vector_int_size(&neis);
+
+                        for (igraph_integer_t j=0; j < dv; j++) {
+                            const igraph_integer_t w = VECTOR(neis)[j];
+
+                            if (! VISITED(w)) {
+                                IGRAPH_CHECK(igraph_dqueue_int_push(&Q, w));
+                            } else if (IN_S(w) && !REACHED(w)) {
+                                S_reached++;
+                                FLIP_REACHED(w); /* set as reachable */
+                            }
+                        }
+                    }
+
+                    bit = !bit;
+
+                    if (S_reached < S_size) {
+                        *is_minimal = false;
+                        break;
+                    }
+                }
+
+                if (! *is_minimal) {
+                    break;
+                }
             }
+
+            igraph_vector_int_destroy(&Sneis);
+            IGRAPH_FINALLY_CLEAN(1);
         }
     }
 
-    /* Look for the next node that was neither removed, not visited */
-    while (start < no_of_nodes && VECTOR(*removed)[start]) {
-        start++;
-    }
+#undef REACHED
+#undef FLIP_REACHED
+#undef VISITED
+#undef SET_VISITED
+#undef IN_S
+#undef SET_IN_S
 
-    /* If there is another component, then we have a separator */
-    *res = (start < no_of_nodes);
+
+    igraph_dqueue_int_destroy(&Q);
+    igraph_vector_int_destroy(&neis);
+    igraph_vector_char_destroy(&mark);
+    igraph_vit_destroy(&vit);
+    IGRAPH_FINALLY_CLEAN(4);
 
     return IGRAPH_SUCCESS;
 }
@@ -133,11 +305,14 @@ static igraph_error_t igraph_i_is_separator(const igraph_t *graph,
  * \function igraph_is_separator
  * \brief Would removing this set of vertices disconnect the graph?
  *
+ * A vertex set \c S is a separator if there are vertices \c u and \c v
+ * in the graph such that all paths between \c u and \c v pass through
+ * some vertices in \c S.
+ *
  * \param graph The input graph. It may be directed, but edge
  *        directions are ignored.
- * \param candidate The candidate separator. It must not contain all
- *        vertices.
- * \param res Pointer to a Boolean variable, the result is stored here.
+ * \param candidate The candidate separator.
+ * \param res Pointer to a boolean variable, the result is stored here.
  * \return Error code.
  *
  * Time complexity: O(|V|+|E|), linear in the number vertices and edges.
@@ -146,48 +321,18 @@ static igraph_error_t igraph_i_is_separator(const igraph_t *graph,
  */
 
 igraph_error_t igraph_is_separator(const igraph_t *graph,
-                        const igraph_vs_t candidate,
-                        igraph_bool_t *res) {
+                                   const igraph_vs_t candidate,
+                                   igraph_bool_t *res) {
 
-    igraph_integer_t no_of_nodes = igraph_vcount(graph);
-    igraph_vector_bool_t removed;
-    igraph_dqueue_int_t Q;
-    igraph_vector_int_t neis;
-    igraph_vit_t vit;
-
-    IGRAPH_CHECK(igraph_vit_create(graph, candidate, &vit));
-    IGRAPH_FINALLY(igraph_vit_destroy, &vit);
-    IGRAPH_CHECK(igraph_vector_bool_init(&removed, no_of_nodes));
-    IGRAPH_FINALLY(igraph_vector_bool_destroy, &removed);
-    IGRAPH_CHECK(igraph_dqueue_int_init(&Q, 100));
-    IGRAPH_FINALLY(igraph_dqueue_int_destroy, &Q);
-    IGRAPH_VECTOR_INT_INIT_FINALLY(&neis, 0);
-
-    IGRAPH_CHECK(igraph_i_is_separator(graph, &vit, -1, res, &removed,
-                                       &Q, &neis, no_of_nodes));
-
-    igraph_vector_int_destroy(&neis);
-    igraph_dqueue_int_destroy(&Q);
-    igraph_vector_bool_destroy(&removed);
-    igraph_vit_destroy(&vit);
-    IGRAPH_FINALLY_CLEAN(4);
-
-    return IGRAPH_SUCCESS;
+    return igraph_i_is_separator(graph, candidate, res, NULL);
 }
 
 /**
  * \function igraph_is_minimal_separator
  * \brief Decides whether a set of vertices is a minimal separator.
  *
- * A set of vertices is a minimal separator, if the removal of the
- * vertices disconnects the graph, and this is not true for any subset
- * of the set.
- *
- * </para><para>This implementation first checks that the given
- * candidate is a separator, by calling \ref
- * igraph_is_separator(). If it is a separator, then it checks that
- * each subset of size n-1, where n is the size of the candidate, is
- * not a separator.
+ * A vertex separator \c S is minimal is no proper subset of \c S
+ * is also a separator.
  *
  * \param graph The input graph. It may be directed, but edge
  *        directions are ignored.
@@ -196,63 +341,17 @@ igraph_error_t igraph_is_separator(const igraph_t *graph,
  *        here.
  * \return Error code.
  *
- * Time complexity: O(n(|V|+|E|)), |V| is the number of vertices, |E|
- * is the number of edges, n is the number vertices in the candidate
- * separator.
+ * Time complexity: O(|V|+|E|), linear in the number vertices and edges.
  *
  * \example examples/simple/igraph_is_minimal_separator.c
  */
 
 igraph_error_t igraph_is_minimal_separator(const igraph_t *graph,
-                                const igraph_vs_t candidate,
-                                igraph_bool_t *res) {
+                                           const igraph_vs_t candidate,
+                                           igraph_bool_t *res) {
 
-    igraph_integer_t no_of_nodes = igraph_vcount(graph);
-    igraph_vector_bool_t removed;
-    igraph_dqueue_int_t Q;
-    igraph_vector_int_t neis;
-    igraph_integer_t candsize;
-    igraph_vit_t vit;
-
-    IGRAPH_CHECK(igraph_vit_create(graph, candidate, &vit));
-    IGRAPH_FINALLY(igraph_vit_destroy, &vit);
-    candsize = IGRAPH_VIT_SIZE(vit);
-
-    IGRAPH_CHECK(igraph_vector_bool_init(&removed, no_of_nodes));
-    IGRAPH_FINALLY(igraph_vector_bool_destroy, &removed);
-    IGRAPH_CHECK(igraph_dqueue_int_init(&Q, 100));
-    IGRAPH_FINALLY(igraph_dqueue_int_destroy, &Q);
-    IGRAPH_VECTOR_INT_INIT_FINALLY(&neis, 0);
-
-    /* Is it a separator at all? */
-    IGRAPH_CHECK(igraph_i_is_separator(graph, &vit, -1, res, &removed,
-                                       &Q, &neis, no_of_nodes));
-    if (! *res) {
-        /* Not a separator at all, nothing to do, *res is already set */
-    } else if (candsize == 0) {
-        /* Nothing to do, minimal, *res is already set */
-    } else {
-        /* General case, we need to remove each vertex from 'candidate'
-         * and check whether the remainder is a separator. If this is
-         * false for all vertices, then 'candidate' is a minimal
-         * separator.
-         */
-        *res = false;
-        for (igraph_integer_t i=0; i < candsize && (! *res); i++) {
-            igraph_vector_bool_null(&removed);
-            IGRAPH_CHECK(igraph_i_is_separator(graph, &vit, i, res, &removed,
-                                               &Q, &neis, no_of_nodes));
-        }
-        *res = ! *res; /* opposite */
-    }
-
-    igraph_vector_int_destroy(&neis);
-    igraph_dqueue_int_destroy(&Q);
-    igraph_vector_bool_destroy(&removed);
-    igraph_vit_destroy(&vit);
-    IGRAPH_FINALLY_CLEAN(4);
-
-    return IGRAPH_SUCCESS;
+    igraph_bool_t is_separator;
+    return igraph_i_is_separator(graph, candidate, &is_separator, res);
 }
 
 /* --------------------------------------------------------------------*/

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -809,6 +809,11 @@ add_examples(
 
 add_legacy_tests(
   FOLDER tests/unit NAMES
+  igraph_is_separator
+)
+
+add_legacy_tests(
+  FOLDER tests/unit NAMES
   igraph_cohesive_blocks
   igraph_minimum_size_separators
 )

--- a/tests/unit/igraph_is_separator.c
+++ b/tests/unit/igraph_is_separator.c
@@ -1,8 +1,6 @@
-/* -*- mode: C -*-  */
 /*
    IGraph library.
-   Copyright (C) 2010-2012  Gabor Csardi <csardi.gabor@gmail.com>
-   334 Harvard st, Cambridge MA, 02139 USA
+   Copyright (C) 2010-2024  The igraph development team <igraph@igraph.org>
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -15,107 +13,281 @@
    GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
-   02110-1301 USA
-
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 #include <igraph.h>
 
 #include "test_utilities.h"
 
-int main(void) {
+/* Brute force test of minimality. */
+igraph_bool_t is_minimal_sep(const igraph_t *graph, const igraph_vector_int_t *S) {
+    igraph_bool_t res;
+    igraph_is_separator(graph, igraph_vss_vector(S), &res);
 
+    if (res) {
+        for (igraph_integer_t i=0; i < igraph_vector_int_size(S); i++) {
+            igraph_bool_t sep;
+            igraph_vector_int_t S2;
+            igraph_vector_int_init_copy(&S2, S);
+            igraph_vector_int_remove_fast(&S2, i);
+            igraph_is_separator(graph, igraph_vss_vector(&S2), &sep);
+            igraph_vector_int_destroy(&S2);
+            if (sep) {
+                res = false;
+                break;
+            }
+        }
+    }
+
+    return res;
+}
+
+int main(void) {
     igraph_t graph;
-    igraph_vector_int_t sep;
-    igraph_bool_t result;
+    igraph_vector_int_t S;
+    igraph_bool_t is_sep, is_min;
 
     /* Simple star graph, remove the center */
     igraph_star(&graph, 10, IGRAPH_STAR_UNDIRECTED, 0);
-    igraph_is_separator(&graph, igraph_vss_1(0), &result);
-    IGRAPH_ASSERT(result);
+    igraph_is_separator(&graph, igraph_vss_1(0), &is_sep);
+    IGRAPH_ASSERT(is_sep);
+    igraph_is_minimal_separator(&graph, igraph_vss_1(0), &is_min);
+    IGRAPH_ASSERT(is_min);
 
     /* Same graph, but another vertex */
-    igraph_is_separator(&graph, igraph_vss_1(6), &result);
-    IGRAPH_ASSERT(! result);
+    igraph_is_separator(&graph, igraph_vss_1(6), &is_sep);
+    IGRAPH_ASSERT(! is_sep);
 
     /* Same graph, all vertices but the center */
-    igraph_is_separator(&graph, igraph_vss_range(1, 10), &result);
-    IGRAPH_ASSERT(! result);
+    igraph_is_separator(&graph, igraph_vss_range(1, 10), &is_sep);
+    IGRAPH_ASSERT(! is_sep);
 
     /* Same graph, all vertices */
-    igraph_is_separator(&graph, igraph_vss_range(0, 10), &result);
-    IGRAPH_ASSERT(! result);
+    igraph_is_separator(&graph, igraph_vss_range(0, 10), &is_sep);
+    IGRAPH_ASSERT(! is_sep);
     igraph_destroy(&graph);
+
+    /* Same graph, no vertices */
+    igraph_is_separator(&graph, igraph_vss_range(0, 0), &is_sep);
+    IGRAPH_ASSERT(! is_sep);
+    igraph_destroy(&graph);
+
+    /* Test graph 2 */
 
     igraph_small(&graph, 0, IGRAPH_UNDIRECTED,
-                 0,1, 1,2, 2,0, 0,3, 4,5, 5,6,
+                 0,1, 1,2, 2,0, 0,3, 4,5, 5,6, 1,1, 5,6,
                  -1);
 
-    igraph_vector_int_init_int_end(&sep, -1,
+    igraph_vector_int_init_int_end(&S, -1,
+                                   0, -1);
+    igraph_is_separator(&graph, igraph_vss_vector(&S), &is_sep);
+    IGRAPH_ASSERT(is_sep);
+    igraph_is_minimal_separator(&graph, igraph_vss_vector(&S), &is_min);
+    IGRAPH_ASSERT(is_min);
+    igraph_vector_int_destroy(&S);
+
+    igraph_vector_int_init_int_end(&S, -1,
+                                   5, -1);
+    igraph_is_separator(&graph, igraph_vss_vector(&S), &is_sep);
+    IGRAPH_ASSERT(is_sep);
+    igraph_is_minimal_separator(&graph, igraph_vss_vector(&S), &is_min);
+    IGRAPH_ASSERT(is_min);
+    igraph_vector_int_destroy(&S);
+
+    igraph_vector_int_init_int_end(&S, -1,
                                    1, 0, -1);
-    igraph_is_separator(&graph, igraph_vss_vector(&sep), &result);
-    IGRAPH_ASSERT(result);
-    igraph_vector_int_destroy(&sep);
+    igraph_is_separator(&graph, igraph_vss_vector(&S), &is_sep);
+    IGRAPH_ASSERT(is_sep);
+    igraph_is_minimal_separator(&graph, igraph_vss_vector(&S), &is_min);
+    IGRAPH_ASSERT(! is_min);
+    igraph_vector_int_destroy(&S);
 
-    igraph_vector_int_init_int_end(&sep, -1,
-                                   1, 3, 0, 3, 3, -1);
-    igraph_is_separator(&graph, igraph_vss_vector(&sep), &result);
-    IGRAPH_ASSERT(!result);
-    igraph_vector_int_destroy(&sep);
+    /* Pass in vertices multiple times */
+    igraph_vector_int_init_int_end(&S, -1,
+                                   1, 3, 0, 1, 3, 3, -1);
+    igraph_is_separator(&graph, igraph_vss_vector(&S), &is_sep);
+    IGRAPH_ASSERT(!is_sep);
+    igraph_is_minimal_separator(&graph, igraph_vss_vector(&S), &is_min);
+    IGRAPH_ASSERT(! is_min);
+    igraph_vector_int_destroy(&S);
 
-    igraph_vector_int_init_int_end(&sep, -1,
+    igraph_vector_int_init_int_end(&S, -1,
                                    4, 1, 0, -1);
-    igraph_is_separator(&graph, igraph_vss_vector(&sep), &result);
-    IGRAPH_ASSERT(result);
-    igraph_vector_int_destroy(&sep);
+    igraph_is_separator(&graph, igraph_vss_vector(&S), &is_sep);
+    IGRAPH_ASSERT(is_sep);
+    igraph_is_minimal_separator(&graph, igraph_vss_vector(&S), &is_min);
+    IGRAPH_ASSERT(! is_min);
+    igraph_vector_int_destroy(&S);
 
-    igraph_vector_int_init_int_end(&sep, -1,
+    igraph_vector_int_init_int_end(&S, -1,
                                    4, 1, 0, 2, -1);
-    igraph_is_separator(&graph, igraph_vss_vector(&sep), &result);
-    IGRAPH_ASSERT(! result);
-    igraph_vector_int_destroy(&sep);
+    igraph_is_separator(&graph, igraph_vss_vector(&S), &is_sep);
+    IGRAPH_ASSERT(! is_sep);
+    igraph_is_minimal_separator(&graph, igraph_vss_vector(&S), &is_min);
+    IGRAPH_ASSERT(! is_min);
+    igraph_vector_int_destroy(&S);
 
-    igraph_vector_int_init_int_end(&sep, -1,
+    igraph_vector_int_init_int_end(&S, -1,
                                    4, 1, 0, 5, 2, -1);
-    igraph_is_separator(&graph, igraph_vss_vector(&sep), &result);
-    IGRAPH_ASSERT(! result);
-    igraph_vector_int_destroy(&sep);
+    igraph_is_separator(&graph, igraph_vss_vector(&S), &is_sep);
+    IGRAPH_ASSERT(! is_sep);
+    igraph_is_minimal_separator(&graph, igraph_vss_vector(&S), &is_min);
+    IGRAPH_ASSERT(! is_min);
+    igraph_vector_int_destroy(&S);
 
-    igraph_vector_int_init_int_end(&sep, -1,
+    igraph_vector_int_init_int_end(&S, -1,
                                    1, 0, 5, 2, -1);
-    igraph_is_separator(&graph, igraph_vss_vector(&sep), &result);
-    IGRAPH_ASSERT(result);
-    igraph_vector_int_destroy(&sep);
+    igraph_is_separator(&graph, igraph_vss_vector(&S), &is_sep);
+    IGRAPH_ASSERT(is_sep);
+    igraph_is_minimal_separator(&graph, igraph_vss_vector(&S), &is_min);
+    IGRAPH_ASSERT(! is_min);
+    igraph_vector_int_destroy(&S);
 
-    igraph_vector_int_init_int_end(&sep, -1,
+    igraph_vector_int_init_int_end(&S, -1,
                                    5, 6, -1);
-    igraph_is_separator(&graph, igraph_vss_vector(&sep), &result);
-    IGRAPH_ASSERT(!result);
-    igraph_vector_int_destroy(&sep);
+    igraph_is_separator(&graph, igraph_vss_vector(&S), &is_sep);
+    IGRAPH_ASSERT(! is_sep);
+    igraph_is_minimal_separator(&graph, igraph_vss_vector(&S), &is_min);
+    IGRAPH_ASSERT(! is_min);
+    igraph_vector_int_destroy(&S);
+
+    igraph_vector_int_init_int_end(&S, -1,
+                                   5, 0, -1);
+    igraph_is_separator(&graph, igraph_vss_vector(&S), &is_sep);
+    IGRAPH_ASSERT(is_sep);
+    igraph_is_minimal_separator(&graph, igraph_vss_vector(&S), &is_min);
+    IGRAPH_ASSERT(! is_min);
+    igraph_vector_int_destroy(&S);
+
+    igraph_is_separator(&graph, igraph_vss_range(0, 0), &is_sep);
+    IGRAPH_ASSERT(!is_sep);
 
     igraph_destroy(&graph);
 
-    /* Karate club */
-    igraph_famous(&graph, "zachary");
-    igraph_vector_int_init(&sep, 0);
-    igraph_vector_int_push_back(&sep, 32);
-    igraph_vector_int_push_back(&sep, 33);
-    igraph_is_separator(&graph, igraph_vss_vector(&sep), &result);
-    IGRAPH_ASSERT(result);
+    /* Test graph 3 */
 
-    igraph_vector_int_resize(&sep, 5);
-    VECTOR(sep)[0] = 8;
-    VECTOR(sep)[1] = 9;
-    VECTOR(sep)[2] = 19;
-    VECTOR(sep)[3] = 30;
-    VECTOR(sep)[4] = 31;
-    igraph_is_separator(&graph, igraph_vss_vector(&sep), &result);
-    IGRAPH_ASSERT(!result);
+    igraph_small(&graph, 6, IGRAPH_UNDIRECTED,
+                 0,1, 1,3, 0,2, 2,3, 2,4,
+                 -1);
+
+    igraph_vector_int_init_int_end(&S, -1,
+                                   5, -1);
+    igraph_is_separator(&graph, igraph_vss_vector(&S), &is_sep);
+    IGRAPH_ASSERT(! is_sep);
+    igraph_is_minimal_separator(&graph, igraph_vss_vector(&S), &is_min);
+    IGRAPH_ASSERT(! is_min);
+    igraph_vector_int_destroy(&S);
+
+    igraph_vector_int_init_int_end(&S, -1,
+                                   1, 2, -1);
+    igraph_is_separator(&graph, igraph_vss_vector(&S), &is_sep);
+    IGRAPH_ASSERT(is_sep);
+    igraph_is_minimal_separator(&graph, igraph_vss_vector(&S), &is_min);
+    IGRAPH_ASSERT(! is_min);
+
+    igraph_add_edge(&graph, 1, 4);
+
+    igraph_is_separator(&graph, igraph_vss_vector(&S), &is_sep);
+    IGRAPH_ASSERT(is_sep);
+    igraph_is_minimal_separator(&graph, igraph_vss_vector(&S), &is_min);
+    IGRAPH_ASSERT(is_min);
+    igraph_vector_int_destroy(&S);
+
+    /* Pass in vertices multiple times */
+    igraph_vector_int_init_int_end(&S, -1,
+                                   1, 2, 1, 2, 2, -1);
+    igraph_is_separator(&graph, igraph_vss_vector(&S), &is_sep);
+    IGRAPH_ASSERT(is_sep);
+    igraph_is_minimal_separator(&graph, igraph_vss_vector(&S), &is_min);
+    IGRAPH_ASSERT(is_min);
+    igraph_vector_int_destroy(&S);
 
     igraph_destroy(&graph);
-    igraph_vector_int_destroy(&sep);
+
+    /* Test graph 4 */
+
+    igraph_small(&graph, 0, IGRAPH_UNDIRECTED,
+                 0,1, 0,2, 0,3, 1,2, 1,3, 2,3,
+                 4,5, 4,6, 4,7, 5,6, 5,7, 6,7,
+                 2,5, 3,4,
+                 -1);
+
+    igraph_vector_int_init_int_end(&S, -1,
+                                   2, 3, -1);
+    igraph_is_separator(&graph, igraph_vss_vector(&S), &is_sep);
+    IGRAPH_ASSERT(is_sep);
+    igraph_is_minimal_separator(&graph, igraph_vss_vector(&S), &is_min);
+    IGRAPH_ASSERT(is_min);
+    igraph_vector_int_destroy(&S);
+
+    igraph_vector_int_init_int_end(&S, -1,
+                                   2, 4, -1);
+    igraph_is_separator(&graph, igraph_vss_vector(&S), &is_sep);
+    IGRAPH_ASSERT(is_sep);
+    igraph_is_minimal_separator(&graph, igraph_vss_vector(&S), &is_min);
+    IGRAPH_ASSERT(is_min);
+    igraph_vector_int_destroy(&S);
+
+    igraph_vector_int_init_int_end(&S, -1,
+                                   3, 5, -1);
+    igraph_is_separator(&graph, igraph_vss_vector(&S), &is_sep);
+    IGRAPH_ASSERT(is_sep);
+    igraph_is_minimal_separator(&graph, igraph_vss_vector(&S), &is_min);
+    IGRAPH_ASSERT(is_min);
+    igraph_vector_int_destroy(&S);
+
+    igraph_vector_int_init_int_end(&S, -1,
+                                   2, 3, 5, -1);
+    igraph_is_separator(&graph, igraph_vss_vector(&S), &is_sep);
+    IGRAPH_ASSERT(is_sep);
+    igraph_is_minimal_separator(&graph, igraph_vss_vector(&S), &is_min);
+    IGRAPH_ASSERT(! is_min);
+    igraph_vector_int_destroy(&S);
+
+    igraph_destroy(&graph);
+
+    /* Karate club network */
+
+    igraph_famous(&graph, "Zachary");
+
+    igraph_vector_int_init_int_end(&S, -1, 32, 33, -1);
+    igraph_is_separator(&graph, igraph_vss_vector(&S), &is_sep);
+    IGRAPH_ASSERT(is_sep);
+    igraph_is_minimal_separator(&graph, igraph_vss_vector(&S), &is_min);
+    IGRAPH_ASSERT(is_min);
+    igraph_vector_int_destroy(&S);
+
+    igraph_vector_int_init_int_end(&S, -1,
+                                   8, 9, 19, 30, 31, -1);
+    igraph_is_separator(&graph, igraph_vss_vector(&S), &is_min);
+    IGRAPH_ASSERT(!is_min);
+    igraph_vector_int_destroy(&S);
+
+    /* Caution:
+     * igraph_all_minimal_st_separators() returns minimal (s,t) separators,
+     * i.e. separators that are minimal with respect to separating a specific
+     * (s,t) pair, but not necessarily minimal separators. See the documentation
+     * for an example.
+     */
+
+    igraph_vector_int_list_t separators;
+    igraph_vector_int_list_init(&separators, 0);
+    igraph_all_minimal_st_separators(&graph, &separators);
+    for (igraph_integer_t i=0; i < igraph_vector_int_list_size(&separators); i++) {
+        const igraph_vector_int_t *sep = igraph_vector_int_list_get_ptr(&separators, i);
+        igraph_is_separator(&graph, igraph_vss_vector(sep), &is_sep);
+        IGRAPH_ASSERT(is_sep);
+        igraph_is_minimal_separator( &graph, igraph_vss_vector(sep), &is_min);
+
+        igraph_bool_t is_min2 = is_minimal_sep(&graph, sep);
+        IGRAPH_ASSERT((!is_min) == (! is_min2));
+    }
+    igraph_vector_int_list_destroy(&separators);
+
+    igraph_destroy(&graph);
+
+    VERIFY_FINALLY_STACK();
 
     return 0;
 }

--- a/tests/unit/igraph_is_separator.c
+++ b/tests/unit/igraph_is_separator.c
@@ -1,0 +1,121 @@
+/* -*- mode: C -*-  */
+/*
+   IGraph library.
+   Copyright (C) 2010-2012  Gabor Csardi <csardi.gabor@gmail.com>
+   334 Harvard st, Cambridge MA, 02139 USA
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+   02110-1301 USA
+
+*/
+
+#include <igraph.h>
+
+#include "test_utilities.h"
+
+int main(void) {
+
+    igraph_t graph;
+    igraph_vector_int_t sep;
+    igraph_bool_t result;
+
+    /* Simple star graph, remove the center */
+    igraph_star(&graph, 10, IGRAPH_STAR_UNDIRECTED, 0);
+    igraph_is_separator(&graph, igraph_vss_1(0), &result);
+    IGRAPH_ASSERT(result);
+
+    /* Same graph, but another vertex */
+    igraph_is_separator(&graph, igraph_vss_1(6), &result);
+    IGRAPH_ASSERT(! result);
+
+    /* Same graph, all vertices but the center */
+    igraph_is_separator(&graph, igraph_vss_range(1, 10), &result);
+    IGRAPH_ASSERT(! result);
+
+    /* Same graph, all vertices */
+    igraph_is_separator(&graph, igraph_vss_range(0, 10), &result);
+    IGRAPH_ASSERT(! result);
+    igraph_destroy(&graph);
+
+    igraph_small(&graph, 0, IGRAPH_UNDIRECTED,
+                 0,1, 1,2, 2,0, 0,3, 4,5, 5,6,
+                 -1);
+
+    igraph_vector_int_init_int_end(&sep, -1,
+                                   1, 0, -1);
+    igraph_is_separator(&graph, igraph_vss_vector(&sep), &result);
+    IGRAPH_ASSERT(result);
+    igraph_vector_int_destroy(&sep);
+
+    igraph_vector_int_init_int_end(&sep, -1,
+                                   1, 3, 0, 3, 3, -1);
+    igraph_is_separator(&graph, igraph_vss_vector(&sep), &result);
+    IGRAPH_ASSERT(!result);
+    igraph_vector_int_destroy(&sep);
+
+    igraph_vector_int_init_int_end(&sep, -1,
+                                   4, 1, 0, -1);
+    igraph_is_separator(&graph, igraph_vss_vector(&sep), &result);
+    IGRAPH_ASSERT(result);
+    igraph_vector_int_destroy(&sep);
+
+    igraph_vector_int_init_int_end(&sep, -1,
+                                   4, 1, 0, 2, -1);
+    igraph_is_separator(&graph, igraph_vss_vector(&sep), &result);
+    IGRAPH_ASSERT(! result);
+    igraph_vector_int_destroy(&sep);
+
+    igraph_vector_int_init_int_end(&sep, -1,
+                                   4, 1, 0, 5, 2, -1);
+    igraph_is_separator(&graph, igraph_vss_vector(&sep), &result);
+    IGRAPH_ASSERT(! result);
+    igraph_vector_int_destroy(&sep);
+
+    igraph_vector_int_init_int_end(&sep, -1,
+                                   1, 0, 5, 2, -1);
+    igraph_is_separator(&graph, igraph_vss_vector(&sep), &result);
+    IGRAPH_ASSERT(result);
+    igraph_vector_int_destroy(&sep);
+
+    igraph_vector_int_init_int_end(&sep, -1,
+                                   5, 6, -1);
+    igraph_is_separator(&graph, igraph_vss_vector(&sep), &result);
+    IGRAPH_ASSERT(!result);
+    igraph_vector_int_destroy(&sep);
+
+    igraph_destroy(&graph);
+
+    /* Karate club */
+    igraph_famous(&graph, "zachary");
+    igraph_vector_int_init(&sep, 0);
+    igraph_vector_int_push_back(&sep, 32);
+    igraph_vector_int_push_back(&sep, 33);
+    igraph_is_separator(&graph, igraph_vss_vector(&sep), &result);
+    IGRAPH_ASSERT(result);
+
+    igraph_vector_int_resize(&sep, 5);
+    VECTOR(sep)[0] = 8;
+    VECTOR(sep)[1] = 9;
+    VECTOR(sep)[2] = 19;
+    VECTOR(sep)[3] = 30;
+    VECTOR(sep)[4] = 31;
+    igraph_is_separator(&graph, igraph_vss_vector(&sep), &result);
+    IGRAPH_ASSERT(!result);
+
+    igraph_destroy(&graph);
+    igraph_vector_int_destroy(&sep);
+
+    return 0;
+}


### PR DESCRIPTION
The R (but not C) documentation includes:

> In the special case of a fully connected graph with $n$ vertices, each set of $n−1$ vertices is considered to be a vertex separator.

This is probably for consistency with the usual convention that assigns vertex connectivity $n-1$ to $K_n$.

I am not in favour of maintaining this definition of separators in complete graphs. However, we will need to make very sure that if we change this, we won't break any functions that call `igraph_is_separator()`.