### PR TITLE
feat: igraph_vector_is_all_finite()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
  - `igraph_hypercube()` creates a hypercube graph (experimental function).
  - `igraph_vector_intersection_size_sorted()` counts elements common to two sorted vectors (experimental function).
  - `igraph_stack_capacity()` returns the allocated capacity of a stack.
+ - `igraph_vector_is_all_finite()` checks if all elements in a vector are finite (i.e. neither NaN nor Inf).
 
 ### Fixed
 

--- a/doc/vector.xxml
+++ b/doc/vector.xxml
@@ -96,6 +96,7 @@
 <!-- doxrox-include igraph_vector_maxdifference -->
 <!-- doxrox-include igraph_vector_is_nan -->
 <!-- doxrox-include igraph_vector_is_any_nan -->
+<!-- doxrox-include igraph_vector_is_all_finite -->
 </section>
 
 <section id="vector-searching-for-elements"><title>Searching for elements</title>

--- a/include/igraph_vector.h
+++ b/include/igraph_vector.h
@@ -146,6 +146,7 @@ IGRAPH_EXPORT igraph_error_t igraph_vector_complex_zapsmall(igraph_vector_comple
 IGRAPH_EXPORT igraph_error_t igraph_vector_is_nan(const igraph_vector_t *v,
                                                   igraph_vector_bool_t *is_nan);
 IGRAPH_EXPORT IGRAPH_FUNCATTR_PURE igraph_bool_t igraph_vector_is_any_nan(const igraph_vector_t *v);
+IGRAPH_EXPORT IGRAPH_FUNCATTR_PURE igraph_bool_t igraph_vector_is_all_finite(const igraph_vector_t *v);
 
 IGRAPH_PRIVATE_EXPORT igraph_error_t igraph_vector_order2(igraph_vector_t *v);
 IGRAPH_PRIVATE_EXPORT igraph_error_t igraph_vector_rank(const igraph_vector_t *v, igraph_vector_int_t *res,

--- a/src/core/vector.c
+++ b/src/core/vector.c
@@ -680,3 +680,29 @@ igraph_bool_t igraph_vector_is_any_nan(const igraph_vector_t *v)
     }
     return false;
 }
+
+
+/**
+ * \ingroup vector
+ * \function igraph_vector_is_all_finite
+ * \brief Check if all elements are finite.
+ *
+ * \param v The \type igraph_vector_t object to check.
+ * \return True if none of the elements are infinite or NaN.
+ *
+ * Time complexity: O(n), the number of elements.
+ */
+igraph_bool_t igraph_vector_is_all_finite(const igraph_vector_t *v)
+{
+    igraph_real_t *ptr;
+    IGRAPH_ASSERT(v != NULL);
+    IGRAPH_ASSERT(v->stor_begin != NULL);
+    ptr = v->stor_begin;
+    while (ptr < v->end) {
+        if (!isfinite(*ptr)) {
+            return false;
+        }
+        ptr++;
+    }
+    return true;
+}


### PR DESCRIPTION
This is a trivial helper function to check that all vector elements are non-NaN and non-Inf. This is sometimes useful for numerical functions where Inf isn't handled well. We already have `igraph_vector_is_any_nan()`, which checks only for NaN but not for Inf.

Since I don't want to make this experimental, I'd prefer if someone took a quick look, but if you don't have the time @ntamas, that's fine, just let me know. I only need comments on the name/API, and whether to add this at all, not the implementation.