### PR TITLE
feat: resolution parameter for community_optimal_modularity()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
  - `igraph_get_all_simple_paths()` returns its results in an integer vector list (`igraph_vector_int_list_t`) instead of a single integer vector.
  - `igraph_get_all_simple_paths()` now has an additional parameter that allows restricting paths by minimum length as well.
  - `igraph_strvector_print()` no longer takes a file parameter. Use `igraph_strvector_fprint()` to print to a file.
+ - `igraph_community_optimal_modularity()` now takes a `resolution` parameter and its `weight` parameter was moved to the second place.
 
 ### Added
 

--- a/examples/simple/igraph_community_optimal_modularity.c
+++ b/examples/simple/igraph_community_optimal_modularity.c
@@ -1,8 +1,5 @@
-/* -*- mode: C -*-  */
-/*
-   IGraph library.
-   Copyright (C) 2010-2012  Gabor Csardi <csardi.gabor@gmail.com>
-   334 Harvard street, Cambridge, MA 02139 USA
+/* IGraph library.
+   Copyright (C) 2010-2024  The igraph development team <igraph@igraph.org>
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -15,107 +12,43 @@
    GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc.,  51 Franklin Street, Fifth Floor, Boston, MA
-   02110-1301 USA
-
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 #include <igraph.h>
 
-void prepare_weights_vector(igraph_vector_t* weights, const igraph_t* graph) {
-    igraph_integer_t i, n = igraph_ecount(graph);
-    igraph_vector_resize(weights, n);
-    for (i = 0; i < n; i++) {
-        VECTOR(*weights)[i] = i % 5;
-    }
-}
-
 int main(void) {
     igraph_t graph;
-
-    igraph_vector_int_t v;
-    igraph_integer_t edges[] = { 0, 1, 0, 2, 0, 3, 0, 4, 0, 5, 0, 6, 0, 7, 0, 8,
-                              0, 10, 0, 11, 0, 12, 0, 13, 0, 17, 0, 19, 0, 21, 0, 31,
-                              1, 2, 1, 3, 1, 7, 1, 13, 1, 17, 1, 19, 1, 21, 1, 30,
-                              2, 3, 2, 7, 2, 27, 2, 28, 2, 32, 2, 9, 2, 8, 2, 13,
-                              3, 7, 3, 12, 3, 13, 4, 6, 4, 10, 5, 6, 5, 10, 5, 16,
-                              6, 16, 8, 30, 8, 32, 8, 33, 9, 33, 13, 33, 14, 32, 14, 33,
-                              15, 32, 15, 33, 18, 32, 18, 33, 19, 33, 20, 32, 20, 33,
-                              22, 32, 22, 33, 23, 25, 23, 27, 23, 32, 23, 33, 23, 29,
-                              24, 25, 24, 27, 24, 31, 25, 31, 26, 29, 26, 33, 27, 33,
-                              28, 31, 28, 33, 29, 32, 29, 33, 30, 32, 30, 33, 31, 32, 31, 33,
-                              32, 33
-                            };
-
     igraph_vector_int_t membership;
-    igraph_vector_t weights;
     igraph_real_t modularity;
-    igraph_bool_t simple;
-    igraph_error_t retval;
+    igraph_error_handler_t *handler;
+    igraph_error_t errcode;
 
-    igraph_vector_int_view(&v, edges, sizeof(edges) / sizeof(edges[0]));
-    igraph_create(&graph, &v, 0, IGRAPH_UNDIRECTED);
-
-    igraph_vector_init(&weights, 0);
-
-    igraph_is_simple(&graph, &simple);
-    if (!simple) {
-        return 1;
-    }
+    igraph_small(&graph, 9, IGRAPH_UNDIRECTED,
+                 0, 3, 0, 4, 0, 1, 0, 2, 0, 5, 0, 6, 1, 3, 3, 5, 4, 7, 7, 8, 2, 4, 1, 2, 6, 8,
+                 -1);
 
     igraph_vector_int_init(&membership, 0);
 
-    igraph_set_error_handler(&igraph_error_handler_printignore);
+    /* Temporarily ignore errors so we can check if the functionality is available. */
+    handler = igraph_set_error_handler(&igraph_error_handler_printignore);
 
