### PR TITLE
Remove/rename internal vector functions

### DIFF
--- a/include/igraph_flow.h
+++ b/include/igraph_flow.h
@@ -153,6 +153,11 @@ IGRAPH_EXPORT igraph_error_t igraph_gomory_hu_tree(const igraph_t *graph,
                                         igraph_vector_t *flows,
                                         const igraph_vector_t *capacity);
 
+IGRAPH_PRIVATE_EXPORT igraph_error_t igraph_i_vector_int_rank(
+    const igraph_vector_int_t *v,
+    igraph_vector_int_t *res,
+    igraph_integer_t nodes);
+
 __END_DECLS
 
 #endif

--- a/include/igraph_flow.h
+++ b/include/igraph_flow.h
@@ -153,11 +153,6 @@ IGRAPH_EXPORT igraph_error_t igraph_gomory_hu_tree(const igraph_t *graph,
                                         igraph_vector_t *flows,
                                         const igraph_vector_t *capacity);
 
-IGRAPH_PRIVATE_EXPORT igraph_error_t igraph_i_vector_int_rank(
-    const igraph_vector_int_t *v,
-    igraph_vector_int_t *res,
-    igraph_integer_t nodes);
-
 __END_DECLS
 
 #endif

--- a/include/igraph_vector.h
+++ b/include/igraph_vector.h
@@ -144,8 +144,6 @@ IGRAPH_EXPORT igraph_error_t igraph_vector_is_nan(const igraph_vector_t *v,
 IGRAPH_EXPORT IGRAPH_FUNCATTR_PURE igraph_bool_t igraph_vector_is_any_nan(const igraph_vector_t *v);
 IGRAPH_EXPORT IGRAPH_FUNCATTR_PURE igraph_bool_t igraph_vector_is_all_finite(const igraph_vector_t *v);
 
-IGRAPH_PRIVATE_EXPORT igraph_error_t igraph_vector_order2(igraph_vector_t *v);
-
 IGRAPH_EXPORT igraph_error_t igraph_vector_int_pair_order(const igraph_vector_int_t* v, const igraph_vector_int_t *v2,
                                       igraph_vector_int_t* res, igraph_integer_t maxval);
 

--- a/include/igraph_vector.h
+++ b/include/igraph_vector.h
@@ -145,8 +145,6 @@ IGRAPH_EXPORT IGRAPH_FUNCATTR_PURE igraph_bool_t igraph_vector_is_any_nan(const 
 IGRAPH_EXPORT IGRAPH_FUNCATTR_PURE igraph_bool_t igraph_vector_is_all_finite(const igraph_vector_t *v);
 
 IGRAPH_PRIVATE_EXPORT igraph_error_t igraph_vector_order2(igraph_vector_t *v);
-IGRAPH_PRIVATE_EXPORT igraph_error_t igraph_vector_rank(const igraph_vector_t *v, igraph_vector_int_t *res,
-                                     igraph_integer_t nodes);
 
 IGRAPH_EXPORT igraph_error_t igraph_vector_int_pair_order(const igraph_vector_int_t* v, const igraph_vector_int_t *v2,
                                       igraph_vector_int_t* res, igraph_integer_t maxval);

--- a/include/igraph_vector.h
+++ b/include/igraph_vector.h
@@ -147,7 +147,7 @@ IGRAPH_EXPORT IGRAPH_FUNCATTR_PURE igraph_bool_t igraph_vector_is_all_finite(con
 IGRAPH_EXPORT igraph_error_t igraph_vector_int_pair_order(const igraph_vector_int_t* v, const igraph_vector_int_t *v2,
                                       igraph_vector_int_t* res, igraph_integer_t maxval);
 
-IGRAPH_PRIVATE_EXPORT igraph_error_t igraph_vector_int_order1(const igraph_vector_int_t* v,
+IGRAPH_PRIVATE_EXPORT igraph_error_t igraph_i_vector_int_order(const igraph_vector_int_t* v,
                                            igraph_vector_int_t* res, igraph_integer_t maxval);
 
 __END_DECLS

--- a/include/igraph_vector.h
+++ b/include/igraph_vector.h
@@ -151,8 +151,6 @@ IGRAPH_EXPORT igraph_error_t igraph_vector_int_pair_order(const igraph_vector_in
 
 IGRAPH_PRIVATE_EXPORT igraph_error_t igraph_vector_int_order1(const igraph_vector_int_t* v,
                                            igraph_vector_int_t* res, igraph_integer_t maxval);
-IGRAPH_PRIVATE_EXPORT igraph_error_t igraph_vector_int_rank(const igraph_vector_int_t *v, igraph_vector_int_t *res,
-                                     igraph_integer_t nodes);
 
 __END_DECLS
 

--- a/include/igraph_vector.h
+++ b/include/igraph_vector.h
@@ -147,8 +147,16 @@ IGRAPH_EXPORT IGRAPH_FUNCATTR_PURE igraph_bool_t igraph_vector_is_all_finite(con
 IGRAPH_EXPORT igraph_error_t igraph_vector_int_pair_order(const igraph_vector_int_t* v, const igraph_vector_int_t *v2,
                                       igraph_vector_int_t* res, igraph_integer_t maxval);
 
-IGRAPH_PRIVATE_EXPORT igraph_error_t igraph_i_vector_int_order(const igraph_vector_int_t* v,
-                                           igraph_vector_int_t* res, igraph_integer_t maxval);
+/* For internal use only: */
+
+IGRAPH_PRIVATE_EXPORT igraph_error_t igraph_i_vector_int_order(
+    const igraph_vector_int_t* v,
+    igraph_vector_int_t* res,
+    igraph_integer_t maxval);
+IGRAPH_PRIVATE_EXPORT igraph_error_t igraph_i_vector_int_rank(
+    const igraph_vector_int_t *v,
+    igraph_vector_int_t *res,
+    igraph_integer_t maxval);
 
 __END_DECLS
 

--- a/src/connectivity/separators.c
+++ b/src/connectivity/separators.c
@@ -695,7 +695,7 @@ static igraph_error_t igraph_i_minimum_size_separators_topkdeg(
      * faster IGRAPH_LOOPS here instead of the slower IGRAPH_NO_LOOPS. */
     IGRAPH_CHECK(igraph_degree(graph, &deg, igraph_vss_all(), IGRAPH_ALL, IGRAPH_LOOPS));
 
-    IGRAPH_CHECK(igraph_vector_int_order1(&deg, &order, no_of_nodes));
+    IGRAPH_CHECK(igraph_i_vector_int_order(&deg, &order, no_of_nodes));
     IGRAPH_CHECK(igraph_vector_int_resize(res, k));
     for (igraph_integer_t i = 0; i < k; i++) {
         VECTOR(*res)[i] = VECTOR(order)[no_of_nodes - 1 - i];

--- a/src/core/vector.c
+++ b/src/core/vector.c
@@ -242,38 +242,6 @@ igraph_error_t igraph_vector_int_order1(const igraph_vector_int_t* v,
     return IGRAPH_SUCCESS;
 }
 
-igraph_error_t igraph_vector_rank(
-        const igraph_vector_t *v, igraph_vector_int_t *res, igraph_integer_t nodes) {
-
-    igraph_vector_int_t rad;
-    igraph_vector_int_t ptr;
-    igraph_integer_t edges = igraph_vector_size(v);
-    igraph_integer_t i, c = 0;
-
-    IGRAPH_VECTOR_INT_INIT_FINALLY(&rad, nodes);
-    IGRAPH_VECTOR_INT_INIT_FINALLY(&ptr, edges);
-    IGRAPH_CHECK(igraph_vector_int_resize(res, edges));
-
-    for (i = 0; i < edges; i++) {
-        igraph_integer_t elem = VECTOR(*v)[i];
-        VECTOR(ptr)[i] = VECTOR(rad)[elem];
-        VECTOR(rad)[elem] = i + 1;
-    }
-
-    for (i = 0; i < nodes; i++) {
-        igraph_integer_t p = VECTOR(rad)[i];
-        while (p != 0) {
-            VECTOR(*res)[p - 1] = c++;
-            p = VECTOR(ptr)[p - 1];
-        }
-    }
-
-    igraph_vector_int_destroy(&ptr);
-    igraph_vector_int_destroy(&rad);
-    IGRAPH_FINALLY_CLEAN(2);
-    return IGRAPH_SUCCESS;
-}
-
 igraph_error_t igraph_vector_int_rank(
         const igraph_vector_int_t *v, igraph_vector_int_t *res, igraph_integer_t nodes) {
 

--- a/src/core/vector.c
+++ b/src/core/vector.c
@@ -183,7 +183,7 @@ igraph_error_t igraph_vector_int_pair_order(const igraph_vector_int_t* v,
     return IGRAPH_SUCCESS;
 }
 
-igraph_error_t igraph_vector_int_order1(const igraph_vector_int_t* v,
+igraph_error_t igraph_i_vector_int_order(const igraph_vector_int_t* v,
                              igraph_vector_int_t* res,
                              igraph_integer_t nodes) {
     igraph_integer_t edges = igraph_vector_int_size(v);

--- a/src/core/vector.c
+++ b/src/core/vector.c
@@ -242,38 +242,6 @@ igraph_error_t igraph_vector_int_order1(const igraph_vector_int_t* v,
     return IGRAPH_SUCCESS;
 }
 
-igraph_error_t igraph_vector_int_rank(
-        const igraph_vector_int_t *v, igraph_vector_int_t *res, igraph_integer_t nodes) {
-
-    igraph_vector_int_t rad;
-    igraph_vector_int_t ptr;
-    igraph_integer_t edges = igraph_vector_int_size(v);
-    igraph_integer_t i, c = 0;
-
-    IGRAPH_VECTOR_INT_INIT_FINALLY(&rad, nodes);
-    IGRAPH_VECTOR_INT_INIT_FINALLY(&ptr, edges);
-    IGRAPH_CHECK(igraph_vector_int_resize(res, edges));
-
-    for (i = 0; i < edges; i++) {
-        igraph_integer_t elem = VECTOR(*v)[i];
-        VECTOR(ptr)[i] = VECTOR(rad)[elem];
-        VECTOR(rad)[elem] = i + 1;
-    }
-
-    for (i = 0; i < nodes; i++) {
-        igraph_integer_t p = VECTOR(rad)[i];
-        while (p != 0) {
-            VECTOR(*res)[p - 1] = c++;
-            p = VECTOR(ptr)[p - 1];
-        }
-    }
-
-    igraph_vector_int_destroy(&ptr);
-    igraph_vector_int_destroy(&rad);
-    IGRAPH_FINALLY_CLEAN(2);
-    return IGRAPH_SUCCESS;
-}
-
 /**
  * \ingroup vector
  * \function igraph_vector_complex_real

--- a/src/core/vector.c
+++ b/src/core/vector.c
@@ -59,8 +59,6 @@
 #include "igraph_pmt_off.h"
 #undef BASE_COMPLEX
 
-#include "core/indheap.h"
-
 /**
  * \ingroup vector
  * \function igraph_vector_floor
@@ -183,23 +181,36 @@ igraph_error_t igraph_vector_int_pair_order(const igraph_vector_int_t* v,
     return IGRAPH_SUCCESS;
 }
 
-igraph_error_t igraph_i_vector_int_order(const igraph_vector_int_t* v,
-                             igraph_vector_int_t* res,
-                             igraph_integer_t nodes) {
-    igraph_integer_t edges = igraph_vector_int_size(v);
+/**
+ * \function igraph_i_vector_int_order
+ *
+ * \param v Integer vector with non-negative entries.
+ * \param res The indices of the elements of \p v will be written here
+ *    in sorted order.
+ * \param maxval The largest value in \p v must be provided here.
+ * \return Error code.
+ *
+ * Time complexity: O(maxval).
+ */
+igraph_error_t igraph_i_vector_int_order(
+        const igraph_vector_int_t *v,
+        igraph_vector_int_t *res,
+        igraph_integer_t maxval) {
+
+    const igraph_integer_t size = igraph_vector_int_size(v);
     igraph_vector_int_t ptr;
     igraph_vector_int_t rad;
-    igraph_integer_t i, j;
+    igraph_integer_t j;
 
     IGRAPH_ASSERT(v != NULL);
     IGRAPH_ASSERT(v->stor_begin != NULL);
 
-    IGRAPH_VECTOR_INT_INIT_FINALLY(&ptr, nodes + 1);
-    IGRAPH_VECTOR_INT_INIT_FINALLY(&rad, edges);
-    IGRAPH_CHECK(igraph_vector_int_resize(res, edges));
+    IGRAPH_VECTOR_INT_INIT_FINALLY(&ptr, maxval + 1);
+    IGRAPH_VECTOR_INT_INIT_FINALLY(&rad, size);
+    IGRAPH_CHECK(igraph_vector_int_resize(res, size));
 
-    for (i = 0; i < edges; i++) {
-        igraph_integer_t radix = v->stor_begin[i];
+    for (igraph_integer_t i = 0; i < size; i++) {
+        igraph_integer_t radix = VECTOR(*v)[i];
         if (VECTOR(ptr)[radix] != 0) {
             VECTOR(rad)[i] = VECTOR(ptr)[radix];
         }
@@ -207,13 +218,13 @@ igraph_error_t igraph_i_vector_int_order(const igraph_vector_int_t* v,
     }
 
     j = 0;
-    for (i = 0; i < nodes + 1; i++) {
+    for (igraph_integer_t i = 0; i < maxval + 1; i++) {
         if (VECTOR(ptr)[i] != 0) {
             igraph_integer_t next = VECTOR(ptr)[i] - 1;
-            res->stor_begin[j++] = next;
+            VECTOR(*res)[j++] = next;
             while (VECTOR(rad)[next] != 0) {
                 next = VECTOR(rad)[next] - 1;
-                res->stor_begin[j++] = next;
+                VECTOR(*res)[j++] = next;
             }
         }
     }

--- a/src/core/vector.c
+++ b/src/core/vector.c
@@ -97,23 +97,6 @@ igraph_error_t igraph_vector_round(const igraph_vector_t *from, igraph_vector_in
     return IGRAPH_SUCCESS;
 }
 
-igraph_error_t igraph_vector_order2(igraph_vector_t *v) {
-    igraph_indheap_t heap;
-
-    IGRAPH_CHECK(igraph_indheap_init_array(&heap, VECTOR(*v), igraph_vector_size(v)));
-    IGRAPH_FINALLY(igraph_indheap_destroy, &heap);
-
-    igraph_vector_clear(v);
-    while (!igraph_indheap_empty(&heap)) {
-        IGRAPH_CHECK(igraph_vector_push_back(v, igraph_indheap_max_index(&heap) - 1));
-        igraph_indheap_delete_max(&heap);
-    }
-
-    igraph_indheap_destroy(&heap);
-    IGRAPH_FINALLY_CLEAN(1);
-    return IGRAPH_SUCCESS;
-}
-
 /**
  * \ingroup vector
  * \function igraph_vector_int_pair_order

--- a/src/core/vector.c
+++ b/src/core/vector.c
@@ -237,6 +237,52 @@ igraph_error_t igraph_i_vector_int_order(
 }
 
 /**
+ * \function igraph_i_vector_int_rank
+ *
+ * \param v Integer vector with non-negative entries.
+ * \param res The zero-based rank of the elements of \p v will be written here
+ *    from smallest to largest.
+ * \param maxval The largest value in \p v must be provided here.
+ * \return Error code.
+ *
+ * Time complexity: O(maxval).
+ */
+igraph_error_t igraph_i_vector_int_rank(
+    const igraph_vector_int_t *v,
+    igraph_vector_int_t *res,
+    igraph_integer_t maxval) {
+
+    const igraph_integer_t size = igraph_vector_int_size(v);
+    igraph_vector_int_t rad;
+    igraph_vector_int_t ptr;
+    igraph_integer_t c = 0;
+
+    IGRAPH_VECTOR_INT_INIT_FINALLY(&rad, maxval);
+    IGRAPH_VECTOR_INT_INIT_FINALLY(&ptr, size);
+    IGRAPH_CHECK(igraph_vector_int_resize(res, size));
+
+    for (igraph_integer_t i = 0; i < size; i++) {
+        igraph_integer_t elem = VECTOR(*v)[i];
+        VECTOR(ptr)[i] = VECTOR(rad)[elem];
+        VECTOR(rad)[elem] = i + 1;
+    }
+
+    for (igraph_integer_t i = 0; i < maxval; i++) {
+        igraph_integer_t p = VECTOR(rad)[i];
+        while (p != 0) {
+            VECTOR(*res)[p - 1] = c++;
+            p = VECTOR(ptr)[p - 1];
+        }
+    }
+
+    igraph_vector_int_destroy(&ptr);
+    igraph_vector_int_destroy(&rad);
+    IGRAPH_FINALLY_CLEAN(2);
+
+    return IGRAPH_SUCCESS;
+}
+
+/**
  * \ingroup vector
  * \function igraph_vector_complex_real
  * \brief Gives the real part of a complex vector.

--- a/src/flow/flow.c
+++ b/src/flow/flow.c
@@ -146,54 +146,6 @@
  * (28) We just call igraph_vertex_connectivity, see (20).
  */
 
-
-/**
- * \function igraph_i_vector_int_rank
- *
- * \param v Integer vector with non-negative entries.
- * \param res The zero-based rank of the elements of \p v will be written here
- *    from smallest to largest.
- * \param maxval The largest value in \p v must be provided here.
- * \return Error code.
- *
- * Time complexity: O(maxval).
- */
-igraph_error_t igraph_i_vector_int_rank(
-        const igraph_vector_int_t *v,
-        igraph_vector_int_t *res,
-        igraph_integer_t maxval) {
-
-    const igraph_integer_t size = igraph_vector_int_size(v);
-    igraph_vector_int_t rad;
-    igraph_vector_int_t ptr;
-    igraph_integer_t c = 0;
-
-    IGRAPH_VECTOR_INT_INIT_FINALLY(&rad, maxval);
-    IGRAPH_VECTOR_INT_INIT_FINALLY(&ptr, size);
-    IGRAPH_CHECK(igraph_vector_int_resize(res, size));
-
-    for (igraph_integer_t i = 0; i < size; i++) {
-        igraph_integer_t elem = VECTOR(*v)[i];
-        VECTOR(ptr)[i] = VECTOR(rad)[elem];
-        VECTOR(rad)[elem] = i + 1;
-    }
-
-    for (igraph_integer_t i = 0; i < maxval; i++) {
-        igraph_integer_t p = VECTOR(rad)[i];
-        while (p != 0) {
-            VECTOR(*res)[p - 1] = c++;
-            p = VECTOR(ptr)[p - 1];
-        }
-    }
-
-    igraph_vector_int_destroy(&ptr);
-    igraph_vector_int_destroy(&rad);
-    IGRAPH_FINALLY_CLEAN(2);
-
-    return IGRAPH_SUCCESS;
-}
-
-
 /*
  * This is an internal function that calculates the maximum flow value
  * on undirected graphs, either for an s-t vertex pair or for the

--- a/src/flow/flow.c
+++ b/src/flow/flow.c
@@ -147,26 +147,38 @@
  */
 
 
-/* internal helper function */
+/**
+ * \function igraph_i_vector_int_rank
+ *
+ * \param v Integer vector with non-negative entries.
+ * \param res The zero-based rank of the elements of \p v will be written here
+ *    from smallest to largest.
+ * \param maxval The largest value in \p v must be provided here.
+ * \return Error code.
+ *
+ * Time complexity: O(maxval).
+ */
 igraph_error_t igraph_i_vector_int_rank(
-    const igraph_vector_int_t *v, igraph_vector_int_t *res, igraph_integer_t nodes) {
+        const igraph_vector_int_t *v,
+        igraph_vector_int_t *res,
+        igraph_integer_t maxval) {
 
+    const igraph_integer_t size = igraph_vector_int_size(v);
     igraph_vector_int_t rad;
     igraph_vector_int_t ptr;
-    igraph_integer_t edges = igraph_vector_int_size(v);
-    igraph_integer_t i, c = 0;
+    igraph_integer_t c = 0;
 
-    IGRAPH_VECTOR_INT_INIT_FINALLY(&rad, nodes);
-    IGRAPH_VECTOR_INT_INIT_FINALLY(&ptr, edges);
-    IGRAPH_CHECK(igraph_vector_int_resize(res, edges));
+    IGRAPH_VECTOR_INT_INIT_FINALLY(&rad, maxval);
+    IGRAPH_VECTOR_INT_INIT_FINALLY(&ptr, size);
+    IGRAPH_CHECK(igraph_vector_int_resize(res, size));
 
-    for (i = 0; i < edges; i++) {
+    for (igraph_integer_t i = 0; i < size; i++) {
         igraph_integer_t elem = VECTOR(*v)[i];
         VECTOR(ptr)[i] = VECTOR(rad)[elem];
         VECTOR(rad)[elem] = i + 1;
     }
 
-    for (i = 0; i < nodes; i++) {
+    for (igraph_integer_t i = 0; i < maxval; i++) {
         igraph_integer_t p = VECTOR(rad)[i];
         while (p != 0) {
             VECTOR(*res)[p - 1] = c++;
@@ -177,6 +189,7 @@ igraph_error_t igraph_i_vector_int_rank(
     igraph_vector_int_destroy(&ptr);
     igraph_vector_int_destroy(&rad);
     IGRAPH_FINALLY_CLEAN(2);
+
     return IGRAPH_SUCCESS;
 }
 

--- a/src/layout/merge_dla.c
+++ b/src/layout/merge_dla.c
@@ -31,6 +31,23 @@
 #include "layout/merge_grid.h"
 #include "layout/layout_internal.h"
 
+static igraph_error_t vector_order(igraph_vector_t *v) {
+    const igraph_integer_t n = igraph_vector_size(v);
+    igraph_vector_int_t ind;
+
+    IGRAPH_VECTOR_INT_INIT_FINALLY(&ind, n);
+    IGRAPH_CHECK(igraph_vector_qsort_ind(v, &ind, IGRAPH_DESCENDING));
+
+    for (igraph_integer_t i=0; i < n; i++) {
+        VECTOR(*v)[i] = VECTOR(ind)[i];
+    }
+
+    igraph_vector_int_destroy(&ind);
+    IGRAPH_FINALLY_CLEAN(1);
+
+    return IGRAPH_SUCCESS;
+}
+
 /**
  * \function igraph_layout_merge_dla
  * \brief Merges multiple layouts by using a DLA algorithm.
@@ -109,7 +126,7 @@ igraph_error_t igraph_layout_merge_dla(
                                   igraph_vector_get_ptr(&ny, i),
                                   igraph_vector_get_ptr(&nr, i));
     }
-    igraph_vector_order2(&sizes); /* largest first */
+    vector_order(&sizes); /* largest first */
 
     /* 0. create grid */
     minx = miny = -sqrt(5 * area);

--- a/src/operators/rewire_edges.c
+++ b/src/operators/rewire_edges.c
@@ -88,7 +88,7 @@ static igraph_error_t igraph_i_rewire_edges_no_multiple(igraph_t *graph, igraph_
         ADD_STUB(from, idx1);
         ADD_STUB(to, idx2);
     }
-    IGRAPH_CHECK(igraph_vector_int_order1(&tmp, &eorder, no_verts));
+    IGRAPH_CHECK(igraph_i_vector_int_order(&tmp, &eorder, no_verts));
     igraph_vector_int_destroy(&tmp);
     IGRAPH_FINALLY_CLEAN(1);
 
@@ -135,7 +135,7 @@ static igraph_error_t igraph_i_rewire_edges_no_multiple(igraph_t *graph, igraph_
     for (i = 0; i < no_edges; i++) {
         VECTOR(tmp)[i] = VECTOR(*edges)[2 * i + 1];
     }
-    IGRAPH_CHECK(igraph_vector_int_order1(&tmp, &eorder, no_verts));
+    IGRAPH_CHECK(igraph_i_vector_int_order(&tmp, &eorder, no_verts));
     igraph_vector_int_destroy(&tmp);
     IGRAPH_FINALLY_CLEAN(1);
 

--- a/src/properties/triangles.c
+++ b/src/properties/triangles.c
@@ -189,7 +189,7 @@ static igraph_error_t igraph_transitivity_local_undirected2(const igraph_t *grap
             maxdegree = deg;
         }
     }
-    IGRAPH_CHECK(igraph_vector_int_order1(&degree, &order, maxdegree + 1));
+    IGRAPH_CHECK(igraph_i_vector_int_order(&degree, &order, maxdegree + 1));
     igraph_vector_int_destroy(&degree);
     IGRAPH_FINALLY_CLEAN(1);
     IGRAPH_VECTOR_INIT_FINALLY(&rank, affected_nodes);
@@ -542,7 +542,7 @@ igraph_error_t igraph_transitivity_undirected(const igraph_t *graph,
     IGRAPH_CHECK(igraph_degree(graph, &degree, igraph_vss_all(), IGRAPH_ALL,
                                IGRAPH_LOOPS));
     maxdegree = igraph_vector_int_max(&degree) + 1;
-    IGRAPH_CHECK(igraph_vector_int_order1(&degree, &order, maxdegree));
+    IGRAPH_CHECK(igraph_i_vector_int_order(&degree, &order, maxdegree));
 
     igraph_vector_int_destroy(&degree);
     IGRAPH_FINALLY_CLEAN(1);
@@ -727,7 +727,7 @@ static igraph_error_t igraph_i_transitivity_barrat4(
     IGRAPH_CHECK(igraph_degree(graph, &degree, igraph_vss_all(), IGRAPH_ALL,
                                IGRAPH_LOOPS));
     maxdegree = igraph_vector_int_max(&degree) + 1;
-    IGRAPH_CHECK(igraph_vector_int_order1(&degree, &order, maxdegree));
+    IGRAPH_CHECK(igraph_i_vector_int_order(&degree, &order, maxdegree));
 
     IGRAPH_CHECK(igraph_strength(graph, &strength, igraph_vss_all(), IGRAPH_ALL,
                                  IGRAPH_LOOPS, weights));

--- a/src/properties/triangles_template.h
+++ b/src/properties/triangles_template.h
@@ -62,7 +62,7 @@ for (i = 0; i < no_of_nodes; i++) {
 }
 
 maxdegree = igraph_vector_int_max(&degree) + 1;
-IGRAPH_CHECK(igraph_vector_int_order1(&degree, &order, maxdegree));
+IGRAPH_CHECK(igraph_i_vector_int_order(&degree, &order, maxdegree));
 IGRAPH_VECTOR_INT_INIT_FINALLY(&rank, no_of_nodes);
 for (i = 0; i < no_of_nodes; i++) {
     VECTOR(rank)[ VECTOR(order)[i] ] = no_of_nodes - i - 1;

--- a/tests/unit/vector.c
+++ b/tests/unit/vector.c
@@ -318,11 +318,13 @@ int main(void) {
     print_vector_format(&v, stdout, "%g");
     igraph_vector_destroy(&v);
 
-    printf("Test rank\n");
+    printf("Test igraph_i_vector_int_rank and igraph_i_vector_int_order\n");
     igraph_vector_int_init_int_end(&v2, -1, 0, 1, 2, 6, 5, 2, 1, 0, -1);
     igraph_vector_int_init(&v4, 0);
     igraph_i_vector_int_rank(&v2, &v4, 7);
     print_vector_int(&v2);
+    print_vector_int(&v4);
+    igraph_i_vector_int_order(&v2, &v4, 7);
     print_vector_int(&v4);
     igraph_vector_int_destroy(&v2);
     igraph_vector_int_destroy(&v4);
@@ -358,8 +360,10 @@ int main(void) {
 
     printf("Test igraph_vector_int_init_range, igraph_i_vector_int_order\n");
     igraph_vector_int_init_range(&v4, 1, 11);
+    igraph_vector_int_reverse(&v4);
+    igraph_vector_int_scale(&v4, 3);
     igraph_vector_int_init(&v5, 0);
-    igraph_i_vector_int_order(&v4, &v5, 10);
+    igraph_i_vector_int_order(&v4, &v5, /* maxval */ igraph_vector_int_max(&v4));
     print_vector_int(&v5);
     igraph_vector_int_destroy(&v4);
     igraph_vector_int_destroy(&v5);

--- a/tests/unit/vector.c
+++ b/tests/unit/vector.c
@@ -333,7 +333,7 @@ int main(void) {
     printf("Test rank\n");
     igraph_vector_int_init_int_end(&v2, -1, 0, 1, 2, 6, 5, 2, 1, 0, -1);
     igraph_vector_int_init(&v4, 0);
-    igraph_vector_int_rank(&v2, &v4, 7);
+    igraph_i_vector_int_rank(&v2, &v4, 7);
     print_vector_int(&v2);
     print_vector_int(&v4);
     igraph_vector_int_destroy(&v2);

--- a/tests/unit/vector.c
+++ b/tests/unit/vector.c
@@ -304,18 +304,6 @@ int main(void) {
     print_vector_format(&v, stdout, "%g");
     igraph_vector_destroy(&v);
 
-    printf("Test order2\n");
-    igraph_vector_init_int_end(&v, -1, 10, 9, 8, 7, 6, 7, 8, 9, 10, -1);
-    igraph_vector_order2(&v);
-    print_vector_format(&v, stdout, "%g");
-    igraph_vector_destroy(&v);
-
-    printf("Test order2 on empty vector\n");
-    igraph_vector_init_int_end(&v, -1, -1);
-    igraph_vector_order2(&v);
-    print_vector_format(&v, stdout, "%g");
-    igraph_vector_destroy(&v);
-
     printf("Test filter_smaller, quite special....\n");
     igraph_vector_init_int_end(&v, -1, 0, 1, 2, 3, 4, 4, 4, 4, 5, 6, 7, 8, -1);
     igraph_vector_filter_smaller(&v, 4);

--- a/tests/unit/vector.c
+++ b/tests/unit/vector.c
@@ -1,8 +1,6 @@
-/* -*- mode: C -*-  */
 /*
    IGraph library.
-   Copyright (C) 2006-2012  Gabor Csardi <csardi.gabor@gmail.com>
-   334 Harvard street, Cambridge MA, 02139 USA
+   Copyright (C) 2006-2024  The igraph development team <igraph@igraph.org>
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -15,21 +13,17 @@
    GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc.,  51 Franklin Street, Fifth Floor, Boston, MA
-   02110-1301 USA
-
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 #include <igraph.h>
-#include <stdlib.h>
 
 #include "test_utilities.h"
 
 int main(void) {
 
     igraph_vector_t v;
-    igraph_vector_int_t v4, v5, v6;
+    igraph_vector_int_t v2, v4, v5, v6;
     igraph_integer_t i;
     igraph_real_t *ptr;
     igraph_integer_t pos;
@@ -337,12 +331,12 @@ int main(void) {
     igraph_vector_destroy(&v);
 
     printf("Test rank\n");
-    igraph_vector_init_int_end(&v, -1, 0, 1, 2, 6, 5, 2, 1, 0, -1);
+    igraph_vector_int_init_int_end(&v2, -1, 0, 1, 2, 6, 5, 2, 1, 0, -1);
     igraph_vector_int_init(&v4, 0);
-    igraph_vector_rank(&v, &v4, 7);
-    print_vector_format(&v, stdout, "%g");
+    igraph_vector_int_rank(&v2, &v4, 7);
+    print_vector_int(&v2);
     print_vector_int(&v4);
-    igraph_vector_destroy(&v);
+    igraph_vector_int_destroy(&v2);
     igraph_vector_int_destroy(&v4);
 
     printf("Test pair order\n");

--- a/tests/unit/vector.c
+++ b/tests/unit/vector.c
@@ -356,10 +356,10 @@ int main(void) {
     }
     igraph_vector_destroy(&v);
 
-    printf("Test igraph_vector_int_init_range, igraph_vector_int_order1\n");
+    printf("Test igraph_vector_int_init_range, igraph_i_vector_int_order\n");
     igraph_vector_int_init_range(&v4, 1, 11);
     igraph_vector_int_init(&v5, 0);
-    igraph_vector_int_order1(&v4, &v5, 10);
+    igraph_i_vector_int_order(&v4, &v5, 10);
     print_vector_int(&v5);
     igraph_vector_int_destroy(&v4);
     igraph_vector_int_destroy(&v5);

--- a/tests/unit/vector.out
+++ b/tests/unit/vector.out
@@ -48,10 +48,6 @@ Test igraph_vector_init_real
 ( 1 2 3 4 5 6 7 8 9 10 )
 Test igraph_vector_init_int
 ( 1 2 3 4 5 6 7 8 9 10 )
-Test order2
-( 0 8 1 7 6 2 3 5 4 )
-Test order2 on empty vector
-( )
 Test filter_smaller, quite special....
 ( 4 4 5 6 7 8 )
 ( 1 2 3 4 4 4 4 5 6 7 8 )

--- a/tests/unit/vector.out
+++ b/tests/unit/vector.out
@@ -52,12 +52,13 @@ Test filter_smaller, quite special....
 ( 4 4 5 6 7 8 )
 ( 1 2 3 4 4 4 4 5 6 7 8 )
 ( 0 1 2 3 4 4 4 4 5 6 7 8 )
-Test rank
+Test igraph_i_vector_int_rank and igraph_i_vector_int_order
 ( 0 1 2 6 5 2 1 0 )
 ( 1 3 5 7 6 4 2 0 )
+( 7 0 6 1 5 2 4 3 )
 Test pair order
 ( 0 1 2 3 )
 Test fill
 Test range
-Test igraph_vector_int_init_range, igraph_vector_int_order1
-( 0 1 2 3 4 5 6 7 8 9 )
+Test igraph_vector_int_init_range, igraph_i_vector_int_order
+( 9 8 7 6 5 4 3 2 1 0 )


### PR DESCRIPTION
Closes #2655
Closes #2654

Also renames `igraph_vector_int_order1()` to `igraph_i_vector_int_order()` to indicate that it is internal.

All of these were marked with `IGRAPH_PRIVATE_EXPORT`.
