### PR TITLE
Refactor SBM model interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@
  - `igraph_rewire()` now takes an `igraph_edge_type_sw_t` parameter to specify whether to create self-loops. The `igraph_rewiring_t` enum type was removed. Instead of the old `IGRAPH_REWIRING_SIMPLE`, use `IGRAPH_SIMPLE_SW`. Instead of the old `IGRAPH_REWIRING_SIMPLE_LOOPS`, use `IGRAPH_LOOPS_SW`.
  - The `history` parameter of `igraph_community_leading_eigenvector()` is now a pointer to an `igraph_vector_int_t` instead of an `igraph_vector_t`.
  - `igraph_matrix_copy_to()` gained an `igraph_matrix_storage_t storage` parameter that specifies whether the data should be written in column-major or row-major format.
+ - `igraph_sbm_game()` gained a `multiple` parameter and now supports generating multigraph with prescribed expected edge multiplicities. The parameter determining the total number of vertices (`n`) was removed as it was redundant.
 
 ### Added
 

--- a/include/igraph_games.h
+++ b/include/igraph_games.h
@@ -179,10 +179,12 @@ IGRAPH_EXPORT igraph_error_t igraph_k_regular_game(igraph_t *graph,
                                         igraph_integer_t no_of_nodes, igraph_integer_t k,
                                         igraph_bool_t directed, igraph_bool_t multiple);
 
