### PR TITLE
Simplified interface to Leiden communities and weighted density calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@
  - `igraph_matrix_copy_to()` gained an `igraph_matrix_storage_t storage` parameter that specifies whether the data should be written in column-major or row-major format.
  - `igraph_sbm_game()` gained a `multiple` parameter and now supports generating multigraph with prescribed expected edge multiplicities. The parameter determining the total number of vertices (`n`) was removed as it was redundant.
  - The `bfs_cutoff` parameter of the experimental functions `igraph_fundamental_cycles()` and `igraph_minimum_cycle_basis()` is now of type `igraph_real_t`.
+ - `igraph_density()` now takes an optional `weights` parameter.
 
 ### Added
 
@@ -91,6 +92,7 @@
  - `igraph_nearest_neighbor_graph()` computes a neighborhood graph of spatial points based on a neighbor count, cutoff distance, and chosen metric (experimental function). Thanks to Arnór Friðriksson @Zepeacedust for implementing this in #2788!
  - `igraph_delaunay_graph()` computes a Delaunay graph of a spatial point set (experimental function). Thanks to Arnór Friðriksson @Zepeacedust for implementing this in #2806!
  - `igraph_spatial_edge_lengths()` computes edges lengths based on spatial vertex coordinates (experimental function).
+ - `igraph_community_leiden_simple()` is a simplified interface to `igraph_community_leiden()` that allows selecting the objective function to maximize directly.
 
 ### Changed
 

--- a/doc/community.xxml
+++ b/doc/community.xxml
@@ -44,6 +44,7 @@
 <!-- doxrox-include igraph_community_fastgreedy -->
 <!-- doxrox-include igraph_community_multilevel -->
 <!-- doxrox-include igraph_community_leiden -->
+<!-- doxrox-include igraph_community_leiden_simple -->
 </section>
 
 <section id="fluid-communities"><title>Fluid communities</title>

--- a/fuzzing/basic_properties_directed.cpp
+++ b/fuzzing/basic_properties_directed.cpp
@@ -69,7 +69,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
         igraph_is_eulerian(&graph, &bres, &bres2);
         igraph_invalidate_cache(&graph);
 
-        igraph_density(&graph, &r, true);
+        igraph_density(&graph, NULL, &r, true);
 
         igraph_destroy(&graph);
     }

--- a/fuzzing/basic_properties_undirected.cpp
+++ b/fuzzing/basic_properties_undirected.cpp
@@ -74,7 +74,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
         igraph_is_chordal(&graph, NULL, NULL, &bres, NULL, NULL);
         igraph_invalidate_cache(&graph);
 
-        igraph_density(&graph, &r, true);
+        igraph_density(&graph, NULL, &r, true);
 
         igraph_destroy(&graph);
     }

--- a/include/igraph_community.h
+++ b/include/igraph_community.h
@@ -230,6 +230,12 @@ IGRAPH_EXPORT igraph_error_t igraph_community_multilevel(const igraph_t *graph,
                                               igraph_matrix_int_t *memberships,
                                               igraph_vector_t *modularity);
 
