### PR TITLE
Minimize weight buffer size when creating weighted graphs

### DIFF
--- a/src/constructors/adjacency.c
+++ b/src/constructors/adjacency.c
@@ -788,6 +788,10 @@ igraph_error_t igraph_weighted_adjacency(
         IGRAPH_ERROR("Invalid adjacency mode.", IGRAPH_EINVAL);
     }
 
+    /* The weighted graph produced by this function is likely to be used
+     * multiple times, so we trim the weight vector size. */
+    igraph_vector_resize_min(weights);
+
     /* Create graph */
     IGRAPH_CHECK(igraph_empty(graph, no_of_nodes, (mode == IGRAPH_ADJ_DIRECTED)));
     IGRAPH_FINALLY(igraph_destroy, graph);
@@ -1415,6 +1419,10 @@ igraph_error_t igraph_sparse_weighted_adjacency(
     default:
         IGRAPH_ERROR("Invalid adjacency mode.", IGRAPH_EINVAL);
     }
+
+    /* The weighted graph produced by this function is likely to be used
+     * multiple times, so we trim the weight vector size. */
+    igraph_vector_resize_min(weights);
 
     /* Create graph */
     IGRAPH_CHECK(igraph_empty(graph, no_of_nodes, (mode == IGRAPH_ADJ_DIRECTED)));

--- a/src/misc/bipartite.c
+++ b/src/misc/bipartite.c
@@ -807,6 +807,8 @@ igraph_error_t igraph_weighted_biadjacency(
         }
     }
 
+    /* The weighted graph produced by this function is likely to be used
+     * multiple times, so we trim the weight vector size. */
     igraph_vector_resize_min(weights);
 
     IGRAPH_CHECK(igraph_create(graph, &edges, no_of_nodes, directed));


### PR DESCRIPTION
This is more of a discussion starter, we need to decide whether to do this vector size minimization in all similar functions, or none of them. This PR brings consistency between the newly added `igraph_weighted_biadjacency()` and its `adjacency` counterparts.

Thinking more about it, the weight vector is likely to be copied to an attribute anyway, so the minimization may be pointless.

Let me know what you think @ntamas, and I'll either merge this or remove the minimization from `igraph_weighted_biadjacency()`.