### PR TITLE
feat: igraph_is_simple() uses the cache in a more granular way

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 ### Other
 
+ - Performance: `igraph_is_simple()` now makes more granular use of the cache.
  - Performance: `igraph_degree()` now makes use of the cache when checking for self-loops.
  - The performance of `igraph_is_minimal_separator()` was improved.
  - Documentation improvements.


### PR DESCRIPTION
Asking for a review, since this touches code that sets the cache.

This PR makes more granular use of the cache in `igraph_is_simple()`. Previously, it would only use the cache when the status of _both_ HAS_LOOP and HAS_MULTI was known.

However, if either of these is true, we already know that the graph is not simple without having to check the other.

Similarly, we can set set the cache in a more granular way when either was found.

The current plan for property deduction is to NOT include a new flag for IS_SIMPLE, therefore we can handle this directly in the `igraph_is_simple()` function instead.