### PR TITLE
Performance improvements to configuration model for simple graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
  - Updated vendored BLAS to 3.12.0 and vendored ARPACK to ARPACK-NG 3.7.0.
  - Re-translated vendored BLAS/LAPACK/ARPACK sources with f2c version 20240504.
  - The performance of `igraph_transitivity_undirected()` is improved by a factor of about 2.5.
+ - The performance of `igraph_degree_sequence_game()` is improved when using `IGRAPH_DEGSEQ_CONFIGURATION_SIMPLE`.
  - Documentation improvements.
 
 ## [0.10.15]


### PR DESCRIPTION
Changes:

 - Rename degree_sequence_game implementations to use shorter, easier to read names.
 - Significant speedup for directed simple configuration model by avoiding sets altogether.
 - Moderate speedup for undirected simple configuration model by using bitsets instead of sets for smallish graphs.

Before:

```
|  1 Degseq of undirected k-regular, N=1000, k=7, CONFIGURATION_SIMPLE              0.85s  0.843s  0.006s
|  2 Degseq of undirected BA, N=1000, m=1, CONFIGURATION_SIMPLE                    0.451s  0.448s  0.003s
|  3 Degseq of undirected G(n,m), N=150, m=450, CONFIGURATION_SIMPLE               0.498s  0.493s  0.005s
|  4 Degseq of GRG, N=10000, r=0.013, CONFIGURATION_SIMPLE                         0.105s  0.103s  0.002s
|  5 Degseq of directed k-regular, N=1000, k=5, CONFIGURATION_SIMPLE               0.399s  0.396s  0.004s
|  6 Degseq of directed BA, N=500, m=2, CONFIGURATION_SIMPLE                        1.12s   1.11s   0.01s
|  7 Degseq of directed G(n,m), N=15000, m=45000, CONFIGURATION_SIMPLE              0.32s  0.318s  0.003s
```

After:

```
|  1 Degseq of undirected k-regular, N=1000, k=7, CONFIGURATION_SIMPLE             0.352s   0.35s  0.002s
|  2 Degseq of undirected BA, N=1000, m=1, CONFIGURATION_SIMPLE                    0.396s  0.393s  0.003s
|  3 Degseq of undirected G(n,m), N=150, m=450, CONFIGURATION_SIMPLE                0.22s  0.218s  0.002s
|  4 Degseq of GRG, N=10000, r=0.013, CONFIGURATION_SIMPLE                         0.111s  0.109s  0.002s
|  5 Degseq of directed k-regular, N=1000, k=5, CONFIGURATION_SIMPLE               0.124s  0.123s  0.002s
|  6 Degseq of directed BA, N=500, m=2, CONFIGURATION_SIMPLE                       0.178s  0.176s  0.002s
|  7 Degseq of directed G(n,m), N=15000, m=45000, CONFIGURATION_SIMPLE             0.078s  0.076s  0.002s
```