### PR TITLE
Validate vertex IDs in Pajek Arcslist/Edgeslist files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
  - `igraph_weighted_adjacency()` correctly passes through NaN values with `IGRAPH_ADJ_MAX`, and correctly recognizes symmetric adjacency matrices containing NaN values with `IGRAPH_ADJ_UNDIRECTED`.
  - `igraph_read_graph_gml()` can now read GML files that use ids larger than what is representable on 32 bits, provided that igraph was configured with a 64-bit `igraph_integer_t` size.
  - Fixed a performance issue in `igraph_read_graph_graphml()` with files containing a very large number of entities, such as `&gt;`.
+ - `igraph_read_graph_pajek()` has improved vertex ID validation that better matches that of Pajek's own behavior.
 
 ### Changed
 

--- a/src/io/pajek-parser.y
+++ b/src/io/pajek-parser.y
@@ -448,11 +448,11 @@ arclistline: arclistfrom arctolist NEWLINE;
 
 arctolist: /* empty */ | arctolist arclistto;
 
-arclistfrom: integer { context->actfrom=labs($1)-1; };
+arclistfrom: vertex { context->actfrom=$1-1; };
 
-arclistto: integer {
+arclistto: vertex {
   IGRAPH_YY_CHECK(igraph_vector_int_push_back(context->vector, context->actfrom));
-  IGRAPH_YY_CHECK(igraph_vector_int_push_back(context->vector, labs($1)-1));
+  IGRAPH_YY_CHECK(igraph_vector_int_push_back(context->vector, $1-1));
 };
 
 edgeslist: EDGESLISTLINE NEWLINE edgelistlines { context->directed=0; };
@@ -463,11 +463,11 @@ edgelistline: edgelistfrom edgetolist NEWLINE;
 
 edgetolist: /* empty */ | edgetolist edgelistto;
 
-edgelistfrom: integer { context->actfrom=labs($1)-1; };
+edgelistfrom: vertex { context->actfrom=$1-1; };
 
-edgelistto: integer {
+edgelistto: vertex {
   IGRAPH_YY_CHECK(igraph_vector_int_push_back(context->vector, context->actfrom));
-  IGRAPH_YY_CHECK(igraph_vector_int_push_back(context->vector, labs($1)-1));
+  IGRAPH_YY_CHECK(igraph_vector_int_push_back(context->vector, $1-1));
 };
 
 /* -----------------------------------------------------*/

--- a/src/io/pajek-parser.y
+++ b/src/io/pajek-parser.y
@@ -238,9 +238,15 @@ vertexline: vertex NEWLINE |
 
 vertex: integer {
   igraph_integer_t v = $1;
+  /* Per feedback from Pajek's authors, negative signs should be ignored.
+   * See https://nascol.discourse.group/t/pajek-arcslist-edgelist-format/44/2 
+   * This applies to all of *Edges, *Arcs, *Edgeslist and *Arcslist section. */
+  if (v < 0) {
+    v = -v;
+  }
   if (v < 1 || v > context->vcount) {
       IGRAPH_YY_ERRORF(
-                  "Invalid vertex id (%" IGRAPH_PRId ") in Pajek file. "
+                  "Invalid vertex ID (%" IGRAPH_PRId ") in Pajek file. "
                   "The number of vertices is %" IGRAPH_PRId ".",
                   IGRAPH_EINVAL, v, context->vcount);
   }

--- a/tests/regression/invalid_pajek2.net
+++ b/tests/regression/invalid_pajek2.net
@@ -1,3 +1,3 @@
 *Network TRALALA
 *vertices 4 1
-  -3 "3."
+  0 "3."

--- a/tests/unit/pajek.c
+++ b/tests/unit/pajek.c
@@ -27,6 +27,7 @@
 
 int main(void) {
     igraph_t g;
+    igraph_bool_t simple;
     FILE *ifile;
 
     /* turn on attribute handling */
@@ -64,6 +65,38 @@ int main(void) {
 
     IGRAPH_ASSERT(igraph_vcount(&g) == 10);
     IGRAPH_ASSERT(igraph_ecount(&g) == 6);
+
+    igraph_destroy(&g);
+
+    /* File in Arcslist format */
+    ifile = fopen("pajek_arcslist.net", "r");
+    IGRAPH_ASSERT(ifile != NULL);
+
+    igraph_read_graph_pajek(&g, ifile);
+    fclose(ifile);
+
+    IGRAPH_ASSERT(igraph_vcount(&g) == 18);
+    IGRAPH_ASSERT(igraph_ecount(&g) == 55);
+    IGRAPH_ASSERT(igraph_is_directed(&g));
+
+    igraph_is_simple(&g, &simple);
+    IGRAPH_ASSERT(simple);
+
+    igraph_destroy(&g);
+
+    /* File in Edgeslist format */
+    ifile = fopen("pajek_edgeslist.net", "r");
+    IGRAPH_ASSERT(ifile != NULL);
+
+    igraph_read_graph_pajek(&g, ifile);
+    fclose(ifile);
+
+    IGRAPH_ASSERT(igraph_vcount(&g) == 3);
+    IGRAPH_ASSERT(igraph_ecount(&g) == 3);
+    IGRAPH_ASSERT(! igraph_is_directed(&g));
+
+    igraph_is_simple(&g, &simple);
+    IGRAPH_ASSERT(simple);
 
     igraph_destroy(&g);
 

--- a/tests/unit/pajek_arcslist.net
+++ b/tests/unit/pajek_arcslist.net
@@ -1,0 +1,40 @@
+This is a simplified version of http://mrvar.fdv.uni-lj.si/pajek/data/sampsonl.net
+
+*Vertices 18
+1 "ROMUL_10"
+2 "BONAVEN_5"
+3 "AMBROSE_9"
+4 "BERTH_6"
+5 "PETER_4"
+6 "LOUIS_11"
+7 "VICTOR_8"
+8 "WINF_12"
+9 "JOHN_1"
+10 "GREG_2"
+11 "HUGH_14"
+12 "BONI_15"
+13 "MARK_7"
+14 "ALBERT_16"
+15 "AMAND_13"
+16 "BASIL_3"
+17 "ELIAS_17"
+18 "SIMP_18"
+*Arcslist
+1 3 5 14
+2 1 7 14
+3 1 2 17
+4 5 6 10
+5 4 11 13
+6 1 4 9
+7 2 8 16
+8 1 2 9
+9 5 8 16
+10 4 8 14
+11 5 8 14
+12 1 2 14
+13 5 7 18
+14 1 11 12 15
+15 1 2 14
+16 1 2 7
+17 3 13 18
+18 1 2 7

--- a/tests/unit/pajek_edgeslist.net
+++ b/tests/unit/pajek_edgeslist.net
@@ -1,0 +1,8 @@
+*Network "C_3 cycle graph"
+*Vertices 3
+1 "Alice"
+2 "Bob"
+3 "Cedric"
+*Edgeslist
+1 2 3
+2 3


### PR DESCRIPTION
Do not merge until we got feedback at https://nascol.discourse.group/t/pajek-arcslist-edgelist-format/44  It is possible that the negative signs were intentional, e.g. to denote signed networks.