-    /* Zachary karate club, unweighted */
-    retval = igraph_community_optimal_modularity(&graph, NULL, 1, &modularity, &membership);
-    if (retval == IGRAPH_UNIMPLEMENTED) {
+    errcode = igraph_community_optimal_modularity(&graph, NULL, 1, &modularity, &membership);
+    if (errcode == IGRAPH_UNIMPLEMENTED) {
+        /* igraph was not build with GLPK; functionality unavailable, so we quit */
         return 77;
     }
-    if (fabs(modularity - 0.4197896) > 0.0000001) {
-        return 2;
-    }
 
-    /* Zachary karate club, weighted */
-    prepare_weights_vector(&weights, &graph);
-    igraph_community_optimal_modularity(&graph, &weights, 1, &modularity, &membership);
-    if (fabs(modularity - 0.5115767) > 0.0000001) {
-        return 3;
-    }
+    /* Restore the previous error handler. */
+    igraph_set_error_handler(handler);
 
-    /* Zachary karate club, unweighted, resolution=2 */
-    igraph_community_optimal_modularity(&graph, NULL, 2, &modularity, &membership);
-    if (fabs(modularity - 0.1645299) > 0.0000001) {
-        return 4;
-    }
+    printf("Highest possible modularity: %g\n", modularity);
+    printf("Membership: ");
+    igraph_vector_int_print(&membership);
 
-    /* Zachary karate club, weighted, resolution=2 */
-    igraph_community_optimal_modularity(&graph, &weights, 2, &modularity, &membership);
-    if (fabs(modularity - 0.2671622) > 0.0000001) {
-        return 5;
-    }
-
-    igraph_destroy(&graph);
-
-    /* simple graph with loop edges, unweighted */
-    igraph_small(&graph, 6, IGRAPH_UNDIRECTED,
-                 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 0, 0, 0, 2, 2, -1);
-    igraph_community_optimal_modularity(&graph, NULL, 1, &modularity,
-                                        &membership);
-    if (fabs(modularity - 0.28125) > 0.00001) {
-        return 6;
-    }
-    /* simple graph with loop edges, weighted */
-    prepare_weights_vector(&weights, &graph);
-    igraph_community_optimal_modularity(&graph, &weights, 1, &modularity, &membership);
-    if (fabs(modularity - 0.36686) > 0.00001) {
-        return 7;
-    }
     igraph_destroy(&graph);
 
     igraph_vector_int_destroy(&membership);
-    igraph_vector_destroy(&weights);
 
     return 0;
 }

