### PR TITLE
refactor!: igraph_matrix_copy_to() can write in either row-major or column-major format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@
  - `igraph_community_leiden()` now takes two `vertex_out_weights` and `vertex_in_weights` parameters in order to support directed graphs, instead of the previou single `node_weights` parameter. To obtain the old behavior for undirected graphs, pass the vertex weights as `vertex_out_weights` and set `vertex_in_weights` to `NULL`.
  - `igraph_rewire()` now takes an `igraph_edge_type_sw_t` parameter to specify whether to create self-loops. The `igraph_rewiring_t` enum type was removed. Instead of the old `IGRAPH_REWIRING_SIMPLE`, use `IGRAPH_SIMPLE_SW`. Instead of the old `IGRAPH_REWIRING_SIMPLE_LOOPS`, use `IGRAPH_LOOPS_SW`.
  - The `history` parameter of `igraph_community_leading_eigenvector()` is now a pointer to an `igraph_vector_int_t` instead of an `igraph_vector_t`.
+ - `igraph_matrix_copy_to()` gained an `igraph_matrix_storage_t storage` parameter that specifies whether the data should be written in column-major or row-major format.
 
 ### Added
 

--- a/include/igraph_matrix_pmt.h
+++ b/include/igraph_matrix_pmt.h
@@ -69,7 +69,7 @@ IGRAPH_EXPORT const TYPE(igraph_matrix) *FUNCTION(igraph_matrix, view_from_vecto
 /* Copying matrices */
 /*------------------*/
 
-IGRAPH_EXPORT void FUNCTION(igraph_matrix, copy_to)(const TYPE(igraph_matrix) *m, BASE *to);
+IGRAPH_EXPORT void FUNCTION(igraph_matrix, copy_to)(const TYPE(igraph_matrix) *m, BASE *to, igraph_matrix_storage_t storage);
 IGRAPH_EXPORT igraph_error_t FUNCTION(igraph_matrix, update)(TYPE(igraph_matrix) *to,
                                                   const TYPE(igraph_matrix) *from);
 IGRAPH_EXPORT igraph_error_t FUNCTION(igraph_matrix, rbind)(TYPE(igraph_matrix) *to,

--- a/src/core/matrix.pmt
+++ b/src/core/matrix.pmt
@@ -313,26 +313,68 @@ igraph_integer_t FUNCTION(igraph_matrix, ncol)(const TYPE(igraph_matrix) *m) {
 }
 
 /**
+ * Copies matrix data stored contiguously while transposing. Applications include implementing
+ * matrix transposition as well as changing between row-major and column-major storage formats.
+ *
+ * \param dst Data will be copied into this vector. It must have length m-by-n. It will not be resized.
+ * \param src Vector containing the data to be copied. It is assumed to have length m-by-n.
+ *   Must not be the same as \p dst .
+ * \param m The size of contiguous blocks. This is the number of columns when using column-major
+ *   storage format, or the number of rows when using row-major format.
+ * \param n The number of blocks. This is the number of rows when using column-major format,
+ *   or the number of columns when using row-major format.
+ */
+static void FUNCTION(igraph_i, transpose_copy)(
+        TYPE(igraph_vector) *dst, const TYPE(igraph_vector) *src,
+        size_t m, size_t n) {
+
+    IGRAPH_ASSERT(dst != src);
+
+    /* Block size of 4 was found to yield the best performance when benchmarking with:
+     *  - Intel Core i7-7920HQ on macOS.
+     *  - AMD Ryzen Threadripper 3990X on Linux.
+     */
+    const size_t blocksize = 4;
+    for (size_t i=0; i < m; i += blocksize) {
+        for (size_t j=0; j < n; j++) {
+            for (size_t k=0; k < blocksize && i+k < m; k++) {
+                VECTOR(*dst)[j + (i+k)*n] = VECTOR(*src)[i+k + j*m];
+            }
+        }
+    }
+}
+
+/**
  * \ingroup matrix
  * \function igraph_matrix_copy_to
  * \brief Copies a matrix to a regular C array.
  *
  * </para><para>
- * The matrix is copied columnwise, as this is the format most
- * programs and languages use.
  * The C array should be of sufficient size; there are (of course) no
  * range checks.
+ *
  * \param m Pointer to an initialized matrix object.
  * \param to Pointer to a C array; the place to copy the data to.
+ * \param storage \c IGRAPH_ROW_MAJOR to write the data in row-major format,
+ *    \c IGRAPH_COLUMN_MAJOR to write it in column-major format. Currently
+ *    igraph uses column-major storage internally, thus \c IGRAPH_COLUMN_MAJOR
+ *    is much faster.
  * \return Error code.
  *
  * Time complexity: O(n),
  * n is the number of
  * elements in the matrix.
  */
-
-void FUNCTION(igraph_matrix, copy_to)(const TYPE(igraph_matrix) *m, BASE *to) {
-    FUNCTION(igraph_vector, copy_to)(&m->data, to);
+void FUNCTION(igraph_matrix, copy_to)(const TYPE(igraph_matrix) *m, BASE *to, igraph_matrix_storage_t storage) {
+    if (storage == IGRAPH_ROW_MAJOR) {
+        TYPE(igraph_vector) dst;
+        FUNCTION(igraph_vector, view)(&dst, to, m->ncol * m->nrow);
+        FUNCTION(igraph_i, transpose_copy)(&dst, &m->data, m->ncol, m->nrow);
+    } else if (storage == IGRAPH_COLUMN_MAJOR) {
+        FUNCTION(igraph_vector, copy_to)(&m->data, to);
+    } else {
+        IGRAPH_FATAL("Invalid matrix storage format.");
+    }
 }
 
 /**
@@ -442,38 +484,6 @@ igraph_error_t FUNCTION(igraph_matrix, permdelete_rows)(
     IGRAPH_CHECK(FUNCTION(igraph_matrix, resize)(m, m->nrow - nremove, m->ncol));
 
     return IGRAPH_SUCCESS;
-}
-
-/**
- * Copies matrix data stored contiguously while transposing. Applications include implementing
- * matrix transposition as well as changing between row-major and column-major storage formats.
- *
- * \param dst Data will be copied into this vector. It must have size m-by-n. It will not be resized.
- * \param src Vector containing the data to be copied. It is assumed to have size m-by-n.
- *   Must not be the same as \p dst .
- * \param m The size of contiguous blocks. This is the number of columns when using column-major
- *   storage format, or the number of rows when using row-major format.
- * \param n The number of blocks. The is the number of rows when using column-major format,
- *   or the number of column when using row-major format.
- */
-static void FUNCTION(igraph_i, transpose_copy)(
-        TYPE(igraph_vector) *dst, const TYPE(igraph_vector) *src,
-        size_t m, size_t n) {
-
-    IGRAPH_ASSERT(dst != src);
-
-    /* Block size of 4 was found to yield the best performance when benchmarking with:
-     *  - Intel Core i7-7920HQ on macOS.
-     *  - AMD Ryzen Threadripper 3990X on Linux.
-     */
-    const size_t blocksize = 4;
-    for (size_t i=0; i < m; i += blocksize) {
-        for (size_t j=0; j < n; j++) {
-            for (size_t k=0; k < blocksize && i+k < m; k++) {
-                VECTOR(*dst)[j + (i+k)*n] = VECTOR(*src)[i+k + j*m];
-            }
-        }
-    }
 }
 
 /**


### PR DESCRIPTION
`igraph_matrix_copy_to()` gained an `igraph_matrix_storage_t storage` parameter that specifies whether the data should be written in column-major or row-major format. This makes it symmetric with `igraph_matrix_init_array()` and helps interop better with other libraries.

The `igraph_i_transpose_copy()` function is moved to a higher position in the file so I could use it. This implemented the transpose-copy operations and was optimized with blocking some time ago.

No test due to lack of time. This will get indirectly tested once we start using it in the Delaunay PR, which was the motivation for adding it. Qhull uses row-major storage.