### PR TITLE
Cache friendly strength and degree

### DIFF
--- a/src/graph/type_indexededgelist.c
+++ b/src/graph/type_indexededgelist.c
@@ -1258,6 +1258,26 @@ igraph_error_t igraph_degree(const igraph_t *graph, igraph_vector_int_t *res,
                 VECTOR(*res)[i] += (VECTOR(graph->is)[vid + 1] - VECTOR(graph->is)[vid]);
             }
         }
+    } else if (igraph_vs_is_all(&vids)) { /* no loops, calculating degree for all vertices */
+        // When calculating degree for all vertices, iterating over edges is faster
+        igraph_integer_t no_of_edges = igraph_ecount(graph);
+
+        if (mode & IGRAPH_OUT) {
+            for (igraph_integer_t edge = 0; edge < no_of_edges; ++edge) {
+                igraph_integer_t from = IGRAPH_FROM(graph, edge);
+                if (from != IGRAPH_TO(graph, edge)) {
+                    VECTOR(*res)[from]++;
+                }
+            }
+        }
+        if (mode & IGRAPH_IN) {
+            for (igraph_integer_t edge = 0; edge < no_of_edges; ++edge) {
+                igraph_integer_t to = IGRAPH_TO(graph, edge);
+                if (IGRAPH_FROM(graph, edge) != to) {
+                    VECTOR(*res)[to]++;
+                }
+            }
+        }
     } else { /* no loops */
         if (mode & IGRAPH_OUT) {
             for (IGRAPH_VIT_RESET(vit), i = 0;

--- a/src/properties/degrees.c
+++ b/src/properties/degrees.c
@@ -536,9 +536,10 @@ igraph_error_t igraph_degree_correlation_vector(
     return IGRAPH_SUCCESS;
 }
 
-igraph_error_t igraph_strength_all(const igraph_t *graph, igraph_vector_t *res,
-                    igraph_neimode_t mode, igraph_bool_t loops,
-                    const igraph_vector_t *weights) {
+igraph_error_t igraph_i_strength_all(
+        const igraph_t *graph, igraph_vector_t *res,
+        igraph_neimode_t mode, igraph_bool_t loops,
+        const igraph_vector_t *weights) {
 
     // When calculating strength for all vertices, iterating over edges is faster
     igraph_integer_t no_of_nodes = igraph_vcount(graph);
@@ -546,10 +547,6 @@ igraph_error_t igraph_strength_all(const igraph_t *graph, igraph_vector_t *res,
 
     IGRAPH_CHECK(igraph_vector_resize(res, no_of_nodes));
     igraph_vector_null(res);
-
-    if (mode != IGRAPH_OUT && mode != IGRAPH_IN && mode != IGRAPH_ALL) {
-        IGRAPH_ERROR("Mode should be either IGRAPH_OUT, IGRAPH_IN or IGRAPH_ALL.", IGRAPH_EINVMODE);
-    }
 
     if (!igraph_is_directed(graph)) {
         mode = IGRAPH_ALL;
@@ -640,8 +637,12 @@ igraph_error_t igraph_strength(const igraph_t *graph, igraph_vector_t *res,
         IGRAPH_ERROR("Invalid weight vector length.", IGRAPH_EINVAL);
     }
 
+    if (mode != IGRAPH_OUT && mode != IGRAPH_IN && mode != IGRAPH_ALL) {
+        IGRAPH_ERROR("Invalid mode for vertex strength calculation.", IGRAPH_EINVMODE);
+    }
+
     if (igraph_vs_is_all(&vids)) {
-        return igraph_strength_all(graph, res, mode, loops, weights);
+        return igraph_i_strength_all(graph, res, mode, loops, weights);
     }
 
     IGRAPH_CHECK(igraph_vit_create(graph, vids, &vit));

--- a/src/properties/degrees.c
+++ b/src/properties/degrees.c
@@ -536,6 +536,58 @@ igraph_error_t igraph_degree_correlation_vector(
     return IGRAPH_SUCCESS;
 }
 
+igraph_error_t igraph_strength_all(const igraph_t *graph, igraph_vector_t *res,
+                    igraph_neimode_t mode, igraph_bool_t loops,
+                    const igraph_vector_t *weights) {
+
+    // When calculating strength for all vertices, iterating over edges is faster
+    igraph_integer_t no_of_nodes = igraph_vcount(graph);
+    igraph_integer_t no_of_edges = igraph_ecount(graph);
+
+    IGRAPH_CHECK(igraph_vector_resize(res, no_of_nodes));
+    igraph_vector_null(res);
+
+    if (mode != IGRAPH_OUT && mode != IGRAPH_IN && mode != IGRAPH_ALL) {
+        IGRAPH_ERROR("Mode should be either IGRAPH_OUT, IGRAPH_IN or IGRAPH_ALL.", IGRAPH_EINVMODE);
+    }
+
+    if (!igraph_is_directed(graph)) {
+        mode = IGRAPH_ALL;
+    }
+
+    if (loops) {
+        if (mode & IGRAPH_OUT) {
+            for (igraph_integer_t edge = 0; edge < no_of_edges; ++edge) {
+                VECTOR(*res)[IGRAPH_FROM(graph, edge)] += VECTOR(*weights)[edge];
+            }
+        }
+        if (mode & IGRAPH_IN) {
+            for (igraph_integer_t edge = 0; edge < no_of_edges; ++edge) {
+                VECTOR(*res)[IGRAPH_TO(graph, edge)] += VECTOR(*weights)[edge];
+            }
+        }
+    } else {
+        if (mode & IGRAPH_OUT) {
+            for (igraph_integer_t edge = 0; edge < no_of_edges; ++edge) {
+                igraph_integer_t from = IGRAPH_FROM(graph, edge);
+                if (from != IGRAPH_TO(graph, edge)) {
+                   VECTOR(*res)[from] += VECTOR(*weights)[edge];
+                }
+            }
+        }
+        if (mode & IGRAPH_IN) {
+            for (igraph_integer_t edge = 0; edge < no_of_edges; ++edge) {
+                igraph_integer_t to = IGRAPH_TO(graph, edge);
+                if (IGRAPH_FROM(graph, edge) != to) {
+                    VECTOR(*res)[to] += VECTOR(*weights)[edge];
+                }
+            }
+        }
+    }
+
+    return IGRAPH_SUCCESS;
+}
+
 /**
  * \function igraph_strength
  * \brief Strength of the vertices, also called weighted vertex degree.
@@ -550,6 +602,7 @@ igraph_error_t igraph_degree_correlation_vector(
  * \param vids The vertices for which the calculation is performed.
  * \param mode Gives whether to count only outgoing (\c IGRAPH_OUT),
  *   incoming (\c IGRAPH_IN) edges or both (\c IGRAPH_ALL).
+ *   This parameter is ignored for undirected graphs.
  * \param loops A logical scalar, whether to count loop edges as well.
  * \param weights A vector giving the edge weights. If this is a \c NULL
  *   pointer, then \ref igraph_degree() is called to perform the
@@ -585,6 +638,10 @@ igraph_error_t igraph_strength(const igraph_t *graph, igraph_vector_t *res,
 
     if (igraph_vector_size(weights) != igraph_ecount(graph)) {
         IGRAPH_ERROR("Invalid weight vector length.", IGRAPH_EINVAL);
+    }
+
+    if (igraph_vs_is_all(&vids)) {
+        return igraph_strength_all(graph, res, mode, loops, weights);
     }
 
     IGRAPH_CHECK(igraph_vit_create(graph, vids, &vit));

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1007,6 +1007,7 @@ add_benchmarks(
   igraph_power_law_fit
   igraph_qsort
   igraph_random_walk
+  igraph_strength
   igraph_transitivity
   igraph_tree_game
   igraph_vertex_connectivity

--- a/tests/benchmarks/igraph_strength.c
+++ b/tests/benchmarks/igraph_strength.c
@@ -1,0 +1,82 @@
+#include <igraph.h>
+
+#include "bench.h"
+
+#define TOSTR1(x) #x
+#define TOSTR(x) TOSTR1(x)
+
+void rand_weight_vec(igraph_vector_t *vec, const igraph_t *graph) {
+    igraph_integer_t i, n = igraph_ecount(graph);
+    igraph_vector_resize(vec, n);
+    for (i=0; i < n; ++i) {
+        VECTOR(*vec)[i] = RNG_UNIF(1, 10);
+    }
+}
+
+int main(void) {
+
+    igraph_t g;
+    igraph_vector_t strength, weights;
+
+    igraph_rng_seed(igraph_rng_default(), 54);
+    BENCH_INIT();
+
+    igraph_vector_init(&strength, 0);
+    igraph_vector_init(&weights, 0);
+
+#define N 10000
+#define M 10
+#define REP 100
+
+    igraph_barabasi_game(&g, N, 1, M, NULL, true, 0, IGRAPH_UNDIRECTED, IGRAPH_BARABASI_PSUMTREE_MULTIPLE, NULL);
+    rand_weight_vec(&weights, &g);
+
+    BENCH(" 1 igraph_strength(), preferential attachment n=" TOSTR(N) ", m=" TOSTR(M) ", " TOSTR(REP) "x",
+          REPEAT(igraph_strength(&g, &strength, igraph_vss_all(), IGRAPH_ALL, IGRAPH_LOOPS, &weights), REP)
+    );
+
+    igraph_destroy(&g);
+
+#undef N
+#undef M
+#undef REP
+
+#define N 100000
+#define M 10
+#define REP 100
+
+    igraph_barabasi_game(&g, N, 1, M, NULL, true, 0, IGRAPH_UNDIRECTED, IGRAPH_BARABASI_PSUMTREE_MULTIPLE, NULL);
+    rand_weight_vec(&weights, &g);
+
+    BENCH(" 2 igraph_strength(), preferential attachment n=" TOSTR(N) ", m=" TOSTR(M) ", " TOSTR(REP) "x",
+          REPEAT(igraph_strength(&g, &strength, igraph_vss_all(), IGRAPH_ALL, IGRAPH_LOOPS, &weights), REP)
+    );
+
+    igraph_destroy(&g);
+
+#undef N
+#undef M
+#undef REP
+
+#define N 100000
+#define M 100
+#define REP 10
+
+    igraph_barabasi_game(&g, N, 1, M, NULL, true, 0, IGRAPH_UNDIRECTED, IGRAPH_BARABASI_PSUMTREE_MULTIPLE, NULL);
+    rand_weight_vec(&weights, &g);
+
+    BENCH(" 3 igraph_strength(), preferential attachment n=" TOSTR(N) ", m=" TOSTR(M) ", " TOSTR(REP) "x",
+          REPEAT(igraph_strength(&g, &strength, igraph_vss_all(), IGRAPH_ALL, IGRAPH_LOOPS, &weights), REP)
+    );
+
+    igraph_destroy(&g);
+
+#undef N
+#undef M
+#undef REP
+
+    igraph_vector_destroy(&weights);
+    igraph_vector_destroy(&strength);
+
+    return 0;
+}

--- a/tests/benchmarks/igraph_strength.c
+++ b/tests/benchmarks/igraph_strength.c
@@ -24,16 +24,53 @@ int main(void) {
     igraph_vector_init(&strength, 0);
     igraph_vector_init(&weights, 0);
 
-#define N 10000
+    /* igraph_strength() uses an optimized, cache friendly code path when given
+     * a vertex selector for which igraph_vs_is_all() returns true (this is
+     * currently igraph_vs_all()). We pass both igraph_vss_all() and
+     * igraph_vss_range(0, igraph_vcount(graph)) as vertex selectors
+     * to compare the performance of the two code paths.
+     *
+     * NOTE: While currently igraph_vs_is_all() does not return true for
+     * a range-type vertex selector, this may change in the future.
+     * An altrenative is to to use igraph_vs_vector(), with the vector
+     * initialized to a range.
+     */
+
+#define N 1000
 #define M 10
-#define REP 100
+#define REP 10000
 
     igraph_barabasi_game(&g, N, 1, M, NULL, true, 0, IGRAPH_UNDIRECTED, IGRAPH_BARABASI_PSUMTREE_MULTIPLE, NULL);
     rand_weight_vec(&weights, &g);
 
-    BENCH(" 1 igraph_strength(), preferential attachment n=" TOSTR(N) ", m=" TOSTR(M) ", " TOSTR(REP) "x",
+    BENCH(" 1a igraph_strength(), preferential attachment n=" TOSTR(N) ", m=" TOSTR(M) ", " TOSTR(REP) "x",
+          REPEAT(igraph_strength(&g, &strength, igraph_vss_all(), IGRAPH_ALL, IGRAPH_LOOPS, &weights), REP)
+          );
+    BENCH(" 1b igraph_strength(), preferential attachment n=" TOSTR(N) ", m=" TOSTR(M) ", " TOSTR(REP) "x",
+          REPEAT(igraph_strength(&g, &strength, igraph_vss_range(0, igraph_vcount(&g)), IGRAPH_ALL, IGRAPH_LOOPS, &weights), REP)
+          );
+    printf("\n");
+
+    igraph_destroy(&g);
+
+#undef N
+#undef M
+#undef REP
+
+#define N 10000
+#define M 10
+#define REP 1000
+
+    igraph_barabasi_game(&g, N, 1, M, NULL, true, 0, IGRAPH_UNDIRECTED, IGRAPH_BARABASI_PSUMTREE_MULTIPLE, NULL);
+    rand_weight_vec(&weights, &g);
+
+    BENCH(" 2a igraph_strength(), preferential attachment n=" TOSTR(N) ", m=" TOSTR(M) ", " TOSTR(REP) "x",
           REPEAT(igraph_strength(&g, &strength, igraph_vss_all(), IGRAPH_ALL, IGRAPH_LOOPS, &weights), REP)
     );
+    BENCH(" 2b igraph_strength(), preferential attachment n=" TOSTR(N) ", m=" TOSTR(M) ", " TOSTR(REP) "x",
+          REPEAT(igraph_strength(&g, &strength, igraph_vss_range(0, igraph_vcount(&g)), IGRAPH_ALL, IGRAPH_LOOPS, &weights), REP)
+    );
+    printf("\n");
 
     igraph_destroy(&g);
 
@@ -48,9 +85,13 @@ int main(void) {
     igraph_barabasi_game(&g, N, 1, M, NULL, true, 0, IGRAPH_UNDIRECTED, IGRAPH_BARABASI_PSUMTREE_MULTIPLE, NULL);
     rand_weight_vec(&weights, &g);
 
-    BENCH(" 2 igraph_strength(), preferential attachment n=" TOSTR(N) ", m=" TOSTR(M) ", " TOSTR(REP) "x",
+    BENCH(" 3a igraph_strength(), preferential attachment n=" TOSTR(N) ", m=" TOSTR(M) ", " TOSTR(REP) "x",
           REPEAT(igraph_strength(&g, &strength, igraph_vss_all(), IGRAPH_ALL, IGRAPH_LOOPS, &weights), REP)
     );
+    BENCH(" 3b igraph_strength(), preferential attachment n=" TOSTR(N) ", m=" TOSTR(M) ", " TOSTR(REP) "x",
+          REPEAT(igraph_strength(&g, &strength, igraph_vss_range(0, igraph_vcount(&g)), IGRAPH_ALL, IGRAPH_LOOPS, &weights), REP)
+    );
+    printf("\n");
 
     igraph_destroy(&g);
 
@@ -65,9 +106,13 @@ int main(void) {
     igraph_barabasi_game(&g, N, 1, M, NULL, true, 0, IGRAPH_UNDIRECTED, IGRAPH_BARABASI_PSUMTREE_MULTIPLE, NULL);
     rand_weight_vec(&weights, &g);
 
-    BENCH(" 3 igraph_strength(), preferential attachment n=" TOSTR(N) ", m=" TOSTR(M) ", " TOSTR(REP) "x",
+    BENCH(" 4a igraph_strength(), preferential attachment n=" TOSTR(N) ", m=" TOSTR(M) ", " TOSTR(REP) "x",
           REPEAT(igraph_strength(&g, &strength, igraph_vss_all(), IGRAPH_ALL, IGRAPH_LOOPS, &weights), REP)
     );
+    BENCH(" 4b igraph_strength(), preferential attachment n=" TOSTR(N) ", m=" TOSTR(M) ", " TOSTR(REP) "x",
+          REPEAT(igraph_strength(&g, &strength, igraph_vss_range(0, igraph_vcount(&g)), IGRAPH_ALL, IGRAPH_LOOPS, &weights), REP)
+    );
+    printf("\n");
 
     igraph_destroy(&g);
 


### PR DESCRIPTION
Implements https://github.com/igraph/igraph/issues/2599. Specifically:

- faster `igraph_degree()` when ignoring loops and calculating degree for all vertices,
- faster `igraph_strength()` when calculating strength for all vertices,
- Added benchmark for `igraph_strength()`.

### Local benchmark results
`igraph_strength()` before:
```
$ ./tests/benchmark_igraph_strength

|  1 igraph_strength(), preferential attachment n=10000, m=10, 100x                 0.03s   0.03s      0s
|  2 igraph_strength(), preferential attachment n=100000, m=10, 100x                0.44s  0.439s      0s
|  3 igraph_strength(), preferential attachment n=100000, m=100, 10x               0.971s  0.971s      0s
```

`igraph_strength()` after:
```
$ ./tests/benchmark_igraph_strength

|  1 igraph_strength(), preferential attachment n=10000, m=10, 100x                0.015s  0.015s      0s
|  2 igraph_strength(), preferential attachment n=100000, m=10, 100x               0.219s  0.219s      0s
|  3 igraph_strength(), preferential attachment n=100000, m=100, 10x               0.284s  0.284s      0s
```
`igraph_degree()` before:
```
$ ./tests/benchmark_igraph_degree

[...]

Do not count loops, O(d) per degree.
|  1 igraph_degree(), preferential attachment n=100000, m=10, 100x                 0.331s  0.331s      0s
```
`igraph_degree()` after:
```
$ ./tests/benchmark_igraph_degree

[...]

Do not count loops, O(d) per degree.
|  1 igraph_degree(), preferential attachment n=100000, m=10, 100x                 0.197s  0.197s      0s
```