### PR TITLE
refactor!: do not interpret empty integers vectors as missing values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,8 @@
  - `igraph_hub_and_authority_scores()` now warns when providing an undirected graph as input, and falls back to the equivalent eigenvector centrality computation.
  - `igraph_get_stochastic_sparse()` no longer throws an error when some row or column sums are zero. This brings its behaviour in line with `igraph_get_stochastic()`.
  - `igraph_vector_append()`, `igraph_strvector_append()` and `igraph_vector_ptr_append()` now use a different allocation strategy: if the `to` vector has insufficient capacity, they double its capacity. Previously they reserved precisely as much capacity as needed for appending the `from` vector.
+ - `igraph_degree_sequence_game()` no longer interprets an empty in-degree vector as a request for generating undirected graphs. To generate undirected graphs, pass `NULL` for in-degrees.
+ - `igraph_barabasi_game()` no longer interprets an empty `outseq` vector as a missing out-degree sequence. Pass `NULL` if you don't wish to specify an out-degree sequence.
 
 ### Fixed
 

--- a/src/games/barabasi.c
+++ b/src/games/barabasi.c
@@ -482,7 +482,7 @@ static igraph_error_t igraph_i_barabasi_game_psumtree(igraph_t *graph,
  * \param m The number of outgoing edges generated for each
  *        vertex. Only used when \p outseq is \c NULL.
  * \param outseq Gives the (out-)degrees of the vertices. If this is
- *        constant, this can be a \c NULL pointer or an empty vector.
+ *        constant, this can be a \c NULL pointer.
  *        In this case \p m contains the constant out-degree.
  *        The very first vertex has by definition no outgoing edges,
  *        so the first number in this vector is ignored.
@@ -547,10 +547,7 @@ igraph_error_t igraph_barabasi_game(igraph_t *graph, igraph_integer_t n,
     igraph_integer_t start_nodes = start_from ? igraph_vcount(start_from) : 0;
     igraph_integer_t newn = start_from ? n - start_nodes : n;
 
-    /* Fix obscure parameterizations */
-    if (outseq && igraph_vector_int_empty(outseq)) {
-        outseq = NULL;
-    }
+    /* In undirected graphs, always consider the total degree. */
     if (!directed) {
         outpref = true;
     }
@@ -570,7 +567,7 @@ igraph_error_t igraph_barabasi_game(igraph_t *graph, igraph_integer_t n,
     if (!outseq && m < 0) {
         IGRAPH_ERROR("Number of edges added per step must not be negative.", IGRAPH_EINVAL);
     }
-    if (outseq && igraph_vector_int_min(outseq) < 0) {
+    if (outseq && newn > 0 && igraph_vector_int_min(outseq) < 0) {
         IGRAPH_ERROR("Negative out-degree in sequence.", IGRAPH_EINVAL);
     }
     if (!outpref && A <= 0) {

--- a/src/games/degree_sequence.c
+++ b/src/games/degree_sequence.c
@@ -37,7 +37,7 @@ static igraph_error_t igraph_i_degree_sequence_game_configuration(igraph_t *grap
                                        const igraph_vector_int_t *out_seq,
                                        const igraph_vector_int_t *in_seq) {
 
-    const igraph_bool_t directed = (in_seq != NULL && igraph_vector_int_size(in_seq) != 0);
+    const igraph_bool_t directed = (in_seq != NULL);
     igraph_integer_t outsum = 0, insum = 0;
     igraph_bool_t graphical;
     igraph_integer_t no_of_nodes, no_of_edges;
@@ -690,13 +690,10 @@ igraph_error_t igraph_i_degree_sequence_game_edge_switching(
  * https://doi.org/10.1088/2632-072x/abced5.
  *
  * \param graph Pointer to an uninitialized graph object.
- * \param out_deg The degree sequence for an undirected graph (if
- *        \p in_seq is \c NULL or of length zero), or the out-degree
- *        sequence of a directed graph (if \p in_deq is not
- *        of length zero).
- * \param in_deg It is either a zero-length vector or
- *        \c NULL (if an undirected
- *        graph is generated), or the in-degree sequence.
+ * \param out_degrees A vector of integers specifying the degree sequence for
+ *     undirected graphs or the out-degree sequence for directed graphs.
+ * \param in_degrees A vector of integers specifying the in-degree sequence for
+ *     directed graphs. For undirected graphs, it must be \c NULL.
  * \param method The method to generate the graph. Possible values:
  *        \clist
  *          \cli IGRAPH_DEGSEQ_CONFIGURATION
@@ -771,36 +768,35 @@ igraph_error_t igraph_i_degree_sequence_game_edge_switching(
  * \example examples/simple/igraph_degree_sequence_game.c
  */
 
-igraph_error_t igraph_degree_sequence_game(igraph_t *graph, const igraph_vector_int_t *out_deg,
-                                const igraph_vector_int_t *in_deg,
-                                igraph_degseq_t method) {
-    if (in_deg && igraph_vector_int_empty(in_deg) && !igraph_vector_int_empty(out_deg)) {
-        in_deg = NULL;
-    }
+igraph_error_t igraph_degree_sequence_game(
+        igraph_t *graph,
+        const igraph_vector_int_t *out_degrees,
+        const igraph_vector_int_t *in_degrees,
+        igraph_degseq_t method) {
 
     switch (method) {
     case IGRAPH_DEGSEQ_CONFIGURATION:
-        return igraph_i_degree_sequence_game_configuration(graph, out_deg, in_deg);
+        return igraph_i_degree_sequence_game_configuration(graph, out_degrees, in_degrees);
 
     case IGRAPH_DEGSEQ_VL:
-        return igraph_degree_sequence_game_vl(graph, out_deg, in_deg);
+        return igraph_degree_sequence_game_vl(graph, out_degrees, in_degrees);
 
     case IGRAPH_DEGSEQ_FAST_HEUR_SIMPLE:
-        if (! in_deg) {
-            return igraph_i_degree_sequence_game_fast_heur_undirected(graph, out_deg);
+        if (! in_degrees) {
+            return igraph_i_degree_sequence_game_fast_heur_undirected(graph, out_degrees);
         } else {
-            return igraph_i_degree_sequence_game_fast_heur_directed(graph, out_deg, in_deg);
+            return igraph_i_degree_sequence_game_fast_heur_directed(graph, out_degrees, in_degrees);
         }
 
     case IGRAPH_DEGSEQ_CONFIGURATION_SIMPLE:
-        if (! in_deg) {
-            return igraph_i_degree_sequence_game_configuration_simple_undirected(graph, out_deg);
+        if (! in_degrees) {
+            return igraph_i_degree_sequence_game_configuration_simple_undirected(graph, out_degrees);
         } else {
-            return igraph_i_degree_sequence_game_configuration_simple_directed(graph, out_deg, in_deg);
+            return igraph_i_degree_sequence_game_configuration_simple_directed(graph, out_degrees, in_degrees);
         }
 
     case IGRAPH_DEGSEQ_EDGE_SWITCHING_SIMPLE:
-        return igraph_i_degree_sequence_game_edge_switching(graph, out_deg, in_deg);
+        return igraph_i_degree_sequence_game_edge_switching(graph, out_degrees, in_degrees);
 
     default:
         IGRAPH_ERROR("Invalid degree sequence game method.", IGRAPH_EINVAL);


### PR DESCRIPTION
refactor!: do not interpret empty integers vectors as missing values in igraph_degree_sequence_game() and igraph_barabasi_game(). Pass NULL to indicate that these vectors are not specified. Closes #2685.