### PR TITLE
Fix efficient st-cuts

### DIFF
--- a/src/flow/st-cuts.c
+++ b/src/flow/st-cuts.c
@@ -1418,7 +1418,7 @@ igraph_error_t igraph_all_st_mincuts(const igraph_t *graph, igraph_real_t *value
 
     /* Invert order to get permutation to ensure vertices follow topological order. */
     igraph_vector_int_t inv_order;
-    IGRAPH_VECTOR_INT_INIT_FINALLY(&inv_order, igraph_vector_int_size(&order));
+    IGRAPH_VECTOR_INT_INIT_FINALLY(&inv_order, no_of_nodes_residual);
     IGRAPH_FINALLY(igraph_vector_int_destroy, &inv_order);
     for (i = 0; i < no_of_nodes_residual; i++) {
         VECTOR(inv_order)[VECTOR(order)[i]] = i;

--- a/src/flow/st-cuts.c
+++ b/src/flow/st-cuts.c
@@ -1419,7 +1419,6 @@ igraph_error_t igraph_all_st_mincuts(const igraph_t *graph, igraph_real_t *value
     /* Invert order to get permutation to ensure vertices follow topological order. */
     igraph_vector_int_t inv_order;
     IGRAPH_VECTOR_INT_INIT_FINALLY(&inv_order, no_of_nodes_residual);
-    IGRAPH_FINALLY(igraph_vector_int_destroy, &inv_order);
     for (i = 0; i < no_of_nodes_residual; i++) {
         VECTOR(inv_order)[VECTOR(order)[i]] = i;
     }

--- a/src/flow/st-cuts.c
+++ b/src/flow/st-cuts.c
@@ -1416,7 +1416,7 @@ igraph_error_t igraph_all_st_mincuts(const igraph_t *graph, igraph_real_t *value
     IGRAPH_VECTOR_INT_INIT_FINALLY(&order, no_of_nodes_residual);
     IGRAPH_CHECK(igraph_topological_sorting(&residual, &order, IGRAPH_OUT));
 
-    /* Invert permutation */
+    /* Invert order to get permutation to ensure vertices follow topological order. */
     igraph_vector_int_t inv_order;
     IGRAPH_VECTOR_INT_INIT_FINALLY(&inv_order, igraph_vector_int_size(&order));
     IGRAPH_FINALLY(igraph_vector_int_destroy, &inv_order);

--- a/src/flow/st-cuts.c
+++ b/src/flow/st-cuts.c
@@ -1425,8 +1425,8 @@ igraph_error_t igraph_all_st_mincuts(const igraph_t *graph, igraph_real_t *value
     }
 
     // Relabel mapping
-    for (i = 0; i < no_of_nodes_residual; i++) {
-        VECTOR(NtoL)[i] = VECTOR(order)[VECTOR(NtoL)[i]];
+    for (i = 0; i < no_of_nodes; i++) {
+        VECTOR(NtoL)[i] = VECTOR(inv_order)[VECTOR(NtoL)[i]];
     }
 
     /* Permute vertices and replace residual with tmpgraph that is topologically


### PR DESCRIPTION
This fixes #2539, which is ultimately not a problem with `minimum_size_separators`, but with `all_st_mincuts`. There were two problems:
- The topological order wasn't properly used to permute the vertices. It used the order directly, while it should use the permutation that results in that sorted order (i.e. the inverse of that order).
- The `NtoL` mapping wasn't correct: 
  - It didn't consider all nodes, but only the (more limited number of) nodes in the condensed residual graph.
  - It didn't use the proper permutation (i.e. the inverse order), but simply the order.

This wasn't caught earlier in other tests, because in those examples, this problem happened to not surface. With this PR, it should now be correct, I believe.