### PR TITLE
Use bitset in LAD and clean up code

### DIFF
--- a/src/isomorphism/lad.c
+++ b/src/isomorphism/lad.c
@@ -516,26 +516,18 @@ static igraph_error_t igraph_i_lad_initDomains(bool initialDomains,
     IGRAPH_BITSET_INIT_FINALLY(&dom, Gt->nbVertices);
 
     IGRAPH_VECTOR_INT_INIT_FINALLY(&D->globalMatchingP, Gp->nbVertices);
-    igraph_vector_int_fill(&D->globalMatchingP, -1L);
+    igraph_vector_int_fill(&D->globalMatchingP, -1);
 
     IGRAPH_VECTOR_INT_INIT_FINALLY(&D->globalMatchingT, Gt->nbVertices);
-    igraph_vector_int_fill(&D->globalMatchingT, -1L);
+    igraph_vector_int_fill(&D->globalMatchingT, -1);
 
     IGRAPH_VECTOR_INT_INIT_FINALLY(&D->nbVal, Gp->nbVertices);
-
-    IGRAPH_CHECK(igraph_vector_int_init(&D->firstVal, Gp->nbVertices));
-    IGRAPH_FINALLY(igraph_vector_int_destroy, &D->firstVal);
-
-    IGRAPH_CHECK(igraph_matrix_int_init(&D->posInVal,
-                                        Gp->nbVertices, Gt->nbVertices));
-    IGRAPH_FINALLY(igraph_matrix_int_destroy, &D->posInVal);
-
-    IGRAPH_CHECK(igraph_matrix_int_init(&D->firstMatch,
-                                        Gp->nbVertices, Gt->nbVertices));
-    IGRAPH_FINALLY(igraph_matrix_int_destroy, &D->firstMatch);
-
+    IGRAPH_VECTOR_INT_INIT_FINALLY(&D->firstVal, Gp->nbVertices);
+    IGRAPH_MATRIX_INT_INIT_FINALLY(&D->posInVal,
+                                   Gp->nbVertices, Gt->nbVertices);
+    IGRAPH_MATRIX_INT_INIT_FINALLY(&D->firstMatch,
+                                   Gp->nbVertices, Gt->nbVertices);
     IGRAPH_BITSET_INIT_FINALLY(&D->markedToFilter, Gp->nbVertices);
-
     IGRAPH_VECTOR_INT_INIT_FINALLY(&D->toFilter, Gp->nbVertices);
 
     D->valSize = 0;
@@ -727,8 +719,7 @@ static igraph_error_t igraph_i_lad_updateMatching(igraph_integer_t sizeOfU, igra
     ALLOC_ARRAY(unmatched, sizeOfU, igraph_integer_t);
     ALLOC_ARRAY(posInUnmatched, sizeOfU, igraph_integer_t);
 
-    IGRAPH_CHECK(igraph_vector_int_init(&path, 0));
-    IGRAPH_FINALLY(igraph_vector_int_destroy, &path);
+    IGRAPH_VECTOR_INT_INIT_FINALLY(&path, 0);
 
     /* initialize matchedWithV and unmatched */
     memset(matchedWithV, -1, (size_t)sizeOfV * sizeof(matchedWithV[0]));
@@ -1054,8 +1045,7 @@ static igraph_error_t igraph_i_lad_ensureGACallDiff(bool induced, Tgraph* Gp, Tg
     ALLOC_ARRAY(numU, Gp->nbVertices, igraph_integer_t);
     IGRAPH_BITSET_INIT_FINALLY(&used, Gp->nbVertices * Gt->nbVertices);
     ALLOC_ARRAY(list, Gt->nbVertices, igraph_integer_t);
-    IGRAPH_CHECK(igraph_vector_int_init(&toMatch, Gp->nbVertices));
-    IGRAPH_FINALLY(igraph_vector_int_destroy, &toMatch);
+    IGRAPH_VECTOR_INT_INIT_FINALLY(&toMatch, Gp->nbVertices);
 
     for (u = 0; u < Gp->nbVertices; u++) {
         for (i = 0; i < VECTOR(D->nbVal)[u]; i++) {
@@ -1210,17 +1200,12 @@ static igraph_error_t igraph_i_lad_checkLAD(igraph_integer_t u, igraph_integer_t
        let V be the set of nodes that are adjacent to v, and that belong
        to domains of nodes of U */
     /* nbComp[u]=number of elements of V that are compatible with u */
-    IGRAPH_CHECK(igraph_vector_int_init(&nbComp, VECTOR(Gp->nbSucc)[u]));
-    IGRAPH_FINALLY(igraph_vector_int_destroy, &nbComp);
-    IGRAPH_CHECK(igraph_vector_int_init(&firstComp, VECTOR(Gp->nbSucc)[u]));
-    IGRAPH_FINALLY(igraph_vector_int_destroy, &firstComp);
+    IGRAPH_VECTOR_INT_INIT_FINALLY(&nbComp, VECTOR(Gp->nbSucc)[u]);
+    IGRAPH_VECTOR_INT_INIT_FINALLY(&firstComp, VECTOR(Gp->nbSucc)[u]);
     /* comp[firstComp[u]..firstComp[u]+nbComp[u]-1] = nodes of Gt that
        are compatible with u */
-    IGRAPH_CHECK(igraph_vector_int_init(&comp, (VECTOR(Gp->nbSucc)[u] *
-                                        Gt->nbVertices)));
-    IGRAPH_FINALLY(igraph_vector_int_destroy, &comp);
-    IGRAPH_CHECK(igraph_vector_int_init(&matchedWithU, VECTOR(Gp->nbSucc)[u]));
-    IGRAPH_FINALLY(igraph_vector_int_destroy, &matchedWithU);
+    IGRAPH_VECTOR_INT_INIT_FINALLY(&comp, (VECTOR(Gp->nbSucc)[u] * Gt->nbVertices));
+    IGRAPH_VECTOR_INT_INIT_FINALLY(&matchedWithU, VECTOR(Gp->nbSucc)[u]);
     memset(num, -1, (size_t) (Gt->nbVertices) * sizeof(num[0]));
     for (i = 0; i < VECTOR(Gp->nbSucc)[u]; i++) {
         u2 = VECTOR(*Gp_uneis)[i]; /* u2 is adjacent to u */
@@ -1628,8 +1613,7 @@ igraph_error_t igraph_subisomorphic_lad(const igraph_t *pattern, const igraph_t 
         VECTOR(D.globalMatchingT)[ VECTOR(D.globalMatchingP)[u] ] = u;
     }
 
-    IGRAPH_CHECK(igraph_vector_int_init(&toMatch, Gp.nbVertices));
-    IGRAPH_FINALLY(igraph_vector_int_destroy, &toMatch);
+    IGRAPH_VECTOR_INT_INIT_FINALLY(&toMatch, Gp.nbVertices);
 
     for (u = 0; u < Gp.nbVertices; u++) {
         if (VECTOR(D.nbVal)[u] == 1) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1018,6 +1018,7 @@ add_benchmarks(
   igraph_vertex_connectivity
   igraph_voronoi
   inc_vs_adj
+  lad
 )
 
 # dot product

--- a/tests/benchmarks/lad.c
+++ b/tests/benchmarks/lad.c
@@ -1,0 +1,50 @@
+
+#include <igraph.h>
+
+#include "bench.h"
+
+void match(const igraph_t *graph,
+           const igraph_t patt[], igraph_integer_t n,
+           igraph_vector_int_list_t *maps) {
+
+    igraph_vector_int_list_clear(maps);
+    for (igraph_integer_t i=0; i < n; i++) {
+        igraph_subisomorphic_lad(&patt[i], graph, NULL, NULL, NULL, maps, false, 0);
+    }
+}
+
+#define NP 8
+
+int main(void) {
+    igraph_t graph;
+    igraph_t patt[NP];
+    igraph_vector_int_list_t maps;
+
+    BENCH_INIT();
+
+    igraph_vector_int_list_init(&maps, 0);
+
+    for (igraph_integer_t i=0; i < NP; i++) {
+        igraph_ring(&patt[i], i+1, IGRAPH_DIRECTED, false, true);
+    }
+
+    igraph_kautz(&graph, 3, 3);
+    BENCH("1 Kautz(3,3) 10x", REPEAT(match(&graph, patt, NP, &maps), 10));
+    igraph_destroy(&graph);
+
+    igraph_kautz(&graph, 3, 4);
+    BENCH("2 Kautz(3,4) 3x", REPEAT(match(&graph, patt, NP, &maps), 3));
+    igraph_destroy(&graph);
+
+    igraph_kautz(&graph, 4, 3);
+    BENCH("3 Kautz(4,3) 1x", REPEAT(match(&graph, patt, NP, &maps), 1));
+    igraph_destroy(&graph);
+
+    for (igraph_integer_t i=0; i < NP; i++) {
+        igraph_destroy(&patt[i]);
+    }
+
+    igraph_vector_int_list_destroy(&maps);
+
+    return 0;
+}


### PR DESCRIPTION
Benchmark before:

```
| 1 Kautz(3,3) 10x                                                                 0.603s   0.57s  0.028s
| 2 Kautz(3,4) 3x                                                                   0.85s  0.829s  0.015s
| 3 Kautz(4,3) 1x                                                                   1.03s      1s  0.022s
```

After:

```
| 1 Kautz(3,3) 10x                                                                 0.597s  0.567s  0.028s
| 2 Kautz(3,4) 3x                                                                  0.807s   0.79s  0.014s
| 3 Kautz(4,3) 1x                                                                  0.942s  0.916s  0.022s
```

