### PR TITLE
Fix #2798: Correct termination logic in leiden community detection loop

### DIFF
--- a/src/community/leiden.c
+++ b/src/community/leiden.c
@@ -1031,9 +1031,9 @@ igraph_error_t igraph_community_leiden(const igraph_t *graph,
      * iteration may still find some improvement. This is because
      * each iteration explores different subsets of nodes.
      */
-    igraph_bool_t changed = false;
+    igraph_bool_t changed = true;
     for (igraph_integer_t itr = 0;
-         n_iterations >= 0 ? itr < n_iterations : !changed;
+         n_iterations < 0 ? changed : itr < n_iterations;
          itr++) {
         IGRAPH_CHECK(igraph_i_community_leiden(graph, i_edge_weights, i_node_weights,
                                                resolution_parameter, beta,


### PR DESCRIPTION
The loop for negative n_iterations was terminating prematurely. This fix #2798, ensuring it iterates until convergence as intended.

<!-- Please disclose any use of LLMs (ChatGPT, Copilot, Gemini, etc.) during the preparation of this PR. -->

<!-- The following text must be left intact and the box checked before the PR can be merged. -->

- [x] By submitting this pull request, I assign the copyright of my contribution to _The igraph development team_.
