### PR TITLE
fix: igraph_linegraph() now considers self-loops to be self-adjacent in undirected graphs, fixes #2524

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
  - `igraph_read_graph_graphml()` now correctly compares attribute values with certain expected values, meaning that prefixes of valid values of `attr.type` are not accepted any more.
  - Empty IDs are not allowed any more in `<key>` tags of GraphML files as this is a violation of the GraphML specification.
  - `igraph_is_separator()` and `igraph_is_minimal_separator()` now work correctly with disconnected graphs.
+ - `igraph_linegraph()` now considers self-loops to be self-adjacent in undirected graphs, bringing consistency with how directed graphs were already handled in previous versions.
 
 ### Other
 

--- a/tests/unit/igraph_linegraph.c
+++ b/tests/unit/igraph_linegraph.c
@@ -26,11 +26,19 @@ int main(void) {
 
     /*    Undirected    */
     igraph_small(&g_start, 7, IGRAPH_UNDIRECTED,
-                 0, 1, 1, 2, 1, 3, 1, 3, 2, 2, 2, 4, 3, 4, 4, 5, -1);
+                 0, 1, // 0
+                 1, 2, // 1
+                 1, 3, // 2
+                 1, 3, // 3
+                 2, 2, // 4
+                 2, 4, // 5
+                 3, 4, // 6
+                 4, 5, // 7
+                 -1);
     IGRAPH_ASSERT(igraph_linegraph(&g_start, &g_line) == IGRAPH_SUCCESS);
     igraph_small(&g_test, 8, IGRAPH_UNDIRECTED,
                  0, 1, 0, 2, 0, 3, 1, 2, 1, 3, 1, 4, 1, 4, 1, 5, 2, 3, 2, 3,
-                 2, 6, 3, 6, 4, 5, 4, 5, 5, 6, 5, 7, 6, 7, -1);
+                 2, 6, 3, 6, 4, 4, 4, 5, 4, 5, 5, 6, 5, 7, 6, 7, -1);
     IGRAPH_ASSERT(igraph_is_same_graph(&g_line, &g_test, &same) == IGRAPH_SUCCESS);
     IGRAPH_ASSERT(same);
     igraph_destroy(&g_start);
@@ -39,7 +47,15 @@ int main(void) {
 
      /*    Directed    */
     igraph_small(&g_start, 7, IGRAPH_DIRECTED,
-                 0, 1, 1, 2, 1, 3, 3, 1, 2, 2, 2, 4, 3, 4, 4, 5, -1);
+                 0, 1, // 0
+                 1, 2, // 1
+                 1, 3, // 2
+                 3, 1, // 3
+                 2, 2, // 4
+                 2, 4, // 5
+                 3, 4, // 6
+                 4, 5, // 7
+                 -1);
     IGRAPH_ASSERT(igraph_linegraph(&g_start, &g_line) == IGRAPH_SUCCESS);
     igraph_small(&g_test, 8, IGRAPH_DIRECTED,
                  0, 1, 0, 2, 1, 4, 1, 5, 2, 3, 2, 6, 3, 1, 3, 2, 4, 4, 4, 5,


### PR DESCRIPTION


It has already considered them self-adjacent in directed graphs.