### PR TITLE
feat: igraph_feedback_vertex_set()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
  - `igraph_vector_rotate_left()` applies a cyclic permutation to a vector.
  - `igraph_strvector_swap_elements()` swaps two strings in an `igraph_strvector_t`.
  - `igraph_find_cycle()` finds a single cycle in a graph, if it exists (experimental function).
+ - `igraph_feefback_vertex_set()` finds a minimum feedback vertex set in a directed or undirected graph (experimental function).
 
 ### Changed
 

--- a/doc/structural.xxml
+++ b/doc/structural.xxml
@@ -224,6 +224,7 @@
 <!-- doxrox-include igraph_is_dag -->
 <!-- doxrox-include igraph_topological_sorting -->
 <!-- doxrox-include igraph_feedback_arc_set -->
+<!-- doxrox-include igraph_feedback_vertex_set -->
 </section>
 
 <section id="maximum-cardinality-search-chordal-graphs"><title>Maximum cardinality search and chordal graphs</title>

--- a/include/igraph_constants.h
+++ b/include/igraph_constants.h
@@ -184,6 +184,9 @@ typedef enum { IGRAPH_FAS_EXACT_IP = 0,
                IGRAPH_FAS_EXACT_IP_TI
              } igraph_fas_algorithm_t;
 
