### PR TITLE
Minor cleanups

### DIFF
--- a/include/igraph_centrality.h
+++ b/include/igraph_centrality.h
@@ -35,30 +35,30 @@ __BEGIN_DECLS
 
 IGRAPH_EXPORT igraph_error_t igraph_closeness(const igraph_t *graph, igraph_vector_t *res,
                                    igraph_vector_int_t *reachable_count, igraph_bool_t *all_reachable,
-                                   const igraph_vs_t vids, igraph_neimode_t mode,
+                                   igraph_vs_t vids, igraph_neimode_t mode,
                                    const igraph_vector_t *weights, igraph_bool_t normalized);
 IGRAPH_EXPORT igraph_error_t igraph_closeness_cutoff(const igraph_t *graph, igraph_vector_t *res,
                                           igraph_vector_int_t *reachable_count, igraph_bool_t *all_reachable,
-                                          const igraph_vs_t vids, igraph_neimode_t mode,
+                                          igraph_vs_t vids, igraph_neimode_t mode,
                                           const igraph_vector_t *weights,
                                           igraph_bool_t normalized,
                                           igraph_real_t cutoff);
 
 IGRAPH_EXPORT igraph_error_t igraph_harmonic_centrality(const igraph_t *graph, igraph_vector_t *res,
-                                             const igraph_vs_t vids, igraph_neimode_t mode,
+                                             igraph_vs_t vids, igraph_neimode_t mode,
                                              const igraph_vector_t *weights,
                                              igraph_bool_t normalized);
 IGRAPH_EXPORT igraph_error_t igraph_harmonic_centrality_cutoff(const igraph_t *graph, igraph_vector_t *res,
-                                                    const igraph_vs_t vids, igraph_neimode_t mode,
+                                                    igraph_vs_t vids, igraph_neimode_t mode,
                                                     const igraph_vector_t *weights,
                                                     igraph_bool_t normalized,
                                                     igraph_real_t cutoff);
 
 IGRAPH_EXPORT igraph_error_t igraph_betweenness(const igraph_t *graph, igraph_vector_t *res,
-                                     const igraph_vs_t vids, igraph_bool_t directed,
+                                     igraph_vs_t vids, igraph_bool_t directed,
                                      const igraph_vector_t *weights);
 IGRAPH_EXPORT igraph_error_t igraph_betweenness_cutoff(const igraph_t *graph, igraph_vector_t *res,
-                                            const igraph_vs_t vids, igraph_bool_t directed,
+                                            igraph_vs_t vids, igraph_bool_t directed,
                                             const igraph_vector_t *weights, igraph_real_t cutoff);
 IGRAPH_EXPORT igraph_error_t igraph_edge_betweenness(const igraph_t *graph, igraph_vector_t *result,
                                           igraph_bool_t directed,
@@ -67,12 +67,12 @@ IGRAPH_EXPORT igraph_error_t igraph_edge_betweenness_cutoff(const igraph_t *grap
                                                  igraph_bool_t directed,
                                                  const igraph_vector_t *weights, igraph_real_t cutoff);
 IGRAPH_EXPORT igraph_error_t igraph_betweenness_subset(const igraph_t *graph, igraph_vector_t *res,
-                                            const igraph_vs_t vids, igraph_bool_t directed,
-                                            const igraph_vs_t sources, const igraph_vs_t targets,
+                                            igraph_vs_t vids, igraph_bool_t directed,
+                                            igraph_vs_t sources, igraph_vs_t targets,
                                             const igraph_vector_t *weights);
 IGRAPH_EXPORT igraph_error_t igraph_edge_betweenness_subset(const igraph_t *graph, igraph_vector_t *res,
-                                            const igraph_es_t eids, igraph_bool_t directed,
-                                            const igraph_vs_t sources, const igraph_vs_t targets,
+                                            igraph_es_t eids, igraph_bool_t directed,
+                                            igraph_vs_t sources, igraph_vs_t targets,
                                             const igraph_vector_t *weights);
 
 /**
@@ -94,19 +94,19 @@ typedef enum {
 
 IGRAPH_EXPORT igraph_error_t igraph_pagerank(const igraph_t *graph, igraph_pagerank_algo_t algo,
                                   igraph_vector_t *vector,
-                                  igraph_real_t *value, const igraph_vs_t vids,
+                                  igraph_real_t *value, igraph_vs_t vids,
                                   igraph_bool_t directed, igraph_real_t damping,
                                   const igraph_vector_t *weights, igraph_arpack_options_t *options);
 IGRAPH_EXPORT igraph_error_t igraph_personalized_pagerank(const igraph_t *graph,
                                                igraph_pagerank_algo_t algo, igraph_vector_t *vector,
-                                               igraph_real_t *value, const igraph_vs_t vids,
+                                               igraph_real_t *value, igraph_vs_t vids,
                                                igraph_bool_t directed, igraph_real_t damping,
                                                const igraph_vector_t *reset,
                                                const igraph_vector_t *weights, igraph_arpack_options_t *options);
 IGRAPH_EXPORT igraph_error_t igraph_personalized_pagerank_vs(const igraph_t *graph,
                                                   igraph_pagerank_algo_t algo,
                                                   igraph_vector_t *vector,
-                                                  igraph_real_t *value, const igraph_vs_t vids,
+                                                  igraph_real_t *value, igraph_vs_t vids,
                                                   igraph_bool_t directed, igraph_real_t damping,
                                                   igraph_vs_t reset_vids,
                                                   const igraph_vector_t *weights, igraph_arpack_options_t *options);

--- a/include/igraph_cocitation.h
+++ b/include/igraph_cocitation.h
@@ -33,28 +33,28 @@ __BEGIN_DECLS
 /* -------------------------------------------------- */
 
 IGRAPH_EXPORT igraph_error_t igraph_cocitation(const igraph_t *graph, igraph_matrix_t *res,
-                                    const igraph_vs_t vids);
+                                    igraph_vs_t vids);
 IGRAPH_EXPORT igraph_error_t igraph_bibcoupling(const igraph_t *graph, igraph_matrix_t *res,
-                                     const igraph_vs_t vids);
+                                     igraph_vs_t vids);
 
 IGRAPH_EXPORT igraph_error_t igraph_similarity_jaccard(const igraph_t *graph, igraph_matrix_t *res,
-                                            const igraph_vs_t vit_from, const igraph_vs_t vit_to,
+                                            igraph_vs_t vit_from, igraph_vs_t vit_to,
                                             igraph_neimode_t mode, igraph_bool_t loops);
 IGRAPH_EXPORT igraph_error_t igraph_similarity_jaccard_pairs(const igraph_t *graph, igraph_vector_t *res,
                                                   const igraph_vector_int_t *pairs, igraph_neimode_t mode, igraph_bool_t loops);
 IGRAPH_EXPORT igraph_error_t igraph_similarity_jaccard_es(const igraph_t *graph, igraph_vector_t *res,
-                                               const igraph_es_t es, igraph_neimode_t mode, igraph_bool_t loops);
+                                               igraph_es_t es, igraph_neimode_t mode, igraph_bool_t loops);
 
 IGRAPH_EXPORT igraph_error_t igraph_similarity_dice(const igraph_t *graph, igraph_matrix_t *res,
-                                         const igraph_vs_t vit_from, const igraph_vs_t vit_to,
+                                         igraph_vs_t vit_from, igraph_vs_t vit_to,
                                          igraph_neimode_t mode, igraph_bool_t loops);
 IGRAPH_EXPORT igraph_error_t igraph_similarity_dice_pairs(const igraph_t *graph, igraph_vector_t *res,
                                                const igraph_vector_int_t *pairs, igraph_neimode_t mode, igraph_bool_t loops);
 IGRAPH_EXPORT igraph_error_t igraph_similarity_dice_es(const igraph_t *graph, igraph_vector_t *res,
-                                            const igraph_es_t es, igraph_neimode_t mode, igraph_bool_t loops);
+                                            igraph_es_t es, igraph_neimode_t mode, igraph_bool_t loops);
 
 IGRAPH_EXPORT igraph_error_t igraph_similarity_inverse_log_weighted(const igraph_t *graph,
-                                                         igraph_matrix_t *res, const igraph_vs_t vids,
+                                                         igraph_matrix_t *res, igraph_vs_t vids,
                                                          igraph_neimode_t mode);
 
 __END_DECLS