+typedef enum {
+    IGRAPH_LEIDEN_OBJECTIVE_MODULARITY = 0,
+    IGRAPH_LEIDEN_OBJECTIVE_CPM,
+    IGRAPH_LEIDEN_OBJECTIVE_ER
+} igraph_leiden_objective_t;
+
 IGRAPH_EXPORT igraph_error_t igraph_community_leiden(
         const igraph_t *graph,
         const igraph_vector_t *edge_weights,
@@ -241,6 +247,18 @@ IGRAPH_EXPORT igraph_error_t igraph_community_leiden(
         igraph_integer_t n_iterations,
         igraph_vector_int_t *membership,
         igraph_integer_t *nb_clusters, igraph_real_t *quality);
+
+IGRAPH_EXPORT igraph_error_t igraph_community_leiden_simple(
+        const igraph_t *graph,
+        const igraph_vector_t *weights,
+        igraph_leiden_objective_t objective,
+        igraph_real_t resolution,
+        igraph_real_t beta,
+        igraph_bool_t start,
+        igraph_integer_t n_iterations,
+        igraph_vector_int_t *membership,
+        igraph_integer_t *nb_clusters,
+        igraph_real_t *quality);
 
 /* -------------------------------------------------- */
 /* Community Structure Comparison                     */

--- a/include/igraph_structural.h
+++ b/include/igraph_structural.h
@@ -38,8 +38,8 @@ IGRAPH_BEGIN_C_DECLS
 IGRAPH_EXPORT igraph_error_t igraph_are_adjacent(const igraph_t *graph, igraph_integer_t v1, igraph_integer_t v2, igraph_bool_t *res);
 IGRAPH_EXPORT igraph_error_t igraph_count_multiple(const igraph_t *graph, igraph_vector_int_t *res, igraph_es_t es);
 IGRAPH_EXPORT igraph_error_t igraph_count_multiple_1(const igraph_t *graph, igraph_integer_t *res, igraph_integer_t eid);
-IGRAPH_EXPORT igraph_error_t igraph_density(const igraph_t *graph, igraph_real_t *res,
-                                 igraph_bool_t loops);
+IGRAPH_EXPORT igraph_error_t igraph_density(const igraph_t *graph, const igraph_vector_t *weights,
+                                            igraph_real_t *res, igraph_bool_t loops);
 IGRAPH_EXPORT igraph_error_t igraph_diversity(const igraph_t *graph, const igraph_vector_t *weights,
                                    igraph_vector_t *res, igraph_vs_t vs);
 IGRAPH_EXPORT igraph_error_t igraph_girth(const igraph_t *graph, igraph_real_t *girth,

--- a/interfaces/functions.yaml
+++ b/interfaces/functions.yaml
@@ -1756,6 +1756,15 @@ igraph_community_leiden:
         OUT INTEGER nb_clusters, OUT REAL quality
     DEPS: weights ON graph, vertex_out_weights ON graph, vertex_in_weights ON graph
 
+igraph_community_leiden_simple:
+    PARAMS: |-
+        GRAPH graph, OPTIONAL EDGE_WEIGHTS weights,
+        LEIDEN_OBJECTIVE objective,
+        REAL resolution, REAL beta=0.01, BOOLEAN start, INTEGER n_iterations=2,
+        OPTIONAL INOUT VECTOR_INT membership,
+        OUT INTEGER nb_clusters, OUT REAL quality
+    DEPS: weights ON graph
+
 igraph_split_join_distance:
     PARAMS: |-
         VECTOR_INT comm1, VECTOR_INT comm2, OUT INTEGER distance12,

--- a/interfaces/functions.yaml
+++ b/interfaces/functions.yaml
@@ -1751,7 +1751,7 @@ igraph_community_leiden:
         GRAPH graph, OPTIONAL EDGE_WEIGHTS weights,
         OPTIONAL VERTEX_WEIGHTS vertex_out_weights,
         OPTIONAL VERTEX_WEIGHTS vertex_in_weights,
-        REAL resolution, REAL beta=0.01, BOOLEAN start, INTEGER n_iterations=2,
+        REAL resolution, REAL beta=0.01, BOOLEAN start=False, INTEGER n_iterations=2,
         OPTIONAL INOUT VECTOR_INT membership,
         OUT INTEGER nb_clusters, OUT REAL quality
     DEPS: weights ON graph, vertex_out_weights ON graph, vertex_in_weights ON graph
@@ -1760,7 +1760,7 @@ igraph_community_leiden_simple:
     PARAMS: |-
         GRAPH graph, OPTIONAL EDGE_WEIGHTS weights,
         LEIDEN_OBJECTIVE objective,
-        REAL resolution, REAL beta=0.01, BOOLEAN start, INTEGER n_iterations=2,
+        REAL resolution, REAL beta=0.01, BOOLEAN start=False, INTEGER n_iterations=2,
         OPTIONAL INOUT VECTOR_INT membership,
         OUT INTEGER nb_clusters, OUT REAL quality
     DEPS: weights ON graph

--- a/interfaces/functions.yaml
+++ b/interfaces/functions.yaml
@@ -814,7 +814,7 @@ igraph_maxdegree:
     DEPS: vids ON graph
 
 igraph_density:
-    PARAMS: GRAPH graph, OUT REAL res, BOOLEAN loops=False
+    PARAMS: GRAPH graph, OPTIONAL EDGE_WEIGHTS weights, OUT REAL res, BOOLEAN loops=False
 
 igraph_mean_degree:
     PARAMS: GRAPH graph, OUT REAL res, BOOLEAN loops=True

--- a/interfaces/types.yaml
+++ b/interfaces/types.yaml
@@ -362,6 +362,12 @@ LAYOUT_GRID:
     CTYPE: igraph_layout_grid_t
     FLAGS: ENUM
 
+LEIDEN_OBJECTIVE:
+    # The objective function to maximize with the Leiden community detection
+    # method.
+    CTYPE: igraph_leiden_objective_t
+    FLAGS: ENUM
+
 LOOPS:
     # Enum that describes how loop edges should be handled in undirected graphs
     # in functions that support it. Possible options are: no loops, loops

--- a/src/community/leiden.c
+++ b/src/community/leiden.c
@@ -26,6 +26,7 @@
 #include "igraph_memory.h"
 #include "igraph_random.h"
 #include "igraph_stack.h"
+#include "igraph_structural.h"
 #include "igraph_vector.h"
 #include "igraph_vector_list.h"
 
@@ -1084,6 +1085,8 @@ static igraph_error_t community_leiden(
  * optimized when you supply the degrees (out- and in-degrees with directed graphs)
  * as the vertex weights and by supplying as a resolution parameter
  * <code>1/(2m)</code> (<code>1/m</code> with directed graphs).
+ * Use the \ref igraph_community_leiden_simple() convenience function to
+ * compute vertex weights automatically for modularity maximization.
  *
  * </para><para>
  * References:
@@ -1110,9 +1113,10 @@ static igraph_error_t community_leiden(
  *    directed graphs. If set to \c NULL, in-weights are assumed to be the same
  *    as out-weights, which effectively ignores edge directions.
  *    Must be \c NULL for undirected graphs.
- * \param resolution The resolution parameter used, which is
- *    represented by γ in the objective function mentioned in the
- *    documentation.
+ * \param n_iterations Iterate the core Leiden algorithm the indicated number
+ *    of times. If this is a negative number, it will continue iterating until
+ *    an iteration did not change the clustering. Two iterations are often
+ *    sufficient, thus 2 is a reasonable default.
  * \param beta The randomness used in the refinement step when merging. A small
  *    amount of randomness (\c beta = 0.01) typically works well.
  * \param start Start from membership vector. If this is true, the optimization
@@ -1134,6 +1138,10 @@ static igraph_error_t community_leiden(
  * \return Error code.
  *
  * Time complexity: near linear on sparse graphs.
+ *
+ * \sa \ref igraph_community_leiden_simple() for a simplified interface
+ * that allows specifying an objective function directly and does not require
+ * vertex weights.
  *
  * \example examples/simple/igraph_community_leiden.c
  */
@@ -1260,6 +1268,232 @@ igraph_error_t igraph_community_leiden(
         IGRAPH_FREE(i_vertex_out_weights);
         IGRAPH_FINALLY_CLEAN(2);
     }
+
+    return IGRAPH_SUCCESS;
+}
+
+/**
+ * \function igraph_community_leiden_simple
+ * \brief Finding community structure using the Leiden algorithm, simple interface.
+ *
+ * This is a simplified interface to \ref igraph_community_leiden() for
+ * convenience purposes. Instead of requiring vertex weights, it allows
+ * choosing from a set of objective functions to maximize, and calculates
+ * the vertex weights and resolution parameter to pass to
+ * \ref igraph_community_leiden() accordingly.
+ *
+ * \param graph The input graph. May be directed or undirected.
+ * \param weights The edge weights. If \c NULL, all weights are assumed to be 1.
+ * \param objective The objective function to maximize.
+ *    \clist
+ *    \cli IGRAPH_LEIDEN_OBJECTIVE_MODULARITY
+ *      Use the generalized modularity, defined as
+ *      <code>Q = 1/(2m) sum_ij (A_ij - γ k_i k_j / (2m)) δ(c_i, c_j)</code>
+ *      for undirected graphs and as
+ *      <code>Q = 1/m sum_ij (A_ij - γ k^out_i k^in_j / m) δ(c_i, c_j)</code>
+ *      for directed graphs. This effectively uses a multigraph configuration
+ *      model as the null model. Edge weights must not be negative.
+ *    \cli IGRAPH_LEIDEN_OBJECTIVE_CPM
+ *      Use the constant Potts model, whose objective function is defined as
+ *      <code>Q = 1/(2m) sum_ij (A_ij - γ) δ(c_i, c_j)</code>
+ *      for undirected graphs and as
+ *      <code>Q = 1/m sum_ij (A_ij - γ) δ(c_i, c_j)</code>
+ *      for directed graphs. Edge weights are allowed to be negative.
+ *      Edge directions have no impact on the result.
+ *    \cli IGRAPH_LEIDEN_OBJECTIVE_ER
+ *      Use an objective function based on the multigraph Erdős-Rényi G(n,p)
+ *      null model, defined as
+ *      <code>Q = 1/(2m) sum_ij (A_ij - γ p) δ(c_i, c_j)</code>
+ *      for undirected graphs and as
+ *      <code>Q = 1/m sum_ij (A_ij - γ p) δ(c_i, c_j)</code>
+ *      for directed graphs. \c p is the weighted density, i.e. the average
+ *      link strength between all vertex pairs (whether adjacent or not).
+ *      Edge weights must not be negative. Edge directions have no impact on
+ *      the result.
+ *    \endclist
+ *    In the above formulas, \c A is the adjacency matrix, \c m is the total
+ *    edge weight, \c k are the (out- and in-) degrees, \c γ is the resolution
+ *    parameter, and <code>δ(c_i, c_j)</code> is 1 if vertices \c i and \c j
+ *    are in the same community and 0 otherwise. Edge directions are only
+ *    relevant with \c IGRAPH_LEIDEN_OBJECTIVE_MODULARITY. The other two
+ *    objective functions are equivalent between directed and undirected graphs:
+ *    the formal difference is due to each edge being included twice in
+ *    undirected (symmetric) adjacency matrices.
+ * \param resolution The resolution parameter, which is represented by γ in
+ *    the objective functions detailed above.
+ * \param beta The randomness used in the refinement step when merging. A small
+ *    amount of randomness (\c beta = 0.01) typically works well.
+ * \param start Start from membership vector. If this is true, the optimization
+ *    will start from the provided membership vector. If this is false, the
+ *    optimization will start from a singleton partition.
+ * \param n_iterations Iterate the core Leiden algorithm the indicated number
+ *    of times. If this is a negative number, it will continue iterating until
+ *    an iteration did not change the clustering. Two iterations are often
+ *    sufficient, thus 2 is a reasonable default.
+ * \param membership The membership vector. If \p start is set to \c false,
+ *    it will be resized appropriately. If \p start is \c true, it must be
+ *    a valid membership vector for the given \p graph.
+ * \param nb_clusters The number of clusters contained in the final \p membership.
+ *    If \c NULL, the number of clusters will not be returned.
+ * \param quality The quality of the partition, in terms of the objective
+ *    function selected by \p objective. If \c NULL the quality will
+ *    not be calculated.
+ * \return Error code.
+ *
+ * Time complexity: near linear on sparse graphs.
+ *
+ * \sa \ref igraph_community_leiden() for a more flexible interface that
+ * allows specifying raw vertex weights.
+ */
+igraph_error_t igraph_community_leiden_simple(
+        const igraph_t *graph,
+        const igraph_vector_t *weights,
+        igraph_leiden_objective_t objective,
+        igraph_real_t resolution,
+        igraph_real_t beta,
+        igraph_bool_t start,
+        igraph_integer_t n_iterations,
+        igraph_vector_int_t *membership,
+        igraph_integer_t *nb_clusters,
+        igraph_real_t *quality) {
+
+    const igraph_integer_t vcount = igraph_vcount(graph);
+    const igraph_integer_t ecount = igraph_ecount(graph);
+    const igraph_bool_t directed = igraph_is_directed(graph);
+    igraph_vector_t vertex_out_weights, vertex_in_weights;
+    igraph_vector_int_t i_membership, *p_membership;
+    igraph_real_t min_weight = IGRAPH_INFINITY;
+
+    /* Basic weight vector validation, calculate properties used for validation steps
+     * specific to different objective functions. */
+    if (weights) {
+        if (igraph_vector_size(weights) != ecount) {
+            IGRAPH_ERROR("Edge weight vector length does not match number of edges.", IGRAPH_EINVAL);
+        }
+        for (igraph_integer_t i=0; i < ecount; i++) {
+            igraph_real_t w = VECTOR(*weights)[i];
+            if (w < min_weight) {
+                min_weight = w;
+            }
+            if (! isfinite(w)) {
+                IGRAPH_ERRORF("Edge weights must not be infinite or NaN, got %g.",
+                              IGRAPH_EINVAL, w);
+            }
+        }
+    }
+
+    IGRAPH_VECTOR_INIT_FINALLY(&vertex_out_weights, vcount);
+    if (directed) {
+        IGRAPH_VECTOR_INIT_FINALLY(&vertex_in_weights, vcount);
+    }
+
+    /* igraph_community_leiden() always requires an initialized membership vector
+     * of the correct size to be given. We relax this requirement to the case
+     * when start = true. */
+    if (start) {
+        if (!membership) {
+            IGRAPH_ERROR("Requesting to start the computation from a specific "
+                         "community assignment, but no membership vector given.",
+                         IGRAPH_EINVAL);
+        }
+        if (igraph_vector_int_size(membership) != vcount) {
+            IGRAPH_ERRORF("Requesting to start the computation from a specific "
+                          "community assignment, but the given membership vector "
+                          "has a different size (%" IGRAPH_PRId " than the vertex "
+                          "count (%" IGRAPH_PRId ").",
+                          IGRAPH_EINVAL,
+                          igraph_vector_int_size(membership), vcount);
+        }
+        p_membership = membership;
+    } else {
+        if (!membership) {
+            IGRAPH_VECTOR_INT_INIT_FINALLY(&i_membership, vcount);
+            p_membership = &i_membership;
+        } else {
+            IGRAPH_CHECK(igraph_vector_int_resize(membership, vcount));
+            p_membership = membership;
+        }
+    }
+
+    switch (objective) {
+    case IGRAPH_LEIDEN_OBJECTIVE_MODULARITY:
+        if (min_weight < 0) {
+            IGRAPH_ERRORF("Edge weights must not be negative for Leiden community "
+                          "detection with modularity objective function, got %g.",
+                          IGRAPH_EINVAL,
+                          min_weight);
+        }
+
+        IGRAPH_CHECK(igraph_strength(
+            graph, &vertex_out_weights,
+            igraph_vss_all(), IGRAPH_OUT, IGRAPH_LOOPS, weights));
+        if (directed) {
+            IGRAPH_CHECK(igraph_strength(
+                graph, &vertex_in_weights,
+                igraph_vss_all(), IGRAPH_IN, IGRAPH_LOOPS, weights));
+        }
+
+        /* If directed, the sum of vertex_out_weights is the total edge weight.
+         * If undirected, it is twice the total edge weight. */
+        resolution /= igraph_vector_sum(&vertex_out_weights);
+
+        break;
+
+    case IGRAPH_LEIDEN_OBJECTIVE_CPM:
+        /* TODO: Potential minor optimization is to use the same vector for both. */
+        igraph_vector_fill(&vertex_out_weights, 1);
+        if (directed) {
+            igraph_vector_fill(&vertex_in_weights, 1);
+        }
+
+        break;
+
+    case IGRAPH_LEIDEN_OBJECTIVE_ER:
+        if (min_weight < 0) {
+            IGRAPH_ERRORF("Edge weights must not be negative for Leiden community "
+                          "detection with ER objective function, got %g.",
+                          IGRAPH_EINVAL,
+                          min_weight);
+        }
+
+        /* TODO: Potential minor optimization is to use the same vector for both. */
+        igraph_vector_fill(&vertex_out_weights, 1);
+        if (directed) {
+            igraph_vector_fill(&vertex_in_weights, 1);
+        }
+
+        {
+            igraph_real_t p;
+            /* Note: Loops must be allowed, as the aggregation step of the
+             * algorithm effectively creates them. */
+            IGRAPH_CHECK(igraph_density(graph, weights, &p, /* loops */ true));
+            resolution *= p;
+        }
+
+        break;
+
+
+    default:
+        IGRAPH_ERROR("Invalid objective function for Leiden community detection.",
+                     IGRAPH_EINVAL);
+    }
+
+    IGRAPH_CHECK(igraph_community_leiden(
+        graph, weights,
+        &vertex_out_weights, directed ? &vertex_in_weights : NULL,
+        resolution, beta, start, n_iterations, p_membership, nb_clusters, quality));
+
+    if (!membership) {
+        igraph_vector_int_destroy(&i_membership);
+        IGRAPH_FINALLY_CLEAN(1);
+    }
+
+    if (directed) {
+        igraph_vector_destroy(&vertex_in_weights);
+        IGRAPH_FINALLY_CLEAN(1);
+    }
+    igraph_vector_destroy(&vertex_out_weights);
+    IGRAPH_FINALLY_CLEAN(1);
 
     return IGRAPH_SUCCESS;
 }

--- a/src/community/leiden.c
+++ b/src/community/leiden.c
@@ -1079,7 +1079,10 @@ static igraph_error_t community_leiden(
  * is the vertex weight of vertex \c i (separate out- and in-weights are used
  * with directed graphs), <code>s_i</code> is the cluster of vertex
  * \c i and <code>δ(x, y) = 1</code> if and only if <code>x = y</code> and 0
- * otherwise. By setting <code>n_i = k_i</code>, the degree of vertex \c i, and
+ * otherwise.
+ *
+ * </para><para>
+ * By setting <code>n_i = k_i</code>, the degree of vertex \c i, and
  * dividing \c γ by <code>2m</code> (by \c m in the directed case), we effectively
  * obtain an expression for modularity. Hence, the standard modularity will be
  * optimized when you supply the degrees (out- and in-degrees with directed graphs)
@@ -1278,9 +1281,10 @@ igraph_error_t igraph_community_leiden(
  *
  * This is a simplified interface to \ref igraph_community_leiden() for
  * convenience purposes. Instead of requiring vertex weights, it allows
- * choosing from a set of objective functions to maximize, and calculates
- * the vertex weights and resolution parameter to pass to
- * \ref igraph_community_leiden() accordingly.
+ * choosing from a set of objective functions to maximize. It implements
+ * these objective functions by passing suitable vertex weights to
+ * \ref igraph_community_leiden(), as explained in the documentation of
+ * that function.
  *
  * \param graph The input graph. May be directed or undirected.
  * \param weights The edge weights. If \c NULL, all weights are assumed to be 1.

--- a/tests/unit/community_leiden.c
+++ b/tests/unit/community_leiden.c
@@ -26,27 +26,45 @@
 
 #define TOL (1e-15)
 
-void run_leiden_CPM(const igraph_t *graph, const igraph_vector_t *edge_weights, const igraph_real_t resolution_parameter) {
+void run_leiden_CPM(const igraph_t *graph, const igraph_vector_t *edge_weights, const igraph_real_t resolution) {
 
     igraph_vector_int_t membership;
     igraph_integer_t nb_clusters = igraph_vcount(graph);
-    igraph_real_t quality;
+    igraph_real_t quality, quality2;
 
     /* Initialize with singleton partition. */
     igraph_vector_int_init(&membership, igraph_vcount(graph));
 
-    igraph_community_leiden(graph, edge_weights, NULL, NULL, resolution_parameter, 0.01, false, 2, &membership,
+    /* Use same seed as for the simplified interface below, to ensure the same result. */
+    igraph_rng_seed(igraph_rng_default(), 123);
+    igraph_community_leiden(graph,
+                            edge_weights, NULL, NULL,
+                            resolution, 0.01, false, 2, &membership,
                             &nb_clusters,
                             &quality);
 
     /* Handle negative zeros. */
     if (fabs(quality) < TOL) quality = 0.0;
 
-    printf("Leiden found %" IGRAPH_PRId " clusters using CPM (resolution parameter=%.2f), quality is %.5f.\n", nb_clusters, resolution_parameter, quality);
+    printf("Leiden found %" IGRAPH_PRId " clusters using CPM (resolution parameter=%.2f), quality is %.5f.\n", nb_clusters, resolution, quality);
 
     printf("Membership: ");
     igraph_vector_int_print(&membership);
     printf("\n");
+
+    quality2 = quality;
+
+    /* Use same seed as for the generic interface above, to ensure the same result. */
+    igraph_rng_seed(igraph_rng_default(), 123);
+    igraph_community_leiden_simple(graph,
+                                   edge_weights,
+                                   IGRAPH_LEIDEN_OBJECTIVE_CPM,
+                                   resolution, 0.01, false, 2, &membership,
+                                   NULL,
+                                   &quality);
+    if (fabs(quality) < TOL) quality = 0.0;
+    IGRAPH_ASSERT((isnan(quality) && isnan(quality2)) ||
+                  igraph_almost_equals(quality, quality2, TOL));
 
     igraph_vector_int_destroy(&membership);
 }
@@ -74,6 +92,8 @@ void run_leiden_modularity(igraph_t *graph, igraph_vector_t *edge_weights) {
     /* Initialize with singleton partition. */
     igraph_vector_int_init(&membership, igraph_vcount(graph));
 
+    /* Use same seed as for the simplified interface below, to ensure the same result. */
+    igraph_rng_seed(igraph_rng_default(), 123);
     igraph_community_leiden(graph,
                             edge_weights, &out_strength, directed ? &in_strength : NULL,
                             1.0 / (directed_multiplier * m), 0.01, false, 2, &membership, &nb_clusters,
@@ -97,6 +117,16 @@ void run_leiden_modularity(igraph_t *graph, igraph_vector_t *edge_weights) {
     printf("Membership: ");
     igraph_vector_int_print(&membership);
     printf("\n");
+
+    /* Use same seed as for the generic interface above, to ensure the same result. */
+    igraph_rng_seed(igraph_rng_default(), 123);
+    igraph_community_leiden_simple(graph,
+                                   edge_weights,
+                                   IGRAPH_LEIDEN_OBJECTIVE_MODULARITY,
+                                   1.0, 0.01, false, 2, &membership, NULL, &quality);
+    if (fabs(quality) < TOL) quality = 0.0;
+    IGRAPH_ASSERT((isnan(quality) && isnan(quality2)) ||
+                  igraph_almost_equals(quality, quality2, TOL));
 
     igraph_vector_int_destroy(&membership);
     if (directed) igraph_vector_destroy(&in_strength);
@@ -242,6 +272,37 @@ int main(void) {
     /* Edgeless graph */
     igraph_empty(&graph, 5, IGRAPH_UNDIRECTED);
     run_leiden_modularity(&graph, &weights);
+    igraph_destroy(&graph);
+
+    /* Check that the input is validated properly. */
+
+    /* Small test graph. */
+    igraph_small(&graph, 4, IGRAPH_UNDIRECTED,
+                 0,1, 1,2, 2,0, 0,3, 3,3,
+                 -1);
+    igraph_vector_range(&weights, 1, igraph_ecount(&graph) + 1);
+
+    /* Omitting membership should raise no error. */
+    igraph_community_leiden_simple(&graph, &weights, IGRAPH_LEIDEN_OBJECTIVE_MODULARITY,
+                                   1.0, 0.01, false, 1, NULL, NULL, NULL);
+
+    /* Negative weight. */
+    VECTOR(weights)[0] = -1;
+    CHECK_ERROR(igraph_community_leiden_simple(&graph, &weights, IGRAPH_LEIDEN_OBJECTIVE_MODULARITY,
+                                               1.0, 0.01, false, 1, NULL, NULL, NULL), IGRAPH_EINVAL);
+    CHECK_ERROR(igraph_community_leiden_simple(&graph, &weights, IGRAPH_LEIDEN_OBJECTIVE_ER,
+                                               1.0, 0.01, false, 1, NULL, NULL, NULL), IGRAPH_EINVAL);
+
+    /* NaN weight. */
+    VECTOR(weights)[0] = IGRAPH_NAN;
+    CHECK_ERROR(igraph_community_leiden_simple(&graph, &weights, IGRAPH_LEIDEN_OBJECTIVE_CPM,
+                                               1.0, 0.01, false, 1, NULL, NULL, NULL), IGRAPH_EINVAL);
+
+    /* Invalid weight vector length. */
+    igraph_vector_range(&weights, 1, igraph_ecount(&graph) + 2);
+    CHECK_ERROR(igraph_community_leiden_simple(&graph, &weights, IGRAPH_LEIDEN_OBJECTIVE_MODULARITY,
+                                               1.0, 0.01, false, 1, NULL, NULL, NULL), IGRAPH_EINVAL);
+
     igraph_destroy(&graph);
 
     igraph_vector_destroy(&weights);

--- a/tests/unit/community_leiden.out
+++ b/tests/unit/community_leiden.out
@@ -35,7 +35,7 @@ Leiden found 3 clusters using modularity, undirected, quality is 0.50000.
 Membership: 0 0 0 0 1 1 1 1 2
 
 Leiden found 4 clusters using modularity, undirected, quality is 0.55000.
-Membership: 0 0 0 0 1 1 1 1 1 0 2 2 3 3 3 3 3 2 2 2
+Membership: 0 0 0 1 1 1 1 1 0 0 2 2 2 2 2 3 3 3 3 3
 
 Leiden found 2 clusters using CPM (resolution parameter=0.05), quality is 0.75000.
 Membership: 0 0 0 0 0 0 0 0 0 0 1 1 1 1 1 1 1 1 1 1

--- a/tests/unit/igraph_density.c
+++ b/tests/unit/igraph_density.c
@@ -27,7 +27,7 @@
 void test_density(const igraph_t *graph, igraph_bool_t loops) {
     igraph_real_t density;
 
-    if (igraph_density(graph, &density, loops)) {
+    if (igraph_density(graph, NULL, &density, loops)) {
         printf("FAILED!\n");
         return;
     }

--- a/tests/unit/igraph_density.c
+++ b/tests/unit/igraph_density.c
@@ -39,6 +39,42 @@ void test_density(const igraph_t *graph, igraph_bool_t loops) {
     }
 }
 
+/* Assumes an attribute handler.
+ *
+ * Takes a multigraph, simplifies edges and records edge multiplicites
+ * as "weights", then verifies that the density of the unweighted multigraph
+ * is the same as the density of the weighted simplified graph.
+ */
+void test_weighted_density(const igraph_t *graph, igraph_bool_t loops) {
+    igraph_t wg;
+    igraph_vector_t weights;
+    igraph_attribute_combination_t comb;
+    igraph_real_t dens1, dens2;
+
+    igraph_copy(&wg, graph);
+
+    igraph_vector_init(&weights, igraph_ecount(graph));
+    igraph_vector_fill(&weights, 1);
+    SETEANV(&wg, "weight", &weights);
+
+    igraph_attribute_combination(&comb,
+                                 "weight", IGRAPH_ATTRIBUTE_COMBINE_SUM,
+                                 IGRAPH_NO_MORE_ATTRIBUTES);
+
+    igraph_simplify(&wg, /* remove_multiple */ true, /* remove_loops */ false, &comb);
+
+    EANV(&wg, "weight", &weights);
+
+    igraph_density(graph, NULL, &dens1, loops);
+    igraph_density(&wg, &weights, &dens2, loops);
+
+    IGRAPH_ASSERT(dens1 == dens2);
+
+    igraph_attribute_combination_destroy(&comb);
+    igraph_vector_destroy(&weights);
+    igraph_destroy(&wg);
+}
+
 int main(void) {
 
     igraph_t g;
@@ -48,23 +84,23 @@ int main(void) {
 
     /* Test graphs with no vertices and no edges */
     igraph_create(&g, &v, 0, IGRAPH_UNDIRECTED);
-    test_density(&g, 0);
-    test_density(&g, 1);
+    test_density(&g, false);
+    test_density(&g, true);
     igraph_destroy(&g);
     igraph_create(&g, &v, 0, IGRAPH_DIRECTED);
-    test_density(&g, 0);
-    test_density(&g, 1);
+    test_density(&g, false);
+    test_density(&g, true);
     igraph_destroy(&g);
     printf("======\n");
 
     /* Test graphs with one vertex and no edges */
     igraph_create(&g, &v, 1, IGRAPH_UNDIRECTED);
-    test_density(&g, 0);
-    test_density(&g, 1);
+    test_density(&g, false);
+    test_density(&g, true);
     igraph_destroy(&g);
     igraph_create(&g, &v, 1, IGRAPH_DIRECTED);
-    test_density(&g, 0);
-    test_density(&g, 1);
+    test_density(&g, false);
+    test_density(&g, true);
     igraph_destroy(&g);
     printf("======\n");
 
@@ -73,10 +109,10 @@ int main(void) {
     VECTOR(v)[0] = 0;
     VECTOR(v)[1] = 0;
     igraph_create(&g, &v, 1, IGRAPH_UNDIRECTED);
-    test_density(&g, 1);
+    test_density(&g, true);
     igraph_destroy(&g);
     igraph_create(&g, &v, 1, IGRAPH_DIRECTED);
-    test_density(&g, 1);
+    test_density(&g, true);
     igraph_destroy(&g);
     printf("======\n");
 
@@ -87,10 +123,10 @@ int main(void) {
     VECTOR(v)[2] = 0;
     VECTOR(v)[3] = 0;
     igraph_create(&g, &v, 1, IGRAPH_UNDIRECTED);
-    test_density(&g, 1);
+    test_density(&g, true);
     igraph_destroy(&g);
     igraph_create(&g, &v, 1, IGRAPH_DIRECTED);
-    test_density(&g, 1);
+    test_density(&g, true);
     igraph_destroy(&g);
     printf("======\n");
 
@@ -99,12 +135,12 @@ int main(void) {
     VECTOR(v)[0] = 0;
     VECTOR(v)[1] = 1;
     igraph_create(&g, &v, 2, IGRAPH_UNDIRECTED);
-    test_density(&g, 0);
-    test_density(&g, 1);
+    test_density(&g, false);
+    test_density(&g, true);
     igraph_destroy(&g);
     igraph_create(&g, &v, 1, IGRAPH_DIRECTED);
-    test_density(&g, 0);
-    test_density(&g, 1);
+    test_density(&g, false);
+    test_density(&g, true);
     igraph_destroy(&g);
     printf("======\n");
 
@@ -116,10 +152,10 @@ int main(void) {
     VECTOR(v)[2] = 1;
     VECTOR(v)[3] = 1;
     igraph_create(&g, &v, 2, IGRAPH_UNDIRECTED);
-    test_density(&g, 1);
+    test_density(&g, true);
     igraph_destroy(&g);
     igraph_create(&g, &v, 1, IGRAPH_DIRECTED);
-    test_density(&g, 1);
+    test_density(&g, true);
     igraph_destroy(&g);
     printf("======\n");
 
@@ -133,20 +169,44 @@ int main(void) {
     VECTOR(v)[4] = 0;
     VECTOR(v)[5] = 0;
     igraph_create(&g, &v, 2, IGRAPH_UNDIRECTED);
-    test_density(&g, 1);
+    test_density(&g, true);
     igraph_destroy(&g);
     igraph_create(&g, &v, 1, IGRAPH_DIRECTED);
-    test_density(&g, 1);
+    test_density(&g, true);
     igraph_destroy(&g);
     printf("======\n");
 
     /* Zachary karate club graph */
     igraph_famous(&g, "zachary");
-    test_density(&g, 0);
-    test_density(&g, 1);
+    test_density(&g, false);
+    test_density(&g, true);
     igraph_destroy(&g);
 
     igraph_vector_int_destroy(&v);
+
+    VERIFY_FINALLY_STACK();
+
+    /* Test weighted density.
+     * These tests require an attribute table and use randomness. */
+
+    igraph_set_attribute_table(&igraph_cattribute_table);
+    igraph_rng_seed(igraph_rng_default(), 1234);
+
+    igraph_erdos_renyi_game_gnm(&g, 10, 30, IGRAPH_UNDIRECTED, IGRAPH_LOOPS, IGRAPH_MULTIPLE);
+    test_weighted_density(&g, IGRAPH_LOOPS);
+    igraph_destroy(&g);
+
+    igraph_erdos_renyi_game_gnm(&g, 9, 30, IGRAPH_UNDIRECTED, IGRAPH_NO_LOOPS, IGRAPH_MULTIPLE);
+    test_weighted_density(&g, IGRAPH_LOOPS);
+    igraph_destroy(&g);
+
+    igraph_erdos_renyi_game_gnm(&g, 8, 30, IGRAPH_DIRECTED, IGRAPH_LOOPS, IGRAPH_MULTIPLE);
+    test_weighted_density(&g, IGRAPH_LOOPS);
+    igraph_destroy(&g);
+
+    igraph_erdos_renyi_game_gnm(&g, 7, 30, IGRAPH_DIRECTED, IGRAPH_NO_LOOPS, IGRAPH_MULTIPLE);
+    test_weighted_density(&g, IGRAPH_LOOPS);
+    igraph_destroy(&g);
 
     VERIFY_FINALLY_STACK();
 


### PR DESCRIPTION
This PR:

 - Generalizes density calculation to weighted graphs
 - Adds a simplified interface to Leiden to avoid re-implementing this separately in each high-level interface