--- a/examples/simple/igraph_community_optimal_modularity.c
+++ b/examples/simple/igraph_community_optimal_modularity.c
@@ -69,37 +69,48 @@ int main(void) {
     igraph_set_error_handler(&igraph_error_handler_printignore);
 
     /* Zachary karate club, unweighted */
-    retval = igraph_community_optimal_modularity(&graph, &modularity,
-             &membership, 0);
+    retval = igraph_community_optimal_modularity(&graph, NULL, 1, &modularity, &membership);
     if (retval == IGRAPH_UNIMPLEMENTED) {
         return 77;
     }
     if (fabs(modularity - 0.4197896) > 0.0000001) {
         return 2;
     }
+
     /* Zachary karate club, weighted */
     prepare_weights_vector(&weights, &graph);
-    igraph_community_optimal_modularity(&graph, &modularity,
-                                        &membership, &weights);
+    igraph_community_optimal_modularity(&graph, &weights, 1, &modularity, &membership);
     if (fabs(modularity - 0.5115767) > 0.0000001) {
+        return 3;
+    }
+
+    /* Zachary karate club, unweighted, resolution=2 */
+    igraph_community_optimal_modularity(&graph, NULL, 2, &modularity, &membership);
+    if (fabs(modularity - 0.1645299) > 0.0000001) {
         return 4;
     }
+
+    /* Zachary karate club, weighted, resolution=2 */
+    igraph_community_optimal_modularity(&graph, &weights, 2, &modularity, &membership);
+    if (fabs(modularity - 0.2671622) > 0.0000001) {
+        return 5;
+    }
+
     igraph_destroy(&graph);
 
     /* simple graph with loop edges, unweighted */
     igraph_small(&graph, 6, IGRAPH_UNDIRECTED,
                  0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 0, 0, 0, 2, 2, -1);
-    igraph_community_optimal_modularity(&graph, &modularity,
-                                        &membership, 0);
+    igraph_community_optimal_modularity(&graph, NULL, 1, &modularity,
+                                        &membership);
     if (fabs(modularity - 0.28125) > 0.00001) {
-        return 3;
+        return 6;
     }
     /* simple graph with loop edges, weighted */
     prepare_weights_vector(&weights, &graph);
-    igraph_community_optimal_modularity(&graph, &modularity,
-                                        &membership, &weights);
+    igraph_community_optimal_modularity(&graph, &weights, 1, &modularity, &membership);
     if (fabs(modularity - 0.36686) > 0.00001) {
-        return 5;
+        return 7;
     }
     igraph_destroy(&graph);
 

--- a/examples/simple/igraph_community_optimal_modularity.out
+++ b/examples/simple/igraph_community_optimal_modularity.out
@@ -1,0 +1,2 @@
+Highest possible modularity: 0.221893
+Membership: 0 0 0 0 1 0 1 1 1

--- a/include/igraph_community.h
+++ b/include/igraph_community.h
@@ -53,9 +53,10 @@ IGRAPH_EXPORT igraph_error_t igraph_trussness(
 /* TODO:  */
 
 IGRAPH_EXPORT igraph_error_t igraph_community_optimal_modularity(const igraph_t *graph,
-                                                      igraph_real_t *modularity,
-                                                      igraph_vector_int_t *membership,
-                                                      const igraph_vector_t *weights);
+                                                                 const igraph_vector_t *weights,
+                                                                 const igraph_real_t resolution,
+                                                                 igraph_real_t *modularity,
+                                                                 igraph_vector_int_t *membership);
 
 IGRAPH_EXPORT igraph_error_t igraph_community_spinglass(const igraph_t *graph,
                                              const igraph_vector_t *weights,

--- a/interfaces/functions.yaml
+++ b/interfaces/functions.yaml
@@ -1707,8 +1707,8 @@ igraph_community_multilevel:
 
 igraph_community_optimal_modularity:
     PARAMS: |-
-        GRAPH graph, OUT REAL modularity, OPTIONAL OUT VECTOR_INT membership,
-        OPTIONAL EDGE_WEIGHTS weights
+        GRAPH graph, OPTIONAL EDGE_WEIGHTS weights, REAL resolution=1.0,
+        OPTIONAL OUT REAL modularity, OPTIONAL OUT VECTOR_INT membership
     DEPS: weights ON graph
 
 igraph_community_leiden:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -680,6 +680,7 @@ add_legacy_tests(
   igraph_community_fluid_communities
   igraph_community_infomap
   igraph_community_leading_eigenvector2
+  igraph_community_optimal_modularity
   igraph_community_voronoi
   igraph_compare_communities
   igraph_le_community_to_membership

--- a/tests/unit/community_indexing.c
+++ b/tests/unit/community_indexing.c
@@ -71,7 +71,7 @@ int main(void) {
     igraph_grg_game(&graph, 20, 0.5, false, NULL, NULL);
 
     handler = igraph_set_error_handler(&igraph_error_handler_ignore);
-    ret = igraph_community_optimal_modularity(&graph, NULL, &membership, NULL);
+    ret = igraph_community_optimal_modularity(&graph, NULL, 1, NULL, &membership);
     igraph_set_error_handler(handler);
     if (ret != IGRAPH_UNIMPLEMENTED) { /* Test only when GLPK is available */
         IGRAPH_ASSERT(ret == IGRAPH_SUCCESS);

--- a/tests/unit/igraph_community_optimal_modularity.c
+++ b/tests/unit/igraph_community_optimal_modularity.c
@@ -1,0 +1,152 @@
+/* IGraph library.
+   Copyright (C) 2010-2024  The igraph development team <igraph@igraph.org>
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include <igraph.h>
+
+void prepare_weights_vector(igraph_vector_t *weights, const igraph_t *graph) {
+    const igraph_integer_t m =igraph_ecount(graph);
+    igraph_edge_betweenness(graph, weights, true, NULL);
+    for (igraph_integer_t i=0; i < m; i++) {
+        VECTOR(*weights)[i] = 1 / VECTOR(*weights)[i];
+    }
+}
+
+/* Only for undirected! */
+void verify_with_leiden(const igraph_t *graph, const igraph_vector_t *weights,
+                        igraph_real_t resolution, igraph_real_t modularity) {
+
+    igraph_vector_int_t leiden_membership;
+    igraph_vector_t vertex_weights;
+    igraph_real_t Q, maxQ = 0.0;
+    igraph_real_t m = weights ? igraph_vector_sum(weights) : igraph_ecount(graph);
+
+    igraph_vector_init(&vertex_weights, 0);
+    igraph_vector_int_init(&leiden_membership, 0);
+
+    igraph_strength(graph, &vertex_weights, igraph_vss_all(), IGRAPH_ALL, /*loops*/ true, weights);
+
+    for (int i=0; i < 10; i++) {
+        igraph_community_leiden(graph, weights, &vertex_weights,
+                                resolution / (2*m),
+                                0.01, false, 2, &leiden_membership, NULL, &Q);
+        if (Q > maxQ) {
+            maxQ = Q;
+        }
+    }
+
+    if (igraph_cmp_epsilon(modularity, maxQ, 1e-15) < 0) {
+        printf("Partitioning doesn't achieve maximum modulairty. "
+               "With Leiden: Q=%g; with optimal modularity: Q=%g\n",
+               maxQ, modularity);
+        IGRAPH_ASSERT(igraph_cmp_epsilon(modularity, maxQ, 1e-15) >= 0);
+    }
+
+    igraph_vector_int_destroy(&leiden_membership);
+    igraph_vector_destroy(&vertex_weights);
+}
+
+int main(void) {
+    igraph_t graph;
+    igraph_vector_t weights;
+    igraph_vector_int_t membership;
+    igraph_real_t modularity;
+    igraph_error_handler_t *handler;
+    igraph_error_t errcode;
+
+    igraph_vector_init(&weights, 0);
+    igraph_vector_int_init(&membership, 0);
+
+    igraph_famous(&graph, "zachary");
+
+    /* Zachary karate club, unweighted */
+    handler = igraph_set_error_handler(&igraph_error_handler_printignore);
+    errcode = igraph_community_optimal_modularity(&graph, NULL, 1, &modularity, &membership);
+    if (errcode == IGRAPH_UNIMPLEMENTED) {
+        igraph_vector_int_destroy(&membership);
+        igraph_vector_destroy(&weights);
+        return 77; /* skip test */
+    } else {
+        IGRAPH_ASSERT(errcode == IGRAPH_SUCCESS);
+    }
+    igraph_set_error_handler(handler);
+
+    verify_with_leiden(&graph, NULL, 1, modularity);
+    IGRAPH_ASSERT(igraph_almost_equals(modularity, 0.4197896120973046, 1e-15));
+
+    /* Zachary karate club, weighted */
+    prepare_weights_vector(&weights, &graph);
+    igraph_community_optimal_modularity(&graph, &weights, 1, &modularity, &membership);
+    verify_with_leiden(&graph, &weights, 1, modularity);
+    IGRAPH_ASSERT(igraph_almost_equals(modularity, 0.6138050900169181, 1e-15));
+
+    /* Zachary karate club, unweighted, resolution=2 */
+    igraph_community_optimal_modularity(&graph, NULL, 2, &modularity, &membership);
+    verify_with_leiden(&graph, NULL, 2, modularity);
+    IGRAPH_ASSERT(igraph_almost_equals(modularity, 0.16452991452991447, 1e-15));
+
+    /* Zachary karate club, weighted, resolution=2 */
+    igraph_community_optimal_modularity(&graph, &weights, 2, &modularity, &membership);
+    verify_with_leiden(&graph, &weights, 2, modularity);
+    IGRAPH_ASSERT(igraph_almost_equals(modularity, 0.4006998679817418, 1e-15));
+
+    /* Zachary karate club, unweighted, resolution=0.5 */
+    igraph_community_optimal_modularity(&graph, NULL, 0.5, &modularity, &membership);
+    verify_with_leiden(&graph, NULL, 0.5, modularity);
+    IGRAPH_ASSERT(igraph_almost_equals(modularity, 0.6217948717948718, 1e-15));
+
+    /* Zachary karate club, weighted, resolution=0.5 */
+    igraph_community_optimal_modularity(&graph, &weights, 0.5, &modularity, &membership);
+    verify_with_leiden(&graph, &weights, 0.5, modularity);
+    IGRAPH_ASSERT(igraph_almost_equals(modularity, 0.752255118181729, 1e-15));
+
+    igraph_destroy(&graph);
+
+    /* simple graph with self-loops and multi-edges, unweighted */
+    igraph_small(&graph, 6, IGRAPH_UNDIRECTED,
+                 0, 1, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 0, 0, 0, 2, 2, 2, 2, -1);
+
+    igraph_community_optimal_modularity(&graph, NULL, 1, &modularity, &membership);
+    verify_with_leiden(&graph, NULL, 1, modularity);
+    IGRAPH_ASSERT(igraph_almost_equals(modularity, 0.36, 1e-15));
+
+    /* simple graph with self-loops and multi-edges, weighted */
+    igraph_vector_resize(&weights, igraph_ecount(&graph));
+    igraph_vector_fill(&weights, 1.0);
+    VECTOR(weights)[2] = 5.0;
+    VECTOR(weights)[4] = 0.1;
+
+    igraph_community_optimal_modularity(&graph, &weights, 1, &modularity, &membership);
+    verify_with_leiden(&graph, &weights, 1, modularity);
+    IGRAPH_ASSERT(igraph_almost_equals(modularity, 0.266855078375386, 1e-15));
+
+    igraph_destroy(&graph);
+
+    /* Directed graph, chosen so that:
+     *  - the directed/undirected solutions differ
+     *  - there is a single maximum on both cases */
+    igraph_small(&graph, 5, IGRAPH_DIRECTED,
+                 1, 0, 1, 2, 1, 4, 2, 0, 2, 3, 3, 1, 3, 4, 4, 0, -1);
+    igraph_community_optimal_modularity(&graph, NULL, 1, &modularity, &membership);
+    IGRAPH_ASSERT(igraph_almost_equals(modularity, 0.09375, 1e-15));
+
+    igraph_destroy(&graph);
+
+    igraph_vector_int_destroy(&membership);
+    igraph_vector_destroy(&weights);
+
+    return 0;
+}

--- a/tests/unit/null_communities.c
+++ b/tests/unit/null_communities.c
@@ -138,7 +138,7 @@ int main(void) {
         igraph_vector_int_resize(&membership, 1);
 
         handler = igraph_set_error_handler(igraph_error_handler_ignore);
-        ret = igraph_community_optimal_modularity(&g, &m, &membership, NULL);
+        ret = igraph_community_optimal_modularity(&g, NULL, 1, &m, &membership);
         igraph_set_error_handler(handler);
 
         if (ret != IGRAPH_UNIMPLEMENTED) {


### PR DESCRIPTION
`igraph_community_optimal_modularity()` now takes a resolution parameter. Fixes #2678.

Since a new parameter was added, I took the opportunity to standardize the parameter ordering according to https://github.com/igraph/igraph/wiki/Guidelines-for-function-argument-ordering