### PR TITLE
silence format-truncation warnings in benchmarks

### DIFF
--- a/tests/benchmarks/erdos_renyi.c
+++ b/tests/benchmarks/erdos_renyi.c
@@ -24,7 +24,7 @@ void run_bench(igraph_integer_t vcount, igraph_real_t meandeg, igraph_integer_t 
     igraph_t g;
     igraph_real_t p = meandeg / vcount;
     igraph_vector_t outdeg, indeg;
-    char msg[255], msg2[255];
+    char msg[511], msg2[255];
 
     snprintf(msg2, sizeof(msg2) / sizeof(msg2[0]),
              "vcount=%" IGRAPH_PRId ", meandeg=%g, %" IGRAPH_PRId "x",

--- a/tests/benchmarks/erdos_renyi.c
+++ b/tests/benchmarks/erdos_renyi.c
@@ -24,7 +24,7 @@ void run_bench(igraph_integer_t vcount, igraph_real_t meandeg, igraph_integer_t 
     igraph_t g;
     igraph_real_t p = meandeg / vcount;
     igraph_vector_t outdeg, indeg;
-    char msg[511], msg2[255];
+    char msg[255], msg2[127];
 
     snprintf(msg2, sizeof(msg2) / sizeof(msg2[0]),
              "vcount=%" IGRAPH_PRId ", meandeg=%g, %" IGRAPH_PRId "x",


### PR DESCRIPTION
Description: upstream: silence format-truncation warnings: benchmarks
 This patch silences format-truncation warnings as detected
 by gcc (Debian 13.3.0-1) in `tests/benchmarks/erdos_renyi.c'.
Origin: Debian
Author: Jerome Benoit <calculus@rezozer.net>
Last-Update: 2024-06-28