### PR TITLE
fix: prevent errors in SIR simulation when infection probability becomes slightly negative due to numerical roundoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [master]
 
+### Fixed
+
+ - Fix failure in SIR simulation due to roundoff errors creating slightly negative rates.
+
 ## [0.10.16] - 2025-06-10
 
 ### Added

--- a/src/misc/sir.c
+++ b/src/misc/sir.c
@@ -233,8 +233,9 @@ igraph_error_t igraph_sir(const igraph_t *graph, igraph_real_t beta,
                     if (VECTOR(status)[nei] == S_S) {
                         igraph_real_t rate = igraph_psumtree_get(&tree, nei);
                         rate -= beta;
-                        /* Because of roundoff error, it may happen that the rate
-                         * becomes slightly negative. We clip to zero in this case.
+                        /* Because of roundoff errors, it may happen that the rate
+                         * becomes slightly negative, which would cause psumtree_update()
+                         * to fail. We clip negative values to zero to avoid this.
                          * See https://github.com/igraph/igraph/issues/2779 */
                         if (rate < 0) rate = 0;
                         IGRAPH_CHECK(igraph_psumtree_update(&tree, nei, rate));


### PR DESCRIPTION
Fixes #2779

It seems to me that the values stored in the psumtree are mostly multiples of beta, but I'd like another pair of eyes on this @ntamas  