### PR TITLE
silence a unused-but-set-variable warning in benchmarks

### DIFF
--- a/tests/benchmarks/intersection.c
+++ b/tests/benchmarks/intersection.c
@@ -34,6 +34,7 @@ void run_bench(int i, int n, int r) {
      * with future compiler versions. */
     volatile igraph_integer_t res;
     BENCH(msg, REPEAT(res = igraph_vector_int_intersection_size_sorted(&a, &b), rep));
+    (void) res;  /* silence unused-but-set-variable warning */
 
     igraph_vector_int_destroy(&a);
     igraph_vector_int_destroy(&b);


### PR DESCRIPTION
Description: upstream: silence unused-but-set-variable warnings: benchmarks
 This patch silences a unused-but-set-variable warning as detected
 by gcc (Debian 13.3.0-1) in `tests/benchmarks/intersection.c'.
Origin: Debian
Author: Jerome Benoit <calculus@rezozer.net>
Last-Update: 2024-06-28