### PR TITLE
feat: `igraph_erdos_renyi_game_gnp()` can now generate graphs with more than 100 million vertices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
  - Documentation improvements.
  - Reduced the memory usage of several functions by using bitsets instead of boolean vectors.
+ - `igraph_erdos_renyi_game_gnp()` can now generate graphs with more than a few tens of millions of vertices.
 
 ## [0.10.12] - 2024-05-06
 

--- a/tests/unit/erdos_renyi_game_gnp.c
+++ b/tests/unit/erdos_renyi_game_gnp.c
@@ -20,7 +20,7 @@
 
 #include "test_utilities.h"
 
-int stress_test(void) {
+void stress_test(void) {
     igraph_rng_seed(igraph_rng_default(), 137);
 
     for (igraph_integer_t size=2; size < 5; size++) {
@@ -62,11 +62,9 @@ int stress_test(void) {
     }
 
     VERIFY_FINALLY_STACK();
-
-    return 0;
 }
 
-int test_examples(void) {
+void test_examples(void) {
     igraph_t g;
     igraph_bool_t simple;
 
@@ -164,20 +162,12 @@ int test_examples(void) {
     igraph_destroy(&g);
 
     VERIFY_FINALLY_STACK();
-
-    return 0;
 }
 
 int main(void) {
-    int retval;
 
-    retval = test_examples();
-    if (retval) {
-        return retval;
-    }
+    test_examples();
+    stress_test();
 
-    retval = stress_test();
-    if (retval) {
-        return retval;
-    }
+    return 0;
 }


### PR DESCRIPTION
Closes #2613 

I benchmarked the new implementation, and it tends to be slower than the original one. Therefore it is only used when the original one would overflow.

I tested this alternative implementation on small graphs manually, and verified that it produces the expected graph density. Including a test in the test suite is not feasible because of high runtime and memory usage. We need over 100 million vertices for the alternative implementation to become necessary.