### PR TITLE
feat: igraph_vertex_path_from_edge_path() can determine the start vertex automatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,12 @@
 
  - `igraph_neighborhood_size()`, `igraph_neighborhood()` and `igraph_neighborhood_graphs()` now accept a negative `order` value and interpret it as infinite order. Previously, a negative `order` value was disallowed.
  - `igraph_famous()` now accepts `Groetzsch` as an alias of `Grotzsch`.
+ - `igraph_vertex_path_from_edge_path()` can now determine the start vertex automatically.
 
 ### Fixed
 
  - `igraph_largest_independent_vertex_sets()` and `igraph_maximal_independent_vertex_sets()` would sometimes return incorrect results for graphs with self-loops. This is now corrected.
+ - `igraph_vertex_path_from_edge_path()` now validates the start vertex.
 
 ### Deprecated
 

--- a/interfaces/functions.yaml
+++ b/interfaces/functions.yaml
@@ -2701,7 +2701,7 @@ igraph_invalidate_cache:
 
 igraph_vertex_path_from_edge_path:
     PARAMS: |-
-        GRAPH graph, VERTEX start, EDGE_INDICES edge_path,
+        GRAPH graph, OPTIONAL VERTEX start, EDGE_INDICES edge_path,
         OUT VERTEX_INDICES vertex_path, NEIMODE mode=OUT
 
 #######################################

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -361,6 +361,7 @@ add_legacy_tests(
   igraph_widest_paths
   igraph_spanner
   knn
+  paths
   random_spanning_tree
   reachability
   single_target_shortest_path

--- a/tests/unit/paths.c
+++ b/tests/unit/paths.c
@@ -1,0 +1,96 @@
+/*
+   IGraph library.
+   Copyright (C) 2024  The igraph development team <igraph@igraph.org>
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include <igraph.h>
+
+#include "test_utilities.h"
+
+int main(void) {
+    igraph_t graph;
+    igraph_vector_int_t edge_walk, vertex_walk;
+
+    igraph_vector_int_init(&vertex_walk, 0);
+    igraph_vector_int_init(&edge_walk, 0);
+
+    igraph_ring(&graph, 4, IGRAPH_DIRECTED, false, true);
+    igraph_vector_int_range(&edge_walk, 0, igraph_ecount(&graph));
+
+    printf("Cycle, detect start:\n");
+    igraph_vertex_path_from_edge_path(&graph, -1, &edge_walk, &vertex_walk, IGRAPH_ALL);
+    print_vector_int(&edge_walk);
+    print_vector_int(&vertex_walk);
+
+    printf("\nCycle plus one vertex, start given:\n");
+    igraph_vector_int_push_back(&edge_walk, 0);
+    igraph_vertex_path_from_edge_path(&graph, 0, &edge_walk, &vertex_walk, IGRAPH_ALL);
+    print_vector_int(&edge_walk);
+    print_vector_int(&vertex_walk);
+
+    /* Inconsistent start vertex */
+    CHECK_ERROR(
+        igraph_vertex_path_from_edge_path(&graph, 1, &edge_walk, &vertex_walk, IGRAPH_ALL),
+        IGRAPH_EINVAL
+    );
+
+    /* Invalid start vertex */
+    CHECK_ERROR(
+        igraph_vertex_path_from_edge_path(&graph, 10, &edge_walk, &vertex_walk, IGRAPH_ALL),
+        IGRAPH_EINVVID
+    );
+
+    printf("\nSingle edge, detect start:\n");
+    igraph_vector_int_clear(&edge_walk);
+    igraph_vector_int_push_back(&edge_walk, 2);
+    igraph_vertex_path_from_edge_path(&graph, -1, &edge_walk, &vertex_walk, IGRAPH_ALL);
+    print_vector_int(&edge_walk);
+    print_vector_int(&vertex_walk);
+
+    printf("\nSingle edge, directed OUT, detect start:\n");
+    igraph_vector_int_clear(&edge_walk);
+    igraph_vector_int_push_back(&edge_walk, 2);
+    igraph_vertex_path_from_edge_path(&graph, -1, &edge_walk, &vertex_walk, IGRAPH_OUT);
+    print_vector_int(&edge_walk);
+    print_vector_int(&vertex_walk);
+
+    printf("\nSingle edge, directed IN, detect start:\n");
+    igraph_vector_int_clear(&edge_walk);
+    igraph_vector_int_push_back(&edge_walk, 2);
+    igraph_vertex_path_from_edge_path(&graph, -1, &edge_walk, &vertex_walk, IGRAPH_IN);
+    print_vector_int(&edge_walk);
+    print_vector_int(&vertex_walk);
+
+    printf("\nZero edges, start given:\n");
+    igraph_vector_int_clear(&edge_walk);
+    igraph_vertex_path_from_edge_path(&graph, 2, &edge_walk, &vertex_walk, IGRAPH_ALL);
+    print_vector_int(&edge_walk);
+    print_vector_int(&vertex_walk);
+
+    /* Zero edges, start not given: */
+    CHECK_ERROR(
+        igraph_vertex_path_from_edge_path(&graph, -1, &edge_walk, &vertex_walk, IGRAPH_ALL),
+        IGRAPH_EINVAL
+    );
+
+    igraph_destroy(&graph);
+    igraph_vector_int_destroy(&edge_walk);
+    igraph_vector_int_destroy(&vertex_walk);
+
+    VERIFY_FINALLY_STACK();
+
+    return 0;
+}

--- a/tests/unit/paths.out
+++ b/tests/unit/paths.out
@@ -1,0 +1,23 @@
+Cycle, detect start:
+( 0 1 2 3 )
+( 0 1 2 3 0 )
+
+Cycle plus one vertex, start given:
+( 0 1 2 3 0 )
+( 0 1 2 3 0 1 )
+
+Single edge, detect start:
+( 2 )
+( 2 3 )
+
+Single edge, directed OUT, detect start:
+( 2 )
+( 2 3 )
+
+Single edge, directed IN, detect start:
+( 2 )
+( 3 2 )
+
+Zero edges, start given:
+( )
+( 2 )


### PR DESCRIPTION
@ntamas, following @GenieTim's comment on wanting both the edges and vertices of cycles, I would like to make it easier to expose and use the `igraph_vertex_path_from_edge_path()` function from high-level interfaces. In 6fd3903c84d741d4bed0284c85db277836a4af79, I improved the docs to make it clear that it works with repeated vertices (meaning that cycles are a valid input, and so are arbitrary walks). But in practical use cases one would often want to avoid having to provide a starting vertex. This PR makes it so that the function can auto-detect the start vertex. 

One ugliness in this approach is that it isn't possible if the path has length zero: in this case this function still returns one vertex, the start vertex. Thus we cannot auto-detect that. Existing igraph functions do rely on this behaviour.

After noticing this issue, I became a bit reluctant about the auto-detection feature. Should we go ahead with this PR?  It can probably still be quite useful.