### PR TITLE
fix: Replace check of constant with a static assertion

### DIFF
--- a/include/igraph_error.h
+++ b/include/igraph_error.h
@@ -794,9 +794,8 @@ IGRAPH_EXPORT int IGRAPH_FINALLY_STACK_SIZE(void);
 #define IGRAPH_CHECK_CALLBACK(expr, code) \
     do { \
         igraph_error_t igraph_i_ret = (expr); \
-        if (code) { \
-            *(code) = igraph_i_ret; \
-        } \
+        IGRAPH_STATIC_ASSERT(code); \
+        *(code) = igraph_i_ret; \
         if (IGRAPH_UNLIKELY(igraph_i_ret != IGRAPH_SUCCESS && igraph_i_ret != IGRAPH_STOP)) { \
             IGRAPH_ERROR("", igraph_i_ret); \
         } \

--- a/include/igraph_error.h
+++ b/include/igraph_error.h
@@ -794,7 +794,6 @@ IGRAPH_EXPORT int IGRAPH_FINALLY_STACK_SIZE(void);
 #define IGRAPH_CHECK_CALLBACK(expr, code) \
     do { \
         igraph_error_t igraph_i_ret = (expr); \
-        IGRAPH_STATIC_ASSERT(code); \
         *(code) = igraph_i_ret; \
         if (IGRAPH_UNLIKELY(igraph_i_ret != IGRAPH_SUCCESS && igraph_i_ret != IGRAPH_STOP)) { \
             IGRAPH_ERROR("", igraph_i_ret); \


### PR DESCRIPTION
Should the new `IGRAPH_STATIC_ASSERT` find a better home?

This is needed to avoid `R CMD check` warnings in R.