### PR TITLE
Fix `igraph_all_st_mincuts` to only return minimal cuts

### DIFF
--- a/src/flow/st-cuts.c
+++ b/src/flow/st-cuts.c
@@ -1290,7 +1290,7 @@ static igraph_error_t igraph_i_all_st_mincuts_pivot(const igraph_t *graph,
             if (u < 0) {
                 break;
             }
-            if (!igraph_estack_iselement(T, u)) {
+            if (!igraph_marked_queue_int_iselement(S, u)) {
                 IGRAPH_CHECK(igraph_vector_int_push_back(Isv, u));
             }
         }

--- a/tests/unit/igraph_all_st_mincuts.c
+++ b/tests/unit/igraph_all_st_mincuts.c
@@ -156,6 +156,36 @@ int main(void) {
     print_and_destroy(&g, value, &partitions, &cuts);
     igraph_destroy(&g);
 
+    /* ---------------------------------------------------------------- */
+
+    printf("Graph 8:\n");
+    igraph_small(&g, 0, IGRAPH_DIRECTED,
+                 0, 2, 3, 0, 1, 2, 5, 1, 2, 4, 3, 5, 5, 4,
+                 -1);
+
+    igraph_vector_int_list_init(&partitions, 0);
+    igraph_vector_int_list_init(&cuts, 0);
+    igraph_all_st_mincuts(&g, &value, &cuts, &partitions,
+                          /*source=*/ 3, /*target=*/ 4, /*capacity=*/ NULL);
+
+    print_and_destroy(&g, value, &partitions, &cuts);
+    igraph_destroy(&g);
+
+    /* ---------------------------------------------------------------- */
+
+    printf("Graph 9:\n");
+    igraph_small(&g, 0, IGRAPH_DIRECTED,
+                 0, 1, 2, 0, 3, 0, 4, 0, 0, 5, 3, 1, 1, 4, 3, 2, 2, 5, 4, 3, 5, 3, 5, 4,
+                 -1);
+
+    igraph_vector_int_list_init(&partitions, 0);
+    igraph_vector_int_list_init(&cuts, 0);
+    igraph_all_st_mincuts(&g, &value, &cuts, &partitions,
+                          /*source=*/ 3, /*target=*/ 0, /*capacity=*/ NULL);
+
+    print_and_destroy(&g, value, &partitions, &cuts);
+    igraph_destroy(&g);
+
     VERIFY_FINALLY_STACK();
     return 0;
 }

--- a/tests/unit/igraph_all_st_mincuts.c
+++ b/tests/unit/igraph_all_st_mincuts.c
@@ -1,6 +1,6 @@
 /*
    IGraph library.
-   Copyright (C) 2023  The igraph development team <igraph@igraph.org>
+   Copyright (C) 2023-2024  The igraph development team <igraph@igraph.org>
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -58,6 +58,7 @@ int main(void) {
     igraph_vector_int_list_t cuts;
     igraph_real_t value;
 
+    printf("Graph 1:\n");
     igraph_small(&g, 5, IGRAPH_DIRECTED,
                  0, 1, 1, 2, 2, 3, 3, 4,
                  -1);
@@ -66,47 +67,52 @@ int main(void) {
     igraph_vector_int_list_init(&cuts, 0);
     igraph_all_st_mincuts(&g, &value, &cuts, &partitions,
                           /*source=*/ 0, /*target=*/ 4,
-                          /*capacity=*/ 0);
+                          /*capacity=*/ NULL);
 
     print_and_destroy(&g, value, &partitions, &cuts);
     igraph_destroy(&g);
 
     /* ---------------------------------------------------------------- */
 
+    printf("Graph 2:\n");
     igraph_small(&g, 6, IGRAPH_DIRECTED, 0, 1, 1, 2, 1, 3, 2, 4, 3, 4, 4, 5, -1);
     igraph_vector_int_list_init(&partitions, 0);
     igraph_vector_int_list_init(&cuts, 0);
     igraph_all_st_mincuts(&g, &value, &cuts, &partitions,
-                          /*source=*/ 0, /*target=*/ 5, /*capacity=*/ 0);
+                          /*source=*/ 0, /*target=*/ 5, /*capacity=*/ NULL);
 
     print_and_destroy(&g, value, &partitions, &cuts);
     igraph_destroy(&g);
 
     /* ---------------------------------------------------------------- */
 
