### PR TITLE
Allow infinite order in neighborhood functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
  - `igraph_count_triangles()` counts undirected triangles in a graph.
  - `igraph_count_adjacent_triangles()` (rename of `igraph_adjacent_triangles()`)
 
+### Changed
+
+ - `igraph_neighborhood_size()`, `igraph_neighborhood()` and `igraph_neighborhood_graphs()` now accept a negative `order` value and interpret it as infinite order. Previously, a negative `order` value was disallowed. 
+
 ### Deprecated
 
  - The undocumented function `igraph_vector_sumsq()` is deprecated. Use `igraph_blas_dnrm2()` to compute the Euclidean norm of real vectors.

--- a/src/connectivity/components.c
+++ b/src/connectivity/components.c
@@ -1583,7 +1583,7 @@ igraph_error_t igraph_bridges(const igraph_t *graph, igraph_vector_int_t *bridge
  * \sa \ref igraph_induced_subgraph() if you want a graph object consisting only
  * a given set of vertices and the edges between them;
  * \ref igraph_reachability() to efficiently compute the reachable set from \em all
- * vertices.
+ * vertices; \ref igraph_neighborhood() to find vertices within a given distance.
  */
 igraph_error_t igraph_subcomponent(
     const igraph_t *graph, igraph_vector_int_t *res, igraph_integer_t vertex,

--- a/src/properties/neighborhood.c
+++ b/src/properties/neighborhood.c
@@ -46,7 +46,8 @@
  * \param res Pointer to an initialized vector, the result will be
  *    stored here. It will be resized as needed.
  * \param vids The vertices for which the calculation is performed.
- * \param order Integer giving the order of the neighborhood.
+ * \param order Integer giving the order of the neighborhood. Negative values
+ *   are treated as infinity.
  * \param mode Specifies how to use the direction of the edges if a
  *   directed graph is analyzed. For \c IGRAPH_OUT only the outgoing
  *   edges are followed, so all vertices reachable from the source
@@ -77,14 +78,18 @@ igraph_error_t igraph_neighborhood_size(const igraph_t *graph, igraph_vector_int
     igraph_vit_t vit;
     igraph_integer_t *added;
     igraph_vector_int_t neis;
+    igraph_bool_t inf_order = false;
 
     if (order < 0) {
-        IGRAPH_ERRORF("Negative order in neighborhood size: %" IGRAPH_PRId ".",
-                      IGRAPH_EINVAL, order);
+        order = no_of_nodes;
+        inf_order = true;
     }
 
-    if (mindist < 0 || mindist > order) {
-        IGRAPH_ERRORF("Minimum distance should be between 0 and the neighborhood order (%" IGRAPH_PRId "), got %" IGRAPH_PRId ".",
+    if (mindist < 0) {
+        IGRAPH_ERRORF("Minium distance must not be negative, got %" IGRAPH_PRId ".", IGRAPH_EINVAL, mindist);
+    }
+    if (!inf_order && mindist > order) {
+        IGRAPH_ERRORF("Minimum distance must not exceed the neighborhood order (%" IGRAPH_PRId "), got %" IGRAPH_PRId ".",
                       IGRAPH_EINVAL, order, mindist);
     }
 
@@ -173,7 +178,8 @@ igraph_error_t igraph_neighborhood_size(const igraph_t *graph, igraph_vector_int
  * \param res An initialized list of integer vectors. The result of the
  *    calculation will be stored here. The list will be resized as needed.
  * \param vids The vertices for which the calculation is performed.
- * \param order Integer giving the order of the neighborhood.
+ * \param order Integer giving the order of the neighborhood. Negative values
+ *   are treated as infinity.
  * \param mode Specifies how to use the direction of the edges if a
  *   directed graph is analyzed. For \c IGRAPH_OUT only the outgoing
  *   edges are followed, so all vertices reachable from the source
@@ -205,13 +211,18 @@ igraph_error_t igraph_neighborhood(const igraph_t *graph, igraph_vector_int_list
     igraph_integer_t *added;
     igraph_vector_int_t neis;
     igraph_vector_int_t tmp;
+    igraph_bool_t inf_order = false;
 
     if (order < 0) {
-        IGRAPH_ERROR("Negative order in neighborhood size.", IGRAPH_EINVAL);
+        order = no_of_nodes;
+        inf_order = true;
     }
 
-    if (mindist < 0 || mindist > order) {
-        IGRAPH_ERRORF("Minimum distance should be between 0 and the neighborhood order (%" IGRAPH_PRId "), got %" IGRAPH_PRId ".",
+    if (mindist < 0) {
+        IGRAPH_ERRORF("Minium distance must not be negative, got %" IGRAPH_PRId ".", IGRAPH_EINVAL, mindist);
+    }
+    if (!inf_order && mindist > order) {
+        IGRAPH_ERRORF("Minimum distance must not exceed the neighborhood order (%" IGRAPH_PRId "), got %" IGRAPH_PRId ".",
                       IGRAPH_EINVAL, order, mindist);
     }
 
@@ -311,7 +322,8 @@ igraph_error_t igraph_neighborhood(const igraph_t *graph, igraph_vector_int_list
  *   here. Each item in the list is an \type igraph_t object. The list will be
  *   resized as needed.
  * \param vids The vertices for which the calculation is performed.
- * \param order Integer giving the order of the neighborhood.
+ * \param order Integer giving the order of the neighborhood. Negative values
+ *   are treated as infinity.
  * \param mode Specifies how to use the direction of the edges if a
  *   directed graph is analyzed. For \c IGRAPH_OUT only the outgoing
  *   edges are followed, so all vertices reachable from the source
@@ -344,13 +356,18 @@ igraph_error_t igraph_neighborhood_graphs(const igraph_t *graph, igraph_graph_li
     igraph_vector_int_t neis;
     igraph_vector_int_t tmp;
     igraph_t newg;
+    igraph_bool_t inf_order = false;
 
     if (order < 0) {
-        IGRAPH_ERROR("Negative order in neighborhood size.", IGRAPH_EINVAL);
+        order = no_of_nodes;
+        inf_order = true;
     }
 
-    if (mindist < 0 || mindist > order) {
-        IGRAPH_ERRORF("Minimum distance should be between 0 and the neighborhood order (%" IGRAPH_PRId "), got %" IGRAPH_PRId ".",
+    if (mindist < 0) {
+        IGRAPH_ERRORF("Minium distance must not be negative, got %" IGRAPH_PRId ".", IGRAPH_EINVAL, mindist);
+    }
+    if (!inf_order && mindist > order) {
+        IGRAPH_ERRORF("Minimum distance must not exceed the neighborhood order (%" IGRAPH_PRId "), got %" IGRAPH_PRId ".",
                       IGRAPH_EINVAL, order, mindist);
     }
 

--- a/src/properties/neighborhood.c
+++ b/src/properties/neighborhood.c
@@ -62,7 +62,7 @@
  *   two, then its neighbors are not counted either, etc.
  * \return Error code.
  *
- * \sa \ref igraph_neighborhood() for calculating the actual neighborhood,
+ * \sa \ref igraph_neighborhood() for calculating the actual neighborhood;
  * \ref igraph_neighborhood_graphs() for creating separate graphs from
  * the neighborhoods.
  *
@@ -199,8 +199,9 @@ igraph_error_t igraph_neighborhood_size(const igraph_t *graph, igraph_vector_int
  * \return Error code.
  *
  * \sa \ref igraph_neighborhood_size() to calculate the size of the
- * neighborhood, \ref igraph_neighborhood_graphs() for creating
- * graphs from the neighborhoods.
+ * neighborhood; \ref igraph_neighborhood_graphs() for creating
+ * graphs from the neighborhoods; \ref igraph_subcomponent() to find vertices
+ * reachable from a single vertex.
  *
  * Time complexity: O(n*d*o), n is the number of vertices for which
  * the calculation is performed, d is the average degree, o is the
@@ -343,7 +344,7 @@ igraph_error_t igraph_neighborhood(const igraph_t *graph, igraph_vector_int_list
  * \return Error code.
  *
  * \sa \ref igraph_neighborhood_size() for calculating the neighborhood
- * sizes only, \ref igraph_neighborhood() for calculating the
+ * sizes only; \ref igraph_neighborhood() for calculating the
  * neighborhoods (but not creating graphs).
  *
  * Time complexity: O(n*(|V|+|E|)), where n is the number vertices for

--- a/src/properties/neighborhood.c
+++ b/src/properties/neighborhood.c
@@ -89,7 +89,7 @@ igraph_error_t igraph_neighborhood_size(const igraph_t *graph, igraph_vector_int
     }
 
     added = IGRAPH_CALLOC(no_of_nodes, igraph_integer_t);
-    IGRAPH_CHECK_OOM(added, "Cannot calculate neighborhood size.");
+    IGRAPH_CHECK_OOM(added, "Insufficient memory to calculate neighborhood sizes.");
     IGRAPH_FINALLY(igraph_free, added);
 
     IGRAPH_DQUEUE_INT_INIT_FINALLY(&q, 100);
@@ -207,16 +207,16 @@ igraph_error_t igraph_neighborhood(const igraph_t *graph, igraph_vector_int_list
     igraph_vector_int_t tmp;
 
     if (order < 0) {
-        IGRAPH_ERROR("Negative order in neighborhood size", IGRAPH_EINVAL);
+        IGRAPH_ERROR("Negative order in neighborhood size.", IGRAPH_EINVAL);
     }
 
     if (mindist < 0 || mindist > order) {
-        IGRAPH_ERROR("Minimum distance should be between zero and order",
-                     IGRAPH_EINVAL);
+        IGRAPH_ERRORF("Minimum distance should be between 0 and the neighborhood order (%" IGRAPH_PRId "), got %" IGRAPH_PRId ".",
+                      IGRAPH_EINVAL, order, mindist);
     }
 
     added = IGRAPH_CALLOC(no_of_nodes, igraph_integer_t);
-    IGRAPH_CHECK_OOM(added, "Cannot calculate neighborhood size.");
+    IGRAPH_CHECK_OOM(added, "Insufficient memory to calculate neighborhood sizes.");
     IGRAPH_FINALLY(igraph_free, added);
 
     IGRAPH_DQUEUE_INT_INIT_FINALLY(&q, 100);
@@ -346,16 +346,16 @@ igraph_error_t igraph_neighborhood_graphs(const igraph_t *graph, igraph_graph_li
     igraph_t newg;
 
     if (order < 0) {
-        IGRAPH_ERROR("Negative order in neighborhood size", IGRAPH_EINVAL);
+        IGRAPH_ERROR("Negative order in neighborhood size.", IGRAPH_EINVAL);
     }
 
     if (mindist < 0 || mindist > order) {
-        IGRAPH_ERROR("Minimum distance should be between zero and order",
-                     IGRAPH_EINVAL);
+        IGRAPH_ERRORF("Minimum distance should be between 0 and the neighborhood order (%" IGRAPH_PRId "), got %" IGRAPH_PRId ".",
+                      IGRAPH_EINVAL, order, mindist);
     }
 
     added = IGRAPH_CALLOC(no_of_nodes, igraph_integer_t);
-    IGRAPH_CHECK_OOM(added, "Cannot calculate neighborhood size");
+    IGRAPH_CHECK_OOM(added, "Insufficient memory to calculate neighborhood graphs.");
     IGRAPH_FINALLY(igraph_free, added);
 
     IGRAPH_DQUEUE_INT_INIT_FINALLY(&q, 100);

--- a/src/properties/neighborhood.c
+++ b/src/properties/neighborhood.c
@@ -75,7 +75,6 @@ igraph_error_t igraph_neighborhood_size(const igraph_t *graph, igraph_vector_int
     igraph_integer_t no_of_nodes = igraph_vcount(graph);
     igraph_dqueue_int_t q;
     igraph_vit_t vit;
-    igraph_integer_t i, j;
     igraph_integer_t *added;
     igraph_vector_int_t neis;
 
@@ -99,8 +98,8 @@ igraph_error_t igraph_neighborhood_size(const igraph_t *graph, igraph_vector_int
     IGRAPH_VECTOR_INT_INIT_FINALLY(&neis, 0);
     IGRAPH_CHECK(igraph_vector_int_resize(res, IGRAPH_VIT_SIZE(vit)));
 
-    for (i = 0; !IGRAPH_VIT_END(vit); IGRAPH_VIT_NEXT(vit), i++) {
-        igraph_integer_t node = IGRAPH_VIT_GET(vit);
+    for (igraph_integer_t i = 0; !IGRAPH_VIT_END(vit); IGRAPH_VIT_NEXT(vit), i++) {
+        const igraph_integer_t node = IGRAPH_VIT_GET(vit);
         igraph_integer_t size = mindist == 0 ? 1 : 0;
         added[node] = i + 1;
         igraph_dqueue_int_clear(&q);
@@ -110,15 +109,15 @@ igraph_error_t igraph_neighborhood_size(const igraph_t *graph, igraph_vector_int
         }
 
         while (!igraph_dqueue_int_empty(&q)) {
-            igraph_integer_t actnode = igraph_dqueue_int_pop(&q);
-            igraph_integer_t actdist = igraph_dqueue_int_pop(&q);
-            igraph_integer_t n;
+            const igraph_integer_t actnode = igraph_dqueue_int_pop(&q);
+            const igraph_integer_t actdist = igraph_dqueue_int_pop(&q);
+
             IGRAPH_CHECK(igraph_neighbors(graph, &neis, actnode, mode));
-            n = igraph_vector_int_size(&neis);
+            const igraph_integer_t n = igraph_vector_int_size(&neis);
 
             if (actdist < order - 1) {
                 /* we add them to the q */
-                for (j = 0; j < n; j++) {
+                for (igraph_integer_t j = 0; j < n; j++) {
                     igraph_integer_t nei = VECTOR(neis)[j];
                     if (added[nei] != i + 1) {
                         added[nei] = i + 1;
@@ -131,8 +130,8 @@ igraph_error_t igraph_neighborhood_size(const igraph_t *graph, igraph_vector_int
                 }
             } else {
                 /* we just count them, but don't add them */
-                for (j = 0; j < n; j++) {
-                    igraph_integer_t nei = VECTOR(neis)[j];
+                for (igraph_integer_t j = 0; j < n; j++) {
+                    const igraph_integer_t nei = VECTOR(neis)[j];
                     if (added[nei] != i + 1) {
                         added[nei] = i + 1;
                         if (actdist + 1 >= mindist) {
@@ -200,10 +199,9 @@ igraph_error_t igraph_neighborhood(const igraph_t *graph, igraph_vector_int_list
                         igraph_vs_t vids, igraph_integer_t order,
                         igraph_neimode_t mode, igraph_integer_t mindist) {
 
-    igraph_integer_t no_of_nodes = igraph_vcount(graph);
+    const igraph_integer_t no_of_nodes = igraph_vcount(graph);
     igraph_dqueue_int_t q;
     igraph_vit_t vit;
-    igraph_integer_t i, j;
     igraph_integer_t *added;
     igraph_vector_int_t neis;
     igraph_vector_int_t tmp;
@@ -229,8 +227,8 @@ igraph_error_t igraph_neighborhood(const igraph_t *graph, igraph_vector_int_list
     IGRAPH_CHECK(igraph_vector_int_list_reserve(res, IGRAPH_VIT_SIZE(vit)));
     igraph_vector_int_list_clear(res);
 
-    for (i = 0; !IGRAPH_VIT_END(vit); IGRAPH_VIT_NEXT(vit), i++) {
-        igraph_integer_t node = IGRAPH_VIT_GET(vit);
+    for (igraph_integer_t i = 0; !IGRAPH_VIT_END(vit); IGRAPH_VIT_NEXT(vit), i++) {
+        const igraph_integer_t node = IGRAPH_VIT_GET(vit);
         added[node] = i + 1;
         igraph_vector_int_clear(&tmp);
         if (mindist == 0) {
@@ -242,16 +240,16 @@ igraph_error_t igraph_neighborhood(const igraph_t *graph, igraph_vector_int_list
         }
 
         while (!igraph_dqueue_int_empty(&q)) {
-            igraph_integer_t actnode = igraph_dqueue_int_pop(&q);
-            igraph_integer_t actdist = igraph_dqueue_int_pop(&q);
-            igraph_integer_t n;
+            const igraph_integer_t actnode = igraph_dqueue_int_pop(&q);
+            const igraph_integer_t actdist = igraph_dqueue_int_pop(&q);
+
             IGRAPH_CHECK(igraph_neighbors(graph, &neis, actnode, mode));
-            n = igraph_vector_int_size(&neis);
+            const igraph_integer_t n = igraph_vector_int_size(&neis);
 
             if (actdist < order - 1) {
                 /* we add them to the q */
-                for (j = 0; j < n; j++) {
-                    igraph_integer_t nei = VECTOR(neis)[j];
+                for (igraph_integer_t j = 0; j < n; j++) {
+                    const igraph_integer_t nei = VECTOR(neis)[j];
                     if (added[nei] != i + 1) {
                         added[nei] = i + 1;
                         IGRAPH_CHECK(igraph_dqueue_int_push(&q, nei));
@@ -263,8 +261,8 @@ igraph_error_t igraph_neighborhood(const igraph_t *graph, igraph_vector_int_list
                 }
             } else {
                 /* we just count them but don't add them to q */
-                for (j = 0; j < n; j++) {
-                    igraph_integer_t nei = VECTOR(neis)[j];
+                for (igraph_integer_t j = 0; j < n; j++) {
+                    const igraph_integer_t nei = VECTOR(neis)[j];
                     if (added[nei] != i + 1) {
                         added[nei] = i + 1;
                         if (actdist + 1 >= mindist) {
@@ -307,9 +305,10 @@ igraph_error_t igraph_neighborhood(const igraph_t *graph, igraph_vector_int_list
  * </para><para>
  * The first version of this function was written by
  * Vincent Matossian, thanks Vincent.
+ *
  * \param graph The input graph.
  * \param res Pointer to a list of graphs, the result will be stored
- *   here. Each item in the list is an \c igraph_t object. The list will be
+ *   here. Each item in the list is an \type igraph_t object. The list will be
  *   resized as needed.
  * \param vids The vertices for which the calculation is performed.
  * \param order Integer giving the order of the neighborhood.
@@ -338,10 +337,9 @@ igraph_error_t igraph_neighborhood_graphs(const igraph_t *graph, igraph_graph_li
                                igraph_vs_t vids, igraph_integer_t order,
                                igraph_neimode_t mode,
                                igraph_integer_t mindist) {
-    igraph_integer_t no_of_nodes = igraph_vcount(graph);
+    const igraph_integer_t no_of_nodes = igraph_vcount(graph);
     igraph_dqueue_int_t q;
     igraph_vit_t vit;
-    igraph_integer_t i, j;
     igraph_integer_t *added;
     igraph_vector_int_t neis;
     igraph_vector_int_t tmp;
@@ -368,8 +366,8 @@ igraph_error_t igraph_neighborhood_graphs(const igraph_t *graph, igraph_graph_li
 
     igraph_graph_list_clear(res);
 
-    for (i = 0; !IGRAPH_VIT_END(vit); IGRAPH_VIT_NEXT(vit), i++) {
-        igraph_integer_t node = IGRAPH_VIT_GET(vit);
+    for (igraph_integer_t i = 0; !IGRAPH_VIT_END(vit); IGRAPH_VIT_NEXT(vit), i++) {
+        const igraph_integer_t node = IGRAPH_VIT_GET(vit);
         added[node] = i + 1;
         igraph_vector_int_clear(&tmp);
         if (mindist == 0) {
@@ -389,8 +387,8 @@ igraph_error_t igraph_neighborhood_graphs(const igraph_t *graph, igraph_graph_li
 
             if (actdist < order - 1) {
                 /* we add them to the q */
-                for (j = 0; j < n; j++) {
-                    igraph_integer_t nei = VECTOR(neis)[j];
+                for (igraph_integer_t j = 0; j < n; j++) {
+                    const igraph_integer_t nei = VECTOR(neis)[j];
                     if (added[nei] != i + 1) {
                         added[nei] = i + 1;
                         IGRAPH_CHECK(igraph_dqueue_int_push(&q, nei));
@@ -402,8 +400,8 @@ igraph_error_t igraph_neighborhood_graphs(const igraph_t *graph, igraph_graph_li
                 }
             } else {
                 /* we just count them but don't add them to q */
-                for (j = 0; j < n; j++) {
-                    igraph_integer_t nei = VECTOR(neis)[j];
+                for (igraph_integer_t j = 0; j < n; j++) {
+                    const igraph_integer_t nei = VECTOR(neis)[j];
                     if (added[nei] != i + 1) {
                         added[nei] = i + 1;
                         if (actdist + 1 >= mindist) {

--- a/src/properties/neighborhood.c
+++ b/src/properties/neighborhood.c
@@ -27,6 +27,7 @@
 #include "igraph_interface.h"
 #include "igraph_memory.h"
 #include "igraph_operators.h"
+#include "igraph_reachability.h"
 
 /**
  * \function igraph_neighborhood_size
@@ -83,6 +84,10 @@ igraph_error_t igraph_neighborhood_size(const igraph_t *graph, igraph_vector_int
     if (order < 0) {
         order = no_of_nodes;
         inf_order = true;
+
+        if (mindist == 0 && igraph_vs_is_all(&vids)) {
+            return igraph_count_reachable(graph, res, mode);
+        }
     }
 
     if (mindist < 0) {

--- a/tests/unit/igraph_neighborhood.c
+++ b/tests/unit/igraph_neighborhood.c
@@ -28,7 +28,7 @@ int main(void) {
     igraph_vs_all(&vids);
 
     igraph_small(&g_empty, 0, 0, -1);
-    igraph_small(&g_lm, 6, 1, 0,1, 0,2, 1,1, 1,3, 2,0, 2,3, 3,4, 3,4, -1);
+    igraph_small(&g_lm, 6, IGRAPH_DIRECTED, 0,1, 0,2, 1,1, 1,3, 2,0, 2,3, 3,4, 3,4, -1);
 
     printf("No vertices:\n");
     IGRAPH_ASSERT(igraph_neighborhood(&g_empty, &result, vids, /*order*/ 1,
@@ -65,16 +65,26 @@ int main(void) {
                   /*mode*/ IGRAPH_ALL, /*mindist*/ 4) == IGRAPH_SUCCESS);
     print_vector_int_list(&result);
 
-    VERIFY_FINALLY_STACK();
-    igraph_set_error_handler(igraph_error_handler_ignore);
+    printf("Directed graph with loops and multi-edges, infinite order, IGRAPH_OUT:\n");
+    igraph_neighborhood(&g_lm, &result, vids, /*order*/ -1,
+                        /*mode*/ IGRAPH_OUT, /*mindist*/ 0);
+    print_vector_int_list(&result);
 
-    printf("Negative order.\n");
-    IGRAPH_ASSERT(igraph_neighborhood(&g_lm, &result, vids, /*order*/ -4,
-                  /*mode*/ IGRAPH_ALL, /*mindist*/ 4) == IGRAPH_EINVAL);
+    printf("Directed graph with loops and multi-edges, infinite order, mindist 2, IGRAPH_OUT:\n");
+    igraph_neighborhood(&g_lm, &result, vids, /*order*/ -1,
+                        /*mode*/ IGRAPH_OUT, /*mindist*/ 2);
+    print_vector_int_list(&result);
+
+    printf("Directed graph with loops and multi-edges, infinite order, mindist 2, IGRAPH_IN:\n");
+    igraph_neighborhood(&g_lm, &result, vids, /*order*/ -1,
+                        /*mode*/ IGRAPH_IN, /*mindist*/ 2);
+    print_vector_int_list(&result);
+
+    VERIFY_FINALLY_STACK();
 
     printf("Negative mindist.\n");
-    IGRAPH_ASSERT(igraph_neighborhood(&g_lm, &result, vids, /*order*/ 4,
-                  /*mode*/ IGRAPH_ALL, /*mindist*/ -4) == IGRAPH_EINVAL);
+    CHECK_ERROR(igraph_neighborhood(&g_lm, &result, vids, /*order*/ 4,
+                  /*mode*/ IGRAPH_ALL, /*mindist*/ -4), IGRAPH_EINVAL);
 
     igraph_vector_int_list_destroy(&result);
     igraph_destroy(&g_empty);

--- a/tests/unit/igraph_neighborhood.out
+++ b/tests/unit/igraph_neighborhood.out
@@ -55,5 +55,31 @@ Directed graph with loops and multi-edges, order 4, mindist 4, IGRAPH_ALL:
   4: ( )
   5: ( )
 }
-Negative order.
+Directed graph with loops and multi-edges, infinite order, IGRAPH_OUT:
+{
+  0: ( 0 1 2 3 4 )
+  1: ( 1 3 4 )
+  2: ( 2 0 3 1 4 )
+  3: ( 3 4 )
+  4: ( 4 )
+  5: ( 5 )
+}
+Directed graph with loops and multi-edges, infinite order, mindist 2, IGRAPH_OUT:
+{
+  0: ( 3 4 )
+  1: ( 4 )
+  2: ( 1 4 )
+  3: ( )
+  4: ( )
+  5: ( )
+}
+Directed graph with loops and multi-edges, infinite order, mindist 2, IGRAPH_IN:
+{
+  0: ( )
+  1: ( 2 )
+  2: ( )
+  3: ( 0 )
+  4: ( 1 2 0 )
+  5: ( )
+}
 Negative mindist.

--- a/tests/unit/igraph_neighborhood_graphs.c
+++ b/tests/unit/igraph_neighborhood_graphs.c
@@ -45,7 +45,7 @@ int main(void) {
     igraph_vs_all(&vids);
 
     igraph_small(&g_empty, 0, 0, -1);
-    igraph_small(&g_lm, 6, 1, 0,1, 0,2, 1,1, 1,3, 2,0, 2,3, 3,4, 3,4, -1);
+    igraph_small(&g_lm, 6, IGRAPH_DIRECTED, 0,1, 0,2, 1,1, 1,3, 2,0, 2,3, 3,4, 3,4, -1);
 
     printf("No vertices:\n");
     IGRAPH_ASSERT(igraph_neighborhood_graphs(&g_empty, &result, vids, /*order*/ 1,
@@ -82,16 +82,26 @@ int main(void) {
                   /*mode*/ IGRAPH_ALL, /*mindist*/ 4) == IGRAPH_SUCCESS);
     print_and_clear(&result);
 
-    VERIFY_FINALLY_STACK();
-    igraph_set_error_handler(igraph_error_handler_ignore);
+    printf("Directed graph with loops and multi-edges, infinite order, IGRAPH_OUT:\n");
+    igraph_neighborhood_graphs(&g_lm, &result, vids, /*order*/ -1,
+                               /*mode*/ IGRAPH_OUT, /*mindist*/ 0);
+    print_and_clear(&result);
 
-    printf("Negative order.\n");
-    IGRAPH_ASSERT(igraph_neighborhood_graphs(&g_lm, &result, vids, /*order*/ -4,
-                  /*mode*/ IGRAPH_ALL, /*mindist*/ 4) == IGRAPH_EINVAL);
+    printf("Directed graph with loops and multi-edges, infinite order, mindist 2, IGRAPH_OUT:\n");
+    igraph_neighborhood_graphs(&g_lm, &result, vids, /*order*/ -1,
+                               /*mode*/ IGRAPH_OUT, /*mindist*/ 2);
+    print_and_clear(&result);
+
+    printf("Directed graph with loops and multi-edges, infinite order, mindist 2, IGRAPH_IN:\n");
+    igraph_neighborhood_graphs(&g_lm, &result, vids, /*order*/ -1,
+                               /*mode*/ IGRAPH_IN, /*mindist*/ 2);
+    print_and_clear(&result);
+
+    VERIFY_FINALLY_STACK();
 
     printf("Negative mindist.\n");
-    IGRAPH_ASSERT(igraph_neighborhood_graphs(&g_lm, &result, vids, /*order*/ 4,
-                  /*mode*/ IGRAPH_ALL, /*mindist*/ -4) == IGRAPH_EINVAL);
+    CHECK_ERROR(igraph_neighborhood_graphs(&g_lm, &result, vids, /*order*/ 4,
+                  /*mode*/ IGRAPH_ALL, /*mindist*/ -4), IGRAPH_EINVAL);
 
     igraph_graph_list_destroy(&result);
     igraph_destroy(&g_empty);

--- a/tests/unit/igraph_neighborhood_graphs.out
+++ b/tests/unit/igraph_neighborhood_graphs.out
@@ -169,5 +169,78 @@ null graph
 null graph
 null graph
 
-Negative order.
+Directed graph with loops and multi-edges, infinite order, IGRAPH_OUT:
+directed: true
+vcount: 5
+edges: {
+0 1
+0 2
+1 1
+1 3
+2 0
+2 3
+3 4
+3 4
+}
+directed: true
+vcount: 3
+edges: {
+0 0
+0 1
+1 2
+1 2
+}
+directed: true
+vcount: 5
+edges: {
+0 1
+0 2
+1 1
+1 3
+2 0
+2 3
+3 4
+3 4
+}
+directed: true
+vcount: 2
+edges: {
+0 1
+0 1
+}
+One vertex, no edges
+One vertex, no edges
+
+Directed graph with loops and multi-edges, infinite order, mindist 2, IGRAPH_OUT:
+directed: true
+vcount: 2
+edges: {
+0 1
+0 1
+}
+One vertex, no edges
+directed: true
+vcount: 2
+edges: {
+0 0
+}
+null graph
+null graph
+null graph
+
+Directed graph with loops and multi-edges, infinite order, mindist 2, IGRAPH_IN:
+null graph
+One vertex, no edges
+null graph
+One vertex, no edges
+directed: true
+vcount: 3
+edges: {
+0 1
+0 2
+1 1
+2 0
+}
+null graph
+
 Negative mindist.

--- a/tests/unit/igraph_neighborhood_size.c
+++ b/tests/unit/igraph_neighborhood_size.c
@@ -30,7 +30,7 @@ int main(void) {
     igraph_vs_all(&vids);
 
     igraph_small(&g_empty, 0, 0, -1);
-    igraph_small(&g_lm, 6, 1, 0,1, 0,2, 1,1, 1,3, 2,0, 2,3, 3,4, 3,4, -1);
+    igraph_small(&g_lm, 6, IGRAPH_DIRECTED, 0,1, 0,2, 1,1, 1,3, 2,0, 2,3, 3,4, 3,4, -1);
 
     printf("No vertices:\n");
     IGRAPH_ASSERT(igraph_neighborhood_size(&g_empty, &result, vids, /*order*/ 1,
@@ -67,11 +67,22 @@ int main(void) {
                   /*mode*/ IGRAPH_ALL, /*mindist*/ 4) == IGRAPH_SUCCESS);
     print_vector_int(&result);
 
-    VERIFY_FINALLY_STACK();
+    printf("Directed graph with loops and multi-edges, infinite order, IGRAPH_OUT:\n");
+    igraph_neighborhood_size(&g_lm, &result, vids, /*order*/ -1,
+                             /*mode*/ IGRAPH_OUT, /*mindist*/ 0);
+    print_vector_int(&result);
 
-    printf("Negative order.\n");
-    CHECK_ERROR(igraph_neighborhood_size(&g_lm, &result, vids, /*order*/ -4,
-                  /*mode*/ IGRAPH_ALL, /*mindist*/ 4), IGRAPH_EINVAL);
+    printf("Directed graph with loops and multi-edges, infinite order, mindist 2, IGRAPH_OUT:\n");
+    igraph_neighborhood_size(&g_lm, &result, vids, /*order*/ -1,
+                             /*mode*/ IGRAPH_OUT, /*mindist*/ 2);
+    print_vector_int(&result);
+
+    printf("Directed graph with loops and multi-edges, infinite order, mindist 2, IGRAPH_IN:\n");
+    igraph_neighborhood_size(&g_lm, &result, vids, /*order*/ -1,
+                             /*mode*/ IGRAPH_IN, /*mindist*/ 2);
+    print_vector_int(&result);
+
+    VERIFY_FINALLY_STACK();
 
     printf("Negative mindist.\n");
     CHECK_ERROR(igraph_neighborhood_size(&g_lm, &result, vids, /*order*/ 4,

--- a/tests/unit/igraph_neighborhood_size.out
+++ b/tests/unit/igraph_neighborhood_size.out
@@ -12,5 +12,10 @@ Directed graph with loops and multi-edges, order 2, mindist 2, IGRAPH_OUT:
 ( 1 1 2 0 0 0 )
 Directed graph with loops and multi-edges, order 4, mindist 4, IGRAPH_ALL:
 ( 0 0 0 0 0 0 )
-Negative order.
+Directed graph with loops and multi-edges, infinite order, IGRAPH_OUT:
+( 5 3 5 2 1 1 )
+Directed graph with loops and multi-edges, infinite order, mindist 2, IGRAPH_OUT:
+( 2 1 2 0 0 0 )
+Directed graph with loops and multi-edges, infinite order, mindist 2, IGRAPH_IN:
+( 0 1 0 1 3 0 )
 Negative mindist.


### PR DESCRIPTION
This PR changes `igraph_neighborhood_size()`, `igraph_neighborhood()` and `igraph_neighborhood_graphs()` to allow an infinite order, indicated by a negative `order` value. Previously, a negative order was treated as an error.

It also changes error checking on `mindist`: `mindist > order` throws an error only if the order is not infinite. Do we want to change this to _never_ throw an error for `mindist > order`?

If this PR is accepted, the Python and R docs should be updated as well (CC @maelle).