--- a/include/igraph_community.h
+++ b/include/igraph_community.h
@@ -49,7 +49,7 @@ IGRAPH_EXPORT igraph_error_t igraph_trussness(
 
 IGRAPH_EXPORT igraph_error_t igraph_community_optimal_modularity(const igraph_t *graph,
                                                                  const igraph_vector_t *weights,
-                                                                 const igraph_real_t resolution,
+                                                                 igraph_real_t resolution,
                                                                  igraph_real_t *modularity,
                                                                  igraph_vector_int_t *membership);
 
@@ -106,7 +106,7 @@ IGRAPH_EXPORT igraph_error_t igraph_community_edge_betweenness(const igraph_t *g
                                                     const igraph_vector_t *weights,
                                                     const igraph_vector_t *lengths);
 IGRAPH_EXPORT igraph_error_t igraph_community_eb_get_merges(const igraph_t *graph,
-                                                 const igraph_bool_t directed,
+                                                 igraph_bool_t directed,
                                                  const igraph_vector_int_t *edges,
                                                  const igraph_vector_t *weights,
                                                  igraph_matrix_int_t *merges,
@@ -139,13 +139,13 @@ IGRAPH_EXPORT igraph_error_t igraph_community_voronoi(
 IGRAPH_EXPORT igraph_error_t igraph_modularity(const igraph_t *graph,
                                     const igraph_vector_int_t *membership,
                                     const igraph_vector_t *weights,
-                                    const igraph_real_t resolution,
-                                    const igraph_bool_t directed,
+                                    igraph_real_t resolution,
+                                    igraph_bool_t directed,
                                     igraph_real_t *modularity);
 
 IGRAPH_EXPORT igraph_error_t igraph_modularity_matrix(const igraph_t *graph,
                                            const igraph_vector_t *weights,
-                                           const igraph_real_t resolution,
+                                           igraph_real_t resolution,
                                            igraph_matrix_t *modmat,
                                            igraph_bool_t directed);
 
@@ -225,7 +225,7 @@ IGRAPH_EXPORT igraph_error_t igraph_community_label_propagation(const igraph_t *
 
 IGRAPH_EXPORT igraph_error_t igraph_community_multilevel(const igraph_t *graph,
                                               const igraph_vector_t *weights,
-                                              const igraph_real_t resolution,
+                                              igraph_real_t resolution,
                                               igraph_vector_int_t *membership,
                                               igraph_matrix_int_t *memberships,
                                               igraph_vector_t *modularity);
@@ -233,10 +233,10 @@ IGRAPH_EXPORT igraph_error_t igraph_community_multilevel(const igraph_t *graph,
 IGRAPH_EXPORT igraph_error_t igraph_community_leiden(const igraph_t *graph,
                                           const igraph_vector_t *edge_weights,
                                           const igraph_vector_t *node_weights,
-                                          const igraph_real_t resolution_parameter,
-                                          const igraph_real_t beta,
-                                          const igraph_bool_t start,
-                                          const igraph_integer_t n_iterations,
+                                          igraph_real_t resolution_parameter,
+                                          igraph_real_t beta,
+                                          igraph_bool_t start,
+                                          igraph_integer_t n_iterations,
                                           igraph_vector_int_t *membership,
                                           igraph_integer_t *nb_clusters,
                                           igraph_real_t *quality);

--- a/include/igraph_constants.h
+++ b/include/igraph_constants.h
@@ -39,8 +39,6 @@ typedef enum { IGRAPH_NO_LOOPS = 0, IGRAPH_LOOPS = 1, IGRAPH_LOOPS_TWICE = 1, IG
 
 typedef enum { IGRAPH_ASCENDING = 0, IGRAPH_DESCENDING = 1 } igraph_order_t;
 
-typedef enum { IGRAPH_MINIMUM = 0, IGRAPH_MAXIMUM = 1 } igraph_optimal_t;
-
 /* Do not renumber the following values! Some internal code treats them as bitmasks
  * and assumes that IGRAPH_ALL == IGRAPH_IN | IGRAPH_OUT and IGRAPH_IN & IGRAPH_OUT == 0. */
 typedef enum { IGRAPH_OUT = 1, IGRAPH_IN = 2, IGRAPH_ALL = 3 } igraph_neimode_t;
@@ -75,10 +73,6 @@ typedef enum { IGRAPH_WHEEL_OUT = 0, IGRAPH_WHEEL_IN,
 typedef enum { IGRAPH_TREE_OUT = 0, IGRAPH_TREE_IN,
                IGRAPH_TREE_UNDIRECTED
              } igraph_tree_mode_t;
-
-typedef enum { IGRAPH_ERDOS_RENYI_GNP = 0,
-               IGRAPH_ERDOS_RENYI_GNM
-             } igraph_erdos_renyi_t;
 
 typedef enum { IGRAPH_GET_ADJACENCY_UPPER = 0,
                IGRAPH_GET_ADJACENCY_LOWER,
@@ -131,10 +125,6 @@ typedef enum { IGRAPH_SPINCOMM_UPDATE_SIMPLE = 0,
                IGRAPH_SPINCOMM_UPDATE_CONFIG
              } igraph_spincomm_update_t;
 
-typedef enum { IGRAPH_DONT_SIMPLIFY = 0,
-               IGRAPH_SIMPLIFY
-             } igraph_lazy_adlist_simplify_t;
-
 typedef enum { IGRAPH_TRANSITIVITY_NAN = 0,
                IGRAPH_TRANSITIVITY_ZERO
              } igraph_transitivity_mode_t;
@@ -173,11 +163,6 @@ typedef enum { IGRAPH_SUBGRAPH_AUTO = 0,
                IGRAPH_SUBGRAPH_COPY_AND_DELETE,
                IGRAPH_SUBGRAPH_CREATE_FROM_SCRATCH
              } igraph_subgraph_implementation_t;
-
-typedef enum { IGRAPH_IMITATE_AUGMENTED = 0,
-               IGRAPH_IMITATE_BLIND,
-               IGRAPH_IMITATE_CONTRACTED
-             } igraph_imitate_algorithm_t;
 
 typedef enum { IGRAPH_LAYOUT_GRID = 0,
                IGRAPH_LAYOUT_NOGRID,

--- a/include/igraph_constructors.h
+++ b/include/igraph_constructors.h
@@ -91,7 +91,7 @@ IGRAPH_EXPORT igraph_error_t igraph_realize_degree_sequence(igraph_t *graph,
                                                  igraph_realize_degseq_t method);
 IGRAPH_EXPORT igraph_error_t igraph_triangular_lattice(igraph_t *graph, const igraph_vector_int_t *dims, igraph_bool_t directed, igraph_bool_t mutual);
 IGRAPH_EXPORT igraph_error_t igraph_hexagonal_lattice(igraph_t *graph, const igraph_vector_int_t *dims, igraph_bool_t directed, igraph_bool_t mutual);
-IGRAPH_EXPORT igraph_error_t igraph_realize_bipartite_degree_sequence(igraph_t *graph, const igraph_vector_int_t *deg1, const igraph_vector_int_t *deg2, const igraph_edge_type_sw_t allowed_edge_types, const igraph_realize_degseq_t method);
+IGRAPH_EXPORT igraph_error_t igraph_realize_bipartite_degree_sequence(igraph_t *graph, const igraph_vector_int_t *deg1, const igraph_vector_int_t *deg2, igraph_edge_type_sw_t allowed_edge_types, igraph_realize_degseq_t method);
 
 __END_DECLS
 

--- a/include/igraph_error.h
+++ b/include/igraph_error.h
@@ -477,7 +477,7 @@ IGRAPH_EXPORT igraph_error_t igraph_errorvf(const char *reason, const char *file
                                             int line, igraph_error_t igraph_errno,
                                             va_list ap);
 
-IGRAPH_EXPORT IGRAPH_FUNCATTR_PURE const char *igraph_strerror(const igraph_error_t igraph_errno);
+IGRAPH_EXPORT IGRAPH_FUNCATTR_PURE const char *igraph_strerror(igraph_error_t igraph_errno);
 
 #define IGRAPH_ERROR_SELECT_2(a,b)       ((a) != IGRAPH_SUCCESS ? (a) : ((b) != IGRAPH_SUCCESS ? (b) : IGRAPH_SUCCESS))
 #define IGRAPH_ERROR_SELECT_3(a,b,c)     ((a) != IGRAPH_SUCCESS ? (a) : IGRAPH_ERROR_SELECT_2(b,c))

--- a/include/igraph_graphicality.h
+++ b/include/igraph_graphicality.h
@@ -40,12 +40,12 @@ enum {
 
 IGRAPH_EXPORT igraph_error_t igraph_is_graphical(const igraph_vector_int_t *out_degrees,
                                       const igraph_vector_int_t *in_degrees,
-                                      const igraph_edge_type_sw_t allowed_edge_types,
+                                      igraph_edge_type_sw_t allowed_edge_types,
                                       igraph_bool_t *res);
 
 IGRAPH_EXPORT igraph_error_t igraph_is_bigraphical(const igraph_vector_int_t *degrees1,
                                         const igraph_vector_int_t *degrees2,
-                                        const igraph_edge_type_sw_t allowed_edge_types,
+                                        igraph_edge_type_sw_t allowed_edge_types,
                                         igraph_bool_t *res);
 
 __END_DECLS

--- a/include/igraph_interface.h
+++ b/include/igraph_interface.h
@@ -48,9 +48,9 @@ IGRAPH_EXPORT igraph_error_t igraph_add_vertices(
     const igraph_attribute_record_list_t* attr
 );
 IGRAPH_EXPORT igraph_error_t igraph_delete_edges(igraph_t *graph, igraph_es_t edges);
-IGRAPH_EXPORT igraph_error_t igraph_delete_vertices(igraph_t *graph, const igraph_vs_t vertices);
+IGRAPH_EXPORT igraph_error_t igraph_delete_vertices(igraph_t *graph, igraph_vs_t vertices);
 IGRAPH_EXPORT igraph_error_t igraph_delete_vertices_map(
-    igraph_t *graph, const igraph_vs_t vertices, igraph_vector_int_t *map,
+    igraph_t *graph, igraph_vs_t vertices, igraph_vector_int_t *map,
     igraph_vector_int_t *invmap
 );
 IGRAPH_EXPORT IGRAPH_FUNCATTR_PURE igraph_integer_t igraph_vcount(const igraph_t *graph);
@@ -65,7 +65,7 @@ IGRAPH_EXPORT igraph_error_t igraph_degree_1(
     igraph_neimode_t mode, igraph_loops_t loops
 );
 IGRAPH_EXPORT igraph_error_t igraph_degree(
-    const igraph_t *graph, igraph_vector_int_t *res, const igraph_vs_t vids,
+    const igraph_t *graph, igraph_vector_int_t *res, igraph_vs_t vids,
     igraph_neimode_t mode, igraph_loops_t loops
 );
 IGRAPH_EXPORT igraph_error_t igraph_edge(const igraph_t *graph, igraph_integer_t eid,
@@ -146,7 +146,7 @@ IGRAPH_EXPORT void igraph_i_property_cache_invalidate_all(const igraph_t *graph)
     ((igraph_integer_t)(IGRAPH_TO(graph,(eid))==(vid) ? IGRAPH_FROM((graph),(eid)) : IGRAPH_TO((graph),(eid))))
 
 IGRAPH_DEPRECATED IGRAPH_EXPORT igraph_error_t igraph_delete_vertices_idx(
-    igraph_t *graph, const igraph_vs_t vertices, igraph_vector_int_t *idx,
+    igraph_t *graph, igraph_vs_t vertices, igraph_vector_int_t *idx,
     igraph_vector_int_t *invidx
 );
 

--- a/include/igraph_iterators.h
+++ b/include/igraph_iterators.h
@@ -236,7 +236,6 @@ typedef enum {
     IGRAPH_ES_RANGE,
     IGRAPH_ES_PAIRS,
     IGRAPH_ES_PATH,
-    IGRAPH_ES_UNUSED_WAS_MULTIPAIRS,  /* placeholder for deprecated IGRAPH_ES_MULTIPAIRS from igraph 0.10 */
     IGRAPH_ES_ALL_BETWEEN,
 } igraph_es_type_t;
 

--- a/include/igraph_motifs.h
+++ b/include/igraph_motifs.h
@@ -86,11 +86,11 @@ IGRAPH_EXPORT igraph_error_t igraph_triad_census(const igraph_t *igraph, igraph_
 
 IGRAPH_EXPORT igraph_error_t igraph_count_adjacent_triangles(const igraph_t *graph,
                                             igraph_vector_t *res,
-                                            const igraph_vs_t vids);
+                                            igraph_vs_t vids);
 
 IGRAPH_EXPORT IGRAPH_DEPRECATED igraph_error_t igraph_adjacent_triangles(const igraph_t *graph,
                                          igraph_vector_t *res,
-                                         const igraph_vs_t vids);
+                                         igraph_vs_t vids);
 
 IGRAPH_EXPORT igraph_error_t igraph_list_triangles(const igraph_t *graph,
                                         igraph_vector_int_t *res);

--- a/include/igraph_nongraph.h
+++ b/include/igraph_nongraph.h
@@ -35,13 +35,6 @@ __BEGIN_DECLS
  */
 #define IGRAPH_SHORTEST_PATH_EPSILON 1e-10
 
-typedef igraph_real_t  igraph_scalar_function_t(const igraph_vector_t *var,
-        const igraph_vector_t *par,
-        void* extra);
-typedef void igraph_vector_function_t(const igraph_vector_t *var,
-                                      const igraph_vector_t *par,
-                                      igraph_vector_t* res, void* extra);
-
 /* -------------------------------------------------- */
 /* Other, not graph related                           */
 /* -------------------------------------------------- */

--- a/include/igraph_operators.h
+++ b/include/igraph_operators.h
@@ -73,17 +73,17 @@ IGRAPH_EXPORT igraph_error_t igraph_simplify(igraph_t *graph,
                                              igraph_bool_t remove_multiple, igraph_bool_t remove_loops,
                                              const igraph_attribute_combination_t *edge_comb);
 IGRAPH_EXPORT igraph_error_t igraph_induced_subgraph_map(const igraph_t *graph, igraph_t *res,
-                                              const igraph_vs_t vids,
+                                              igraph_vs_t vids,
                                               igraph_subgraph_implementation_t impl,
                                               igraph_vector_int_t *map,
                                               igraph_vector_int_t *invmap);
 IGRAPH_EXPORT igraph_error_t igraph_induced_subgraph(const igraph_t *graph, igraph_t *res,
-                                          const igraph_vs_t vids, igraph_subgraph_implementation_t impl);
+                                          igraph_vs_t vids, igraph_subgraph_implementation_t impl);
 IGRAPH_EXPORT igraph_error_t igraph_induced_subgraph_edges(
         const igraph_t *graph, igraph_vs_t vids, igraph_vector_int_t *edges);
 IGRAPH_EXPORT igraph_error_t igraph_subgraph_from_edges(const igraph_t *graph, igraph_t *res,
-                                        const igraph_es_t eids, igraph_bool_t delete_vertices);
-IGRAPH_EXPORT igraph_error_t igraph_reverse_edges(igraph_t *graph, const igraph_es_t eids);
+                                        igraph_es_t eids, igraph_bool_t delete_vertices);
+IGRAPH_EXPORT igraph_error_t igraph_reverse_edges(igraph_t *graph, igraph_es_t eids);
 IGRAPH_EXPORT igraph_error_t igraph_product(igraph_t *res,
                                             const igraph_t *g1,
                                             const igraph_t *g2,

--- a/include/igraph_paths.h
+++ b/include/igraph_paths.h
@@ -76,34 +76,34 @@ IGRAPH_EXPORT igraph_error_t igraph_diameter(
 );
 
 IGRAPH_EXPORT igraph_error_t igraph_distances_cutoff(const igraph_t *graph, igraph_matrix_t *res,
-                                                     const igraph_vs_t from, const igraph_vs_t to,
+                                                     igraph_vs_t from, igraph_vs_t to,
                                                      igraph_neimode_t mode, igraph_real_t cutoff);
 IGRAPH_EXPORT igraph_error_t igraph_distances(const igraph_t *graph, igraph_matrix_t *res,
-                                              const igraph_vs_t from, const igraph_vs_t to,
+                                              igraph_vs_t from, igraph_vs_t to,
                                               igraph_neimode_t mode);
 IGRAPH_EXPORT igraph_error_t igraph_distances_bellman_ford(const igraph_t *graph,
                                                      igraph_matrix_t *res,
-                                                     const igraph_vs_t from,
-                                                     const igraph_vs_t to,
+                                                     igraph_vs_t from,
+                                                     igraph_vs_t to,
                                                      const igraph_vector_t *weights,
                                                      igraph_neimode_t mode);
 IGRAPH_EXPORT igraph_error_t igraph_distances_dijkstra_cutoff(const igraph_t *graph,
                                                               igraph_matrix_t *res,
-                                                              const igraph_vs_t from,
-                                                              const igraph_vs_t to,
+                                                              igraph_vs_t from,
+                                                              igraph_vs_t to,
                                                               const igraph_vector_t *weights,
                                                               igraph_neimode_t mode,
                                                               igraph_real_t cutoff);
 IGRAPH_EXPORT igraph_error_t igraph_distances_dijkstra(const igraph_t *graph,
                                                        igraph_matrix_t *res,
-                                                       const igraph_vs_t from,
-                                                       const igraph_vs_t to,
+                                                       igraph_vs_t from,
+                                                       igraph_vs_t to,
                                                        const igraph_vector_t *weights,
                                                        igraph_neimode_t mode);
 IGRAPH_EXPORT igraph_error_t igraph_distances_johnson(const igraph_t *graph,
                                                 igraph_matrix_t *res,
-                                                const igraph_vs_t from,
-                                                const igraph_vs_t to,
+                                                igraph_vs_t from,
+                                                igraph_vs_t to,
                                                 const igraph_vector_t *weights,
                                                 igraph_neimode_t mode);
 IGRAPH_EXPORT igraph_error_t igraph_distances_floyd_warshall(const igraph_t *graph,
@@ -117,7 +117,7 @@ IGRAPH_EXPORT igraph_error_t igraph_distances_floyd_warshall(const igraph_t *gra
 IGRAPH_EXPORT igraph_error_t igraph_get_shortest_paths(const igraph_t *graph,
                                             igraph_vector_int_list_t *vertices,
                                             igraph_vector_int_list_t *edges,
-                                            igraph_integer_t from, const igraph_vs_t to,
+                                            igraph_integer_t from, igraph_vs_t to,
                                             igraph_neimode_t mode,
                                             igraph_vector_int_t *parents,
                                             igraph_vector_int_t *inbound_edges);
@@ -175,7 +175,7 @@ IGRAPH_EXPORT igraph_error_t igraph_get_all_shortest_paths(const igraph_t *graph
                                                 igraph_vector_int_list_t *vertices,
                                                 igraph_vector_int_list_t *edges,
                                                 igraph_vector_int_t *nrgeo,
-                                                igraph_integer_t from, const igraph_vs_t to,
+                                                igraph_integer_t from, igraph_vs_t to,
                                                 igraph_neimode_t mode);
 IGRAPH_EXPORT igraph_error_t igraph_get_all_shortest_paths_dijkstra(const igraph_t *graph,
                                                          igraph_vector_int_list_t *vertices,
@@ -198,7 +198,7 @@ IGRAPH_EXPORT igraph_error_t igraph_global_efficiency(
 );
 IGRAPH_EXPORT igraph_error_t igraph_local_efficiency(
     const igraph_t *graph, const igraph_vector_t *weights, igraph_vector_t *res,
-    const igraph_vs_t vids, igraph_bool_t directed, igraph_neimode_t mode
+    igraph_vs_t vids, igraph_bool_t directed, igraph_neimode_t mode
 );
 IGRAPH_EXPORT igraph_error_t igraph_average_local_efficiency(
     const igraph_t *graph, const igraph_vector_t *weights, igraph_real_t *res,
@@ -230,7 +230,7 @@ IGRAPH_EXPORT igraph_error_t igraph_pseudo_diameter(
 IGRAPH_EXPORT igraph_error_t igraph_get_all_simple_paths(const igraph_t *graph,
                                                          igraph_vector_int_list_t *res,
                                                          igraph_integer_t from,
-                                                         const igraph_vs_t to,
+                                                         igraph_vs_t to,
                                                          igraph_integer_t minlen,
                                                          igraph_integer_t maxlen,
                                                          igraph_neimode_t mode);
@@ -276,14 +276,14 @@ IGRAPH_EXPORT igraph_error_t igraph_get_widest_path(const igraph_t *graph,
                                              igraph_neimode_t mode);
 IGRAPH_EXPORT igraph_error_t igraph_widest_path_widths_floyd_warshall(const igraph_t *graph,
                                                    igraph_matrix_t *res,
-                                                   const igraph_vs_t from,
-                                                   const igraph_vs_t to,
+                                                   igraph_vs_t from,
+                                                   igraph_vs_t to,
                                                    const igraph_vector_t *weights,
                                                    igraph_neimode_t mode);
 IGRAPH_EXPORT igraph_error_t igraph_widest_path_widths_dijkstra(const igraph_t *graph,
                                              igraph_matrix_t *res,
-                                             const igraph_vs_t from,
-                                             const igraph_vs_t to,
+                                             igraph_vs_t from,
+                                             igraph_vs_t to,
                                              const igraph_vector_t *weights,
                                              igraph_neimode_t mode);
 IGRAPH_EXPORT igraph_error_t igraph_voronoi(const igraph_t *graph,

--- a/include/igraph_separators.h
+++ b/include/igraph_separators.h
@@ -30,14 +30,14 @@
 __BEGIN_DECLS
 
 IGRAPH_EXPORT igraph_error_t igraph_is_separator(const igraph_t *graph,
-                                      const igraph_vs_t candidate,
+                                      igraph_vs_t candidate,
                                       igraph_bool_t *res);
 
 IGRAPH_EXPORT igraph_error_t igraph_all_minimal_st_separators(const igraph_t *graph,
                                                    igraph_vector_int_list_t *separators);
 
 IGRAPH_EXPORT igraph_error_t igraph_is_minimal_separator(const igraph_t *graph,
-                                              const igraph_vs_t candidate,
+                                              igraph_vs_t candidate,
                                               igraph_bool_t *res);
 
 IGRAPH_EXPORT igraph_error_t igraph_minimum_size_separators(const igraph_t *graph,

--- a/include/igraph_structural.h
+++ b/include/igraph_structural.h
@@ -41,7 +41,7 @@ IGRAPH_EXPORT igraph_error_t igraph_count_multiple_1(const igraph_t *graph, igra
 IGRAPH_EXPORT igraph_error_t igraph_density(const igraph_t *graph, igraph_real_t *res,
                                  igraph_bool_t loops);
 IGRAPH_EXPORT igraph_error_t igraph_diversity(const igraph_t *graph, const igraph_vector_t *weights,
-                                   igraph_vector_t *res, const igraph_vs_t vs);
+                                   igraph_vector_t *res, igraph_vs_t vs);
 IGRAPH_EXPORT igraph_error_t igraph_girth(const igraph_t *graph, igraph_real_t *girth,
                                igraph_vector_int_t *circle);
 IGRAPH_EXPORT igraph_error_t igraph_has_loop(const igraph_t *graph, igraph_bool_t *res);
@@ -67,7 +67,7 @@ IGRAPH_EXPORT igraph_error_t igraph_reciprocity(const igraph_t *graph, igraph_re
                                      igraph_bool_t ignore_loops,
                                      igraph_reciprocity_t mode);
 IGRAPH_EXPORT igraph_error_t igraph_strength(
-    const igraph_t *graph, igraph_vector_t *res, const igraph_vs_t vids,
+    const igraph_t *graph, igraph_vector_t *res, igraph_vs_t vids,
     igraph_neimode_t mode, igraph_loops_t loops, const igraph_vector_t *weights
 );
 IGRAPH_EXPORT igraph_error_t igraph_sort_vertex_ids_by_degree(

--- a/include/igraph_transitivity.h
+++ b/include/igraph_transitivity.h
@@ -32,16 +32,16 @@ IGRAPH_EXPORT igraph_error_t igraph_transitivity_undirected(const igraph_t *grap
                                                  igraph_transitivity_mode_t mode);
 IGRAPH_EXPORT igraph_error_t igraph_transitivity_local_undirected(const igraph_t *graph,
                                                        igraph_vector_t *res,
-                                                       const igraph_vs_t vids,
+                                                       igraph_vs_t vids,
                                                        igraph_transitivity_mode_t mode);
 IGRAPH_EXPORT igraph_error_t igraph_transitivity_avglocal_undirected(const igraph_t *graph,
                                                           igraph_real_t *res,
                                                           igraph_transitivity_mode_t mode);
 IGRAPH_EXPORT igraph_error_t igraph_transitivity_barrat(const igraph_t *graph,
                                              igraph_vector_t *res,
-                                             const igraph_vs_t vids,
+                                             igraph_vs_t vids,
                                              const igraph_vector_t *weights,
-                                             const igraph_transitivity_mode_t mode);
+                                             igraph_transitivity_mode_t mode);
 IGRAPH_EXPORT igraph_error_t igraph_ecc(const igraph_t *graph,
                                         igraph_vector_t *res,
                                         igraph_es_t eids,

--- a/interfaces/types.yaml
+++ b/interfaces/types.yaml
@@ -349,11 +349,6 @@ GREEDY_COLORING_HEURISTIC:
     CTYPE: igraph_coloring_greedy_t
     FLAGS: ENUM
 
-IMITATE_ALGORITHM:
-    # This enum controls which algorithm to use in stochastic imitation
-    CTYPE: igraph_imitate_algorithm_t
-    FLAGS: ENUM
-
 LAPLACIAN_NORMALIZATION:
     # Enum representing the possible normalization methods of a Laplacian
     # matrix
@@ -389,11 +384,6 @@ NEIMODE:
     # Enum that describes how a particular function should take into account
     # the neighbors of vertices
     CTYPE: igraph_neimode_t
-    FLAGS: ENUM
-
-OPTIMALITY:
-    # This enum controls which algorithm to use in deterministic optimal imitation
-    CTYPE: igraph_optimal_t
     FLAGS: ENUM
 
 ORDER:


### PR DESCRIPTION
@ntamas These are various little cleanups for 1.0. Let me know if you have any objection.

 - `const` has no effect in a function declaration when using pass-by-value (i.e. when the parameter is not a pointer). It does have an effect in the definition, as it means that the parameter is treated as constant in the implementation. But this does not carry over from the declaration to the definition. Removing these silences some annoying clang tidy warnings.
 - Removing an enum value for `igraph_es_type_t` changes the numerical values of the subsequent enum values. This is IMO not an issue between major releases where binary compatibility can't be preserved anyway.