+    printf("Graph 3:\n");
     igraph_small(&g, 6, IGRAPH_DIRECTED, 0, 1, 1, 2, 1, 3, 2, 4, 3, 4, 4, 5, -1);
     igraph_vector_int_list_init(&partitions, 0);
     igraph_vector_int_list_init(&cuts, 0);
     igraph_all_st_mincuts(&g, &value, &cuts, &partitions,
-                          /*source=*/ 0, /*target=*/ 4, /*capacity=*/ 0);
+                          /*source=*/ 0, /*target=*/ 4, /*capacity=*/ NULL);
 
     print_and_destroy(&g, value, &partitions, &cuts);
     igraph_destroy(&g);
 
     /* ---------------------------------------------------------------- */
 
+    printf("Graph 4:\n");
     igraph_small(&g, 9, IGRAPH_DIRECTED, 0, 1, 0, 2, 1, 3, 2, 3,
                  1, 4, 4, 2, 1, 5, 5, 2, 1, 6, 6, 2, 1, 7, 7, 2, 1, 8, 8, 2,
                  -1);
     igraph_vector_int_list_init(&partitions, 0);
     igraph_vector_int_list_init(&cuts, 0);
     igraph_all_st_mincuts(&g, &value, &cuts, &partitions,
-                          /*source=*/ 0, /*target=*/ 3, /*capacity=*/ 0);
+                          /*source=*/ 0, /*target=*/ 3, /*capacity=*/ NULL);
 
     print_and_destroy(&g, value, &partitions, &cuts);
     igraph_destroy(&g);
 
     /* ---------------------------------------------------------------- */
+
+    printf("Graph 5:\n");
     igraph_small(&g, 4, IGRAPH_DIRECTED,
                  1, 0, 2, 0, 2, 1, 3, 2,
                  -1);
@@ -114,12 +120,14 @@ int main(void) {
     igraph_vector_int_list_init(&partitions, 0);
     igraph_vector_int_list_init(&cuts, 0);
     igraph_all_st_mincuts(&g, &value, &cuts, &partitions,
-                          /*source=*/ 2, /*target=*/ 0, /*capacity=*/ 0);
+                          /*source=*/ 2, /*target=*/ 0, /*capacity=*/ NULL);
 
     print_and_destroy(&g, value, &partitions, &cuts);
     igraph_destroy(&g);
 
     /* ---------------------------------------------------------------- */
+
+    printf("Graph 6:\n");
     igraph_small(&g, 4, IGRAPH_DIRECTED,
                  1, 0, 2, 0, 2, 1, 2, 3,
                  -1);
@@ -127,12 +135,14 @@ int main(void) {
     igraph_vector_int_list_init(&partitions, 0);
     igraph_vector_int_list_init(&cuts, 0);
     igraph_all_st_mincuts(&g, &value, &cuts, &partitions,
-                          /*source=*/ 2, /*target=*/ 0, /*capacity=*/ 0);
+                          /*source=*/ 2, /*target=*/ 0, /*capacity=*/ NULL);
 
     print_and_destroy(&g, value, &partitions, &cuts);
     igraph_destroy(&g);
 
     /* ---------------------------------------------------------------- */
