### PR TITLE
refactor: spanning tree is not needed for LGL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
  - `igraph_is_graphical()` and `igraph_is_bigraphical()` are now linear-time in all cases, and generally several times faster than before (thanks to @gendelpiekel, contributed in #2605).
  - `igraph_erdos_renyi_game_gnp()` can now generate graphs with more than a hundred million vertices.
  - `igraph_hub_and_authority_scores()` now warns when negative edge weights are present.
+ - `igraph_layout_lgl()` now uses a BFS tree rooted in the vertex specified as `proot` to guide the layout. Previously it used an unspecified (arbitrary) spanning tree.
  - Updated the internal heuristics used by igraph's ARPACK interface, `igraph_arpack_rssolve()` and `igraph_arpack_rnsolve()`, to improve the robustness of calculations.
  - Updated the initial vector construction in `igraph_hub_and_authority_scores()`, `igraph_eigenvector_centrality()` and `igraph_(personalized_)pagerank()` with `IGRAPH_PAGERANK_ALGO_ARPACK`. This improves the robustness and convergence of calculations.
 


### PR DESCRIPTION
I don't know how the LGL layout works in details, but creating the spanning tree seems not only unnecessary, but actually wrong. 

The code creates a spanning tree graph object, then traversed that using BFS, placing vertices on successively more distance layers _in the tree_.  First, this is pointless as the BFS already effectively produces a tree. Second, traversing an arbitrary tree won't give proper layers in the original graph. In principle, the tree could be anything at all. The spanning tree function doesn't _guarantee_ that we get a BFS tree, which is what the algorithm likely needs. 

Note: currently the spanning tree function does actually do a BFS, so the behaviour shouldn't change from this refactoring.