### PR TITLE
Dedicated function for a random Boolean / random bit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 ### Added
 
  - `igraph_count_triangles()` counts undirected triangles in a graph.
- - `igraph_count_adjacent_triangles()` (rename of `igraph_adjacent_triangles()`)
+ - `igraph_count_adjacent_triangles()` (rename of `igraph_adjacent_triangles()`).
+ - `igraph_rng_get_bool()` and `RNG_BOOL()` produce a single random boolean.
 
 ### Changed
 

--- a/doc/random.xxml
+++ b/doc/random.xxml
@@ -24,6 +24,7 @@
 </section>
 
 <section id="generating-random-numbers"><title>Generating random numbers</title>
+<!-- doxrox-include igraph_rng_get_bool -->
 <!-- doxrox-include igraph_rng_get_integer -->
 <!-- doxrox-include igraph_rng_get_unif01 -->
 <!-- doxrox-include igraph_rng_get_unif -->

--- a/examples/simple/igraph_assortativity_degree.out
+++ b/examples/simple/igraph_assortativity_degree.out
@@ -1,17 +1,17 @@
 Forest fire model network with 1000 vertices and 0.2 forward burning probability.
 
 Assortativity before rewiring = 0.164775
-Assortativity after rewiring = -0.0126025
+Assortativity after rewiring = -0.0244963
 
-Assortativity before rewiring = 0.151338
-Assortativity after rewiring = -0.00941098
+Assortativity before rewiring = 0.204558
+Assortativity after rewiring = -0.0115178
 
-Assortativity before rewiring = 0.125732
-Assortativity after rewiring = -0.012306
+Assortativity before rewiring = 0.25205
+Assortativity after rewiring = -0.0198939
 
-Assortativity before rewiring = 0.154392
-Assortativity after rewiring = -0.00993259
+Assortativity before rewiring = 0.136678
+Assortativity after rewiring = 0.00245584
 
-Assortativity before rewiring = 0.154686
-Assortativity after rewiring = -0.00258259
+Assortativity before rewiring = 0.262014
+Assortativity after rewiring = -0.00207304
 

--- a/examples/simple/igraph_assortativity_nominal.out
+++ b/examples/simple/igraph_assortativity_nominal.out
@@ -1,17 +1,17 @@
 Randomly generated graph with 120 nodes and 4 vertex types
 
 Assortativity before rewiring = 0.690908
-Assortativity after rewiring = 0.0451254
+Assortativity after rewiring = -0.0376672
 
-Assortativity before rewiring = 0.729653
-Assortativity after rewiring = -0.0153034
+Assortativity before rewiring = 0.669352
+Assortativity after rewiring = -0.0178763
 
-Assortativity before rewiring = 0.688232
-Assortativity after rewiring = -0.0430041
+Assortativity before rewiring = 0.722101
+Assortativity after rewiring = 0.0421349
 
-Assortativity before rewiring = 0.722913
-Assortativity after rewiring = -0.0310209
+Assortativity before rewiring = 0.704048
+Assortativity after rewiring = -0.0244487
 
-Assortativity before rewiring = 0.686532
-Assortativity after rewiring = 0.00735045
+Assortativity before rewiring = 0.668842
+Assortativity after rewiring = 0.000612194
 

