### PR TITLE
chore: update PR template to require copyright assignment

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,1 +1,5 @@
 <!-- Please disclose any use of LLMs (ChatGPT, Copilot, Gemini, etc.) during the preparation of this PR. -->
+
+<!-- The following text must be left intact and the box checked before the PR can be merged. -->
+
+- [ ] By submitting this pull request, I assign the copyright of my contribution to _The igraph development team_.


### PR DESCRIPTION
We discussed this lightweight solution with @ntamas as a means of requiring copyright assignment for PRs. This of course requires manually verifying that the box was checked by the submitter, but it is much less hassle for new contributors than dealing with a CLA bot, which in @ntamas's experience drives people away.

@krlmlr Would you be happy with adopting a similar solution for R/igraph? I can submit a PR with the same text.

_The igraph development team_ is what currently appears in new copyright headers, e.g. [here](https://github.com/igraph/igraph/blob/3b32b7395a06c1592bdb3fb3b3063ae992418841/src/centrality/betweenness.c#L3).

Even though I didn't note this in the PR template, it makes sense that team members should not have to bother with this, but just delete the text. when creating the PR.

CC @vtraag @iosonofabio as discussed at the steering committee meeting.