### PR TITLE
`igraph_is_clique()` and `igraph_is_independent_vertex_set()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
  - `igraph_count_loops()` counts self-loops in the graph (experimental function).
  - `igraph_stack_capacity()` returns the allocated capacity of a stack.
  - `igraph_is_clique()` checks if all pairs within a set of vertices are connected (experimental function).
+ - `igraph_is_independent_vertex_set()` checks if no pairs within a set of vertices are connected (experimental function).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
  - `igraph_mean_degree()` computes the average of vertex degrees (experimental function).
  - `igraph_count_loops()` counts self-loops in the graph (experimental function).
  - `igraph_stack_capacity()` returns the allocated capacity of a stack.
+ - `igraph_is_clique()` checks if all pairs within a set of vertices are connected (experimental function).
 
 ### Fixed
 

--- a/doc/cliques.xxml
+++ b/doc/cliques.xxml
@@ -35,6 +35,7 @@ to cliques and independent vertex sets.
 </section>
 
 <section id="independent-vertex-sets"><title>Independent vertex sets</title>
+<!-- doxrox-include igraph_is_independent_vertex_set -->
 <!-- doxrox-include igraph_independent_vertex_sets -->
 <!-- doxrox-include igraph_largest_independent_vertex_sets -->
 <!-- doxrox-include igraph_maximal_independent_vertex_sets -->

--- a/doc/cliques.xxml
+++ b/doc/cliques.xxml
@@ -13,6 +13,7 @@ to cliques and independent vertex sets.
 
 <section id="cliques"><title>Cliques</title>
 <!-- doxrox-include igraph_is_complete -->
+<!-- doxrox-include igraph_is_clique -->
 <!-- doxrox-include igraph_cliques -->
 <!-- doxrox-include igraph_clique_size_hist -->
 <!-- doxrox-include igraph_cliques_callback -->

--- a/include/igraph_structural.h
+++ b/include/igraph_structural.h
@@ -91,6 +91,8 @@ IGRAPH_EXPORT igraph_error_t igraph_is_perfect(const igraph_t *graph, igraph_boo
 IGRAPH_EXPORT igraph_error_t igraph_is_complete(const igraph_t *graph, igraph_bool_t *res);
 IGRAPH_EXPORT igraph_error_t igraph_is_clique(const igraph_t *graph, igraph_vs_t candidate,
                                               igraph_bool_t directed, igraph_bool_t *res);
+IGRAPH_EXPORT igraph_error_t igraph_is_independent_vertex_set(const igraph_t *graph, igraph_vs_t candidate,
+                                                       igraph_bool_t *res);
 IGRAPH_EXPORT igraph_error_t igraph_minimum_spanning_tree(const igraph_t *graph, igraph_vector_int_t *res,
                                                const igraph_vector_t *weights);
 IGRAPH_EXPORT igraph_error_t igraph_minimum_spanning_tree_unweighted(const igraph_t *graph,

--- a/include/igraph_structural.h
+++ b/include/igraph_structural.h
@@ -89,6 +89,8 @@ IGRAPH_EXPORT igraph_error_t igraph_is_perfect(const igraph_t *graph, igraph_boo
 /* -------------------------------------------------- */
 
 IGRAPH_EXPORT igraph_error_t igraph_is_complete(const igraph_t *graph, igraph_bool_t *res);
+IGRAPH_EXPORT igraph_error_t igraph_is_clique(const igraph_t *graph, igraph_vs_t candidate,
+                                              igraph_bool_t directed, igraph_bool_t *res);
 IGRAPH_EXPORT igraph_error_t igraph_minimum_spanning_tree(const igraph_t *graph, igraph_vector_int_t *res,
                                                const igraph_vector_t *weights);
 IGRAPH_EXPORT igraph_error_t igraph_minimum_spanning_tree_unweighted(const igraph_t *graph,

--- a/interfaces/functions.yaml
+++ b/interfaces/functions.yaml
@@ -1301,6 +1301,11 @@ igraph_count_reachable:
 # Cliques
 #######################################
 
+igraph_is_clique:
+    PARAMS: |-
+        GRAPH graph, VERTEX_SELECTOR candidate, BOOLEAN directed=False,
+        OUT BOOLEAN res
+
 igraph_cliques:
     PARAMS: |-
         GRAPH graph, OUT VERTEXSET_LIST res, INTEGER min_size=0,
@@ -1364,6 +1369,9 @@ igraph_largest_weighted_cliques:
 igraph_weighted_clique_number:
     PARAMS: GRAPH graph, VERTEXWEIGHTS vertex_weights=NULL, OUT REAL res
     DEPS: vertex_weights ON graph
+
+igraph_is_independent_vertex_set:
+    PARAMS: GRAPH graph, VERTEX_SELECTOR candidate, OUT BOOLEAN res
 
 igraph_independent_vertex_sets:
     PARAMS: |-

--- a/src/properties/complete.c
+++ b/src/properties/complete.c
@@ -155,38 +155,13 @@ cleanup:
 }
 
 
-/**
- * \ingroup structural
- * \function igraph_is_clique
- * \brief Does a set of vertices form a clique?
- *
- * \experimental
- *
- * Tests if all pairs within a set of vertices are connected, i.e. whether they
- * form a clique. An empty set and singleton set are considered to be a clique.
- *
- * \param graph The input graph.
- * \param candidate The vertex set to test for being a clique.
- * \param directed Whether to take edge directions into account in directed graphs.
- * \param res The result will be stored here.
- * \return Error code.
- *
- * Time complexity: O(n^2 log(d)) where n is the number of vertices in the
- * candidate set and d is the typical vertex degree.
- */
-igraph_error_t igraph_is_clique(const igraph_t *graph, igraph_vs_t candidate,
-                                igraph_bool_t directed, igraph_bool_t *res) {
+/* Test for cliques or independent sets, depending on whether independent_set == true. */
+static igraph_error_t is_clique(const igraph_t *graph, igraph_vs_t candidate,
+                                igraph_bool_t directed, igraph_bool_t *res,
+                                igraph_bool_t independent_set) {
     igraph_vector_int_t vids;
     igraph_integer_t n; /* clique size */
-    igraph_bool_t is_clique = true; /* be optimistic */
-
-    if (! igraph_is_directed(graph)) {
-        directed = false;
-    }
-
-    if (igraph_is_directed(graph) == directed && igraph_vs_is_all(&candidate)) {
-        return igraph_is_complete(graph, res);
-    }
+    igraph_bool_t result = true; /* be optimistic */
 
     /* The following implementation is optimized for testing for small cliques
      * in large graphs. */
@@ -205,9 +180,16 @@ igraph_error_t igraph_is_clique(const igraph_t *graph, igraph_vs_t candidate,
             if (u != v) {
                 igraph_integer_t eid;
                 IGRAPH_CHECK(igraph_get_eid(graph, &eid, u, v, directed, false));
-                if (eid == -1) {
-                    is_clique = false;
-                    goto done;
+                if (independent_set) {
+                    if (eid != -1) {
+                        result = false;
+                        goto done;
+                    }
+                } else {
+                    if (eid == -1) {
+                        result = false;
+                        goto done;
+                    }
                 }
             }
         }
@@ -215,10 +197,80 @@ igraph_error_t igraph_is_clique(const igraph_t *graph, igraph_vs_t candidate,
 
 done:
 
-    *res = is_clique;
+    *res = result;
 
     igraph_vector_int_destroy(&vids);
     IGRAPH_FINALLY_CLEAN(1);
 
     return IGRAPH_SUCCESS;
+}
+
+/**
+ * \ingroup structural
+ * \function igraph_is_clique
+ * \brief Does a set of vertices form a clique?
+ *
+ * \experimental
+ *
+ * Tests if all pairs within a set of vertices are adjacent, i.e. whether they
+ * form a clique. An empty set and singleton set are considered to be a clique.
+ *
+ * \param graph The input graph.
+ * \param candidate The vertex set to test for being a clique.
+ * \param directed Whether to take edge directions into account in directed graphs.
+ * \param res The result will be stored here.
+ * \return Error code.
+ *
+ * \sa \ref igraph_is_complete(), \ref igraph_is_independent_vertex_set()
+ *
+ * Time complexity: O(n^2 log(d)) where n is the number of vertices in the
+ * candidate set and d is the typical vertex degree.
+ */
+igraph_error_t igraph_is_clique(const igraph_t *graph, igraph_vs_t candidate,
+                                igraph_bool_t directed, igraph_bool_t *res) {
+
+    if (! igraph_is_directed(graph)) {
+        directed = false;
+    }
+
+    if (igraph_is_directed(graph) == directed && igraph_vs_is_all(&candidate)) {
+        return igraph_is_complete(graph, res);
+    }
+
+    return is_clique(graph, candidate, directed, res, /* independent_set */ false);
+}
+
+/**
+ * \ingroup structural
+ * \function igraph_is_independent_vertex_set
+ * \brief Does a set of vertices form an independent set?
+ *
+ * \experimental
+ *
+ * Tests if no pairs within a set of vertices are adjacenct, i.e. whether they
+ * form a an independent set. An empty set and singleton set are both considered
+ * to be an independent set.
+ *
+ * \param graph The input graph.
+ * \param candidate The vertex set to test for being an independent set.
+ * \param res The result will be stored here.
+ * \return Error code.
+ *
+ * \sa \ref igraph_is_clique()
+ *
+ * Time complexity: O(n^2 log(d)) where n is the number of vertices in the
+ * candidate set and d is the typical vertex degree.
+ */
+igraph_error_t igraph_is_independent_vertex_set(const igraph_t *graph, igraph_vs_t candidate,
+                                         igraph_bool_t *res) {
+
+    /* Note: igraph_count_loops() already makes use of the cache. */
+    if (igraph_vs_is_all(&candidate)) {
+        igraph_integer_t loop_count;
+        igraph_count_loops(graph, &loop_count);
+        *res = (igraph_ecount(graph) - loop_count) == 0;
+        return IGRAPH_SUCCESS;
+    }
+
+    return is_clique(graph, candidate, /* directed */ false, res, /* independent_set */ true);
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -327,6 +327,7 @@ add_legacy_tests(
   igraph_is_bipartite
   igraph_is_connected
   igraph_is_chordal
+  igraph_is_clique
   igraph_is_complete
   igraph_is_dag
   igraph_is_mutual

--- a/tests/unit/igraph_is_clique.c
+++ b/tests/unit/igraph_is_clique.c
@@ -21,7 +21,7 @@
 
 int main(void) {
     igraph_t g;
-    igraph_bool_t is_clique;
+    igraph_bool_t is_clique, is_indep_set;
     igraph_vector_int_t vids;
 
     igraph_small(&g, 10, IGRAPH_DIRECTED,
@@ -104,6 +104,40 @@ int main(void) {
     is_clique = true;
     igraph_is_clique(&g, igraph_vss_all(), false, &is_clique);
     IGRAPH_ASSERT(! is_clique);
+
+    /* Independent sets */
+
+    /* Empty set */
+    igraph_vector_int_init(&vids, 0);
+    is_indep_set = false;
+    igraph_is_independent_vertex_set(&g, igraph_vss_vector(&vids), &is_indep_set);
+    IGRAPH_ASSERT(is_indep_set);
+    igraph_vector_int_destroy(&vids);
+
+    /* Singleton set */
+    is_indep_set = false;
+    igraph_is_independent_vertex_set(&g, igraph_vss_1(5), &is_indep_set);
+    IGRAPH_ASSERT(is_indep_set);
+
+    igraph_vector_int_init_int_end(&vids, -1,
+                                   6, 9, -1);
+    is_indep_set = false;
+    igraph_is_independent_vertex_set(&g, igraph_vss_vector(&vids), &is_indep_set);
+    IGRAPH_ASSERT(is_indep_set);
+    igraph_vector_int_destroy(&vids);
+
+    igraph_vector_int_init_int_end(&vids, -1,
+                                   5, 6, 9, -1);
+    is_indep_set = true;
+    igraph_is_independent_vertex_set(&g, igraph_vss_vector(&vids), &is_indep_set);
+    IGRAPH_ASSERT(! is_indep_set);
+    igraph_vector_int_destroy(&vids);
+
+    is_indep_set = true;
+    igraph_is_independent_vertex_set(&g, igraph_vss_all(), &is_indep_set);
+    IGRAPH_ASSERT(! is_indep_set);
+
+    igraph_destroy(&g);
 
     VERIFY_FINALLY_STACK();
 

--- a/tests/unit/igraph_is_clique.c
+++ b/tests/unit/igraph_is_clique.c
@@ -1,0 +1,111 @@
+/*
+  IGraph library.
+  Copyright (C) 2024 The igraph development team <igraph@igraph.org>
+
+  This program is free software; you can redistribute it and/or modify it under
+  the terms of the GNU General Public License as published by the Free Software
+  Foundation; either version 2 of the License, or (at your option) any later
+  version.
+
+  This program is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+  FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along with
+  this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include <igraph.h>
+
+#include "test_utilities.h"
+
+int main(void) {
+    igraph_t g;
+    igraph_bool_t is_clique;
+    igraph_vector_int_t vids;
+
+    igraph_small(&g, 10, IGRAPH_DIRECTED,
+                 0, 2, 0, 3, 0, 4, 0, 6, 0, 7, 0, 8, 0, 9, 1, 2, 1, 4, 2, 1, 2, 3, 2, \
+                 7, 2, 8, 2, 9, 3, 0, 3, 1, 3, 2, 3, 4, 3, 5, 3, 6, 3, 7, 3, 9, 4, 0, \
+                 4, 2, 4, 3, 4, 5, 4, 6, 5, 1, 5, 2, 5, 4, 5, 7, 5, 9, 6, 0, 6, 1, 6, \
+                 4, 6, 8, 7, 2, 7, 3, 7, 6, 7, 9, 8, 2, 8, 4, 8, 6, 8, 7, 9, 0, 9, 2, \
+                 9, 3, 9, 4, 9, 7, 9, 8,
+                 -1);
+
+    /* Empty set */
+    igraph_vector_int_init(&vids, 0);
+    is_clique = false;
+    igraph_is_clique(&g, igraph_vss_vector(&vids), true, &is_clique);
+    IGRAPH_ASSERT(is_clique);
+    igraph_vector_int_destroy(&vids);
+
+    /* Singleton set */
+    is_clique = false;
+    igraph_is_clique(&g, igraph_vss_1(0), true, &is_clique);
+    IGRAPH_ASSERT(is_clique);
+
+    igraph_vector_int_init_int_end(&vids, -1,
+                                   1, 2, -1);
+    is_clique = false;
+    igraph_is_clique(&g, igraph_vss_vector(&vids), true, &is_clique);
+    IGRAPH_ASSERT(is_clique);
+    igraph_vector_int_destroy(&vids);
+
+    /* It is a clique: Duplicates handled? */
+    igraph_vector_int_init_int_end(&vids, -1,
+                                   1, 2, 2, 2, 1, -1);
+    is_clique = false;
+    igraph_is_clique(&g, igraph_vss_vector(&vids), true, &is_clique);
+    IGRAPH_ASSERT(is_clique);
+    igraph_vector_int_destroy(&vids);
+
+    igraph_vector_int_init_int_end(&vids, -1,
+                                   9, 2, 7, 3, -1);
+    is_clique = false;
+    igraph_is_clique(&g, igraph_vss_vector(&vids), true, &is_clique);
+    IGRAPH_ASSERT(is_clique);
+    igraph_vector_int_destroy(&vids);
+
+    /* Not a clique, in either a directed or undirected sense. */
+    igraph_vector_int_init_int_end(&vids, -1,
+                                   3, 8, 5, -1);
+    is_clique = true;
+    igraph_is_clique(&g, igraph_vss_vector(&vids), true, &is_clique);
+    IGRAPH_ASSERT(! is_clique);
+    is_clique = true;
+    igraph_is_clique(&g, igraph_vss_vector(&vids), false, &is_clique);
+    IGRAPH_ASSERT(! is_clique);
+    igraph_vector_int_destroy(&vids);
+
+    /* Not a clique: Duplicates handled? */
+    igraph_vector_int_init_int_end(&vids, -1,
+                                   5, 3, 4, 3, 4, 5, 5, 5, -1);
+    is_clique = true;
+    igraph_is_clique(&g, igraph_vss_vector(&vids), true, &is_clique);
+    IGRAPH_ASSERT(! is_clique);
+    igraph_vector_int_destroy(&vids);
+
+    /* This is only an undirected clique, but not a directed one. */
+    igraph_vector_int_init_int_end(&vids, -1,
+                                   4, 0, 8, 9, 2, -1);
+    is_clique = true;
+    igraph_is_clique(&g, igraph_vss_vector(&vids), true, &is_clique);
+    IGRAPH_ASSERT(! is_clique);
+    igraph_is_clique(&g, igraph_vss_vector(&vids), false, &is_clique);
+    IGRAPH_ASSERT(is_clique);
+    igraph_vector_int_destroy(&vids);
+
+    /* Complete vertex set */
+
+    is_clique = true;
+    igraph_is_clique(&g, igraph_vss_all(), true, &is_clique);
+    IGRAPH_ASSERT(! is_clique);
+
+    is_clique = true;
+    igraph_is_clique(&g, igraph_vss_all(), false, &is_clique);
+    IGRAPH_ASSERT(! is_clique);
+
+    VERIFY_FINALLY_STACK();
+
+    return 0;
+}

--- a/tests/unit/igraph_is_complete.c
+++ b/tests/unit/igraph_is_complete.c
@@ -201,5 +201,7 @@ int main(void)
     check(true, 50);
     check(true, 51);
 
+    VERIFY_FINALLY_STACK();
+
     return 0;
 }


### PR DESCRIPTION
Closes #2380

This functionality is quite useful for teaching.

It seems to me that this is the most efficient way to do this assuming that cliques are small, and that igraph is compiled with LTO. At a later we can think about alternate implementations for large cliques, but we need to keep in mind that if the set is indeed a clique, we'll need $O(n^2)$ anyway.