+typedef enum { IGRAPH_FVS_EXACT_IP = 0
+             } igraph_fvs_algorithm_t;
+
 typedef enum { IGRAPH_SUBGRAPH_AUTO = 0,
                IGRAPH_SUBGRAPH_COPY_AND_DELETE,
                IGRAPH_SUBGRAPH_CREATE_FROM_SCRATCH

--- a/include/igraph_structural.h
+++ b/include/igraph_structural.h
@@ -131,8 +131,13 @@ IGRAPH_EXPORT igraph_error_t igraph_degree_correlation_vector(
         igraph_neimode_t from_mode, igraph_neimode_t to_mode,
         igraph_bool_t directed_neighbors);
 
-IGRAPH_EXPORT igraph_error_t igraph_feedback_arc_set(const igraph_t *graph, igraph_vector_int_t *result,
-                                          const igraph_vector_t *weights, igraph_fas_algorithm_t algo);
+IGRAPH_EXPORT igraph_error_t igraph_feedback_arc_set(
+    const igraph_t *graph, igraph_vector_int_t *result,
+    const igraph_vector_t *weights, igraph_fas_algorithm_t algo);
+
+IGRAPH_EXPORT igraph_error_t igraph_feedback_vertex_set(
+    const igraph_t *graph, igraph_vector_int_t *result,
+    const igraph_vector_t *vertex_weights, igraph_fvs_algorithm_t algo);
 
 /* -------------------------------------------------- */
 /* Spectral Properties                                */

--- a/interfaces/functions.yaml
+++ b/interfaces/functions.yaml
@@ -839,6 +839,10 @@ igraph_feedback_arc_set:
     PARAMS: GRAPH graph, OUT EDGE_INDICES result, EDGEWEIGHTS weights=NULL, FAS_ALGORITHM algo=APPROX_EADES
     DEPS: result ON graph, weights ON graph
 
+igraph_feedback_vertex_set:
+    PARAMS: GRAPH graph, OUT EDGE_INDICES result, VERTEXWEIGHTS weights=NULL, FVS_ALGORITHM algo=EXACT_IP
+    DEPS: result ON graph, weights ON graph
+
 igraph_is_loop:
     PARAMS: GRAPH graph, OUT VECTOR_BOOL res, EDGE_SELECTOR es=ALL
     DEPS: es ON graph

--- a/interfaces/functions.yaml
+++ b/interfaces/functions.yaml
@@ -840,7 +840,7 @@ igraph_feedback_arc_set:
     DEPS: result ON graph, weights ON graph
 
 igraph_feedback_vertex_set:
-    PARAMS: GRAPH graph, OUT EDGE_INDICES result, VERTEXWEIGHTS weights=NULL, FVS_ALGORITHM algo=EXACT_IP
+    PARAMS: GRAPH graph, OUT VERTEX_INDICES result, VERTEXWEIGHTS weights=NULL, FVS_ALGORITHM algo=EXACT_IP
     DEPS: result ON graph, weights ON graph
 
 igraph_is_loop:

--- a/interfaces/types.yaml
+++ b/interfaces/types.yaml
@@ -339,6 +339,11 @@ FAS_ALGORITHM:
     CTYPE: igraph_fas_algorithm_t
     FLAGS: ENUM
 
+FVS_ALGORITHM:
+    # Enum representing feedback vertex set algorithms
+    CTYPE: igraph_fvs_algorithm_t
+    FLAGS: ENUM
+
 FWALGORITHM:
     # Enum that describes the variant of the Floyd-Warshall algorithm to use in
     # Floyd-Warshall graph distances computing function

--- a/src/misc/feedback_arc_set.h
+++ b/src/misc/feedback_arc_set.h
@@ -43,6 +43,10 @@ igraph_error_t igraph_i_feedback_arc_set_undirected(
         const igraph_vector_t *weights, igraph_vector_int_t *layering
 );
 
+igraph_error_t igraph_i_feedback_vertex_set_ip_cg(
+        const igraph_t *graph, igraph_vector_int_t *result,
+        const igraph_vector_t *weights);
+
 __END_DECLS
 
 #endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -313,6 +313,7 @@ add_legacy_tests(
   igraph_edge_betweenness
   igraph_edge_betweenness_subset
   igraph_feedback_arc_set
+  igraph_feedback_vertex_set
   igraph_get_all_simple_paths
   igraph_get_all_shortest_paths_dijkstra
   igraph_get_k_shortest_paths

--- a/tests/unit/igraph_feedback_vertex_set.c
+++ b/tests/unit/igraph_feedback_vertex_set.c
@@ -1,0 +1,210 @@
+/*
+   IGraph library.
+   Copyright (C) 2024  The igraph development team <igraph@igraph.org>
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include <igraph.h>
+
+#include "test_utilities.h"
+
+void check_fvs(const igraph_t *graph, const igraph_vector_int_t *fvs) {
+    igraph_t g;
+    igraph_bool_t is_acyclic = false;
+
+    igraph_copy(&g, graph);
+    igraph_delete_vertices(&g, igraph_vss_vector(fvs));
+
+    igraph_is_acyclic(&g, &is_acyclic);
+    IGRAPH_ASSERT(is_acyclic);
+
+    igraph_destroy(&g);
+}
+
+igraph_real_t weight(const igraph_vector_t *weights, const igraph_vector_int_t *fvs) {
+    const igraph_integer_t size = igraph_vector_int_size(fvs);
+    if (!weights) {
+        return (igraph_real_t) size;
+    } else {
+        igraph_real_t total = 0;
+        for (igraph_integer_t i=0; i < size; i++) {
+            total += VECTOR(*weights)[ VECTOR(*fvs)[i] ];
+        }
+        return total;
+    }
+}
+
+void compare_methods(const igraph_t *graph, const igraph_vector_t *weights) {
+    igraph_vector_int_t fvs;
+
+    igraph_vector_int_init(&fvs, 0);
+
+    igraph_feedback_vertex_set(graph, &fvs, weights, IGRAPH_FVS_EXACT_IP);
+    check_fvs(graph, &fvs);
+
+    igraph_vector_int_destroy(&fvs);
+    igraph_vector_int_destroy(&fvs);
+}
+
+void rand_weights(const igraph_t *graph, igraph_vector_t *weights) {
+    const igraph_integer_t ecount = igraph_ecount(graph);
+    igraph_vector_resize(weights, ecount);
+    for (igraph_integer_t i=0; i < ecount; i++) {
+        VECTOR(*weights)[i] = RNG_UNIF01();
+    }
+}
+
+void test_undirected(void) {
+    igraph_t graph;
+    igraph_vector_int_t result;
+    igraph_vector_t weights;
+
+    igraph_vector_int_init(&result, 0);
+    igraph_vector_init(&weights, 0);
+
+    /* Null graph */
+    igraph_empty(&graph, 0, IGRAPH_UNDIRECTED);
+    igraph_feedback_vertex_set(&graph, &result, NULL, IGRAPH_FVS_EXACT_IP);
+    IGRAPH_ASSERT(igraph_vector_int_size(&result) == 0);
+    igraph_destroy(&graph);
+
+    /* Singleton graph */
+    igraph_empty(&graph, 1, IGRAPH_UNDIRECTED);
+    igraph_feedback_vertex_set(&graph, &result, NULL, IGRAPH_FVS_EXACT_IP);
+    IGRAPH_ASSERT(igraph_vector_int_size(&result) == 0);
+    igraph_destroy(&graph);
+
+    /* Two isolated vertices */
+    igraph_empty(&graph, 2, IGRAPH_UNDIRECTED);
+    igraph_feedback_vertex_set(&graph, &result, NULL, IGRAPH_FVS_EXACT_IP);
+    IGRAPH_ASSERT(igraph_vector_int_size(&result) == 0);
+    igraph_destroy(&graph);
+
+    /* Single vertex with loop */
+    igraph_small(&graph, 1, IGRAPH_UNDIRECTED,
+                 0,0,
+                 -1);
+    igraph_feedback_vertex_set(&graph, &result, NULL, IGRAPH_FVS_EXACT_IP);
+    IGRAPH_ASSERT(igraph_vector_int_size(&result) == 1);
+    IGRAPH_ASSERT(VECTOR(result)[0] == 0);
+    check_fvs(&graph, &result);
+    igraph_destroy(&graph);
+
+    /* Small graph */
+    igraph_small(&graph, 6, IGRAPH_UNDIRECTED,
+                 0, 1, 1, 2, 0, 2, 2, 3, 1, 3, 0, 4, 2, 4, -1);
+    igraph_feedback_vertex_set(&graph, &result, NULL, IGRAPH_FVS_EXACT_IP);
+    IGRAPH_ASSERT(igraph_vector_int_size(&result) == 1);
+    IGRAPH_ASSERT(VECTOR(result)[0] == 2);
+    check_fvs(&graph, &result);
+    igraph_destroy(&graph);
+
+    igraph_small(&graph, 5, IGRAPH_UNDIRECTED,
+                 0, 1, 1, 2, 2, 0, 2, 3, 3, 1, 0, 4, 4, 2, 4, 3, -1);
+    igraph_vector_resize(&weights, 5);
+    VECTOR(weights)[0] = 3;
+    VECTOR(weights)[1] = 3;
+    VECTOR(weights)[2] = 2;
+    VECTOR(weights)[3] = 2;
+    VECTOR(weights)[4] = 1;
+    igraph_feedback_vertex_set(&graph, &result, &weights, IGRAPH_FVS_EXACT_IP);
+    IGRAPH_ASSERT(igraph_vector_int_size(&result) == 2);
+    igraph_vector_int_sort(&result);
+    IGRAPH_ASSERT(VECTOR(result)[0] == 2);
+    IGRAPH_ASSERT(VECTOR(result)[1] == 4);
+    igraph_destroy(&graph);
+
+    /* Random graph */
+    igraph_erdos_renyi_game_gnm(&graph, 10, 20, IGRAPH_UNDIRECTED, IGRAPH_LOOPS);
+    igraph_feedback_vertex_set(&graph, &result, NULL, IGRAPH_FVS_EXACT_IP);
+    check_fvs(&graph, &result);
+    igraph_destroy(&graph);
+
+    igraph_vector_destroy(&weights);
+    igraph_vector_int_destroy(&result);
+
+    VERIFY_FINALLY_STACK();
+}
+
+void test_directed(void) {
+    igraph_t graph;
+    igraph_vector_int_t result;
+
+    igraph_vector_int_init(&result, 0);
+
+    /* Null graph */
+    igraph_empty(&graph, 0, IGRAPH_DIRECTED);
+    igraph_feedback_vertex_set(&graph, &result, NULL, IGRAPH_FVS_EXACT_IP);
+    IGRAPH_ASSERT(igraph_vector_int_size(&result) == 0);
+    igraph_destroy(&graph);
+
+    /* Singleton graph */
+    igraph_empty(&graph, 1, IGRAPH_DIRECTED);
+    igraph_feedback_vertex_set(&graph, &result, NULL, IGRAPH_FVS_EXACT_IP);
+    IGRAPH_ASSERT(igraph_vector_int_size(&result) == 0);
+    igraph_destroy(&graph);
+
+    /* Two isolated vertices */
+    igraph_empty(&graph, 2, IGRAPH_DIRECTED);
+    igraph_feedback_vertex_set(&graph, &result, NULL, IGRAPH_FVS_EXACT_IP);
+    IGRAPH_ASSERT(igraph_vector_int_size(&result) == 0);
+    igraph_destroy(&graph);
+
+    /* Single vertex with loop */
+    igraph_small(&graph, 1, IGRAPH_DIRECTED,
+                 0,0,
+                 -1);
+    igraph_feedback_vertex_set(&graph, &result, NULL, IGRAPH_FVS_EXACT_IP);
+    IGRAPH_ASSERT(igraph_vector_int_size(&result) == 1);
+    IGRAPH_ASSERT(VECTOR(result)[0] == 0);
+    check_fvs(&graph, &result);
+    igraph_destroy(&graph);
+
+    /* Small graph */
+    igraph_small(&graph, 6, IGRAPH_DIRECTED,
+                 0, 1, 1, 2, 2, 0, 2, 3, 3, 1, 0, 4, 4, 2, 4, 3, -1);
+    igraph_feedback_vertex_set(&graph, &result, NULL, IGRAPH_FVS_EXACT_IP);
+    IGRAPH_ASSERT(igraph_vector_int_size(&result) == 1);
+    IGRAPH_ASSERT(VECTOR(result)[0] == 2);
+    check_fvs(&graph, &result);
+    igraph_destroy(&graph);
+
+    /* Kautz graph, see https://doi.org/10.1016/j.disc.2006.09.010 Fig. 1 */
+    igraph_kautz(&graph, 2, 2);
+    igraph_feedback_vertex_set(&graph, &result, NULL, IGRAPH_FVS_EXACT_IP);
+    IGRAPH_ASSERT(igraph_vector_int_size(&result) == 5);
+    check_fvs(&graph, &result);
+    igraph_destroy(&graph);
+
+    /* Random graph */
+    igraph_erdos_renyi_game_gnm(&graph, 10, 20, IGRAPH_DIRECTED, IGRAPH_LOOPS);
+    igraph_feedback_vertex_set(&graph, &result, NULL, IGRAPH_FVS_EXACT_IP);
+    check_fvs(&graph, &result);
+    igraph_destroy(&graph);
+
+    igraph_vector_int_destroy(&result);
+
+    VERIFY_FINALLY_STACK();
+}
+
+int main(void) {
+
+    igraph_rng_seed(igraph_rng_default(), 137);
+
+    test_undirected();
+    test_directed();
+
+    return 0;
+}


