### PR TITLE
feat: tests bitsets for all/any zeros/ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
  - `igraph_bitset_fill()` sets all elements of a bitset to the same value (experimental function).
  - `igraph_bitset_null()` clears all elements of a bitset (experimental function).
+ - `igraph_bitset_is_all_zero()`, `igraph_bitset_is_all_one()`, `igraph_bitset_is_any_zero()`, `igraph_bitset_is_any_one()` check if any/all elements of a bitset are zeros/ones (experimental functions).
  - `igraph_chung_lu_game()` implements the classic Chung-Lu model, as well as a number of its variants (experimental function).
  - `igraph_mean_degree()` computes the average of vertex degrees (experimental function).
  - `igraph_count_loops()` counts self-loops in the graph (experimental function).

--- a/doc/bitset.xxml
+++ b/doc/bitset.xxml
@@ -40,6 +40,10 @@
 <!-- doxrox-include igraph_bitset_countl_one -->
 <!-- doxrox-include igraph_bitset_countr_zero -->
 <!-- doxrox-include igraph_bitset_countr_one -->
+<!-- doxrox-include igraph_bitset_is_all_zero -->
+<!-- doxrox-include igraph_bitset_is_all_one -->
+<!-- doxrox-include igraph_bitset_is_any_zero -->
+<!-- doxrox-include igraph_bitset_is_any_one -->
 </section>
 
 <section id="bitset-properties"><title>Bitset properties</title>