-IGRAPH_EXPORT igraph_error_t igraph_sbm_game(igraph_t *graph,
-                                  const igraph_matrix_t *pref_matrix,
-                                  const igraph_vector_int_t *block_sizes,
-                                  igraph_bool_t directed, igraph_bool_t loops);
+IGRAPH_EXPORT igraph_error_t igraph_sbm_game(
+        igraph_t *graph,
+        const igraph_matrix_t *pref_matrix,
+        const igraph_vector_int_t *block_sizes,
+        igraph_bool_t directed,
+        igraph_bool_t loops, igraph_bool_t multiple);
 
 IGRAPH_EXPORT igraph_error_t igraph_hsbm_game(igraph_t *graph, igraph_integer_t n,
                                    igraph_integer_t m, const igraph_vector_t *rho,

--- a/include/igraph_games.h
+++ b/include/igraph_games.h
@@ -179,7 +179,7 @@ IGRAPH_EXPORT igraph_error_t igraph_k_regular_game(igraph_t *graph,
                                         igraph_integer_t no_of_nodes, igraph_integer_t k,
                                         igraph_bool_t directed, igraph_bool_t multiple);
 
-IGRAPH_EXPORT igraph_error_t igraph_sbm_game(igraph_t *graph, igraph_integer_t n,
+IGRAPH_EXPORT igraph_error_t igraph_sbm_game(igraph_t *graph,
                                   const igraph_matrix_t *pref_matrix,
                                   const igraph_vector_int_t *block_sizes,
                                   igraph_bool_t directed, igraph_bool_t loops);

--- a/interfaces/functions.yaml
+++ b/interfaces/functions.yaml
@@ -406,7 +406,7 @@ igraph_sbm_game:
     PARAMS: |-
         OUT GRAPH graph, MATRIX pref_matrix,
         VECTOR_INT block_sizes, BOOLEAN directed=False,
-        BOOLEAN loops=False
+        BOOLEAN loops=False, BOOLEAN multiple=False
 
 igraph_hsbm_game:
     INTERNAL: true

--- a/interfaces/functions.yaml
+++ b/interfaces/functions.yaml
@@ -404,7 +404,7 @@ igraph_k_regular_game:
 
 igraph_sbm_game:
     PARAMS: |-
-        OUT GRAPH graph, INTEGER n, MATRIX pref_matrix,
+        OUT GRAPH graph, MATRIX pref_matrix,
         VECTOR_INT block_sizes, BOOLEAN directed=False,
         BOOLEAN loops=False
 

--- a/src/games/sbm.c
+++ b/src/games/sbm.c
@@ -72,7 +72,7 @@ igraph_error_t igraph_sbm_game(
         const igraph_vector_int_t *block_sizes,
         igraph_bool_t directed, igraph_bool_t loops) {
 
-#define IGRAPH_CHECK_MAXEDGES() \
+#define CHECK_MAXEDGES() \
     do {if (maxedges > IGRAPH_MAX_EXACT_REAL) { \
         IGRAPH_ERROR("Too many vertices, overflow in maximum number of edges.", IGRAPH_EOVERFLOW); \
     }} while (0)
@@ -137,7 +137,7 @@ igraph_error_t igraph_sbm_game(
 
             if (directed && loops) {
                 maxedges = ((igraph_real_t) fromsize) * tosize;
-                IGRAPH_CHECK_MAXEDGES();
+                CHECK_MAXEDGES();
                 while (last < maxedges) {
                     vto = floor(last / fromsize);
                     vfrom = last - ((igraph_real_t) vto) * fromsize;
@@ -148,7 +148,7 @@ igraph_error_t igraph_sbm_game(
                 }
             } else if (directed && !loops && from != to) {
                 maxedges = ((igraph_real_t) fromsize) * tosize;
-                IGRAPH_CHECK_MAXEDGES();
+                CHECK_MAXEDGES();
                 while (last < maxedges) {
                     vto = floor(last / fromsize);
                     vfrom = last - ((igraph_real_t) vto) * fromsize;
@@ -159,7 +159,7 @@ igraph_error_t igraph_sbm_game(
                 }
             } else if (directed && !loops && from == to) {
                 maxedges = ((igraph_real_t) fromsize) * (fromsize - 1.0);
-                IGRAPH_CHECK_MAXEDGES();
+                CHECK_MAXEDGES();
                 while (last < maxedges) {
                     vto = floor(last / fromsize);
                     vfrom = last - ((igraph_real_t) vto) * fromsize;
@@ -173,7 +173,7 @@ igraph_error_t igraph_sbm_game(
                 }
             } else if (!directed && loops && from != to) {
                 maxedges = ((igraph_real_t) fromsize) * tosize;
-                IGRAPH_CHECK_MAXEDGES();
+                CHECK_MAXEDGES();
                 while (last < maxedges) {
                     vto = floor(last / fromsize);
                     vfrom = last - ((igraph_real_t) vto) * fromsize;
@@ -184,7 +184,7 @@ igraph_error_t igraph_sbm_game(
                 }
             } else if (!directed && loops && from == to) {
                 maxedges = ((igraph_real_t) fromsize) * (fromsize + 1.0) / 2.0;
-                IGRAPH_CHECK_MAXEDGES();
+                CHECK_MAXEDGES();
                 while (last < maxedges) {
                     vto = floor((sqrt(8 * last + 1) - 1) / 2);
                     vfrom = last - (((igraph_real_t) vto) * (vto + 1.0)) / 2.0;
@@ -195,7 +195,7 @@ igraph_error_t igraph_sbm_game(
                 }
             } else if (!directed && !loops && from != to) {
                 maxedges = ((igraph_real_t) fromsize) * tosize;
-                IGRAPH_CHECK_MAXEDGES();
+                CHECK_MAXEDGES();
                 while (last < maxedges) {
                     vto = floor(last / fromsize);
                     vfrom = last - ((igraph_real_t) vto) * fromsize;
@@ -206,7 +206,7 @@ igraph_error_t igraph_sbm_game(
                 }
             } else { /*!directed && !loops && from==to */
                 maxedges = ((igraph_real_t) fromsize) * (fromsize - 1.0) / 2.0;
-                IGRAPH_CHECK_MAXEDGES();
+                CHECK_MAXEDGES();
                 while (last < maxedges) {
                     vto = floor((sqrt(8 * last + 1) + 1) / 2);
                     vfrom = last - (((igraph_real_t) vto) * (vto - 1.0)) / 2.0;
@@ -228,7 +228,7 @@ igraph_error_t igraph_sbm_game(
     IGRAPH_FINALLY_CLEAN(1);
 
     return IGRAPH_SUCCESS;
-#undef IGRAPH_CHECK_MAXEDGES
+#undef CHECK_MAXEDGES
 }
 
 /**
@@ -259,7 +259,7 @@ igraph_error_t igraph_hsbm_game(igraph_t *graph, igraph_integer_t n,
                      igraph_integer_t m, const igraph_vector_t *rho,
                      const igraph_matrix_t *C, igraph_real_t p) {
 
-#define IGRAPH_CHECK_MAXEDGES() \
+#define CHECK_MAXEDGES() \
     do {if (maxedges > IGRAPH_MAX_EXACT_REAL) { \
         IGRAPH_ERROR("Too many vertices, overflow in maximum number of edges.", IGRAPH_EOVERFLOW); \
     }} while (0)
@@ -331,7 +331,7 @@ igraph_error_t igraph_hsbm_game(igraph_t *graph, igraph_integer_t n,
                 igraph_real_t last = RNG_GEOM(prob);  /* RNG_GEOM may return NaN so igraph_integer_t is not suitable */
                 if (from != to) {
                     maxedges = ((igraph_real_t) fromsize) * tosize;
-                    IGRAPH_CHECK_MAXEDGES();
+                    CHECK_MAXEDGES();
                     while (last < maxedges) {
                         igraph_integer_t vto = floor(last / fromsize);
                         igraph_integer_t vfrom = last - ((igraph_real_t) vto) * fromsize;
@@ -342,7 +342,7 @@ igraph_error_t igraph_hsbm_game(igraph_t *graph, igraph_integer_t n,
                     }
                 } else { /* from==to */
                     maxedges = ((igraph_real_t) fromsize) * (fromsize - 1.0) / 2.0;
-                    IGRAPH_CHECK_MAXEDGES();
+                    CHECK_MAXEDGES();
                     while (last < maxedges) {
                         igraph_integer_t vto = floor((sqrt(8 * last + 1) + 1) / 2);
                         igraph_integer_t vfrom = last - (((igraph_real_t) vto) * (vto - 1.0)) / 2.0;
@@ -384,7 +384,7 @@ igraph_error_t igraph_hsbm_game(igraph_t *graph, igraph_integer_t n,
             igraph_integer_t fromsize = m;
             igraph_integer_t tosize = n - tooff;
             igraph_real_t maxedges = ((igraph_real_t) fromsize) * tosize;
-            IGRAPH_CHECK_MAXEDGES();
+            CHECK_MAXEDGES();
             igraph_real_t last = RNG_GEOM(p);  /* RNG_GEOM may return NaN so igraph_integer_t is not suitable */
             while (last < maxedges) {
                 igraph_integer_t vto = floor(last / fromsize);
@@ -407,7 +407,7 @@ igraph_error_t igraph_hsbm_game(igraph_t *graph, igraph_integer_t n,
     IGRAPH_FINALLY_CLEAN(2);
 
     return IGRAPH_SUCCESS;
-#undef IGRAPH_CHECK_MAXEDGES
+#undef CHECK_MAXEDGES
 }
 
 /**

--- a/tests/unit/igraph_sbm_game.c
+++ b/tests/unit/igraph_sbm_game.c
@@ -19,9 +19,9 @@
 #include <igraph.h>
 #include "test_utilities.h"
 
-void call_and_print(igraph_integer_t n, igraph_matrix_t *pref_matrix, igraph_vector_int_t *block_sizes, igraph_bool_t directed, igraph_bool_t loops) {
+void call_and_print(igraph_matrix_t *pref_matrix, igraph_vector_int_t *block_sizes, igraph_bool_t directed, igraph_bool_t loops) {
     igraph_t result;
-    IGRAPH_ASSERT(igraph_sbm_game(&result, n, pref_matrix, block_sizes, directed, loops) == IGRAPH_SUCCESS);
+    IGRAPH_ASSERT(igraph_sbm_game(&result, pref_matrix, block_sizes, directed, loops) == IGRAPH_SUCCESS);
     print_graph_canon(&result);
     printf("\n");
     igraph_destroy(&result);
@@ -65,42 +65,39 @@ int main(void) {
     igraph_vector_int_init_int(&block_sizes_neg, 3, 2, 2, -2);
 
     printf("No vertices.\n");
-    call_and_print(0, &pref_matrix_0, &block_sizes_0, 0, 0);
+    call_and_print(&pref_matrix_0, &block_sizes_0, 0, 0);
 
     printf("One vertex, directed, with loops.\n");
-    call_and_print(1, &pref_matrix_1, &block_sizes_1, 1, 1);
+    call_and_print(&pref_matrix_1, &block_sizes_1, 1, 1);
 
     printf("Six vertices, directed, only edges from block 0 to 1 and 2 to 2.\n");
-    call_and_print(6, &pref_matrix_3, &block_sizes_3, 1, 1);
+    call_and_print(&pref_matrix_3, &block_sizes_3, 1, 1);
 
     printf("Six vertices, directed, only edges from block 0 to 1 and 2 to 2, no loops.\n");
-    call_and_print(6, &pref_matrix_3, &block_sizes_3, 1, 0);
+    call_and_print(&pref_matrix_3, &block_sizes_3, 1, 0);
 
     printf("Six vertices, undirected, only edges between block 0 and 1, and inside block 2.\n");
-    call_and_print(6, &pref_matrix_3u, &block_sizes_3, 0, 1);
+    call_and_print(&pref_matrix_3u, &block_sizes_3, 0, 1);
 
     printf("Six vertices, undirected, only edges between block 0 and 1, and inside block 2, no loops.\n");
-    call_and_print(6, &pref_matrix_3u, &block_sizes_3, 0, 0);
+    call_and_print(&pref_matrix_3u, &block_sizes_3, 0, 0);
 
     VERIFY_FINALLY_STACK();
 
     printf("Check for nonsquare matrix error handling.\n");
-    CHECK_ERROR(igraph_sbm_game(&result, 6, &pref_matrix_nonsq, &block_sizes_3, 0, 0), IGRAPH_EINVAL);
+    CHECK_ERROR(igraph_sbm_game(&result, &pref_matrix_nonsq, &block_sizes_3, 0, 0), IGRAPH_EINVAL);
 
     printf("Check for preference matrix probability out of range error handling.\n");
-    CHECK_ERROR(igraph_sbm_game(&result, 6, &pref_matrix_oor, &block_sizes_3, 0, 0), IGRAPH_EINVAL);
+    CHECK_ERROR(igraph_sbm_game(&result, &pref_matrix_oor, &block_sizes_3, 0, 0), IGRAPH_EINVAL);
 
     printf("Check for nonsymmetric preference matrix for undirected graph error handling.\n");
-    CHECK_ERROR(igraph_sbm_game(&result, 6, &pref_matrix_nsym, &block_sizes_3, 0, 0), IGRAPH_EINVAL);
+    CHECK_ERROR(igraph_sbm_game(&result, &pref_matrix_nsym, &block_sizes_3, 0, 0), IGRAPH_EINVAL);
 
     printf("Check for incorrect block size vector error handling.\n");
-    CHECK_ERROR(igraph_sbm_game(&result, 6, &pref_matrix_3, &block_sizes_1, 1, 0), IGRAPH_EINVAL);
+    CHECK_ERROR(igraph_sbm_game(&result, &pref_matrix_3, &block_sizes_1, 1, 0), IGRAPH_EINVAL);
 
     printf("Check for negative block size error handling.\n");
-    CHECK_ERROR(igraph_sbm_game(&result, 6, &pref_matrix_3, &block_sizes_neg, 1, 0), IGRAPH_EINVAL);
-
-    printf("Check for sum of block sizes not equal to number of vertices error handling.\n");
-    CHECK_ERROR(igraph_sbm_game(&result, 3, &pref_matrix_3, &block_sizes_3, 1, 0), IGRAPH_EINVAL);
+    CHECK_ERROR(igraph_sbm_game(&result, &pref_matrix_3, &block_sizes_neg, 1, 0), IGRAPH_EINVAL);
 
     igraph_matrix_destroy(&pref_matrix_0);
     igraph_matrix_destroy(&pref_matrix_1);

--- a/tests/unit/igraph_sbm_game.c
+++ b/tests/unit/igraph_sbm_game.c
@@ -19,9 +19,14 @@
 #include <igraph.h>
 #include "test_utilities.h"
 
-void call_and_print(igraph_matrix_t *pref_matrix, igraph_vector_int_t *block_sizes, igraph_bool_t directed, igraph_bool_t loops) {
+void call_and_print(
+        igraph_matrix_t *pref_matrix,
+        igraph_vector_int_t *block_sizes,
+        igraph_bool_t directed,
+        igraph_bool_t loops, igraph_bool_t multiple) {
+
     igraph_t result;
-    IGRAPH_ASSERT(igraph_sbm_game(&result, pref_matrix, block_sizes, directed, loops) == IGRAPH_SUCCESS);
+    IGRAPH_ASSERT(igraph_sbm_game(&result, pref_matrix, block_sizes, directed, loops, multiple) == IGRAPH_SUCCESS);
     print_graph_canon(&result);
     printf("\n");
     igraph_destroy(&result);
@@ -65,39 +70,39 @@ int main(void) {
     igraph_vector_int_init_int(&block_sizes_neg, 3, 2, 2, -2);
 
     printf("No vertices.\n");
-    call_and_print(&pref_matrix_0, &block_sizes_0, 0, 0);
+    call_and_print(&pref_matrix_0, &block_sizes_0, false, false, false);
 
     printf("One vertex, directed, with loops.\n");
-    call_and_print(&pref_matrix_1, &block_sizes_1, 1, 1);
+    call_and_print(&pref_matrix_1, &block_sizes_1, true, true, false);
 
     printf("Six vertices, directed, only edges from block 0 to 1 and 2 to 2.\n");
-    call_and_print(&pref_matrix_3, &block_sizes_3, 1, 1);
+    call_and_print(&pref_matrix_3, &block_sizes_3, true, true, false);
 
     printf("Six vertices, directed, only edges from block 0 to 1 and 2 to 2, no loops.\n");
-    call_and_print(&pref_matrix_3, &block_sizes_3, 1, 0);
+    call_and_print(&pref_matrix_3, &block_sizes_3, true, false, false);
 
     printf("Six vertices, undirected, only edges between block 0 and 1, and inside block 2.\n");
-    call_and_print(&pref_matrix_3u, &block_sizes_3, 0, 1);
+    call_and_print(&pref_matrix_3u, &block_sizes_3, false, true, false);
 
     printf("Six vertices, undirected, only edges between block 0 and 1, and inside block 2, no loops.\n");
-    call_and_print(&pref_matrix_3u, &block_sizes_3, 0, 0);
+    call_and_print(&pref_matrix_3u, &block_sizes_3, false, false, false);
 
     VERIFY_FINALLY_STACK();
 
     printf("Check for nonsquare matrix error handling.\n");
-    CHECK_ERROR(igraph_sbm_game(&result, &pref_matrix_nonsq, &block_sizes_3, 0, 0), IGRAPH_EINVAL);
+    CHECK_ERROR(igraph_sbm_game(&result, &pref_matrix_nonsq, &block_sizes_3, false, false, false), IGRAPH_EINVAL);
 
     printf("Check for preference matrix probability out of range error handling.\n");
-    CHECK_ERROR(igraph_sbm_game(&result, &pref_matrix_oor, &block_sizes_3, 0, 0), IGRAPH_EINVAL);
+    CHECK_ERROR(igraph_sbm_game(&result, &pref_matrix_oor, &block_sizes_3, false, false, false), IGRAPH_EINVAL);
 
     printf("Check for nonsymmetric preference matrix for undirected graph error handling.\n");
-    CHECK_ERROR(igraph_sbm_game(&result, &pref_matrix_nsym, &block_sizes_3, 0, 0), IGRAPH_EINVAL);
+    CHECK_ERROR(igraph_sbm_game(&result, &pref_matrix_nsym, &block_sizes_3, false, false, false), IGRAPH_EINVAL);
 
     printf("Check for incorrect block size vector error handling.\n");
-    CHECK_ERROR(igraph_sbm_game(&result, &pref_matrix_3, &block_sizes_1, 1, 0), IGRAPH_EINVAL);
+    CHECK_ERROR(igraph_sbm_game(&result, &pref_matrix_3, &block_sizes_1, true, false, false), IGRAPH_EINVAL);
 
     printf("Check for negative block size error handling.\n");
-    CHECK_ERROR(igraph_sbm_game(&result, &pref_matrix_3, &block_sizes_neg, 1, 0), IGRAPH_EINVAL);
+    CHECK_ERROR(igraph_sbm_game(&result, &pref_matrix_3, &block_sizes_neg, true, false, false), IGRAPH_EINVAL);
 
     igraph_matrix_destroy(&pref_matrix_0);
     igraph_matrix_destroy(&pref_matrix_1);

--- a/tests/unit/igraph_sbm_game.out
+++ b/tests/unit/igraph_sbm_game.out
@@ -66,4 +66,3 @@ Check for preference matrix probability out of range error handling.
 Check for nonsymmetric preference matrix for undirected graph error handling.
 Check for incorrect block size vector error handling.
 Check for negative block size error handling.
-Check for sum of block sizes not equal to number of vertices error handling.


### PR DESCRIPTION
 - Drop the `n` vertex count parameter as it is redundant. The vertex count is the sum of block sizes. Providing any other value in `n` used to throw an error anyway, thus setting `n` correctly is just an annoyance.
 - Add multigraph support in the same way as I did for G(n,p) in #2761.

I don't love the HSBM game functions, and will not touch them in this PR.