+
+    printf("Graph 7:\n");
     igraph_small(&g, 9, IGRAPH_DIRECTED,
                  0, 4,  0, 7,  1, 6,  2, 1,  3, 8,  4, 0,  4, 2,
                  4, 5,  5, 0,  5, 3,  6, 7,  7, 8,
@@ -141,7 +151,7 @@ int main(void) {
     igraph_vector_int_list_init(&partitions, 0);
     igraph_vector_int_list_init(&cuts, 0);
     igraph_all_st_mincuts(&g, &value, &cuts, &partitions,
-                          /*source=*/ 0, /*target=*/ 8, /*capacity=*/ 0);
+                          /*source=*/ 0, /*target=*/ 8, /*capacity=*/ NULL);
 
     print_and_destroy(&g, value, &partitions, &cuts);
     igraph_destroy(&g);

--- a/tests/unit/igraph_all_st_mincuts.out
+++ b/tests/unit/igraph_all_st_mincuts.out
@@ -1,3 +1,4 @@
+Graph 1:
 Found 4 cuts, value: 1
 Partition 0: 0
 Cut 0:
@@ -12,6 +13,7 @@ Partition 3: 0 1 2 3
 Cut 3:
   3 -> 4
 
+Graph 2:
 Found 2 cuts, value: 1
 Partition 0: 0
 Cut 0:
@@ -20,29 +22,28 @@ Partition 1: 0 4 3 2 1
 Cut 1:
   4 -> 5
 
+Graph 3:
 Found 1 cuts, value: 1
 Partition 0: 0
 Cut 0:
   0 -> 1
 
-Found 4 cuts, value: 2
+Graph 4:
+Found 3 cuts, value: 2
 Partition 0: 0
 Cut 0:
   0 -> 1
   0 -> 2
-Partition 1: 0 1 8 7 6 5 4
+Partition 1: 0 2
 Cut 1:
-  0 -> 2
-  1 -> 3
-Partition 2: 0 2
-Cut 2:
   0 -> 1
   2 -> 3
-Partition 3: 0 2 1 8 7 6 5 4
-Cut 3:
+Partition 2: 0 2 1 8 7 6 5 4
+Cut 2:
   1 -> 3
   2 -> 3
 
+Graph 5:
 Found 2 cuts, value: 2
 Partition 0: 2
 Cut 0:
@@ -53,6 +54,7 @@ Cut 1:
   1 -> 0
   2 -> 0
 
+Graph 6:
 Found 2 cuts, value: 2
 Partition 0: 2 3
 Cut 0:
@@ -63,37 +65,26 @@ Cut 1:
   1 -> 0
   2 -> 0
 
-Found 8 cuts, value: 2
+Graph 7:
+Found 5 cuts, value: 2
 Partition 0: 0
 Cut 0:
   0 -> 4
   0 -> 7
-Partition 1: 0 4 2 1 6
+Partition 1: 0 7
 Cut 1:
-  0 -> 7
-  4 -> 5
-Partition 2: 0 4 2 1 6 5
-Cut 2:
-  0 -> 7
-  5 -> 3
-Partition 3: 0 4 2 1 6 5 3
-Cut 3:
-  0 -> 7
-  3 -> 8
-Partition 4: 0 7
-Cut 4:
   0 -> 4
   7 -> 8
-Partition 5: 0 7 4 2 1 6
-Cut 5:
+Partition 2: 0 7 4 2 1 6
+Cut 2:
   4 -> 5
   7 -> 8
-Partition 6: 0 7 4 2 1 6 5
-Cut 6:
+Partition 3: 0 7 4 2 1 6 5
+Cut 3:
   5 -> 3
   7 -> 8
-Partition 7: 0 7 4 2 1 6 5 3
-Cut 7:
+Partition 4: 0 7 4 2 1 6 5 3
+Cut 4:
   3 -> 8
   7 -> 8
 

--- a/tests/unit/igraph_all_st_mincuts.out
+++ b/tests/unit/igraph_all_st_mincuts.out
@@ -88,3 +88,45 @@ Cut 4:
   3 -> 8
   7 -> 8
 
+Graph 8:
+Found 4 cuts, value: 2
+Partition 0: 3
+Cut 0:
+  3 -> 0
+  3 -> 5
+Partition 1: 3 0
+Cut 1:
+  0 -> 2
+  3 -> 5
+Partition 2: 3 0 2
+Cut 2:
+  2 -> 4
+  3 -> 5
+Partition 3: 3 0 2 5 1
+Cut 3:
+  2 -> 4
+  5 -> 4
+
+Graph 9:
+Found 4 cuts, value: 3
+Partition 0: 3
+Cut 0:
+  3 -> 0
+  3 -> 1
+  3 -> 2
+Partition 1: 3 1
+Cut 1:
+  3 -> 0
+  1 -> 4
+  3 -> 2
+Partition 2: 3 1 4
+Cut 2:
+  3 -> 0
+  4 -> 0
+  3 -> 2
+Partition 3: 3 1 4 2 5
+Cut 3:
+  2 -> 0
+  3 -> 0
+  4 -> 0
+


### PR DESCRIPTION
This fixes #2532 by correcting two issues:
- The calculation of $I(S, v)$ was incorrect.
- The identification of minimal nodes was incorrect.

Preliminary checks show that the example reported in https://github.com/igraph/igraph/issues/2532#issuecomment-1997752428 is now processed correctly, and only correct, minimal cuts are found. It would be good to double check these fixes compared to the original publication [1]. In addition, it would be good to test a few more of the reported examples.

Finally, once these fixes check out, we should also add a simple test of this mincut functionality that checks two things: (1) if cuts are indeed correct cuts; and (2) if cuts are indeed minimal, or at least, compared to the reported minimal value.

References
[1] Provan, J. S., & Shier, D. R. (1996). A paradigm for listing (s, t)-cuts in graphs. Algorithmica, 15(4), 351–372. https://doi.org/10.1007/BF01961544