### PR TITLE
Add coloring verification functions (#2758)

### DIFF
--- a/doc/coloring.xxml
+++ b/doc/coloring.xxml
@@ -9,6 +9,11 @@
 
 <!-- doxrox-include igraph_vertex_coloring_greedy -->
 <!-- doxrox-include igraph_coloring_greedy_t -->
+
+<!-- doxrox-include igraph_is_vertex_coloring -->
+<!-- doxrox-include igraph_is_bipartite_coloring -->
+<!-- doxrox-include igraph_is_edge_coloring -->
+
 <!-- doxrox-include igraph_is_perfect -->
 
 </chapter>

--- a/include/igraph_coloring.h
+++ b/include/igraph_coloring.h
@@ -50,6 +50,10 @@ typedef enum {
 
 IGRAPH_EXPORT igraph_error_t igraph_vertex_coloring_greedy(const igraph_t *graph, igraph_vector_int_t *colors, igraph_coloring_greedy_t heuristic);
 
+IGRAPH_EXPORT igraph_error_t igraph_is_vertex_coloring(const igraph_t *graph, const igraph_vector_int_t *types, igraph_bool_t *res);
+IGRAPH_EXPORT igraph_error_t igraph_is_bipartite_coloring(const igraph_t *graph, const igraph_vector_bool_t *types, igraph_bool_t *res, igraph_neimode_t *mode);
+IGRAPH_EXPORT igraph_error_t igraph_is_edge_coloring(const igraph_t *graph, const igraph_vector_int_t *types, igraph_bool_t *res);
+
 __END_DECLS
 
 #endif /* IGRAPH_COLORING_H */

--- a/interfaces/functions.yaml
+++ b/interfaces/functions.yaml
@@ -2673,6 +2673,18 @@ igraph_vertex_coloring_greedy:
     PARAMS: GRAPH graph, OUT VERTEX_COLOR colors, GREEDY_COLORING_HEURISTIC heuristic=NEIGHBORS
     DEPS: colors ON graph
 
+igraph_is_vertex_coloring:
+    PARAMS: GRAPH graph, VERTEX_COLOR types, OUT BOOLEAN res
+    DEPS: types ON graph
+
+igraph_is_bipartite_coloring:
+    PARAMS: GRAPH graph, VERTEX_BIPARTITE_TYPES types, OUT BOOLEAN res, OPTIONAL OUT NEIMODE mode
+    DEPS: types ON graph
+
+igraph_is_edge_coloring:
+    PARAMS: GRAPH graph, EDGE_COLOR types, OUT BOOLEAN res
+    DEPS: types ON graph
+
 #######################################
 # Microscopic update
 #######################################

--- a/interfaces/functions.yaml
+++ b/interfaces/functions.yaml
@@ -2678,7 +2678,7 @@ igraph_is_vertex_coloring:
     DEPS: types ON graph
 
 igraph_is_bipartite_coloring:
-    PARAMS: GRAPH graph, VERTEX_BIPARTITE_TYPES types, OUT BOOLEAN res, OPTIONAL OUT NEIMODE mode
+    PARAMS: GRAPH graph, BIPARTITE_TYPES types, OUT BOOLEAN res, OPTIONAL OUT NEIMODE mode
     DEPS: types ON graph
 
 igraph_is_edge_coloring:

--- a/src/misc/coloring.c
+++ b/src/misc/coloring.c
@@ -311,6 +311,8 @@ igraph_error_t igraph_vertex_coloring_greedy(const igraph_t *graph, igraph_vecto
  * \function igraph_is_vertex_coloring
  * \brief Checks whether a vertex coloring is valid.
  *
+ * \experimental
+ *
  * This function checks whether the given vertex type/color assignment is a valid
  * vertex coloring, i.e., no two adjacent vertices have the same color.
  * Self-loops are ignored.
@@ -357,6 +359,8 @@ igraph_error_t igraph_is_vertex_coloring(
 /**
  * \function igraph_is_bipartite_coloring
  * \brief Checks whether a bipartite vertex coloring is valid.
+ *
+ * \experimental
  *
  * This function checks whether the given vertex type assignment is a valid
  * bipartite coloring, i.e., no two adjacent vertices have the same type.
@@ -436,6 +440,8 @@ igraph_error_t igraph_is_bipartite_coloring(const igraph_t *graph, const igraph_
 /**
  * \function igraph_is_edge_coloring
  * \brief Checks whether an edge coloring is valid.
+ *
+ * \experimental
  *
  * This function checks whether the given edge color assignment is a valid
  * edge coloring, i.e., no two adjacent edges have the same color.

--- a/src/misc/coloring.c
+++ b/src/misc/coloring.c
@@ -479,7 +479,7 @@ igraph_error_t igraph_is_edge_coloring(const igraph_t *graph, const igraph_vecto
         IGRAPH_VECTOR_INT_INIT_FINALLY(&edges, 0);
         IGRAPH_VECTOR_INT_INIT_FINALLY(&edge_colors, 0);
         
-        IGRAPH_CHECK(igraph_i_incident(graph, &edges, v, IGRAPH_ALL, IGRAPH_LOOPS_ONCE));
+        IGRAPH_CHECK(igraph_incident(graph, &edges, v, IGRAPH_ALL));
         igraph_integer_t degree = igraph_vector_int_size(&edges);
         
         /* Create a list of colors for all incident edges */

--- a/src/misc/coloring.c
+++ b/src/misc/coloring.c
@@ -306,3 +306,177 @@ igraph_error_t igraph_vertex_coloring_greedy(const igraph_t *graph, igraph_vecto
         IGRAPH_ERROR("Invalid heuristic for greedy vertex coloring.", IGRAPH_EINVAL);
     }
 }
+
+/**
+ * \function igraph_is_vertex_coloring
+ * \brief Check whether a vertex coloring is valid.
+ *
+ * This function checks whether the given vertex type/color assignment is a valid
+ * vertex coloring, i.e., no two adjacent vertices have the same color.
+ *
+ * \param graph The input graph.
+ * \param types The vertex types/colors as an integer vector.
+ * \param res Pointer to a boolean, the result is stored here.
+ * \return Error code.
+ *
+ * Time complexity: O(|E|), linear in the number of edges.
+ */
+igraph_error_t igraph_is_vertex_coloring(const igraph_t *graph, const igraph_vector_int_t *types, igraph_bool_t *res) {
+    igraph_integer_t no_of_nodes = igraph_vcount(graph);
+    igraph_integer_t no_of_edges = igraph_ecount(graph);
+    
+    if (igraph_vector_int_size(types) != no_of_nodes) {
+        IGRAPH_ERROR("Invalid vertex type vector length.", IGRAPH_EINVAL);
+    }
+    
+    *res = true;
+    
+    for (igraph_integer_t i = 0; i < no_of_edges; i++) {
+        igraph_integer_t from = IGRAPH_FROM(graph, i);
+        igraph_integer_t to = IGRAPH_TO(graph, i);
+        
+        /* Skip self-loops */
+        if (from == to) {
+            continue;
+        }
+        
+        if (VECTOR(*types)[from] == VECTOR(*types)[to]) {
+            *res = false;
+            break;
+        }
+    }
+    
+    return IGRAPH_SUCCESS;
+}
+
+/**
+ * \function igraph_is_bipartite_coloring
+ * \brief Check whether a bipartite vertex coloring is valid.
+ *
+ * This function checks whether the given vertex type assignment is a valid
+ * bipartite coloring, i.e., no two adjacent vertices have the same type.
+ * Additionally, for directed graphs, it determines the mode of edge directions.
+ *
+ * \param graph The input graph.
+ * \param types The vertex types as a boolean vector.
+ * \param res Pointer to a boolean, the result is stored here.
+ * \param mode Pointer to store the edge direction mode. Can be NULL if not needed.
+ *   If all edges go from false to true vertices, IGRAPH_OUT is returned.
+ *   If all edges go from true to false vertices, IGRAPH_IN is returned.
+ *   If edges go in both directions or graph is undirected, IGRAPH_ALL is returned.
+ * \return Error code.
+ *
+ * Time complexity: O(|E|), linear in the number of edges.
+ */
+igraph_error_t igraph_is_bipartite_coloring(const igraph_t *graph, const igraph_vector_bool_t *types, igraph_bool_t *res, igraph_neimode_t *mode) {
+    igraph_integer_t no_of_nodes = igraph_vcount(graph);
+    igraph_integer_t no_of_edges = igraph_ecount(graph);
+    
+    if (igraph_vector_bool_size(types) != no_of_nodes) {
+        IGRAPH_ERROR("Invalid vertex type vector length.", IGRAPH_EINVAL);
+    }
+    
+    *res = true;
+    if (mode) {
+        *mode = IGRAPH_ALL;
+    }
+    
+    igraph_bool_t directed = igraph_is_directed(graph);
+    igraph_bool_t has_false_to_true = false;
+    igraph_bool_t has_true_to_false = false;
+    
+    for (igraph_integer_t i = 0; i < no_of_edges; i++) {
+        igraph_integer_t from = IGRAPH_FROM(graph, i);
+        igraph_integer_t to = IGRAPH_TO(graph, i);
+        
+        /* Skip self-loops */
+        if (from == to) {
+            continue;
+        }
+        
+        igraph_bool_t from_type = VECTOR(*types)[from];
+        igraph_bool_t to_type = VECTOR(*types)[to];
+        
+        /* Check if adjacent vertices have the same type */
+        if (from_type == to_type) {
+            *res = false;
+            break;
+        }
+        
+        /* Track edge directions for directed graphs */
+        if (directed && mode) {
+            if (!from_type && to_type) {
+                has_false_to_true = true;
+            } else if (from_type && !to_type) {
+                has_true_to_false = true;
+            }
+        }
+    }
+    
+    /* Determine the mode for directed graphs */
+    if (*res && directed && mode) {
+        if (has_false_to_true && !has_true_to_false) {
+            *mode = IGRAPH_OUT;
+        } else if (!has_false_to_true && has_true_to_false) {
+            *mode = IGRAPH_IN;
+        } else {
+            *mode = IGRAPH_ALL;
+        }
+    }
+    
+    return IGRAPH_SUCCESS;
+}
+
+/**
+ * \function igraph_is_edge_coloring
+ * \brief Check whether an edge coloring is valid.
+ *
+ * This function checks whether the given edge color assignment is a valid
+ * edge coloring, i.e., no two adjacent edges have the same color.
+ *
+ * \param graph The input graph.
+ * \param types The edge colors as an integer vector.
+ * \param res Pointer to a boolean, the result is stored here.
+ * \return Error code.
+ *
+ * Time complexity: O(|V|*d^2), where d is the maximum degree.
+ */
+igraph_error_t igraph_is_edge_coloring(const igraph_t *graph, const igraph_vector_int_t *types, igraph_bool_t *res) {
+    igraph_integer_t no_of_nodes = igraph_vcount(graph);
+    igraph_integer_t no_of_edges = igraph_ecount(graph);
+    
+    if (igraph_vector_int_size(types) != no_of_edges) {
+        IGRAPH_ERROR("Invalid edge type vector length.", IGRAPH_EINVAL);
+    }
+    
+    *res = true;
+    
+    /* For each vertex, check that all incident edges have different colors */
+    for (igraph_integer_t v = 0; v < no_of_nodes; v++) {
+        igraph_vector_int_t edges;
+        IGRAPH_VECTOR_INT_INIT_FINALLY(&edges, 0);
+        
+        IGRAPH_CHECK(igraph_incident(graph, &edges, v, IGRAPH_ALL));
+        igraph_integer_t degree = igraph_vector_int_size(&edges);
+        
+        /* Check all pairs of incident edges */
+        for (igraph_integer_t i = 0; i < degree; i++) {
+            for (igraph_integer_t j = i + 1; j < degree; j++) {
+                igraph_integer_t edge1 = VECTOR(edges)[i];
+                igraph_integer_t edge2 = VECTOR(edges)[j];
+                
+                if (VECTOR(*types)[edge1] == VECTOR(*types)[edge2]) {
+                    *res = false;
+                    igraph_vector_int_destroy(&edges);
+                    IGRAPH_FINALLY_CLEAN(1);
+                    return IGRAPH_SUCCESS;
+                }
+            }
+        }
+        
+        igraph_vector_int_destroy(&edges);
+        IGRAPH_FINALLY_CLEAN(1);
+    }
+    
+    return IGRAPH_SUCCESS;
+}

--- a/src/misc/coloring.c
+++ b/src/misc/coloring.c
@@ -332,13 +332,13 @@ igraph_error_t igraph_is_vertex_coloring(
 
     const igraph_integer_t vcount = igraph_vcount(graph);
     const igraph_integer_t ecount = igraph_ecount(graph);
+    int iter = 0;
 
     if (igraph_vector_int_size(types) != vcount) {
         IGRAPH_ERROR("Invalid vertex type vector length.", IGRAPH_EINVAL);
     }
 
     *res = true;
-    int iter = 0;
 
     for (igraph_integer_t e = 0; e < ecount; e++) {
         igraph_integer_t from = IGRAPH_FROM(graph, e);
@@ -382,9 +382,15 @@ igraph_error_t igraph_is_vertex_coloring(
  *
  * Time complexity: O(|E|), linear in the number of edges.
  */
-igraph_error_t igraph_is_bipartite_coloring(const igraph_t *graph, const igraph_vector_bool_t *types, igraph_bool_t *res, igraph_neimode_t *mode) {
+igraph_error_t igraph_is_bipartite_coloring(
+        const igraph_t *graph,
+        const igraph_vector_bool_t *types,
+        igraph_bool_t *res,
+        igraph_neimode_t *mode) {
+
     const igraph_integer_t vcount = igraph_vcount(graph);
     const igraph_integer_t ecount = igraph_ecount(graph);
+    int iter = 0;
 
     if (igraph_vector_bool_size(types) != vcount) {
         IGRAPH_ERROR("Invalid vertex type vector length.", IGRAPH_EINVAL);
@@ -398,7 +404,6 @@ igraph_error_t igraph_is_bipartite_coloring(const igraph_t *graph, const igraph_
     igraph_bool_t directed = igraph_is_directed(graph);
     igraph_bool_t has_false_to_true = false;
     igraph_bool_t has_true_to_false = false;
-    int iter = 0;
 
     for (igraph_integer_t e = 0; e < ecount; e++) {
         igraph_integer_t from = IGRAPH_FROM(graph, e);
@@ -472,6 +477,7 @@ igraph_error_t igraph_is_edge_coloring(
     const igraph_integer_t vcount = igraph_vcount(graph);
     const igraph_integer_t ecount = igraph_ecount(graph);
     igraph_vector_int_t edges, edge_colors;
+    int iter = 0;
 
     if (igraph_vector_int_size(types) != ecount) {
         IGRAPH_ERROR("Invalid edge type vector length.", IGRAPH_EINVAL);
@@ -500,7 +506,7 @@ igraph_error_t igraph_is_edge_coloring(
             }
         }
 
-        IGRAPH_ALLOW_INTERRUPTION();
+        IGRAPH_ALLOW_INTERRUPTION_LIMITED(iter, 1 << 7);
     }
 
 done:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -490,7 +490,7 @@ add_examples(
 add_legacy_tests(
   FOLDER tests/unit NAMES
   igraph_coloring
-  igraph_is_coloring
+  is_coloring
 )
 
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -490,6 +490,7 @@ add_examples(
 add_legacy_tests(
   FOLDER tests/unit NAMES
   igraph_coloring
+  igraph_is_coloring
 )
 
 

--- a/tests/unit/igraph_is_coloring.c
+++ b/tests/unit/igraph_is_coloring.c
@@ -1,6 +1,6 @@
 /*
    IGraph library.
-   Copyright (C) 2024  The igraph development team <igraph@igraph.org>
+   Copyright (C) 2025  The igraph development team <igraph@igraph.org>
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -25,7 +25,7 @@ void test_vertex_coloring(void) {
     igraph_vector_int_t types;
     igraph_bool_t res;
 
-    printf("Testing igraph_is_vertex_coloring\n");
+    printf("Testing igraph_is_vertex_coloring()\n");
 
     /* Empty graph */
     igraph_empty(&graph, 0, IGRAPH_UNDIRECTED);
@@ -79,7 +79,7 @@ void test_vertex_coloring(void) {
     igraph_vector_int_destroy(&types);
     igraph_destroy(&graph);
 
-    printf("igraph_is_vertex_coloring tests passed\n");
+    printf("igraph_is_vertex_coloring() tests passed\n");
 }
 
 void test_bipartite_coloring(void) {
@@ -88,7 +88,7 @@ void test_bipartite_coloring(void) {
     igraph_bool_t res;
     igraph_neimode_t mode;
 
-    printf("Testing igraph_is_bipartite_coloring\n");
+    printf("Testing igraph_is_bipartite_coloring()\n");
 
     /* Empty graph */
     igraph_empty(&graph, 0, IGRAPH_UNDIRECTED);
@@ -160,7 +160,7 @@ void test_bipartite_coloring(void) {
     igraph_vector_bool_destroy(&types);
     igraph_destroy(&graph);
 
-    printf("igraph_is_bipartite_coloring tests passed\n");
+    printf("igraph_is_bipartite_coloring() tests passed\n");
 }
 
 void test_edge_coloring(void) {
@@ -168,7 +168,7 @@ void test_edge_coloring(void) {
     igraph_vector_int_t types;
     igraph_bool_t res;
 
-    printf("Testing igraph_is_edge_coloring\n");
+    printf("Testing igraph_is_edge_coloring()\n");
 
     /* Empty graph */
     igraph_empty(&graph, 0, IGRAPH_UNDIRECTED);
@@ -230,7 +230,7 @@ void test_edge_coloring(void) {
     igraph_vector_int_destroy(&types);
     igraph_destroy(&graph);
 
-    printf("igraph_is_edge_coloring tests passed\n");
+    printf("igraph_is_edge_coloring() tests passed\n");
 }
 
 void test_error_conditions(void) {
@@ -274,6 +274,6 @@ int main(void) {
     test_error_conditions();
 
     VERIFY_FINALLY_STACK();
-    printf("All tests passed!\n");
+
     return 0;
 }

--- a/tests/unit/igraph_is_coloring.c
+++ b/tests/unit/igraph_is_coloring.c
@@ -1,0 +1,279 @@
+/*
+   IGraph library.
+   Copyright (C) 2024  The igraph development team <igraph@igraph.org>
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include <igraph.h>
+
+#include "test_utilities.h"
+
+void test_vertex_coloring(void) {
+    igraph_t graph;
+    igraph_vector_int_t types;
+    igraph_bool_t res;
+
+    printf("Testing igraph_is_vertex_coloring\n");
+
+    /* Empty graph */
+    igraph_empty(&graph, 0, IGRAPH_UNDIRECTED);
+    igraph_vector_int_init(&types, 0);
+    igraph_is_vertex_coloring(&graph, &types, &res);
+    IGRAPH_ASSERT(res);
+    igraph_vector_int_destroy(&types);
+    igraph_destroy(&graph);
+
+    /* Single vertex */
+    igraph_empty(&graph, 1, IGRAPH_UNDIRECTED);
+    igraph_vector_int_init_int(&types, 1, 0);
+    igraph_is_vertex_coloring(&graph, &types, &res);
+    IGRAPH_ASSERT(res);
+    igraph_vector_int_destroy(&types);
+    igraph_destroy(&graph);
+
+    /* Two connected vertices with different colors */
+    igraph_small(&graph, 2, IGRAPH_UNDIRECTED, 0, 1, -1);
+    igraph_vector_int_init_int(&types, 2, 0, 1);
+    igraph_is_vertex_coloring(&graph, &types, &res);
+    IGRAPH_ASSERT(res);
+    igraph_vector_int_destroy(&types);
+
+    /* Two connected vertices with same colors (invalid) */
+    igraph_vector_int_init_int(&types, 2, 0, 0);
+    igraph_is_vertex_coloring(&graph, &types, &res);
+    IGRAPH_ASSERT(!res);
+    igraph_vector_int_destroy(&types);
+    igraph_destroy(&graph);
+
+    /* Triangle with valid 3-coloring */
+    igraph_small(&graph, 3, IGRAPH_UNDIRECTED, 0, 1, 1, 2, 2, 0, -1);
+    igraph_vector_int_init_int(&types, 3, 0, 1, 2);
+    igraph_is_vertex_coloring(&graph, &types, &res);
+    IGRAPH_ASSERT(res);
+    igraph_vector_int_destroy(&types);
+
+    /* Triangle with invalid coloring (two adjacent vertices same color) */
+    igraph_vector_int_init_int(&types, 3, 0, 0, 1);
+    igraph_is_vertex_coloring(&graph, &types, &res);
+    IGRAPH_ASSERT(!res);
+    igraph_vector_int_destroy(&types);
+    igraph_destroy(&graph);
+
+    /* Self-loop should not affect coloring validity */
+    igraph_small(&graph, 2, IGRAPH_UNDIRECTED, 0, 0, 0, 1, -1);
+    igraph_vector_int_init_int(&types, 2, 0, 1);
+    igraph_is_vertex_coloring(&graph, &types, &res);
+    IGRAPH_ASSERT(res);
+    igraph_vector_int_destroy(&types);
+    igraph_destroy(&graph);
+
+    printf("igraph_is_vertex_coloring tests passed\n");
+}
+
+void test_bipartite_coloring(void) {
+    igraph_t graph;
+    igraph_vector_bool_t types;
+    igraph_bool_t res;
+    igraph_neimode_t mode;
+
+    printf("Testing igraph_is_bipartite_coloring\n");
+
+    /* Empty graph */
+    igraph_empty(&graph, 0, IGRAPH_UNDIRECTED);
+    igraph_vector_bool_init(&types, 0);
+    igraph_is_bipartite_coloring(&graph, &types, &res, &mode);
+    IGRAPH_ASSERT(res);
+    IGRAPH_ASSERT(mode == IGRAPH_ALL);
+    igraph_vector_bool_destroy(&types);
+    igraph_destroy(&graph);
+
+    /* Single vertex */
+    igraph_empty(&graph, 1, IGRAPH_UNDIRECTED);
+    igraph_vector_bool_init_int(&types, 1, 0);
+    igraph_is_bipartite_coloring(&graph, &types, &res, &mode);
+    IGRAPH_ASSERT(res);
+    IGRAPH_ASSERT(mode == IGRAPH_ALL);
+    igraph_vector_bool_destroy(&types);
+    igraph_destroy(&graph);
+
+    /* Valid bipartite undirected graph */
+    igraph_small(&graph, 4, IGRAPH_UNDIRECTED, 0, 2, 0, 3, 1, 2, 1, 3, -1);
+    igraph_vector_bool_init_int(&types, 4, 0, 0, 1, 1);
+    igraph_is_bipartite_coloring(&graph, &types, &res, &mode);
+    IGRAPH_ASSERT(res);
+    IGRAPH_ASSERT(mode == IGRAPH_ALL);  /* Undirected graph */
+    igraph_vector_bool_destroy(&types);
+    igraph_destroy(&graph);
+
+    /* Invalid bipartite coloring (two adjacent vertices same type) */
+    igraph_small(&graph, 4, IGRAPH_UNDIRECTED, 0, 1, 0, 2, 1, 3, 2, 3, -1);
+    igraph_vector_bool_init_int(&types, 4, 0, 0, 1, 1);
+    igraph_is_bipartite_coloring(&graph, &types, &res, &mode);
+    IGRAPH_ASSERT(!res);
+    igraph_vector_bool_destroy(&types);
+    igraph_destroy(&graph);
+
+    /* Directed bipartite graph - all edges from false to true */
+    igraph_small(&graph, 4, IGRAPH_DIRECTED, 0, 2, 0, 3, 1, 2, 1, 3, -1);
+    igraph_vector_bool_init_int(&types, 4, 0, 0, 1, 1);
+    igraph_is_bipartite_coloring(&graph, &types, &res, &mode);
+    IGRAPH_ASSERT(res);
+    IGRAPH_ASSERT(mode == IGRAPH_OUT);
+    igraph_vector_bool_destroy(&types);
+    igraph_destroy(&graph);
+
+    /* Directed bipartite graph - all edges from true to false */
+    igraph_small(&graph, 4, IGRAPH_DIRECTED, 2, 0, 3, 0, 2, 1, 3, 1, -1);
+    igraph_vector_bool_init_int(&types, 4, 0, 0, 1, 1);
+    igraph_is_bipartite_coloring(&graph, &types, &res, &mode);
+    IGRAPH_ASSERT(res);
+    IGRAPH_ASSERT(mode == IGRAPH_IN);
+    igraph_vector_bool_destroy(&types);
+    igraph_destroy(&graph);
+
+    /* Directed bipartite graph - edges in both directions */
+    igraph_small(&graph, 4, IGRAPH_DIRECTED, 0, 2, 2, 1, 1, 3, 3, 0, -1);
+    igraph_vector_bool_init_int(&types, 4, 0, 0, 1, 1);
+    igraph_is_bipartite_coloring(&graph, &types, &res, &mode);
+    IGRAPH_ASSERT(res);
+    IGRAPH_ASSERT(mode == IGRAPH_ALL);
+    igraph_vector_bool_destroy(&types);
+    igraph_destroy(&graph);
+
+    /* Self-loop should not affect bipartite coloring validity */
+    igraph_small(&graph, 3, IGRAPH_UNDIRECTED, 0, 0, 0, 2, 1, 2, -1);
+    igraph_vector_bool_init_int(&types, 3, 0, 0, 1);
+    igraph_is_bipartite_coloring(&graph, &types, &res, NULL);
+    IGRAPH_ASSERT(res);
+    igraph_vector_bool_destroy(&types);
+    igraph_destroy(&graph);
+
+    printf("igraph_is_bipartite_coloring tests passed\n");
+}
+
+void test_edge_coloring(void) {
+    igraph_t graph;
+    igraph_vector_int_t types;
+    igraph_bool_t res;
+
+    printf("Testing igraph_is_edge_coloring\n");
+
+    /* Empty graph */
+    igraph_empty(&graph, 0, IGRAPH_UNDIRECTED);
+    igraph_vector_int_init(&types, 0);
+    igraph_is_edge_coloring(&graph, &types, &res);
+    IGRAPH_ASSERT(res);
+    igraph_vector_int_destroy(&types);
+    igraph_destroy(&graph);
+
+    /* Single vertex, no edges */
+    igraph_empty(&graph, 1, IGRAPH_UNDIRECTED);
+    igraph_vector_int_init(&types, 0);
+    igraph_is_edge_coloring(&graph, &types, &res);
+    IGRAPH_ASSERT(res);
+    igraph_vector_int_destroy(&types);
+    igraph_destroy(&graph);
+
+    /* Two vertices, one edge */
+    igraph_small(&graph, 2, IGRAPH_UNDIRECTED, 0, 1, -1);
+    igraph_vector_int_init_int(&types, 1, 0);
+    igraph_is_edge_coloring(&graph, &types, &res);
+    IGRAPH_ASSERT(res);
+    igraph_vector_int_destroy(&types);
+    igraph_destroy(&graph);
+
+    /* Triangle with valid edge coloring */
+    igraph_small(&graph, 3, IGRAPH_UNDIRECTED, 0, 1, 1, 2, 2, 0, -1);
+    igraph_vector_int_init_int(&types, 3, 0, 1, 2);  /* Three different colors */
+    igraph_is_edge_coloring(&graph, &types, &res);
+    IGRAPH_ASSERT(res);
+    igraph_vector_int_destroy(&types);
+
+    /* Triangle with invalid edge coloring (two incident edges same color) */
+    igraph_vector_int_init_int(&types, 3, 0, 1, 0);  /* Edges 0 and 2 both color 0, both incident to vertex 0 */
+    igraph_is_edge_coloring(&graph, &types, &res);
+    IGRAPH_ASSERT(!res);
+    igraph_vector_int_destroy(&types);
+    igraph_destroy(&graph);
+
+    /* Star graph with valid edge coloring */
+    igraph_small(&graph, 4, IGRAPH_UNDIRECTED, 0, 1, 0, 2, 0, 3, -1);
+    igraph_vector_int_init_int(&types, 3, 0, 1, 2);  /* All edges incident to vertex 0 have different colors */
+    igraph_is_edge_coloring(&graph, &types, &res);
+    IGRAPH_ASSERT(res);
+    igraph_vector_int_destroy(&types);
+
+    /* Star graph with invalid edge coloring */
+    igraph_vector_int_init_int(&types, 3, 0, 0, 1);  /* Two edges incident to vertex 0 have same color */
+    igraph_is_edge_coloring(&graph, &types, &res);
+    IGRAPH_ASSERT(!res);
+    igraph_vector_int_destroy(&types);
+    igraph_destroy(&graph);
+
+    /* Path graph with valid edge coloring */
+    igraph_small(&graph, 4, IGRAPH_UNDIRECTED, 0, 1, 1, 2, 2, 3, -1);
+    igraph_vector_int_init_int(&types, 3, 0, 1, 0);  /* Alternating colors */
+    igraph_is_edge_coloring(&graph, &types, &res);
+    IGRAPH_ASSERT(res);
+    igraph_vector_int_destroy(&types);
+    igraph_destroy(&graph);
+
+    printf("igraph_is_edge_coloring tests passed\n");
+}
+
+void test_error_conditions(void) {
+    igraph_t graph;
+    igraph_vector_int_t int_types;
+    igraph_vector_bool_t bool_types;
+    igraph_bool_t res;
+    igraph_neimode_t mode;
+
+    printf("Testing error conditions\n");
+
+    /* Create a simple graph */
+    igraph_small(&graph, 3, IGRAPH_UNDIRECTED, 0, 1, 1, 2, -1);
+
+    /* Wrong size vector for vertex coloring */
+    igraph_vector_int_init_int(&int_types, 2, 0, 1);  /* Size 2, but graph has 3 vertices */
+    CHECK_ERROR(igraph_is_vertex_coloring(&graph, &int_types, &res), IGRAPH_EINVAL);
+    igraph_vector_int_destroy(&int_types);
+
+    /* Wrong size vector for bipartite coloring */
+    igraph_vector_bool_init_int(&bool_types, 2, 0, 1);  /* Size 2, but graph has 3 vertices */
+    CHECK_ERROR(igraph_is_bipartite_coloring(&graph, &bool_types, &res, &mode), IGRAPH_EINVAL);
+    igraph_vector_bool_destroy(&bool_types);
+
+    igraph_destroy(&graph);
+
+    /* Wrong size vector for edge coloring */
+    igraph_small(&graph, 2, IGRAPH_UNDIRECTED, 0, 1, -1);  /* Graph with 1 edge */
+    igraph_vector_int_init_int(&int_types, 2, 0, 1);  /* Size 2, but graph has 1 edge */
+    CHECK_ERROR(igraph_is_edge_coloring(&graph, &int_types, &res), IGRAPH_EINVAL);
+    igraph_vector_int_destroy(&int_types);
+    igraph_destroy(&graph);
+
+    printf("Error condition tests passed\n");
+}
+
+int main(void) {
+    test_vertex_coloring();
+    test_bipartite_coloring();
+    test_edge_coloring();
+    test_error_conditions();
+
+    VERIFY_FINALLY_STACK();
+    printf("All tests passed!\n");
+    return 0;
+}

--- a/tests/unit/is_coloring.c
+++ b/tests/unit/is_coloring.c
@@ -230,6 +230,21 @@ void test_edge_coloring(void) {
     igraph_vector_int_destroy(&types);
     igraph_destroy(&graph);
 
+    /* Graph with self-loop: 1 - 1 - 2 (self-loop and regular edge) */
+    /* Self-loops are not considered adjacent to themselves */
+    igraph_small(&graph, 2, IGRAPH_UNDIRECTED, 1, 1, 1, 0, -1);  /* vertex 1 self-loop, edge 1-0 */
+    igraph_vector_int_init_int(&types, 2, 0, 1);  /* Different colors - should be valid */
+    igraph_is_edge_coloring(&graph, &types, &res);
+    IGRAPH_ASSERT(res);
+    igraph_vector_int_destroy(&types);
+    
+    /* Same colors for self-loop and adjacent edge - should be invalid */
+    igraph_vector_int_init_int(&types, 2, 0, 0);  /* Same colors - should be invalid */
+    igraph_is_edge_coloring(&graph, &types, &res);
+    IGRAPH_ASSERT(!res);
+    igraph_vector_int_destroy(&types);
+    igraph_destroy(&graph);
+
     printf("igraph_is_edge_coloring() tests passed\n");
 }
 


### PR DESCRIPTION
This PR implements the coloring verification functions requested in issue #2758.

## Summary
- Add `igraph_is_vertex_coloring()` for multipartite vertex coloring validation
- Add `igraph_is_bipartite_coloring()` for bipartite vertex coloring with edge direction support  
- Add `igraph_is_edge_coloring()` for edge coloring validation
- Include comprehensive unit tests covering various graph configurations
- All functions validate input sizes and return proper error codes

## Implementation Details
- Used efficient algorithms for duplicate color detection (sorting instead of pairwise comparisons)
- Replaced `igraph_incident()` with `igraph_i_incident()` with `IGRAPH_LOOPS_ONCE`
- Added proper interruption support using `IGRAPH_ALLOW_INTERRUPTION()`
- Functions handle self-loops appropriately (documented that self-edges are not considered self-adjacent)
- Added interface definitions in `interfaces/functions.yaml`
- Added documentation in `doc/coloring.xxml`

## Testing
- Added comprehensive test suite in `tests/unit/igraph_is_coloring.c`
- All tests pass successfully including edge cases with self-loops
- Functions handle error conditions properly

## AI Usage Disclosure
Yes, I used AI tools for debugging purposes to help identify and fix implementation issues during development.

## Copyright Assignment
- [x] By submitting this pull request, I assign the copyright of my contribution to _The igraph development team_.

Fixes #2758