### PR DESCRIPTION
This is a naive generalization to feedback vertex sets of the exact minimum FAS algorithm I implemented in #2668.

Perhaps this is not the best way to do it, but it works, and it wasn't too much effort on top of #2668. 

I give a short summary of the feedback vertex set (FVS) problem so people can give better feedback about the interface of this functionality:

  - It is NP-complete both for undirected and directed graphs (FAS is hard only for directed).
  - There seems to be more work for heuristic methods for the undirected case, as this is more generally useful. When we add heuristic methods in the future, some methods may work _only_ for the undirected case.
  - There is a weighted generalization, with vertex weights (not edge weights). This implementation supports weights.

PR notes:

 - The interface mirror that of `igraph_feedback_arc_set()`, even at the cost of deviating from [the standard parameter ordering](https://github.com/igraph/igraph/wiki/Guidelines-for-function-argument-ordering).
 - This is an exact (thus slow) method based on integer programming. Eventually it will be nice to have some heuristic methods, as that will be useful for speeding up the minimum cycle basis calculation.
 - I called the method `IGRAPH_FVS_EXACT_IP`, and did NOT add an `IGRAPH_FVS_EXACT_IP_CG`, even though this is analogous to `IGRAPH_FAS_EXACT_IP_CG`. We can add a more fine-grained method selection at the point when we add more IP methods (which may never happen)
 
Travis ppc64le and s390x has been broken for [everyone](https://travis-ci.community/t/ppc64-s390x-failing-on-startup/14358) (not just igraph) for the past few days; this CI failure is unrelated to the PR.