### PR TITLE
benchmark: igraph_induced_subgraph()

### DIFF
--- a/src/operators/subgraph.c
+++ b/src/operators/subgraph.c
@@ -338,8 +338,7 @@ static igraph_error_t igraph_i_induced_subgraph_suggest_implementation(
         ratio = (igraph_real_t) num_vs / igraph_vcount(graph);
     }
 
-    /* TODO: needs benchmarking; threshold was chosen totally arbitrarily */
-    if (ratio > 0.5) {
+    if (ratio > log(graph->n) / log(10) / 10) {
         *result = IGRAPH_SUBGRAPH_COPY_AND_DELETE;
     } else {
         *result = IGRAPH_SUBGRAPH_CREATE_FROM_SCRATCH;

--- a/src/operators/subgraph.c
+++ b/src/operators/subgraph.c
@@ -338,7 +338,10 @@ static igraph_error_t igraph_i_induced_subgraph_suggest_implementation(
         ratio = (igraph_real_t) num_vs / igraph_vcount(graph);
     }
 
-    if (ratio > log(graph->n) / log(10) / 10) {
+    /* The threshold of 0.5 is justified by the benchmarking done in
+     * https://github.com/igraph/igraph/pull/2708
+     * Small improvements may be possible by using better heuristics. */
+    if (ratio > 0.5) {
         *result = IGRAPH_SUBGRAPH_COPY_AND_DELETE;
     } else {
         *result = IGRAPH_SUBGRAPH_CREATE_FROM_SCRATCH;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1006,6 +1006,7 @@ add_benchmarks(
   igraph_degree_sequence_game
   igraph_distances
   igraph_ecc
+  igraph_induced_subgraph
   igraph_induced_subgraph_edges
   igraph_layout_umap
   igraph_matrix_transpose

--- a/tests/benchmarks/igraph_induced_subgraph.c
+++ b/tests/benchmarks/igraph_induced_subgraph.c
@@ -1,0 +1,126 @@
+/*
+    IGraph library.
+    Copyright (C) 2024  The igraph development team <igraph@igraph.org>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "bench.h"
+#include "igraph_constants.h"
+#include <igraph.h>
+#include <stdio.h>
+
+// Function to generate random vertex indices for subgraph extraction
+void generate_random_vertices(igraph_vector_int_t *vertices,
+                              igraph_integer_t graph_size,
+                              igraph_integer_t subset_size) {
+    igraph_vector_int_init(vertices, 0);
+    igraph_vector_int_resize(vertices, subset_size);
+
+    // Create a vector to track used vertices
+    igraph_vector_int_t used_vertices;
+    igraph_vector_int_init(&used_vertices, graph_size);
+    for (igraph_integer_t i = 0; i < graph_size; i++) {
+        VECTOR(used_vertices)[i] = i;
+    }
+
+    // Randomly select subset_size unique vertices
+    for (igraph_integer_t i = 0; i < subset_size; i++) {
+        igraph_integer_t index = RNG_INTEGER(0, graph_size - i - 1);
+        VECTOR(*vertices)[i] = VECTOR(used_vertices)[index];
+
+        // Remove the selected vertex from used_vertices
+        VECTOR(used_vertices)[index] = VECTOR(used_vertices)[graph_size - i - 1];
+    }
+
+    // Sort the vertices to simulate real-world scenarios
+    igraph_vector_int_sort(vertices);
+
+    igraph_vector_int_destroy(&used_vertices);
+}
+
+// Benchmark function
+void bench_induced_subgraph(igraph_t *graph, igraph_vector_int_t *vertices,
+                            igraph_subgraph_implementation_t impl) {
+    igraph_t subgraph;
+    igraph_vs_t vs;
+
+    igraph_vs_vector(&vs, vertices);
+    igraph_induced_subgraph(graph, &subgraph, vs, impl);
+    igraph_vs_destroy(&vs);
+    igraph_destroy(&subgraph);
+}
+
+void run_bench(int i, int n, int m, int subset_percentage) {
+    igraph_t graph;
+    igraph_vector_int_t vertices;
+
+    // Calculate subset size based on percentage
+    igraph_integer_t subset_size = (n * subset_percentage) / 100;
+
+    // Prepare random graph and vertices
+    igraph_erdos_renyi_game_gnm(&graph, n, m, IGRAPH_UNDIRECTED, 0);
+    generate_random_vertices(&vertices, n, subset_size);
+
+    char msg[255];
+    int rep = 300000000 / (n * subset_percentage);
+
+    // Benchmark method 1 (COPY_AND_DELETE)
+    snprintf(msg, sizeof(msg),
+             "Method 1 (COPY_AND_DELETE):     n=%5d, subset=%3d%%, %dx", n,
+             subset_percentage, rep);
+    BENCH(msg, REPEAT(bench_induced_subgraph(&graph, &vertices,
+                                             IGRAPH_SUBGRAPH_COPY_AND_DELETE),
+                      rep));
+
+    // Benchmark method 2 (CREATE_FROM_SCRATCH)
+    snprintf(msg, sizeof(msg),
+             "Method 2 (CREATE_FROM_SCRATCH): n=%5d, subset=%3d%%, %dx", n,
+             subset_percentage, rep);
+    BENCH(msg, REPEAT(bench_induced_subgraph(&graph, &vertices,
+                                             IGRAPH_SUBGRAPH_CREATE_FROM_SCRATCH),
+                      rep));
+
+    // Cleanup
+    igraph_vector_int_destroy(&vertices);
+    igraph_destroy(&graph);
+}
+
+int main(void) {
+    int i = 0;
+
+    // Initialize random number generator
+    igraph_rng_seed(igraph_rng_default(), 42);
+    BENCH_INIT();
+
+// Macro to run benchmarks for different graph sizes and subset percentages
+#define BENCHSET(n, m)                                                           \
+    run_bench(++i, n, m, 20); /* 20% subset */                                   \
+    run_bench(++i, n, m, 25); /* 25% subset */                                   \
+    run_bench(++i, n, m, 30); /* 30% subset */                                   \
+    run_bench(++i, n, m, 35); /* 35% subset */                                   \
+    run_bench(++i, n, m, 40); /* 40% subset */                                   \
+    run_bench(++i, n, m, 45); /* 45% subset */                                   \
+    run_bench(++i, n, m, 50); /* 50% subset */                                   \
+    run_bench(++i, n, m, 55); /* 55% subset */                                   \
+    printf("\n");
+
+    // Benchmark different graph sizes
+    BENCHSET(100, 500);
+    BENCHSET(1000, 5000);
+    BENCHSET(10000, 50000);
+    BENCHSET(100000, 500000);
+
+    return 0;
+}

--- a/tests/benchmarks/igraph_induced_subgraph.c
+++ b/tests/benchmarks/igraph_induced_subgraph.c
@@ -1,6 +1,6 @@
 /*
     IGraph library.
-    Copyright (C) 2024  The igraph development team <igraph@igraph.org>
+    Copyright (C) 2025  The igraph development team <igraph@igraph.org>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -16,10 +16,9 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include "bench.h"
-#include "igraph_constants.h"
 #include <igraph.h>
-#include <stdio.h>
+
+#include "bench.h"
 
 // Function to generate random vertex indices for subgraph extraction
 void generate_random_vertices(igraph_vector_int_t *vertices,


### PR DESCRIPTION
This PR addresses #2635, updating the automatic implementation selection heuristic for `igraph_induced_subgraph`. This involved adding a benchmark for the two possible methods for various graph sizes and subgraph ratios.

- Added a benchmark to compare the two methods used by `igraph_induced_subgraph` (copy and delete vs create from scratch)
- Evaluated the performance difference between the two methods for graph sizes between 100 vertices and 100000 vertices and 20%-55% subsets
- Updated the implementation selection heuristic based on findings

Sample results are summarized here:
![image](https://github.com/user-attachments/assets/e1f5ecd7-ef36-4f7d-b795-a9f4903e8c7b)
The line shows the chosen heuristic for implementation selection.

Time Difference represents time taken by `create_from_scratch` minus time taken by `copy_and_delete`.

| Graph Size | Proportion of Vertices | Time Difference |
| ---------- | ---------------------- | --------------- |
|        100 |                     20 |          -0.841 |
|        100 |                     25 |           0.161 |
|        100 |                     30 |           0.201 |
|        100 |                     35 |           0.561 |
|        100 |                     40 |           1.061 |
|        100 |                     45 |           0.791 |
|        100 |                     50 |           0.921 |
|        100 |                     55 |           1.051 |
|       1000 |                     20 |          -0.641 |
|       1000 |                     25 |          -0.391 |
|       1000 |                     30 |          -0.111 |
|       1000 |                     35 |           0.111 |
|       1000 |                     40 |           0.281 |
|       1000 |                     45 |           0.461 |
|       1000 |                     50 |           0.501 |
|       1000 |                     55 |           0.641 |
|      10000 |                     20 |          -1.051 |
|      10000 |                     25 |          -0.671 |
|      10000 |                     30 |          -0.671 |
|      10000 |                     35 |          -0.111 |
|      10000 |                     40 |           0.101 |
|      10000 |                     45 |           0.371 |
|      10000 |                     50 |           0.401 |
|      10000 |                     55 |           0.631 |
|     100000 |                     20 |          -1.741 |
|     100000 |                     25 |          -1.471 |
|     100000 |                     30 |          -0.941 |
|     100000 |                     35 |          -0.561 |
|     100000 |                     40 |          -0.261 |
|     100000 |                     45 |          -0.041 |
|     100000 |                     50 |           0.151 |
|     100000 |                     55 |           0.351 |


ChatGPT and Claude AI were used for this PR, primarily for helping to debug and help me understand the igraph functions I needed to use, as it is my first time working closely with this project.