### PR TITLE
refactor!: remove igraph_fileformat_type_t

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,7 @@
  - The deprecated `igraph_random_edge_walk()` was removed. Its functionality is incorporated in `igraph_random_walk()`.
  - The deprecated `igraph_vector_qsort_ind()` was removed. Use `igraph_vector_sort_ind()` instead.
  - The deprecated `igraph_vector_binsearch2()` was removed. Use `igraph_vector_contains_sorted()` instead.
+ - The unused enum type `igraph_fileformat_type_t` was removed.
 
 ### Deprecated
 

--- a/include/igraph_constants.h
+++ b/include/igraph_constants.h
@@ -106,13 +106,6 @@ typedef enum { IGRAPH_RANDOM_TREE_PRUFER = 0,
                IGRAPH_RANDOM_TREE_LERW
              } igraph_random_tree_t;
 
-typedef enum { IGRAPH_FILEFORMAT_EDGELIST = 0,
-               IGRAPH_FILEFORMAT_NCOL,
-               IGRAPH_FILEFORMAT_PAJEK,
-               IGRAPH_FILEFORMAT_LGL,
-               IGRAPH_FILEFORMAT_GRAPHML
-             } igraph_fileformat_type_t;
-
 typedef enum { IGRAPH_REWIRING_SIMPLE = 0,
                IGRAPH_REWIRING_SIMPLE_LOOPS
              } igraph_rewiring_t;


### PR DESCRIPTION
This enum type is not used anywhere, not even in the high-level interfaces, so I don't think we need a deprecation cycle. Note that the this PR targets `develop`.

The one exception is the ctype-based new Python interface, where it is referenced, but probably not needed.



