### PR TITLE
refactor: undirected hub/authority score calculation now falls back to eigenvector centrality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
  - The order of edges in the graph returned by `igraph_(weighted_)adjacency()` and `igraph_biadjacency()` has changed. Note that these functions do not guarantee any specific edge order.
  - `igraph_eigenvector_centrality()` now warns about eigenvector centralities equal to zero, as these indicate a disconnected graph, for which eigenvector centrality is not meaningful.
  - `igraph_hub_and_authority_scores()` now warns when a large fraction of centrality scores are zero, as this indicates a non-unique solution, and thus the returned result may not be meaningful.
+ - `igraph_hub_and_authority_scores()` now warns when providing an undirected graph as input, and falls back to the equivalent eigenvector centrality computation.
 
 ### Fixed
 


### PR DESCRIPTION
Fall back to eigenvector centrality calculation when passing an undirected graph to `igraph_hub_and_authority_scores()`. The explanation is in the code comments. If something is unclear, it needs to be improved there.

When using undirected graphs, a warning is issued now. This is useful because it makes little sense to compute hub and authority scores on undirected graphs. People who do it are usually confused and "just want to find hubs". I have seen this more than once. The warning is also necessary because further warnings (such as about negative weights) will now come from `igraph_eigenvector_centrality()`, which would otherwise be confusing.