--- a/include/igraph_random.h
+++ b/include/igraph_random.h
@@ -121,6 +121,7 @@ IGRAPH_EXPORT IGRAPH_FUNCATTR_PURE igraph_integer_t igraph_rng_bits(const igraph
 IGRAPH_EXPORT IGRAPH_FUNCATTR_PURE igraph_uint_t igraph_rng_max(const igraph_rng_t *rng);
 IGRAPH_EXPORT IGRAPH_FUNCATTR_PURE const char *igraph_rng_name(const igraph_rng_t *rng);
 
+IGRAPH_EXPORT igraph_bool_t igraph_rng_get_bool(igraph_rng_t *rng) ;
 IGRAPH_EXPORT igraph_integer_t igraph_rng_get_integer(
     igraph_rng_t *rng, igraph_integer_t l, igraph_integer_t h
 );
@@ -174,6 +175,7 @@ void PutRNGstate(void);
     do { /* nothing */ } while (0)
 #endif
 
+#define RNG_BOOL()       (igraph_rng_get_bool(igraph_rng_default()))
 #define RNG_INTEGER(l,h) (igraph_rng_get_integer(igraph_rng_default(),(l),(h)))
 #define RNG_NORMAL(m,s)  (igraph_rng_get_normal(igraph_rng_default(),(m),(s)))
 #define RNG_UNIF(l,h)    (igraph_rng_get_unif(igraph_rng_default(),(l),(h)))

--- a/src/graph/cattributes.c
+++ b/src/graph/cattributes.c
@@ -1354,7 +1354,7 @@ static igraph_error_t igraph_i_cattributes_cb_majority(const igraph_attribute_re
             VECTOR(*newv)[i] = (num_trues > n / 2);
         } else {
             if (num_trues == n / 2) {
-                VECTOR(*newv)[i] = (RNG_UNIF01() < 0.5);
+                VECTOR(*newv)[i] = RNG_BOOL();
             } else {
                 VECTOR(*newv)[i] = (num_trues > n / 2);
             }

--- a/src/hrg/hrg_types.cc
+++ b/src/hrg/hrg_types.cc
@@ -1594,7 +1594,7 @@ void dendro::monteCarloMove(double &delta, bool &ftaken, const double T) {
     t        = tempPair->t;
 
     if (t == LEFT) {
-        if (RNG_UNIF01() < 0.5) { // ## LEFT ALPHA move: ((i,j),k) -> ((i,k),j)
+        if (RNG_BOOL()) { // ## LEFT ALPHA move: ((i,j),k) -> ((i,k),j)
             // We need to calculate the change in the likelihood (dLogL)
             // that would result from this move. Most of the information
             // needed to do this is already available, the exception being
@@ -1726,7 +1726,7 @@ void dendro::monteCarloMove(double &delta, bool &ftaken, const double T) {
 
         // right-edge: t == RIGHT
 
-        if (RNG_UNIF01() < 0.5) {
+        if (RNG_BOOL()) {
 
             // alpha move: (i,(j,k)) -> ((i,k),j)
 

--- a/src/layout/umap.c
+++ b/src/layout/umap.c
@@ -793,7 +793,7 @@ static igraph_error_t igraph_i_umap_apply_forces(
         /* we move all vertices on one end of the edges, then we come back for
          * the vertices on the other end. This way we don't move both ends at the
          * same time, which is almost a wasted move since they attract each other */
-        int swapflag = (int)(RNG_UNIF01() > 0.5);
+        int swapflag = (int)(RNG_BOOL());
         int swapflag_end = swapflag + 2;
         for (; swapflag < swapflag_end; swapflag++) {
 

--- a/src/operators/rewire.c
+++ b/src/operators/rewire.c
@@ -112,7 +112,7 @@ igraph_error_t igraph_i_rewire(igraph_t *graph, igraph_integer_t n, igraph_rewir
             /* For an undirected graph, we have two "variants" of each edge, i.e.
              * a -- b and b -- a. Since some rewirings can be performed only when we
              * "swap" the endpoints, we do it now with probability 0.5 */
-            if (!directed && RNG_UNIF01() < 0.5) {
+            if (!directed && RNG_BOOL()) {
                 dummy = c; c = d; d = dummy;
                 if (use_adjlist) {
                     /* Flip the edge in the unordered edge-list, so the update later on

--- a/src/random/random.c
+++ b/src/random/random.c
@@ -547,6 +547,31 @@ static igraph_uint_t igraph_i_rng_get_uint_bounded(igraph_rng_t *rng, igraph_uin
 #endif
 }
 
+
+/**
+ * \function igraph_rng_get_bool
+ * \brief Generate a random boolean.
+ *
+ * Use this function only when a single random boolean, i.e. a single bit
+ * is needed at a time. It is not efficient for generating multiple bits.
+ *
+ * \param rng Pointer to the RNG to use for the generation. Use \ref
+ *        igraph_rng_default() here to use the default igraph RNG.
+ * \return The generated bit, as a truth value.
+ */
+
+igraph_bool_t igraph_rng_get_bool(igraph_rng_t *rng) {
+    const igraph_rng_type_t *type = rng->type;
+    const igraph_integer_t rng_bitwidth = igraph_rng_bits(rng);
+    /* Keep the highest bit as RNGs sometimes tend to have lower entropy in
+     * low bits than in high bits.
+     *
+     * Ensure that the return value is stricly 0 or 1 even if igraph_bool_t is
+     * defined to something else than a native bool.
+     */
+    return (type->get(rng->state) >> (rng_bitwidth - 1)) & (igraph_uint_t)1;
+}
+
 /**
  * \function igraph_rng_get_integer
  * \brief Generate an integer random number from an interval.

--- a/tests/unit/random_sampling.c
+++ b/tests/unit/random_sampling.c
@@ -126,6 +126,17 @@ void stats(void) {
         printf("norm: %g; expected: %g; std. dev.: %g\n", m, tm, tsd);
         IGRAPH_ASSERT(tm - tol*tsd < m && m < tm + tol*tsd);
     }
+
+    {
+        tm = 0.5; tsd = 0.5;
+        m = 0;
+        for (k = 0; k < n; k++) {
+            m += RNG_BOOL();
+        }
+        m /= n;
+        printf("binary: %g; expected: %g; std. dev.: %g\n", m, tm, tsd);
+        IGRAPH_ASSERT(tm - tol*tsd < m && m < tm + tol*tsd);
+    }
 }
 
 /* These is merely a smoke test for various random samplers.
@@ -135,6 +146,7 @@ void stats(void) {
 void sample(void) {
     igraph_integer_t i;
     igraph_real_t x;
+    igraph_bool_t b;
 
     i = RNG_INTEGER(-100, 100);
     printf("integer: %" IGRAPH_PRId "\n", i);
@@ -238,6 +250,8 @@ void sample(void) {
     IGRAPH_ASSERT(0 <= x && isfinite(x));
 #endif
 
+    b = RNG_BOOL();
+    IGRAPH_ASSERT(b == true || b == false);
 }
 
 void test_and_destroy(igraph_rng_type_t *rng_type) {


### PR DESCRIPTION
 - For symmetry: all basic types have a uniform random generator.
 - Reduce the number of low-level calls to the RNG.
 - Provide an obvious, uniform way to "flip a coin".