### PR TITLE
Versioning and stability policy after 1.0

### DIFF
--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -1,0 +1,61 @@
+# Versioning and stability
+
+This document is provided for informational purposes only, to help igraph users understand how igraph's programming interface is evolving, and what stability guaratees you can rely on.  It concerns the igraph C library only.  igraph's high level interfaces (R, Python, Mathematica) have their own separate versioning schemes and compatibility policies.
+
+
+## Versioning
+
+Starting with version 1.0, igraph follows the spirit of semantic versioning, with some differences, as described below.  The version number consists of three parts in the `MAJOR.MINOR.PATCH` format.
+
+ - `MAJOR` is incremented after making _incompatible changes_ to the stable programming interface.  Major releases are intended to be infrequent, and are accompanied by release notes where we make the effort to provide detailed guidance on adapting to incompatible changes.
+ - `MINOR` is incremented after making _additions_ to the stable programming interface.  Minor releases are issued regularly.
+ - `PATCH` is incremented when making changes that do not affect compatibility (usually bug fixes, documentation improvements, or build systems changes).
+
+The three version parts are available at compile time as the macros `IGRAPH_VERSION_MAJOR`, `IGRAPH_VERSION_MINOR` and `IGRAPH_VERSION_PATCH`, or at runtime through the `igraph_version()` function.
+
+The majority of public, documented functions are considered to be part of the _stable programming interface_, but there are some notable exceptions:
+
+ - **Experimental functions** may change at any time without notice.  These are clearly marked in their documentation ([example](https://igraph.org/c/html/0.10.13/igraph-Generators.html#igraph_chung_lu_game)).  Most newly added functions start out as _experimental_, and stay in this state until we are confident in their design, typically for one or two minor releases.  User feedback about experimental functions is particularly welcome.  We make the effort to avoid changes to experimental functions in patch releases, but do not guarantee this.
+ - **Internal and undocumented functions** are not part of the stable programming interface, not even if they are present in public headers.  They may change at any time. The names of internal functions usually start with the prefix `igraph_i_` (capitalized for macros), while public functions start with `igraph_`.
+
+
+## Symbol lifecycle
+
+Most new symbols start out as _experimental_ in minor releases.  Eventually, their API is declared stable, and the experimental marker is removed from their documentation in the next minor release.
+
+Symbols go through a deprecation phase before they are removed.  Deprecated symbols are marked in their documentation ([example](https://igraph.org/c/html/0.10.13/igraph-Structural.html#igraph_clusters)), and functions are prefixed with `IGRAPH_DEPRECATED` in the public headers ([example](https://github.com/igraph/igraph/blob/997f59ad742892fff199824a248fab382b40f526/include/igraph_components.h#L45-L47)). With GCC-compatible compilers, use the `-Wdeprecated` flag to get a warning for the use of deprecated functions, but keep in mind that deprecation warnings are not supported for all symbol types (e.g. macros) with all compilers.  The ultimate reference for deprecations is the [changelog][1].
+
+
+## Stability of behaviour
+
+Whether changes in function behaviour are considered breaking is somewhat subjective, and is decided on a case-by-case basis.  Expect some changes within minor releases.  For example, a function that ignored edge multiplicities may gain support for multigraphs in a new minor release.  Do not rely on details of behaviour that are not explicitly documented.
+
+A notable case is stochastic functions: we do not guarantee that the same output is returned across different releases (even patch releases) for the same random seed.  We only guarantee the same statistical properties.  
+
+
+## Advice to users and package maintainers
+
+**Users:**
+
+For as long as you don't use _experimental_ functions, you can be confident that your code will continue to work with future releases having the same major version.  If you do use _experimental_ functions, it is your responsibility to check the [release notes][1] of each igraph release and adapt accordingly.  The use of _internal_ functions is completely unsupported: if you feel you need them, please talk to us.
+
+If you do use _experimental_ functions, make this clear in your README file for the benefit of package maintainers.
+
+While igraph comes with multiple header files, only `#include <igraph.h>` is supported. The rest of the headers exist for internal organizational purposes only, and may change without notice.
+
+**Package maintainers:**
+
+Software that does not use experimental functions from igraph can safely link to future igraph versions with the same major version.  Ask the developer of any software you are packaging if they are using experimental igraph functions.
+
+The high-level interfaces of igraph do use both experimental and internal functions. Each high-level interface release is only guaranteed to be compatible with one specific release of C/igraph. As of this writing, this is a concern only for the Python interface, as the other interfaces (R and Mathematica) cannot link dynamically to C/igraph.
+
+
+## Notes
+
+For the purposes of this document, "API compatibiltiy" means that the same sources can be compiled with different igraph versions of igraph headers.  "ABI compatibility" means that a program that only uses stable API can be linked to a different version of the igraph shared library than what it was compiled with.
+
+We strive to maintain both API and ABI compatibility.
+
+However, it must be pointed out that we do not support manipulating the same in-memory igraph data structures with different igraph versions (for example, if two libraries that exchange data are each statically linked to different igraph versions).
+
+ [1]: https://github.com/igraph/igraph/blob/master/CHANGELOG.md

--- a/include/igraph_version.h.in
+++ b/include/igraph_version.h.in
@@ -1,8 +1,6 @@
-/* -*- mode: C -*-  */
 /*
    IGraph library.
-   Copyright (C) 2010-2012  Gabor Csardi <csardi.gabor@gmail.com>
-   334 Harvard street, Cambridge, MA 02139 USA
+   Copyright (C) 2010-2024  The igraph development team <igraph@igraph.org>
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -15,10 +13,7 @@
    GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc.,  51 Franklin Street, Fifth Floor, Boston, MA
-   02110-1301 USA
-
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 #ifndef IGRAPH_VERSION_H
@@ -37,7 +32,7 @@ __BEGIN_DECLS
 IGRAPH_EXPORT void igraph_version(const char **version_string,
                                   int *major,
                                   int *minor,
-                                  int *subminor);
+                                  int *patch);
 
 __END_DECLS
 

--- a/src/version.c
+++ b/src/version.c
@@ -1,6 +1,6 @@
 /*
    IGraph library.
-   Copyright (C) 2008-2022  The igraph development team <igraph@igraph.org>
+   Copyright (C) 2008-2024  The igraph development team <igraph@igraph.org>
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -26,15 +26,17 @@ static const char *igraph_version_string = IGRAPH_VERSION;
  * \function igraph_version
  * \brief The version of the igraph C library.
  *
- * \param version_string Pointer to a string pointer. If not null, it
- *    is set to the igraph version string, e.g. "0.9.11" or "0.10.0". This
- *    string must not be modified or deallocated.
- * \param major If not a null pointer, then it is set to the major
- *    igraph version. E.g. for version "0.9.11" this is 0.
- * \param minor If not a null pointer, then it is set to the minor
- *    igraph version. E.g. for version "0.9.11" this is 11.
- * \param subminor If not a null pointer, then it is set to the
- *    subminor igraph version. E.g. for version "0.9.11" this is 11.
+ * \param version_string Pointer to a string pointer. If not \c NULL, it
+ *    is set to the igraph version string, e.g. "0.10.13", "1.2.0", or
+ *    "0.10.13-14-g997f59ad7". It consists of three dot-separated numerical
+ *    parts and potentially of a dash-separated suffix, used in prerelease
+ *    versions. This string must not be modified or deallocated.
+ * \param major If not a \c NULL pointer, then it is set to the major
+ *    igraph version. E.g. for version "0.10.13" this is 0.
+ * \param minor If not a \c NULL pointer, then it is set to the minor
+ *    igraph version. E.g. for version "0.10.13" this is 10.
+ * \param patch If not a \c NULL pointer, then it is set to the
+ *    subminor igraph version. E.g. for version "0.10.13" this is 13.
  *
  * \example examples/simple/igraph_version.c
  */
@@ -42,11 +44,11 @@ static const char *igraph_version_string = IGRAPH_VERSION;
 void igraph_version(const char **version_string,
                     int *major,
                     int *minor,
-                    int *subminor) {
+                    int *patch) {
     int i1, i2, i3;
     int *p1 = major ? major : &i1;
     int *p2 = minor ? minor : &i2;
-    int *p3 = subminor ? subminor : &i3;
+    int *p3 = patch ? patch : &i3;
 
     if (version_string) {
         *version_string = igraph_version_string;


### PR DESCRIPTION
The major feature of 1.0 is better API stability. Let's help our users understand what we mean by this. I wrote it up a `VERSIONING.md` file. I treat this as informational rather than strict policy.

@ntamas I need your input here. What's missing:

 - Do we promise not to remove deprecated functions except in major releases? Or do we go for a "continuous improvement" approach where deprecated functions can be removed even in minor release, provided that they were kept in a deprecated state for a while?
 
     With the first alternative (which is currently in these notes) we change functions in major versions only, but this may force major versions more often than ideal. With the second alternative we add new variants of functions with different names, deprecate the old variant, and eventually remove it. This way the library evolves gradually, and a major breaking release is very rarely necessary.
 
 - What about the SOVERSION? We should have a policy for this, and include information for package maintainers. I never fully understood how SOVERSION worked, and how the linker uses it. There are differences in shared library versioning between platforms (Linux/macOS), so we shouldn't base this solely on Linux practices.
 - Do we want to promise zero changes to experimental functions in patch releases?