### PR TITLE
fix: do not define GCC_VERSION_MAJOR macro in public header

### DIFF
--- a/include/igraph_error.h
+++ b/include/igraph_error.h
@@ -674,13 +674,9 @@ IGRAPH_EXPORT int IGRAPH_FINALLY_STACK_SIZE(void);
         IGRAPH_FINALLY_REAL((igraph_finally_func_t*)(func), (ptr)); \
     } while (0)
 
-#if !defined(GCC_VERSION_MAJOR) && defined(__GNUC__)
-    #define GCC_VERSION_MAJOR  __GNUC__
-#endif
-
-#if defined(GCC_VERSION_MAJOR) && (GCC_VERSION_MAJOR >= 3)
-    #define IGRAPH_UNLIKELY(a) __builtin_expect((a), 0)
-    #define IGRAPH_LIKELY(a)   __builtin_expect((a), 1)
+#if defined(__GNUC__)
+    #define IGRAPH_UNLIKELY(a) __builtin_expect(!!(a), 0)
+    #define IGRAPH_LIKELY(a)   __builtin_expect(!!(a), 1)
 #else
     #define IGRAPH_UNLIKELY(a) a
     #define IGRAPH_LIKELY(a)   a


### PR DESCRIPTION
It is not nice that igraph defines a macro like `GCC_VERSION_MAJOR` in its public headers.

We do not support GCC 3 anyway, so there's no reason for this check.

I'm also adding a double negation to properly handle all non-zero values (not just 1) as "true".