### PR TITLE
feat: igraph_assortativity() now supports edge weights

### DIFF
--- a/examples/simple/igraph_assortativity_nominal.c
+++ b/examples/simple/igraph_assortativity_nominal.c
@@ -27,13 +27,13 @@ int main(void) {
         /* Generate undirected graph with 1000 nodes and 50 vertex types */
         igraph_preference_game(&g, nodes, types, /* type_dist= */ NULL, /* fixed_sizes= */ 1, &pref_matrix, &node_type_vec, IGRAPH_UNDIRECTED, IGRAPH_NO_LOOPS);
 
-        igraph_assortativity_nominal(&g, &node_type_vec, &assortativity, IGRAPH_UNDIRECTED, 1);
+        igraph_assortativity_nominal(&g, NULL, &node_type_vec, &assortativity, IGRAPH_UNDIRECTED, 1);
         printf("Assortativity before rewiring = %g\n", assortativity);
 
         /* Rewire graph */
         igraph_rewire(&g, 10 * igraph_ecount(&g), IGRAPH_SIMPLE_SW);
 
-        igraph_assortativity_nominal(&g, &node_type_vec, &assortativity, IGRAPH_UNDIRECTED, 1);
+        igraph_assortativity_nominal(&g, NULL, &node_type_vec, &assortativity, IGRAPH_UNDIRECTED, 1);
         printf("Assortativity after rewiring = %g\n\n", assortativity);
 
         igraph_destroy(&g);

--- a/fuzzing/community.cpp
+++ b/fuzzing/community.cpp
@@ -99,7 +99,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
 
             igraph_modularity(&graph, &membership, NULL, 1.5, IGRAPH_UNDIRECTED, &m);
             igraph_modularity_matrix(&graph, NULL, 0.75, &mat, IGRAPH_DIRECTED);
-            igraph_assortativity_nominal(&graph, &membership, &r, IGRAPH_DIRECTED, true);
+            igraph_assortativity_nominal(&graph, NULL, &membership, &r, IGRAPH_DIRECTED, true);
 
             igraph_simplify(&graph, true, true, NULL);
             igraph_community_voronoi(&graph, &membership, &iv, &m, NULL, NULL, IGRAPH_OUT, 1.0);

--- a/include/igraph_mixing.h
+++ b/include/igraph_mixing.h
@@ -28,11 +28,11 @@
 
 IGRAPH_BEGIN_C_DECLS
 
-IGRAPH_EXPORT igraph_error_t igraph_assortativity_nominal(const igraph_t *graph,
-                                               const igraph_vector_int_t *types,
-                                               igraph_real_t *res,
-                                               igraph_bool_t directed,
-                                               igraph_bool_t normalized);
+IGRAPH_EXPORT igraph_error_t igraph_assortativity_nominal(
+        const igraph_t *graph, const igraph_vector_t *weights,
+        const igraph_vector_int_t *types,
+        igraph_real_t *res,
+        igraph_bool_t directed, igraph_bool_t normalized);
 
 IGRAPH_EXPORT igraph_error_t igraph_assortativity(const igraph_t *graph,
                                                   const igraph_vector_t *weights,

--- a/include/igraph_mixing.h
+++ b/include/igraph_mixing.h
@@ -35,11 +35,12 @@ IGRAPH_EXPORT igraph_error_t igraph_assortativity_nominal(const igraph_t *graph,
                                                igraph_bool_t normalized);
 
 IGRAPH_EXPORT igraph_error_t igraph_assortativity(const igraph_t *graph,
-                                       const igraph_vector_t *values,
-                                       const igraph_vector_t *values_in,
-                                       igraph_real_t *res,
-                                       igraph_bool_t directed,
-                                       igraph_bool_t normalized);
+                                                  const igraph_vector_t *weights,
+                                                  const igraph_vector_t *values,
+                                                  const igraph_vector_t *values_in,
+                                                  igraph_real_t *res,
+                                                  igraph_bool_t directed,
+                                                  igraph_bool_t normalized);
 
 IGRAPH_EXPORT igraph_error_t igraph_assortativity_degree(const igraph_t *graph,
                                               igraph_real_t *res,

--- a/include/igraph_mixing.h
+++ b/include/igraph_mixing.h
@@ -34,13 +34,11 @@ IGRAPH_EXPORT igraph_error_t igraph_assortativity_nominal(
         igraph_real_t *res,
         igraph_bool_t directed, igraph_bool_t normalized);
 
-IGRAPH_EXPORT igraph_error_t igraph_assortativity(const igraph_t *graph,
-                                                  const igraph_vector_t *weights,
-                                                  const igraph_vector_t *values,
-                                                  const igraph_vector_t *values_in,
-                                                  igraph_real_t *res,
-                                                  igraph_bool_t directed,
-                                                  igraph_bool_t normalized);
+IGRAPH_EXPORT igraph_error_t igraph_assortativity(
+        const igraph_t *graph, const igraph_vector_t *weights,
+        const igraph_vector_t *values, const igraph_vector_t *values_in,
+        igraph_real_t *res,
+        igraph_bool_t directed, igraph_bool_t normalized);
 
 IGRAPH_EXPORT igraph_error_t igraph_assortativity_degree(const igraph_t *graph,
                                               igraph_real_t *res,

--- a/interfaces/functions.yaml
+++ b/interfaces/functions.yaml
@@ -1021,14 +1021,18 @@ igraph_centralization_eigenvector_centrality_tmax:
 
 igraph_assortativity_nominal:
     PARAMS: |-
-        GRAPH graph, INDEX_VECTOR types, OUT REAL res,
+        GRAPH graph, OPTIONAL EDGE_WEIGHTS weights,
+        INDEX_VECTOR types,
+        OUT REAL res,
         BOOLEAN directed=True, BOOLEAN normalized=True
+    DEPS: weights ON graph, types ON graph
 
 igraph_assortativity:
     PARAMS: |-
         GRAPH graph, OPTIONAL EDGE_WEIGHTS weights,
         VECTOR values, OPTIONAL VECTOR values_in,
         OUT REAL res, BOOLEAN directed=True, BOOLEAN normalized=True
+    DEPS: weights ON graph, values ON graph, values_in ON graph
 
 igraph_assortativity_degree:
     PARAMS: GRAPH graph, OUT REAL res, BOOLEAN directed=True

--- a/interfaces/functions.yaml
+++ b/interfaces/functions.yaml
@@ -1026,7 +1026,8 @@ igraph_assortativity_nominal:
 
 igraph_assortativity:
     PARAMS: |-
-        GRAPH graph, VECTOR values, OPTIONAL VECTOR values_in,
+        GRAPH graph, OPTIONAL EDGE_WEIGHTS weights,
+        VECTOR values, OPTIONAL VECTOR values_in,
         OUT REAL res, BOOLEAN directed=True, BOOLEAN normalized=True
 
 igraph_assortativity_degree:

--- a/src/misc/mixing.c
+++ b/src/misc/mixing.c
@@ -270,13 +270,11 @@ igraph_error_t igraph_assortativity_nominal(
  * based on vertex degrees.
  */
 
-igraph_error_t igraph_assortativity(const igraph_t *graph,
-                         const igraph_vector_t *weights,
-                         const igraph_vector_t *values,
-                         const igraph_vector_t *values_in,
-                         igraph_real_t *res,
-                         igraph_bool_t directed,
-                         igraph_bool_t normalized) {
+igraph_error_t igraph_assortativity(
+        const igraph_t *graph, const igraph_vector_t *weights,
+        const igraph_vector_t *values, const igraph_vector_t *values_in,
+        igraph_real_t *res,
+        igraph_bool_t directed, igraph_bool_t normalized) {
 
     const igraph_integer_t no_of_nodes = igraph_vcount(graph);
     const igraph_integer_t no_of_edges = igraph_ecount(graph);

--- a/src/misc/mixing.c
+++ b/src/misc/mixing.c
@@ -72,6 +72,8 @@
  * https://doi.org/10.1093/acprof%3Aoso/9780199206650.001.0001.
  *
  * \param graph The input graph, it can be directed or undirected.
+ * \param weights Weighted nominal assortativity is not currently implemented.
+ *    Pass \c NULL to ignore.
  * \param types Integer vector giving the vertex categories. The types
  *    are represented by integers starting at zero.
  * \param res Pointer to a real variable, the result is stored here.
@@ -94,11 +96,11 @@
  * \example examples/simple/igraph_assortativity_nominal.c
  */
 
-igraph_error_t igraph_assortativity_nominal(const igraph_t *graph,
-                                            const igraph_vector_int_t *types,
-                                            igraph_real_t *res,
-                                            igraph_bool_t directed,
-                                            igraph_bool_t normalized) {
+igraph_error_t igraph_assortativity_nominal(
+        const igraph_t *graph, const igraph_vector_t *weights,
+        const igraph_vector_int_t *types,
+        igraph_real_t *res,
+        igraph_bool_t directed, igraph_bool_t normalized) {
 
     igraph_integer_t no_of_nodes = igraph_vcount(graph);
     igraph_integer_t no_of_edges = igraph_ecount(graph);
@@ -106,6 +108,11 @@ igraph_error_t igraph_assortativity_nominal(const igraph_t *graph,
     igraph_integer_t no_of_types;
     igraph_vector_int_t ai, bi, eii;
     igraph_real_t sumaibi = 0.0, sumeii = 0.0;
+
+    if (weights) {
+        IGRAPH_ERROR("Weighted nominal assortativity is not yet implemented.",
+                     IGRAPH_UNIMPLEMENTED);
+    }
 
     if (igraph_vector_int_size(types) != no_of_nodes) {
         IGRAPH_ERROR("Invalid types vector length.", IGRAPH_EINVAL);

--- a/src/misc/mixing.c
+++ b/src/misc/mixing.c
@@ -102,7 +102,7 @@ igraph_error_t igraph_assortativity_nominal(const igraph_t *graph,
 
     igraph_integer_t no_of_nodes = igraph_vcount(graph);
     igraph_integer_t no_of_edges = igraph_ecount(graph);
-    igraph_real_t no_of_edges_real = no_of_edges;   /* for divisions */
+    igraph_real_t no_of_edges_real = (igraph_real_t) no_of_edges;   /* for divisions */
     igraph_integer_t no_of_types;
     igraph_vector_int_t ai, bi, eii;
     igraph_real_t sumaibi = 0.0, sumeii = 0.0;

--- a/tests/unit/assortativity.c
+++ b/tests/unit/assortativity.c
@@ -36,14 +36,14 @@ void assortativity_unnormalized(const igraph_t *graph, igraph_real_t *res, igrap
         igraph_vector_init(&indeg, 0);
         igraph_strength(graph, &outdeg, igraph_vss_all(), IGRAPH_OUT, IGRAPH_LOOPS, NULL);
         igraph_strength(graph, &indeg, igraph_vss_all(), IGRAPH_IN, IGRAPH_LOOPS, NULL);
-        igraph_assortativity(graph, &outdeg, &indeg, res, directed, 0);
+        igraph_assortativity(graph, NULL, &outdeg, &indeg, res, directed, false);
         igraph_vector_destroy(&outdeg);
         igraph_vector_destroy(&indeg);
     } else {
         igraph_vector_t deg;
         igraph_vector_init(&deg, 0);
         igraph_strength(graph, &deg, igraph_vss_all(), IGRAPH_ALL, IGRAPH_LOOPS, NULL);
-        igraph_assortativity(graph, &deg, NULL, res, directed, 0);
+        igraph_assortativity(graph, NULL, &deg, NULL, res, directed, false);
         igraph_vector_destroy(&deg);
     }
 }
@@ -62,11 +62,11 @@ int main(void) {
     igraph_vector_init(&values, 0);
 
     igraph_empty(&g, 0, IGRAPH_UNDIRECTED);
-    igraph_assortativity_nominal(&g, &types, &assort, IGRAPH_UNDIRECTED, /* normalized */ 1);
+    igraph_assortativity_nominal(&g, &types, &assort, IGRAPH_UNDIRECTED, /* normalized */ true);
     printf("Null graph nominal assortativity: ");
     igraph_real_printf(assort);
     printf("\n");
-    igraph_assortativity(&g, &values, NULL, &assort, IGRAPH_UNDIRECTED, /* normalized */ 1);
+    igraph_assortativity(&g, NULL, &values, NULL, &assort, IGRAPH_UNDIRECTED, /* normalized */ true);
     printf("Null graph value assortativity: ");
     igraph_real_printf(assort);
     printf("\n");
@@ -80,37 +80,37 @@ int main(void) {
     igraph_vector_resize(&values, 1);
     VECTOR(values)[0] = 0;
 
-    igraph_assortativity_nominal(&g, &types, &assort, IGRAPH_UNDIRECTED, /* normalized */ 1);
+    igraph_assortativity_nominal(&g, &types, &assort, IGRAPH_UNDIRECTED, /* normalized */ true);
     printf("Singleton graph nominal assortativity: ");
     igraph_real_printf(assort);
     printf("\n");
-    igraph_assortativity_nominal(&g, &types, &assort, IGRAPH_UNDIRECTED, /* normalized */ 0);
+    igraph_assortativity_nominal(&g, &types, &assort, IGRAPH_UNDIRECTED, /* normalized */ false);
     printf("Singleton graph nominal assortativity, unnormalized: ");
     igraph_real_printf(assort);
     printf("\n");
-    igraph_assortativity(&g, &values, NULL, &assort, IGRAPH_UNDIRECTED, /* normalized */ 1);
+    igraph_assortativity(&g, NULL, &values, NULL, &assort, IGRAPH_UNDIRECTED, /* normalized */ true);
     printf("Singleton graph value assortativity: ");
     igraph_real_printf(assort);
     printf("\n");
-    igraph_assortativity(&g, &values, NULL, &assort, IGRAPH_UNDIRECTED, /* normalized */ 0);
+    igraph_assortativity(&g, NULL, &values, NULL, &assort, IGRAPH_UNDIRECTED, /* normalized */ false);
     printf("Singleton graph value assortativity, unnormalized: ");
     igraph_real_printf(assort);
     printf("\n");
 
     igraph_add_edge(&g, 0, 0);
-    igraph_assortativity_nominal(&g, &types, &assort, IGRAPH_UNDIRECTED, /* normalized */ 1);
+    igraph_assortativity_nominal(&g, &types, &assort, IGRAPH_UNDIRECTED, /* normalized */ true);
     printf("Singleton graph with loop, nominal assortativity: ");
     igraph_real_printf(assort);
     printf("\n");
-    igraph_assortativity_nominal(&g, &types, &assort, IGRAPH_UNDIRECTED, /* normalized */ 0);
+    igraph_assortativity_nominal(&g, &types, &assort, IGRAPH_UNDIRECTED, /* normalized */ false);
     printf("Singleton graph with loop, nominal assortativity, unnormalized: ");
     igraph_real_printf(assort);
     printf("\n");
-    igraph_assortativity(&g, &values, NULL, &assort, IGRAPH_UNDIRECTED, /* normalized */ 1);
+    igraph_assortativity(&g, NULL, &values, NULL, &assort, IGRAPH_UNDIRECTED, /* normalized */ true);
     printf("Singleton graph with loop, value assortativity: ");
     igraph_real_printf(assort);
     printf("\n");
-    igraph_assortativity(&g, &values, NULL, &assort, IGRAPH_UNDIRECTED, /* normalized */ 0);
+    igraph_assortativity(&g, NULL, &values, NULL, &assort, IGRAPH_UNDIRECTED, /* normalized */ false);
     printf("Singleton graph with loop, value assortativity, unnormalized: ");
     igraph_real_printf(assort);
     printf("\n");
@@ -124,14 +124,14 @@ int main(void) {
 
     igraph_degree(&g, &types, igraph_vss_all(), IGRAPH_ALL, IGRAPH_LOOPS);
 
-    igraph_assortativity_nominal(&g, &types, &assort, IGRAPH_UNDIRECTED, /* normalized */ 1);
+    igraph_assortativity_nominal(&g, &types, &assort, IGRAPH_UNDIRECTED, /* normalized */ true);
     printf("Karate club, normalized assortativity based on degree categories: %g\n", assort);
 
-    igraph_assortativity_nominal(&g, &types, &assort_unnorm, IGRAPH_UNDIRECTED, /* normalized */ 0);
+    igraph_assortativity_nominal(&g, &types, &assort_unnorm, IGRAPH_UNDIRECTED, /* normalized */ false);
     printf("Karate club, non-normalized assortativity based on degree categories: %g\n", assort_unnorm);
 
     /* unnormalized assortativity based on categories is the same as modularity */
-    igraph_modularity(&g, &types, NULL, 1, 0, &modularity);
+    igraph_modularity(&g, &types, NULL, 1, IGRAPH_UNDIRECTED, &modularity);
     IGRAPH_ASSERT(igraph_almost_equals(assort_unnorm, modularity, 1e-15));
 
     igraph_destroy(&g);
@@ -144,22 +144,22 @@ int main(void) {
 
     igraph_vector_init_range(&values, 0, igraph_vcount(&g));
 
-    igraph_assortativity(&g, &values, 0, &assort, IGRAPH_UNDIRECTED, /*normalized=*/ 1);
+    igraph_assortativity(&g, NULL, &values, NULL, &assort, IGRAPH_UNDIRECTED, /* normalized */ true);
     printf("Assortativity based on values: %g\n", assort);
 
     /* Assortativity is a Pearson correlation, thus it must be invariant to
      * a constant shift in the values. */
     igraph_vector_add_constant(&values, -5);
-    igraph_assortativity(&g, &values, 0, &assort2, IGRAPH_UNDIRECTED, /*normalized=*/ 1);
+    igraph_assortativity(&g, NULL, &values, NULL, &assort2, IGRAPH_UNDIRECTED, /* normalized */ true);
     IGRAPH_ASSERT(igraph_almost_equals(assort, assort2, 1e-15));
 
-    igraph_assortativity(&g, &values, 0, &assort, IGRAPH_UNDIRECTED, /*normalized=*/ 0);
+    igraph_assortativity(&g, NULL, &values, NULL, &assort, IGRAPH_UNDIRECTED, /* normalized */ false);
     printf("Assortativity based on values, unnormalized: %g\n", assort);
 
     /* Assortativity is a Pearson correlation, thus it must be invariant to
      * a constant shift in the values. */
     igraph_vector_add_constant(&values, -5);
-    igraph_assortativity(&g, &values, 0, &assort2, IGRAPH_UNDIRECTED, /*normalized=*/ 0);
+    igraph_assortativity(&g, NULL, &values, NULL, &assort2, IGRAPH_UNDIRECTED, /* normalized */ false);
     IGRAPH_ASSERT(igraph_almost_equals(assort, assort2, 1e-15));
 
     igraph_vector_destroy(&values);

--- a/tests/unit/assortativity.c
+++ b/tests/unit/assortativity.c
@@ -58,7 +58,7 @@ int main(void) {
     igraph_vector_init(&values, 0);
 
     igraph_empty(&g, 0, IGRAPH_UNDIRECTED);
-    igraph_assortativity_nominal(&g, &types, &assort, IGRAPH_UNDIRECTED, /* normalized */ true);
+    igraph_assortativity_nominal(&g, NULL, &types, &assort, IGRAPH_UNDIRECTED, /* normalized */ true);
     printf("Null graph nominal assortativity: ");
     igraph_real_printf(assort);
     printf("\n");
@@ -76,11 +76,11 @@ int main(void) {
     igraph_vector_resize(&values, 1);
     VECTOR(values)[0] = 0;
 
-    igraph_assortativity_nominal(&g, &types, &assort, IGRAPH_UNDIRECTED, /* normalized */ true);
+    igraph_assortativity_nominal(&g, NULL, &types, &assort, IGRAPH_UNDIRECTED, /* normalized */ true);
     printf("Singleton graph nominal assortativity: ");
     igraph_real_printf(assort);
     printf("\n");
-    igraph_assortativity_nominal(&g, &types, &assort, IGRAPH_UNDIRECTED, /* normalized */ false);
+    igraph_assortativity_nominal(&g, NULL, &types, &assort, IGRAPH_UNDIRECTED, /* normalized */ false);
     printf("Singleton graph nominal assortativity, unnormalized: ");
     igraph_real_printf(assort);
     printf("\n");
@@ -94,11 +94,11 @@ int main(void) {
     printf("\n");
 
     igraph_add_edge(&g, 0, 0);
-    igraph_assortativity_nominal(&g, &types, &assort, IGRAPH_UNDIRECTED, /* normalized */ true);
+    igraph_assortativity_nominal(&g, NULL, &types, &assort, IGRAPH_UNDIRECTED, /* normalized */ true);
     printf("Singleton graph with loop, nominal assortativity: ");
     igraph_real_printf(assort);
     printf("\n");
-    igraph_assortativity_nominal(&g, &types, &assort, IGRAPH_UNDIRECTED, /* normalized */ false);
+    igraph_assortativity_nominal(&g, NULL, &types, &assort, IGRAPH_UNDIRECTED, /* normalized */ false);
     printf("Singleton graph with loop, nominal assortativity, unnormalized: ");
     igraph_real_printf(assort);
     printf("\n");
@@ -120,10 +120,10 @@ int main(void) {
 
     igraph_degree(&g, &types, igraph_vss_all(), IGRAPH_ALL, IGRAPH_LOOPS);
 
-    igraph_assortativity_nominal(&g, &types, &assort, IGRAPH_UNDIRECTED, /* normalized */ true);
+    igraph_assortativity_nominal(&g, NULL, &types, &assort, IGRAPH_UNDIRECTED, /* normalized */ true);
     printf("Karate club, normalized assortativity based on degree categories: %g\n", assort);
 
-    igraph_assortativity_nominal(&g, &types, &assort_unnorm, IGRAPH_UNDIRECTED, /* normalized */ false);
+    igraph_assortativity_nominal(&g, NULL, &types, &assort_unnorm, IGRAPH_UNDIRECTED, /* normalized */ false);
     printf("Karate club, non-normalized assortativity based on degree categories: %g\n", assort_unnorm);
 
     /* unnormalized assortativity based on categories is the same as modularity */
@@ -346,7 +346,7 @@ int main(void) {
                  -1);
     igraph_simplify(&g, /*remove_multiple=*/ true, /*remove_loops=*/ true, /*edge_comb=*/ NULL);
     igraph_vector_int_view(&types, football_types, sizeof(football_types) / sizeof(football_types[0]));
-    igraph_assortativity_nominal(&g, &types, &assort, IGRAPH_UNDIRECTED, /*normalized=*/ true);
+    igraph_assortativity_nominal(&g, NULL, &types, &assort, IGRAPH_UNDIRECTED, /*normalized=*/ true);
     printf("%g\n", assort);
 
     igraph_destroy(&g);

--- a/tests/unit/assortativity.c
+++ b/tests/unit/assortativity.c
@@ -1,7 +1,6 @@
 /*
    IGraph library.
-   Copyright (C) 2009-2012  Gabor Csardi <csardi.gabor@gmail.com>
-   334 Harvard street, Cambridge, MA 02139 USA
+   Copyright (C) 2009-2025  The igraph development team <igraph@igraph.org>
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -13,11 +12,8 @@
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
    GNU General Public License for more details.
 
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
-   02110-1301 USA
-
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 #include <igraph.h>

--- a/tests/unit/igraph_joint_degree_distribution.c
+++ b/tests/unit/igraph_joint_degree_distribution.c
@@ -108,7 +108,8 @@ void check_jdm(const igraph_t *g, const igraph_vector_t *weights) {
     igraph_matrix_destroy(&jdm);
 }
 
-void check_assort_i(const igraph_t *g, igraph_neimode_t from_mode, igraph_neimode_t to_mode) {
+void check_assort_i(const igraph_t *g, const igraph_vector_t *weights,
+                    igraph_neimode_t from_mode, igraph_neimode_t to_mode) {
     igraph_matrix_t p;
     igraph_real_t r1, r2;
     igraph_integer_t nrow, ncol;
@@ -125,12 +126,12 @@ void check_assort_i(const igraph_t *g, igraph_neimode_t from_mode, igraph_neimod
     igraph_strength(g, &dto, igraph_vss_all(), to_mode, IGRAPH_LOOPS, NULL);
 
     igraph_matrix_init(&p, 0, 0);
-    igraph_joint_degree_distribution(g, NULL, &p, from_mode, to_mode, true, /*normalized*/ true, -1, -1);
+    igraph_joint_degree_distribution(g, weights, &p, from_mode, to_mode, true, /*normalized*/ true, -1, -1);
 
     nrow = igraph_matrix_nrow(&p);
     ncol = igraph_matrix_ncol(&p);
 
-    igraph_assortativity(g, &dfrom, directed ? &dto : NULL, &r1, IGRAPH_DIRECTED, /*normalized*/ false);
+    igraph_assortativity(g, weights, &dfrom, directed ? &dto : NULL, &r1, IGRAPH_DIRECTED, /*normalized*/ false);
 
     igraph_matrix_rowsum(&p, &a);
     igraph_matrix_colsum(&p, &b);
@@ -153,18 +154,18 @@ void check_assort_i(const igraph_t *g, igraph_neimode_t from_mode, igraph_neimod
 }
 
 /* Compare to igraph_assortativity() */
-void check_assort(const igraph_t *g) {
+void check_assort(const igraph_t *g, const igraph_vector_t *weights) {
     if (igraph_is_directed(g)) {
-        check_assort_i(g, IGRAPH_OUT, IGRAPH_IN);
-        check_assort_i(g, IGRAPH_IN, IGRAPH_OUT);
-        check_assort_i(g, IGRAPH_OUT, IGRAPH_OUT);
-        check_assort_i(g, IGRAPH_IN, IGRAPH_IN);
-        check_assort_i(g, IGRAPH_ALL, IGRAPH_IN);
-        check_assort_i(g, IGRAPH_ALL, IGRAPH_OUT);
-        check_assort_i(g, IGRAPH_OUT, IGRAPH_ALL);
-        check_assort_i(g, IGRAPH_IN, IGRAPH_ALL);
+        check_assort_i(g, weights, IGRAPH_OUT, IGRAPH_IN);
+        check_assort_i(g, weights, IGRAPH_IN, IGRAPH_OUT);
+        check_assort_i(g, weights, IGRAPH_OUT, IGRAPH_OUT);
+        check_assort_i(g, weights, IGRAPH_IN, IGRAPH_IN);
+        check_assort_i(g, weights, IGRAPH_ALL, IGRAPH_IN);
+        check_assort_i(g, weights, IGRAPH_ALL, IGRAPH_OUT);
+        check_assort_i(g, weights, IGRAPH_OUT, IGRAPH_ALL);
+        check_assort_i(g, weights, IGRAPH_IN, IGRAPH_ALL);
     } else {
-        check_assort_i(g, IGRAPH_ALL, IGRAPH_ALL);
+        check_assort_i(g, weights, IGRAPH_ALL, IGRAPH_ALL);
     }
 }
 
@@ -248,17 +249,18 @@ int main(void) {
 
     igraph_small(&dg, 2, IGRAPH_DIRECTED, 0,0, 0,1, 0,1, 1,0, -1);
     check_jdm(&dg, NULL);
-    check_assort(&dg);
+    check_assort(&dg, NULL);
     check_knnk(&dg, NULL);
     igraph_destroy(&dg);
 
     igraph_erdos_renyi_game_gnm(&dg, 10, 30, IGRAPH_DIRECTED, /*loops*/ true, /* multiple */ false);
     check_jdm(&dg, NULL);
-    check_assort(&dg);
+    check_assort(&dg, NULL);
     check_knnk(&dg, NULL);
 
     igraph_vector_init_range(&weights, 0, igraph_ecount(&dg));
     check_jdm(&dg, &weights);
+    check_assort(&dg, &weights);
     check_knnk(&dg, &weights);
     igraph_vector_destroy(&weights);
 
@@ -282,17 +284,18 @@ int main(void) {
 
     igraph_small(&ug, 2, IGRAPH_UNDIRECTED, 0,1, 0,1, 1,1, -1);
     check_jdm(&ug, NULL);
-    check_assort(&ug);
+    check_assort(&ug, NULL);
     check_knnk(&ug, NULL);
     igraph_destroy(&ug);
 
     igraph_erdos_renyi_game_gnm(&ug, 10, 30, IGRAPH_UNDIRECTED, /*loops*/ true, /* multiple */ false);
     check_jdm(&ug, NULL);
-    check_assort(&ug);
+    check_assort(&ug, NULL);
     check_knnk(&ug, NULL);
 
     igraph_vector_init_range(&weights, 0, igraph_ecount(&ug));
     check_jdm(&ug, &weights);
+    check_assort(&ug, &weights);
     check_knnk(&ug, &weights);
     igraph_vector_destroy(&weights);
 

--- a/tests/unit/igraph_joint_type_distribution.c
+++ b/tests/unit/igraph_joint_type_distribution.c
@@ -53,7 +53,7 @@ void check_assort(const igraph_t *g, const igraph_vector_t *weights, const igrap
 
     if (! weights) {
         q1 /= 1 - c2;
-        igraph_assortativity_nominal(g, types, &q2, /*directed*/ true, /*normalized*/ true);
+        igraph_assortativity_nominal(g, NULL, types, &q2, /*directed*/ true, /*normalized*/ true);
         // printf("Normalized nominal assortativity: %g == %g\n", q1, q2);
         IGRAPH_ASSERT(igraph_almost_equals(q1, q2, 1e-14));
     }


### PR DESCRIPTION
Still a WIP. Adds weight support to assortativity functions. Weights are effectively treated as edge multiplicities.

 - [x] `assortativity()`
 - [ ] `assortativity_nominal()`
 - [ ] exhaustive tests

Closes #2428