--- a/include/igraph_bitset.h
+++ b/include/igraph_bitset.h
@@ -245,6 +245,10 @@ IGRAPH_EXPORT IGRAPH_FUNCATTR_PURE igraph_integer_t igraph_bitset_countl_zero(co
 IGRAPH_EXPORT IGRAPH_FUNCATTR_PURE igraph_integer_t igraph_bitset_countl_one(const igraph_bitset_t *bitset);
 IGRAPH_EXPORT IGRAPH_FUNCATTR_PURE igraph_integer_t igraph_bitset_countr_zero(const igraph_bitset_t *bitset);
 IGRAPH_EXPORT IGRAPH_FUNCATTR_PURE igraph_integer_t igraph_bitset_countr_one(const igraph_bitset_t *bitset);
+IGRAPH_EXPORT IGRAPH_FUNCATTR_PURE igraph_bool_t igraph_bitset_is_all_zero(const igraph_bitset_t *bitset);
+IGRAPH_EXPORT IGRAPH_FUNCATTR_PURE igraph_bool_t igraph_bitset_is_all_one(const igraph_bitset_t *bitset);
+IGRAPH_EXPORT IGRAPH_FUNCATTR_PURE igraph_bool_t igraph_bitset_is_any_zero(const igraph_bitset_t *bitset);
+IGRAPH_EXPORT IGRAPH_FUNCATTR_PURE igraph_bool_t igraph_bitset_is_any_one(const igraph_bitset_t *bitset);
 IGRAPH_EXPORT void igraph_bitset_or(igraph_bitset_t *dest, const igraph_bitset_t *src1, const igraph_bitset_t *src2);
 IGRAPH_EXPORT void igraph_bitset_and(igraph_bitset_t *dest, const igraph_bitset_t *src1, const igraph_bitset_t *src2);
 IGRAPH_EXPORT void igraph_bitset_xor(igraph_bitset_t *dest, const igraph_bitset_t *src1, const igraph_bitset_t *src2);

--- a/src/core/bitset.c
+++ b/src/core/bitset.c
@@ -554,6 +554,100 @@ igraph_integer_t igraph_bitset_countr_one(const igraph_bitset_t *bitset) {
 
 /**
  * \ingroup bitset
+ * \function igraph_bitset_is_all_zero
+ * \brief Are all bits zeros?
+ *
+ * \experimental
+ *
+ * \param bitset The bitset object to test.
+ * \return True if none of the bits are set.
+ *
+ * Time complexity: O(n/w).
+ */
+
+igraph_bool_t igraph_bitset_is_all_zero(const igraph_bitset_t *bitset) {
+    const igraph_integer_t final_block_size = bitset->size % IGRAPH_INTEGER_SIZE ? bitset->size % IGRAPH_INTEGER_SIZE : IGRAPH_INTEGER_SIZE;
+    const igraph_integer_t slots = IGRAPH_BIT_NSLOTS(bitset->size);
+    const igraph_uint_t one = 1, zero = 0; /* to avoid the need to cast 1 and 0 to igraph_uint_t below */
+    const igraph_uint_t mask = final_block_size == IGRAPH_INTEGER_SIZE ? ~zero : ((one << final_block_size) - one);
+
+    for (igraph_integer_t i = 0; i < slots - 1; i++) {
+        if (VECTOR(*bitset)[i] != zero) {
+            return false;
+        }
+    }
+    if (bitset->size && (mask & VECTOR(*bitset)[slots - 1]) != zero) {
+        return false;
+    }
+    return true;
+}
+
+/**
+ * \ingroup bitset
+ * \function igraph_bitset_is_all_one
+ * \brief Are all bits ones?
+ *
+ * \experimental
+ *
+ * \param bitset The bitset object to test.
+ * \return True if all of the bits are set.
+ *
+ * Time complexity: O(n/w).
+ */
+
+igraph_bool_t igraph_bitset_is_all_one(const igraph_bitset_t *bitset) {
+    const igraph_integer_t final_block_size = bitset->size % IGRAPH_INTEGER_SIZE ? bitset->size % IGRAPH_INTEGER_SIZE : IGRAPH_INTEGER_SIZE;
+    const igraph_integer_t slots = IGRAPH_BIT_NSLOTS(bitset->size);
+    const igraph_uint_t one = 1, zero = 0; /* to avoid the need to cast 1 and 0 to igraph_uint_t below */
+    const igraph_uint_t mask = final_block_size == IGRAPH_INTEGER_SIZE ? zero : ~((one << final_block_size) - one);
+
+    for (igraph_integer_t i = 0; i < slots - 1; i++) {
+        if (VECTOR(*bitset)[i] != ~zero) {
+            return false;
+        }
+    }
+    if (bitset->size && (mask | VECTOR(*bitset)[slots - 1]) != ~zero) {
+        return false;
+    }
+    return true;
+}
+
+/**
+ * \ingroup bitset
+ * \function igraph_bitset_is_any_zero
+ * \brief Are any bits zeros?
+ *
+ * \experimental
+ *
+ * \param bitset The bitset object to test.
+ * \return True if at least one bit is zero.
+ *
+ * Time complexity: O(n/w).
+ */
+
+igraph_bool_t igraph_bitset_is_any_zero(const igraph_bitset_t *bitset) {
+    return ! igraph_bitset_is_all_one(bitset);
+}
+
+/**
+ * \ingroup bitset
+ * \function igraph_bitset_is_any_one
+ * \brief Are any bits ones?
+ *
+ * \experimental
+ *
+ * \param bitset The bitset object to test.
+ * \return True if at least one bit is one.
+ *
+ * Time complexity: O(n/w).
+ */
+
+igraph_bool_t igraph_bitset_is_any_one(const igraph_bitset_t *bitset) {
+    return ! igraph_bitset_is_all_zero(bitset);
+}
+
+/**
+ * \ingroup bitset
  * \function igraph_bitset_or
  * \brief Bitwise OR of two bitsets.
  *

--- a/tests/unit/bitset.c
+++ b/tests/unit/bitset.c
@@ -330,6 +330,75 @@ int main(void) {
     igraph_bitset_destroy(&v1);
     printf("\n");
 
+    printf("Test checking all elements\n");
+    /* 0000 */
+    igraph_bitset_init(&v1, 4);
+    IGRAPH_ASSERT(! igraph_bitset_is_all_one(&v1));
+    IGRAPH_ASSERT(! igraph_bitset_is_any_one(&v1));
+    IGRAPH_ASSERT(igraph_bitset_is_all_zero(&v1));
+    IGRAPH_ASSERT(igraph_bitset_is_any_zero(&v1));
+    /* 1000 */
+    IGRAPH_BIT_SET(v1, 3);
+    IGRAPH_ASSERT(! igraph_bitset_is_all_one(&v1));
+    IGRAPH_ASSERT(igraph_bitset_is_any_one(&v1));
+    IGRAPH_ASSERT(! igraph_bitset_is_all_zero(&v1));
+    IGRAPH_ASSERT(igraph_bitset_is_any_zero(&v1));
+    /* 000 */
+    /* This resize leaves a set bit in the unused part of the last word of the.
+     * bitset. This helps test that masking out the unused part is working. */
+    igraph_bitset_resize(&v1, 3);
+    IGRAPH_ASSERT(! igraph_bitset_is_all_one(&v1));
+    IGRAPH_ASSERT(! igraph_bitset_is_any_one(&v1));
+    IGRAPH_ASSERT(igraph_bitset_is_all_zero(&v1));
+    IGRAPH_ASSERT(igraph_bitset_is_any_zero(&v1));
+    /* 001 */
+    IGRAPH_BIT_SET(v1, 0);
+    IGRAPH_ASSERT(! igraph_bitset_is_all_one(&v1));
+    IGRAPH_ASSERT(igraph_bitset_is_any_one(&v1));
+    IGRAPH_ASSERT(! igraph_bitset_is_all_zero(&v1));
+    IGRAPH_ASSERT(igraph_bitset_is_any_zero(&v1));
+    /* 111 */
+    IGRAPH_BIT_SET(v1, 1); IGRAPH_BIT_SET(v1, 2);
+    IGRAPH_ASSERT(igraph_bitset_is_all_one(&v1));
+    IGRAPH_ASSERT(igraph_bitset_is_any_one(&v1));
+    IGRAPH_ASSERT(! igraph_bitset_is_all_zero(&v1));
+    IGRAPH_ASSERT(! igraph_bitset_is_any_zero(&v1));
+    igraph_bitset_destroy(&v1);
+
+    igraph_bitset_init(&v1, 67);
+    /* all zeros */
+    IGRAPH_ASSERT(! igraph_bitset_is_all_one(&v1));
+    IGRAPH_ASSERT(! igraph_bitset_is_any_one(&v1));
+    IGRAPH_ASSERT(igraph_bitset_is_all_zero(&v1));
+    IGRAPH_ASSERT(igraph_bitset_is_any_zero(&v1));
+    /* some ones */
+    IGRAPH_BIT_SET(v1, 10);
+    IGRAPH_ASSERT(! igraph_bitset_is_all_one(&v1));
+    IGRAPH_ASSERT(igraph_bitset_is_any_one(&v1));
+    IGRAPH_ASSERT(! igraph_bitset_is_all_zero(&v1));
+    IGRAPH_ASSERT(igraph_bitset_is_any_zero(&v1));
+    /* all ones */
+    igraph_bitset_fill(&v1, true);
+    IGRAPH_ASSERT(igraph_bitset_is_all_one(&v1));
+    IGRAPH_ASSERT(igraph_bitset_is_any_one(&v1));
+    IGRAPH_ASSERT(! igraph_bitset_is_all_zero(&v1));
+    IGRAPH_ASSERT(! igraph_bitset_is_any_zero(&v1));
+    /* some zeros */
+    IGRAPH_BIT_CLEAR(v1, 20);
+    IGRAPH_ASSERT(! igraph_bitset_is_all_one(&v1));
+    IGRAPH_ASSERT(igraph_bitset_is_any_one(&v1));
+    IGRAPH_ASSERT(! igraph_bitset_is_all_zero(&v1));
+    IGRAPH_ASSERT(igraph_bitset_is_any_zero(&v1));
+    igraph_bitset_destroy(&v1);
+
+    /* Empty bitset */
+    igraph_bitset_init(&v1, 0);
+    IGRAPH_ASSERT(igraph_bitset_is_all_one(&v1));
+    IGRAPH_ASSERT(! igraph_bitset_is_any_one(&v1));
+    IGRAPH_ASSERT(igraph_bitset_is_all_zero(&v1));
+    IGRAPH_ASSERT(! igraph_bitset_is_any_zero(&v1));
+    igraph_bitset_destroy(&v1);
+
     VERIFY_FINALLY_STACK();
 
     return 0;

--- a/tests/unit/bitset.out
+++ b/tests/unit/bitset.out
@@ -134,3 +134,4 @@ Trailing ones: 66
 ( 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 0 1 1 )
 Trailing ones: 2
 
+Test checking all elements


### PR DESCRIPTION
This is useful for checking if subsets represented as bitsets overlap/intersect. It will be helpful for the later Kneser graph implementation.

Any concerns about the function naming?