### PR TITLE
refactor!: add normalized parameter for betweenness functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /build
 /build-*
 /tools/**/*.pyc
+/include/igraph_version.h

--- a/examples/simple/igraph_minimum_spanning_tree.c
+++ b/examples/simple/igraph_minimum_spanning_tree.c
@@ -31,7 +31,7 @@ int main(void) {
 
     /* Compute the edge betweenness. */
     igraph_vector_init(&eb, igraph_ecount(&graph));
-    igraph_edge_betweenness(&graph, &eb, IGRAPH_UNDIRECTED, /*weights=*/ NULL);
+    igraph_edge_betweenness(&graph, /*weights=*/ NULL, &eb, IGRAPH_UNDIRECTED, false);
 
     /* Use Prim's algorithm to compute the edges that belong to the minimum weight
      * spanning tree, using edge betweenness values as edge weights. */

--- a/examples/simple/igraph_minimum_spanning_tree.c
+++ b/examples/simple/igraph_minimum_spanning_tree.c
@@ -31,7 +31,7 @@ int main(void) {
 
     /* Compute the edge betweenness. */
     igraph_vector_init(&eb, igraph_ecount(&graph));
-    igraph_edge_betweenness(&graph, /*weights=*/ NULL, &eb, IGRAPH_UNDIRECTED, false);
+    igraph_edge_betweenness(&graph, /*weights=*/ NULL, &eb, igraph_ess_all(IGRAPH_EDGEORDER_ID), IGRAPH_UNDIRECTED, false);
 
     /* Use Prim's algorithm to compute the edges that belong to the minimum weight
      * spanning tree, using edge betweenness values as edge weights. */

--- a/examples/tutorial/tutorial3.c
+++ b/examples/tutorial/tutorial3.c
@@ -40,7 +40,7 @@ int main(void) {
            igraph_vector_which_max(&result_real));
 
     igraph_betweenness(&graph, /* weights= */ NULL, &result_real, igraph_vss_all(),
-                       IGRAPH_UNDIRECTED, false);
+                       IGRAPH_UNDIRECTED, /* normalized= */ false);
     printf("Maximum betweenness is %10g, vertex %2" IGRAPH_PRId ".\n",
            (double) igraph_vector_max(&result_real),
            igraph_vector_which_max(&result_real));

--- a/examples/tutorial/tutorial3.c
+++ b/examples/tutorial/tutorial3.c
@@ -39,8 +39,8 @@ int main(void) {
            (double) igraph_vector_max(&result_real),
            igraph_vector_which_max(&result_real));
 
-    igraph_betweenness(&graph, &result_real, igraph_vss_all(),
-                       IGRAPH_UNDIRECTED, /* weights= */ NULL);
+    igraph_betweenness(&graph, /* weights= */ NULL, &result_real, igraph_vss_all(),
+                       IGRAPH_UNDIRECTED, false);
     printf("Maximum betweenness is %10g, vertex %2" IGRAPH_PRId ".\n",
            (double) igraph_vector_max(&result_real),
            igraph_vector_which_max(&result_real));

--- a/fuzzing/centrality.cpp
+++ b/fuzzing/centrality.cpp
@@ -49,13 +49,17 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
             igraph_vector_init(&v, 0);
             igraph_vector_int_init(&iv, 0);
 
-            igraph_betweenness_cutoff(&graph, &v, igraph_vss_all(), IGRAPH_UNDIRECTED, NULL, 4);
-            igraph_betweenness_cutoff(&graph, &v, igraph_vss_all(), IGRAPH_DIRECTED, NULL, 5);
-            igraph_edge_betweenness_cutoff(&graph, &v, IGRAPH_DIRECTED, NULL, 4);
-            igraph_edge_betweenness_cutoff(&graph, &v, IGRAPH_UNDIRECTED, NULL, 3);
+            igraph_betweenness_cutoff(&graph, NULL, &v, igraph_vss_all(), IGRAPH_UNDIRECTED, false, 4);
+            igraph_betweenness_cutoff(&graph, NULL, &v, igraph_vss_all(), IGRAPH_DIRECTED, false, 5);
+            igraph_edge_betweenness_cutoff(&graph, NULL, &v, IGRAPH_DIRECTED, false, 4);
+            igraph_edge_betweenness_cutoff(&graph, NULL, &v, IGRAPH_UNDIRECTED, false, 3);
             if (igraph_vcount(&graph) >= 10) {
-                igraph_betweenness_subset(&graph, &v, igraph_vss_all(), IGRAPH_DIRECTED, igraph_vss_range(0,5), igraph_vss_range(5,10), NULL);
-                igraph_edge_betweenness_subset(&graph, &v, igraph_ess_all(IGRAPH_EDGEORDER_ID), IGRAPH_DIRECTED, igraph_vss_range(0,10), igraph_vss_range(0,10), NULL);
+                igraph_betweenness_subset(&graph, NULL, &v,
+                                          igraph_vss_range(0,5), igraph_vss_range(5,10),
+                                          igraph_vss_all(), IGRAPH_DIRECTED, false);
+                igraph_edge_betweenness_subset(&graph, NULL, &v,
+                                               igraph_vss_range(0,10), igraph_vss_range(0,10),
+                                               igraph_ess_all(IGRAPH_EDGEORDER_ID), IGRAPH_DIRECTED, false);
             }
             igraph_closeness_cutoff(&graph, &v, &iv, &b, igraph_vss_all(), IGRAPH_ALL, NULL, true, 3);
             igraph_closeness_cutoff(&graph, &v, &iv, &b, igraph_vss_all(), IGRAPH_OUT, NULL, true, 4);

--- a/fuzzing/centrality.cpp
+++ b/fuzzing/centrality.cpp
@@ -51,8 +51,10 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
 
             igraph_betweenness_cutoff(&graph, NULL, &v, igraph_vss_all(), IGRAPH_UNDIRECTED, false, 4);
             igraph_betweenness_cutoff(&graph, NULL, &v, igraph_vss_all(), IGRAPH_DIRECTED, false, 5);
-            igraph_edge_betweenness_cutoff(&graph, NULL, &v, IGRAPH_DIRECTED, false, 4);
-            igraph_edge_betweenness_cutoff(&graph, NULL, &v, IGRAPH_UNDIRECTED, false, 3);
+            igraph_edge_betweenness_cutoff(&graph, NULL, &v, igraph_ess_all(IGRAPH_EDGEORDER_ID), IGRAPH_DIRECTED,
+                                           false, 4);
+            igraph_edge_betweenness_cutoff(&graph, NULL, &v, igraph_ess_all(IGRAPH_EDGEORDER_ID), IGRAPH_UNDIRECTED,
+                                           false, 3);
             if (igraph_vcount(&graph) >= 10) {
                 igraph_betweenness_subset(&graph, NULL, &v,
                                           igraph_vss_range(0,5), igraph_vss_range(5,10),

--- a/fuzzing/weighted_centrality.cpp
+++ b/fuzzing/weighted_centrality.cpp
@@ -59,13 +59,19 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
             igraph_vector_init(&v, 0);
             igraph_vector_int_init(&iv, 0);
 
-            igraph_betweenness_cutoff(&graph, &v, igraph_vss_all(), IGRAPH_ALL, &weights, 4);
-            igraph_betweenness_cutoff(&graph, &v, igraph_vss_all(), IGRAPH_IN, &weights, 5);
-            igraph_edge_betweenness_cutoff(&graph, &v, IGRAPH_DIRECTED, &weights, 4);
-            igraph_edge_betweenness_cutoff(&graph, &v, IGRAPH_UNDIRECTED, &weights, 3);
+            igraph_betweenness_cutoff(&graph, &weights, &v, igraph_vss_all(), IGRAPH_ALL, false, 4);
+            igraph_betweenness_cutoff(&graph, &weights, &v, igraph_vss_all(), IGRAPH_IN, false, 5);
+            igraph_edge_betweenness_cutoff(&graph, &weights, &v, IGRAPH_DIRECTED, false, 4);
+            igraph_edge_betweenness_cutoff(&graph, &weights, &v, IGRAPH_UNDIRECTED, false, 3);
             if (igraph_vcount(&graph) >= 10) {
-                igraph_betweenness_subset(&graph, &v, igraph_vss_all(), IGRAPH_DIRECTED, igraph_vss_range(0,5), igraph_vss_range(5,10), &weights);
-                igraph_edge_betweenness_subset(&graph, &v, igraph_ess_all(IGRAPH_EDGEORDER_ID), IGRAPH_DIRECTED, igraph_vss_range(0,10), igraph_vss_range(0,10), &weights);
+                igraph_betweenness_subset(&graph, &weights,
+                                          &v,
+                                          igraph_vss_range(0,5), igraph_vss_range(5,10),
+                                          igraph_vss_all(), IGRAPH_DIRECTED, false);
+                igraph_edge_betweenness_subset(&graph, &weights,
+                                               &v,
+                                               igraph_vss_range(0,10), igraph_vss_range(0, 10),
+                                               igraph_ess_all(IGRAPH_EDGEORDER_ID), IGRAPH_DIRECTED,false);
             }
             igraph_closeness_cutoff(&graph, &v, &iv, &b, igraph_vss_all(), IGRAPH_ALL, &weights, true, 3);
             igraph_closeness_cutoff(&graph, &v, &iv, &b, igraph_vss_all(), IGRAPH_OUT, &weights, true, 4);

--- a/fuzzing/weighted_centrality.cpp
+++ b/fuzzing/weighted_centrality.cpp
@@ -61,8 +61,10 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
 
             igraph_betweenness_cutoff(&graph, &weights, &v, igraph_vss_all(), IGRAPH_ALL, false, 4);
             igraph_betweenness_cutoff(&graph, &weights, &v, igraph_vss_all(), IGRAPH_IN, false, 5);
-            igraph_edge_betweenness_cutoff(&graph, &weights, &v, IGRAPH_DIRECTED, false, 4);
-            igraph_edge_betweenness_cutoff(&graph, &weights, &v, IGRAPH_UNDIRECTED, false, 3);
+            igraph_edge_betweenness_cutoff(&graph, &weights, &v, igraph_ess_all(IGRAPH_EDGEORDER_ID), IGRAPH_DIRECTED,
+                                           false, 4);
+            igraph_edge_betweenness_cutoff(&graph, &weights, &v, igraph_ess_all(IGRAPH_EDGEORDER_ID), IGRAPH_UNDIRECTED,
+                                           false, 3);
             if (igraph_vcount(&graph) >= 10) {
                 igraph_betweenness_subset(&graph, &weights,
                                           &v,

--- a/include/igraph_centrality.h
+++ b/include/igraph_centrality.h
@@ -54,26 +54,42 @@ IGRAPH_EXPORT igraph_error_t igraph_harmonic_centrality_cutoff(const igraph_t *g
                                                     igraph_bool_t normalized,
                                                     igraph_real_t cutoff);
 
-IGRAPH_EXPORT igraph_error_t igraph_betweenness(const igraph_t *graph, igraph_vector_t *res,
-                                     igraph_vs_t vids, igraph_bool_t directed,
-                                     const igraph_vector_t *weights);
-IGRAPH_EXPORT igraph_error_t igraph_betweenness_cutoff(const igraph_t *graph, igraph_vector_t *res,
-                                            igraph_vs_t vids, igraph_bool_t directed,
-                                            const igraph_vector_t *weights, igraph_real_t cutoff);
-IGRAPH_EXPORT igraph_error_t igraph_edge_betweenness(const igraph_t *graph, igraph_vector_t *result,
-                                          igraph_bool_t directed,
-                                          const igraph_vector_t *weights);
-IGRAPH_EXPORT igraph_error_t igraph_edge_betweenness_cutoff(const igraph_t *graph, igraph_vector_t *result,
-                                                 igraph_bool_t directed,
-                                                 const igraph_vector_t *weights, igraph_real_t cutoff);
-IGRAPH_EXPORT igraph_error_t igraph_betweenness_subset(const igraph_t *graph, igraph_vector_t *res,
-                                            igraph_vs_t vids, igraph_bool_t directed,
-                                            igraph_vs_t sources, igraph_vs_t targets,
-                                            const igraph_vector_t *weights);
-IGRAPH_EXPORT igraph_error_t igraph_edge_betweenness_subset(const igraph_t *graph, igraph_vector_t *res,
-                                            igraph_es_t eids, igraph_bool_t directed,
-                                            igraph_vs_t sources, igraph_vs_t targets,
-                                            const igraph_vector_t *weights);
+IGRAPH_EXPORT igraph_error_t igraph_betweenness(
+        const igraph_t *graph, const igraph_vector_t *weights,
+        igraph_vector_t *res,
+        igraph_vs_t vids,
+        igraph_bool_t directed, igraph_bool_t normalized);
+
+IGRAPH_EXPORT igraph_error_t igraph_betweenness_cutoff(
+        const igraph_t *graph, const igraph_vector_t *weights,
+        igraph_vector_t *res,
+        igraph_vs_t vids,
+        igraph_bool_t directed, igraph_bool_t normalized,
+        igraph_real_t cutoff);
+
+IGRAPH_EXPORT igraph_error_t igraph_edge_betweenness(
+        const igraph_t *graph, const igraph_vector_t *weights,
+        igraph_vector_t *res,
+        igraph_bool_t directed, igraph_bool_t normalized);
+
+IGRAPH_EXPORT igraph_error_t igraph_edge_betweenness_cutoff(
+        const igraph_t *graph, const igraph_vector_t *weights, igraph_vector_t *res,
+        igraph_bool_t directed, igraph_bool_t normalized,
+        igraph_real_t cutoff);
+
+IGRAPH_EXPORT igraph_error_t igraph_betweenness_subset(
+        const igraph_t *graph, const igraph_vector_t *weights,
+        igraph_vector_t *res,
+        igraph_vs_t sources, igraph_vs_t targets,
+        igraph_vs_t vids,
+        igraph_bool_t directed, igraph_bool_t normalized);
+
+IGRAPH_EXPORT igraph_error_t igraph_edge_betweenness_subset(
+        const igraph_t *graph, const igraph_vector_t *weights,
+        igraph_vector_t *res,
+        igraph_vs_t sources, igraph_vs_t targets,
+        igraph_es_t eids,
+        igraph_bool_t directed, igraph_bool_t normalized);
 
 /**
  * \typedef igraph_pagerank_algo_t

--- a/include/igraph_centrality.h
+++ b/include/igraph_centrality.h
@@ -69,11 +69,12 @@ IGRAPH_EXPORT igraph_error_t igraph_betweenness_cutoff(
 
 IGRAPH_EXPORT igraph_error_t igraph_edge_betweenness(
         const igraph_t *graph, const igraph_vector_t *weights,
-        igraph_vector_t *res,
+        igraph_vector_t *res, igraph_es_t eids,
         igraph_bool_t directed, igraph_bool_t normalized);
 
 IGRAPH_EXPORT igraph_error_t igraph_edge_betweenness_cutoff(
-        const igraph_t *graph, const igraph_vector_t *weights, igraph_vector_t *res,
+        const igraph_t *graph, const igraph_vector_t *weights,
+        igraph_vector_t *res, igraph_es_t eids,
         igraph_bool_t directed, igraph_bool_t normalized,
         igraph_real_t cutoff);
 

--- a/interfaces/functions.yaml
+++ b/interfaces/functions.yaml
@@ -657,42 +657,42 @@ igraph_subcomponent:
 
 igraph_betweenness:
     PARAMS: |-
-        GRAPH graph, OUT VERTEX_QTY res, VERTEX_SELECTOR vids=ALL,
-        BOOLEAN directed=True, OPTIONAL EDGE_WEIGHTS weights
+        GRAPH graph, OPTIONAL EDGE_WEIGHTS weights, OUT VERTEX_QTY res,
+        VERTEX_SELECTOR vids=ALL, BOOLEAN directed=True, BOOLEAN normalized=False
     DEPS: weights ON graph, vids ON graph, res ON graph vids
 
 igraph_betweenness_cutoff:
     PARAMS: |-
-        GRAPH graph, OUT VERTEX_QTY res, VERTEX_SELECTOR vids=ALL,
-        BOOLEAN directed=True, OPTIONAL EDGE_WEIGHTS weights,
+        GRAPH graph, OPTIONAL EDGE_WEIGHTS weights, OUT VERTEX_QTY res,
+        VERTEX_SELECTOR vids=ALL, BOOLEAN directed=True, BOOLEAN normalized=False,
         REAL cutoff=-1
     DEPS: vids ON graph, weights ON graph, res ON graph vids
 
 igraph_betweenness_subset:
     PARAMS: |-
-        GRAPH graph, OUT VERTEX_QTY res, VERTEX_SELECTOR vids=ALL,
-        BOOLEAN directed=True, VERTEX_SELECTOR sources=ALL, VERTEX_SELECTOR targets=ALL,
-        OPTIONAL EDGE_WEIGHTS weights
+        GRAPH graph, OPTIONAL EDGE_WEIGHTS weights, OUT VERTEX_QTY res,
+        VERTEX_SELECTOR vids=ALL, VERTEX_SELECTOR sources=ALL, VERTEX_SELECTOR targets=ALL,
+        BOOLEAN directed=True, BOOLEAN normalized=False
     DEPS: |-
         vids ON graph, weights ON graph, res ON graph vids, sources ON graph, targets ON graph
 
 igraph_edge_betweenness:
     PARAMS: |-
-        GRAPH graph, OUT VECTOR res, BOOLEAN directed=True,
-        OPTIONAL EDGE_WEIGHTS weights
+        GRAPH graph, OPTIONAL EDGE_WEIGHTS weights, OUT VECTOR res,
+        BOOLEAN directed=True, BOOLEAN normalized=False
     DEPS: weights ON graph
 
 igraph_edge_betweenness_cutoff:
     PARAMS: |-
-        GRAPH graph, OUT VECTOR res, BOOLEAN directed=True,
-        OPTIONAL EDGE_WEIGHTS weights, REAL cutoff=-1
+        GRAPH graph, OPTIONAL EDGE_WEIGHTS weights, OUT VECTOR res,
+        BOOLEAN directed=True, BOOLEAN normalized=False, REAL cutoff=-1
     DEPS: weights ON graph
 
 igraph_edge_betweenness_subset:
     PARAMS: |-
-        GRAPH graph, OUT VERTEX_QTY res, EDGE_SELECTOR eids=ALL,
-        BOOLEAN directed=True, VERTEX_SELECTOR sources=ALL, VERTEX_SELECTOR targets=ALL,
-        OPTIONAL EDGE_WEIGHTS weights
+        GRAPH graph, OPTIONAL EDGE_WEIGHTS weights, OUT VECTOR res,
+        VERTEX_SELECTOR sources=ALL, VERTEX_SELECTOR targets=ALL, EDGE_SELECTOR eids=ALL,
+        BOOLEAN directed=True, BOOLEAN normalized=False
     DEPS: |-
         eids ON graph, weights ON graph, res ON graph, sources ON graph, targets ON graph
 

--- a/interfaces/functions.yaml
+++ b/interfaces/functions.yaml
@@ -678,13 +678,13 @@ igraph_betweenness_subset:
 
 igraph_edge_betweenness:
     PARAMS: |-
-        GRAPH graph, OPTIONAL EDGE_WEIGHTS weights, OUT VECTOR res,
+        GRAPH graph, OPTIONAL EDGE_WEIGHTS weights, OUT VECTOR res, EDGE_SELECTOR eids=ALL,
         BOOLEAN directed=True, BOOLEAN normalized=False
     DEPS: weights ON graph
 
 igraph_edge_betweenness_cutoff:
     PARAMS: |-
-        GRAPH graph, OPTIONAL EDGE_WEIGHTS weights, OUT VECTOR res,
+        GRAPH graph, OPTIONAL EDGE_WEIGHTS weights, OUT VECTOR res, EDGE_SELECTOR eids=ALL,
         BOOLEAN directed=True, BOOLEAN normalized=False, REAL cutoff=-1
     DEPS: weights ON graph
 

--- a/interfaces/functions.yaml
+++ b/interfaces/functions.yaml
@@ -680,13 +680,13 @@ igraph_edge_betweenness:
     PARAMS: |-
         GRAPH graph, OPTIONAL EDGE_WEIGHTS weights, OUT VECTOR res, EDGE_SELECTOR eids=ALL,
         BOOLEAN directed=True, BOOLEAN normalized=False
-    DEPS: weights ON graph
+    DEPS: eids ON graph, weights ON graph, res ON graph eids
 
 igraph_edge_betweenness_cutoff:
     PARAMS: |-
         GRAPH graph, OPTIONAL EDGE_WEIGHTS weights, OUT VECTOR res, EDGE_SELECTOR eids=ALL,
         BOOLEAN directed=True, BOOLEAN normalized=False, REAL cutoff=-1
-    DEPS: weights ON graph
+    DEPS: eids ON graph, weights ON graph, res ON graph eids
 
 igraph_edge_betweenness_subset:
     PARAMS: |-
@@ -694,7 +694,7 @@ igraph_edge_betweenness_subset:
         VERTEX_SELECTOR sources=ALL, VERTEX_SELECTOR targets=ALL, EDGE_SELECTOR eids=ALL,
         BOOLEAN directed=True, BOOLEAN normalized=False
     DEPS: |-
-        eids ON graph, weights ON graph, res ON graph, sources ON graph, targets ON graph
+        eids ON graph, weights ON graph, res ON graph eids, sources ON graph, targets ON graph
 
 igraph_harmonic_centrality:
     PARAMS: |-

--- a/src/centrality/betweenness.c
+++ b/src/centrality/betweenness.c
@@ -423,24 +423,25 @@ static igraph_error_t sspf_weighted_edge(
 }
 
 static igraph_error_t betweenness_check_weights(
-    const igraph_vector_t* weights, igraph_integer_t no_of_edges
+    const igraph_vector_t *weights, igraph_integer_t no_of_edges
 ) {
     igraph_real_t minweight;
 
     if (weights) {
         if (igraph_vector_size(weights) != no_of_edges) {
-            IGRAPH_ERROR("Weight vector length must match the number of edges.", IGRAPH_EINVAL);
+            IGRAPH_ERROR("Edge weight vector length must match the number of edges.", IGRAPH_EINVAL);
         }
         if (no_of_edges > 0) {
             minweight = igraph_vector_min(weights);
             if (minweight <= 0) {
-                IGRAPH_ERROR("Weight vector must be positive.", IGRAPH_EINVAL);
+                IGRAPH_ERROR("Edge weights must be positive for betweenness.", IGRAPH_EINVAL);
             } else if (isnan(minweight)) {
-                IGRAPH_ERROR("Weight vector must not contain NaN values.", IGRAPH_EINVAL);
+                IGRAPH_ERROR("Edge weights must not contain NaN values.", IGRAPH_EINVAL);
             } else if (minweight <= IGRAPH_SHORTEST_PATH_EPSILON) {
-                IGRAPH_WARNING(
-                    "Some weights are smaller than epsilon, calculations may "
-                    "suffer from numerical precision issues."
+                IGRAPH_WARNINGF(
+                    "Some weights are smaller than the path length comparison tolerance (%g), "
+                    "betweenness calculations may suffer from numerical precision issues.",
+                    IGRAPH_SHORTEST_PATH_EPSILON
                 );
             }
         }

--- a/src/centrality/betweenness.c
+++ b/src/centrality/betweenness.c
@@ -59,7 +59,7 @@
  * \param  adjlist the adjacency list of the graph
  * \param  cutoff  cutoff length of shortest paths
  */
-static igraph_error_t igraph_i_sspf(
+static igraph_error_t sspf(
         igraph_integer_t source,
         igraph_vector_t *dist,
         igraph_real_t *nrgeo,
@@ -139,7 +139,7 @@ static igraph_error_t igraph_i_sspf(
  * \param  inclist the incidence list of the graph
  * \param  cutoff  cutoff length of shortest paths
  */
-static igraph_error_t igraph_i_sspf_edge(
+static igraph_error_t sspf_edge(
         const igraph_t *graph,
         igraph_integer_t source,
         igraph_vector_t *dist,
@@ -222,7 +222,7 @@ static igraph_error_t igraph_i_sspf_edge(
  * \param  inclist the incidence list of the graph
  * \param  cutoff  cutoff length of shortest paths
  */
-static igraph_error_t igraph_i_sspf_weighted(
+static igraph_error_t sspf_weighted(
         const igraph_t *graph,
         igraph_integer_t source,
         igraph_vector_t *dist,
@@ -331,7 +331,7 @@ static igraph_error_t igraph_i_sspf_weighted(
  * \param  inclist the incidence list of the graph
  * \param  cutoff  cutoff length of shortest paths
  */
-static igraph_error_t igraph_i_sspf_weighted_edge(
+static igraph_error_t sspf_weighted_edge(
         const igraph_t *graph,
         igraph_integer_t source,
         igraph_vector_t *dist,
@@ -422,7 +422,7 @@ static igraph_error_t igraph_i_sspf_weighted_edge(
     return IGRAPH_SUCCESS;
 }
 
-static igraph_error_t igraph_i_betweenness_check_weights(
+static igraph_error_t betweenness_check_weights(
     const igraph_vector_t* weights, igraph_integer_t no_of_edges
 ) {
     igraph_real_t minweight;
@@ -575,7 +575,7 @@ igraph_error_t igraph_betweenness_cutoff(
         IGRAPH_ERROR("Normalization is not yet implemented for betweenness.", IGRAPH_UNIMPLEMENTED);
     }
 
-    IGRAPH_CHECK(igraph_i_betweenness_check_weights(weights, no_of_edges));
+    IGRAPH_CHECK(betweenness_check_weights(weights, no_of_edges));
 
     if (weights) {
         IGRAPH_CHECK(igraph_inclist_init(graph, &inclist, mode, IGRAPH_NO_LOOPS));
@@ -627,9 +627,9 @@ igraph_error_t igraph_betweenness_cutoff(
 
         /* Conduct a single-source shortest path search from the source node */
         if (weights) {
-            IGRAPH_CHECK(igraph_i_sspf_weighted(graph, source, &dist, nrgeo, weights, &S, &parents, &inclist, cutoff));
+            IGRAPH_CHECK(sspf_weighted(graph, source, &dist, nrgeo, weights, &S, &parents, &inclist, cutoff));
         } else {
-            IGRAPH_CHECK(igraph_i_sspf(source, &dist, nrgeo, &S, &parents, &adjlist, cutoff));
+            IGRAPH_CHECK(sspf(source, &dist, nrgeo, &S, &parents, &adjlist, cutoff));
         }
 
         /* Aggregate betweenness scores for the nodes we have reached in this
@@ -804,7 +804,7 @@ igraph_error_t igraph_edge_betweenness_cutoff(
         IGRAPH_ERROR("Normalization is not yet implemented for betweenness.", IGRAPH_UNIMPLEMENTED);
     }
 
-    IGRAPH_CHECK(igraph_i_betweenness_check_weights(weights, no_of_edges));
+    IGRAPH_CHECK(betweenness_check_weights(weights, no_of_edges));
 
     IGRAPH_CHECK(igraph_inclist_init(graph, &inclist, mode, IGRAPH_NO_LOOPS));
     IGRAPH_FINALLY(igraph_inclist_destroy, &inclist);
@@ -846,9 +846,9 @@ igraph_error_t igraph_edge_betweenness_cutoff(
 
         /* Conduct a single-source shortest path search from the source node */
         if (weights) {
-            IGRAPH_CHECK(igraph_i_sspf_weighted_edge(graph, source, &dist, nrgeo, weights, &S, &parents, &inclist, cutoff));
+            IGRAPH_CHECK(sspf_weighted_edge(graph, source, &dist, nrgeo, weights, &S, &parents, &inclist, cutoff));
         } else {
-            IGRAPH_CHECK(igraph_i_sspf_edge(graph, source, &dist, nrgeo, &S, &parents, &inclist, cutoff));
+            IGRAPH_CHECK(sspf_edge(graph, source, &dist, nrgeo, &S, &parents, &inclist, cutoff));
         }
 
         /* Aggregate betweenness scores for the edges we have reached in this
@@ -959,7 +959,7 @@ igraph_error_t igraph_betweenness_subset(
         IGRAPH_ERROR("Normalization is not yet implemented for betweenness.", IGRAPH_UNIMPLEMENTED);
     }
 
-    IGRAPH_CHECK(igraph_i_betweenness_check_weights(weights, no_of_edges));
+    IGRAPH_CHECK(betweenness_check_weights(weights, no_of_edges));
 
     IGRAPH_CHECK(igraph_vs_size(graph, &sources, &no_of_sources));
 
@@ -1043,9 +1043,9 @@ igraph_error_t igraph_betweenness_subset(
 
         /* Conduct a single-source shortest path search from the source node */
         if (weights) {
-            IGRAPH_CHECK(igraph_i_sspf_weighted(graph, source, &dist, nrgeo, weights, &S, &parents, &inclist, -1));
+            IGRAPH_CHECK(sspf_weighted(graph, source, &dist, nrgeo, weights, &S, &parents, &inclist, -1));
         } else {
-            IGRAPH_CHECK(igraph_i_sspf(source, &dist, nrgeo, &S, &parents, &adjlist, -1));
+            IGRAPH_CHECK(sspf(source, &dist, nrgeo, &S, &parents, &adjlist, -1));
         }
 
         /* Aggregate betweenness scores for the nodes we have reached in this
@@ -1184,7 +1184,7 @@ igraph_error_t igraph_edge_betweenness_subset(
         IGRAPH_ERROR("Normalization is not yet implemented for betweenness.", IGRAPH_UNIMPLEMENTED);
     }
 
-    IGRAPH_CHECK(igraph_i_betweenness_check_weights(weights, no_of_edges));
+    IGRAPH_CHECK(betweenness_check_weights(weights, no_of_edges));
 
     IGRAPH_CHECK(igraph_vs_size(graph, &sources, &no_of_sources));
 
@@ -1262,9 +1262,9 @@ igraph_error_t igraph_edge_betweenness_subset(
 
         /* Conduct a single-source shortest path search from the source node */
         if (weights) {
-            IGRAPH_CHECK(igraph_i_sspf_weighted_edge(graph, source, &dist, nrgeo, weights, &S, &parents, &inclist, -1));
+            IGRAPH_CHECK(sspf_weighted_edge(graph, source, &dist, nrgeo, weights, &S, &parents, &inclist, -1));
         } else {
-            IGRAPH_CHECK(igraph_i_sspf_edge(graph, source, &dist, nrgeo, &S, &parents, &inclist, -1));
+            IGRAPH_CHECK(sspf_edge(graph, source, &dist, nrgeo, &S, &parents, &inclist, -1));
         }
 
         /* Aggregate betweenness scores for the nodes we have reached in this

--- a/src/centrality/betweenness.c
+++ b/src/centrality/betweenness.c
@@ -751,7 +751,7 @@ igraph_error_t igraph_edge_betweenness(
         const igraph_t *graph, const igraph_vector_t *weights,
         igraph_vector_t *res, igraph_es_t eids,
         igraph_bool_t directed, igraph_bool_t normalized) {
-    
+
     return igraph_edge_betweenness_cutoff(
             graph, weights,
             res, eids,
@@ -875,12 +875,12 @@ igraph_error_t igraph_edge_betweenness_cutoff(
          * traversal */
         while (!igraph_stack_int_empty(&S)) {
             igraph_integer_t actnode = igraph_stack_int_pop(&S);
-            igraph_vector_int_t *fatv = igraph_inclist_get(&parents, actnode);
-            igraph_integer_t fatv_len = igraph_vector_int_size(fatv);
+            igraph_vector_int_t *parentv = igraph_inclist_get(&parents, actnode);
+            igraph_integer_t parentv_len = igraph_vector_int_size(parentv);
             igraph_real_t coeff = (1 + tmpscore[actnode]) / nrgeo[actnode];
 
-            for (j = 0; j < fatv_len; j++) {
-                igraph_integer_t fedge = VECTOR(*fatv)[j];
+            for (j = 0; j < parentv_len; j++) {
+                igraph_integer_t fedge = VECTOR(*parentv)[j];
                 igraph_integer_t neighbor = IGRAPH_OTHER(graph, fedge, actnode);
                 tmpscore[neighbor] += nrgeo[neighbor] * coeff;
                 VECTOR(*tmpres)[fedge] += nrgeo[neighbor] * coeff;
@@ -892,7 +892,7 @@ igraph_error_t igraph_edge_betweenness_cutoff(
             VECTOR(dist)[actnode] = 0;
             nrgeo[actnode] = 0;
             tmpscore[actnode] = 0;
-            igraph_vector_int_clear(fatv);
+            igraph_vector_int_clear(parentv);
         }
     } /* source < no_of_nodes */
 
@@ -988,7 +988,7 @@ igraph_error_t igraph_betweenness_subset(
     igraph_stack_int_t S;
     igraph_vector_t v_tmpres, *tmpres = &v_tmpres;
     igraph_neimode_t mode = directed ? IGRAPH_OUT : IGRAPH_ALL;
-    igraph_integer_t father;
+    igraph_integer_t parent;
     igraph_vector_t dist;
     igraph_real_t *nrgeo;
     igraph_real_t *tmpscore;
@@ -1092,8 +1092,8 @@ igraph_error_t igraph_betweenness_subset(
          * traversal */
         while (!igraph_stack_int_empty(&S)) {
             igraph_integer_t actnode = igraph_stack_int_pop(&S);
-            igraph_vector_int_t *fatv = igraph_adjlist_get(&parents, actnode);
-            igraph_integer_t fatv_len = igraph_vector_int_size(fatv);
+            igraph_vector_int_t *parentv = igraph_adjlist_get(&parents, actnode);
+            igraph_integer_t parentv_len = igraph_vector_int_size(parentv);
             igraph_real_t coeff;
 
             if (is_target[actnode]) {
@@ -1102,9 +1102,9 @@ igraph_error_t igraph_betweenness_subset(
                 coeff = tmpscore[actnode] / nrgeo[actnode];
             }
 
-            for (j = 0; j < fatv_len; j++) {
-                father = VECTOR(*fatv)[j];
-                tmpscore[father] += nrgeo[father] * coeff;
+            for (j = 0; j < parentv_len; j++) {
+                parent = VECTOR(*parentv)[j];
+                tmpscore[parent] += nrgeo[parent] * coeff;
             }
 
             if (actnode != source) {
@@ -1117,7 +1117,7 @@ igraph_error_t igraph_betweenness_subset(
             VECTOR(dist)[actnode] = 0;
             nrgeo[actnode] = 0;
             tmpscore[actnode] = 0;
-            igraph_vector_int_clear(fatv);
+            igraph_vector_int_clear(parentv);
         }
     }
 
@@ -1312,8 +1312,8 @@ igraph_error_t igraph_edge_betweenness_subset(
          * traversal */
         while (!igraph_stack_int_empty(&S)) {
             igraph_integer_t actnode = igraph_stack_int_pop(&S);
-            igraph_vector_int_t *fatv = igraph_inclist_get(&parents, actnode);
-            igraph_integer_t fatv_len = igraph_vector_int_size(fatv);
+            igraph_vector_int_t *parentv = igraph_inclist_get(&parents, actnode);
+            igraph_integer_t parentv_len = igraph_vector_int_size(parentv);
             igraph_real_t coeff;
 
             if (is_target[actnode]) {
@@ -1322,11 +1322,11 @@ igraph_error_t igraph_edge_betweenness_subset(
                 coeff = tmpscore[actnode] / nrgeo[actnode];
             }
 
-            for (j = 0; j < fatv_len; j++) {
-                igraph_integer_t father_edge = VECTOR(*fatv)[j];
-                igraph_integer_t neighbor = IGRAPH_OTHER(graph, father_edge, actnode);
+            for (j = 0; j < parentv_len; j++) {
+                igraph_integer_t parent_edge = VECTOR(*parentv)[j];
+                igraph_integer_t neighbor = IGRAPH_OTHER(graph, parent_edge, actnode);
                 tmpscore[neighbor] += nrgeo[neighbor] * coeff;
-                VECTOR(*tmpres)[father_edge] += nrgeo[neighbor] * coeff;
+                VECTOR(*tmpres)[parent_edge] += nrgeo[neighbor] * coeff;
             }
 
             /* Reset variables to ensure that the 'for' loop invariant will
@@ -1335,7 +1335,7 @@ igraph_error_t igraph_edge_betweenness_subset(
             VECTOR(dist)[actnode] = 0;
             nrgeo[actnode] = 0;
             tmpscore[actnode] = 0;
-            igraph_vector_int_clear(fatv);
+            igraph_vector_int_clear(parentv);
         }
     }
 

--- a/src/centrality/betweenness.c
+++ b/src/centrality/betweenness.c
@@ -457,10 +457,9 @@ static igraph_error_t betweenness_check_weights(
  * \function igraph_betweenness
  * \brief Betweenness centrality of some vertices.
  *
- * The betweenness centrality of a vertex is the number of geodesics
- * going through it. If there are more than one geodesic between two
- * vertices, the value of these geodesics are weighted by one over the
- * number of geodesics.
+ * The betweenness centrality of a vertex \c v is the number of shortest paths
+ * passing through it. If there is more than one shortest path between two
+ * vertices, the fraction of these passing through \c v is counted.
  *
  * </para><para>
  * Reference:
@@ -476,8 +475,10 @@ static igraph_error_t betweenness_check_weights(
  *        Supply a null pointer here for unweighted betweenness.
  * \param res The result of the computation, a vector containing the
  *        betweenness scores for the specified vertices.
- * \param vids The vertices of which the betweenness centrality scores
- *        will be calculated.
+ * \param vids The vertices for which the range-limited betweenness centrality
+ *        scores will be returned. This paramerer is for convenience only and
+ *        does not affect performance. Internally, the betewenness of all
+ *        vertices is calculated.
  * \param directed If true directed paths will be considered
  *        for directed graphs. It is ignored for undirected graphs.
  * \param normalized Whether to normalize betweenness scores by the number of
@@ -494,10 +495,11 @@ static igraph_error_t betweenness_check_weights(
  * Note that the time complexity is independent of the number of
  * vertices for which the score is calculated.
  *
- * \sa Other centrality types: \ref igraph_degree(), \ref igraph_closeness().
- *     See \ref igraph_edge_betweenness() for calculating the betweenness score
- *     of the edges in a graph. See \ref igraph_betweenness_cutoff() to
- *     calculate the range-limited betweenness of the vertices in a graph.
+ * \sa \ref igraph_edge_betweenness() for calculating the betweenness score
+ * of the edges in a graph; \ref igraph_betweenness_cutoff() to
+ * calculate the range-limited betweenness of the vertices in a graph;
+ * \ref igraph_betweenness_subset() to consider shortest paths only between
+ * two vertex subsets for calculating betweenness.
  */
 igraph_error_t igraph_betweenness(
         const igraph_t *graph, const igraph_vector_t *weights,
@@ -522,7 +524,9 @@ igraph_error_t igraph_betweenness(
  * \param res The result of the computation, a vector containing the
  *        range-limited betweenness scores for the specified vertices.
  * \param vids The vertices for which the range-limited betweenness centrality
- *        scores will be computed.
+ *        scores will be returned. This paramerer is for convenience only and
+ *        does not affect performance. Internally, the betewenness of all
+ *        vertices is calculated.
  * \param directed If true directed paths will be considered
  *        for directed graphs. It is ignored for undirected graphs.
  * \param normalized Whether to normalize betweenness scores by the number of
@@ -717,10 +721,9 @@ igraph_error_t igraph_betweenness_cutoff(
  * \function igraph_edge_betweenness
  * \brief Betweenness centrality of the edges.
  *
- * The betweenness centrality of an edge is the number of geodesics
- * going through it. If there are more than one geodesics between two
- * vertices, the value of these geodesics are weighted by one over the
- * number of geodesics.
+ * The betweenness centrality of an edge \c e is the number of shortest paths
+ * passing through it. If there is more than one shortest path between two
+ * vertices, the fraction of these passing through \c e is counted.
  *
  * </para><para>
  * Reference:
@@ -736,9 +739,10 @@ igraph_error_t igraph_betweenness_cutoff(
  *        pointer here for the unweighted version.
  * \param res The result of the computation, vector containing the
  *        betweenness scores for the edges.
- * \param eids The edges for which the subset-limited betweenness centrality
- *        scores will be returned. This parameter is for convenience only.
- *        Internally, the betweenness will be calculated for all edges.
+ * \param eids The edges for which the betweenness centrality will be returned.
+ *        This parameter is for convenience only, and does not affect
+ *        performance. Internally, the betweenness is be calculated for all
+ *        edges.
  * \param directed If true directed paths will be considered
  *        for directed graphs. It is ignored for undirected graphs.
  * \param normalized Whether to normalize betweenness scores by the number of
@@ -753,10 +757,11 @@ igraph_error_t igraph_betweenness_cutoff(
  * |E| are the number of vertices and
  * edges in the graph.
  *
- * \sa Other centrality types: \ref igraph_degree(), \ref igraph_closeness().
- *     See \ref igraph_edge_betweenness() for calculating the betweenness score
- *     of the edges in a graph. See \ref igraph_edge_betweenness_cutoff() to
- *     compute the range-limited betweenness score of the edges in a graph.
+ * \sa \ref igraph_betweenness() for calculating the betweenness score of the
+ * vertices in a graph; \ref igraph_edge_betweenness_cutoff() to compute the
+ * range-limited betweenness score of the edges in a graph;
+ * \ref igraph_edge_betweenness_subset() to consider shortest paths only between
+ * two vertex subsets for calculating betweenness.
  */
 igraph_error_t igraph_edge_betweenness(
         const igraph_t *graph, const igraph_vector_t *weights,
@@ -784,9 +789,10 @@ igraph_error_t igraph_edge_betweenness(
  *        pointer here for unweighted betweenness.
  * \param res The result of the computation, vector containing the
  *        betweenness scores for the edges.
- * \param eids The edges for which the subset-limited betweenness centrality
- *        scores will be returned. This parameter is for convenience only.
- *        Internally, the betweenness will be calculated for all edges.
+ * \param eids The edges for which the betweenness centrality will be returned.
+ *        This parameter is for convenience only, and does not affect
+ *        performance. Internally, the betweenness is be calculated for all
+ *        edges.
  * \param directed If true directed paths will be considered
  *        for directed graphs. It is ignored for undirected graphs.
  * \param normalized Whether to normalize betweenness scores by the number of

--- a/src/centrality/centralization.c
+++ b/src/centrality/centralization.c
@@ -322,7 +322,7 @@ igraph_error_t igraph_centralization_betweenness(const igraph_t *graph,
         IGRAPH_VECTOR_INIT_FINALLY(scores, 0);
     }
 
-    IGRAPH_CHECK(igraph_betweenness(graph, scores, igraph_vss_all(), directed, /*weights=*/ 0));
+    IGRAPH_CHECK(igraph_betweenness(graph, /*weights=*/ 0, scores, igraph_vss_all(), directed, false));
 
     IGRAPH_CHECK(igraph_centralization_betweenness_tmax(graph, 0, directed, tmax));
 

--- a/tests/benchmarks/igraph_betweenness.c
+++ b/tests/benchmarks/igraph_betweenness.c
@@ -34,14 +34,14 @@ int main(void) {
 
     igraph_kautz(&graph, 4, 5);
     BENCH(" 1 Betweenness, Kautz(4,5), directed",
-          igraph_betweenness(&graph, &betweenness, igraph_vss_all(), IGRAPH_DIRECTED, NULL));
+          igraph_betweenness(&graph, NULL, &betweenness, igraph_vss_all(), IGRAPH_DIRECTED, false));
     BENCH(" 2 Betweenness, Kautz(4,5), undirected",
-          igraph_betweenness(&graph, &betweenness, igraph_vss_all(), IGRAPH_UNDIRECTED, NULL));
+          igraph_betweenness(&graph, NULL, &betweenness, igraph_vss_all(), IGRAPH_UNDIRECTED, false));
     igraph_destroy(&graph);
 
     igraph_de_bruijn(&graph, 6, 5);
     BENCH(" 3 Betweenness, DeBruijn(6,5), directed",
-          igraph_betweenness(&graph, &betweenness, igraph_vss_all(), IGRAPH_DIRECTED, NULL));
+          igraph_betweenness(&graph, NULL, &betweenness, igraph_vss_all(), IGRAPH_DIRECTED, false));
     igraph_destroy(&graph);
 
     {
@@ -50,32 +50,32 @@ int main(void) {
         igraph_vector_int_init_int_end(&dims, -1, 8, 8, 8, 8, -1);
         igraph_square_lattice(&graph, &dims, 1, IGRAPH_UNDIRECTED, /* mutual */ 0, /* periodic */ 0);
         BENCH(" 4 Betweenness, Grid(8,8,8,8), undirected",
-              igraph_betweenness(&graph, &betweenness, igraph_vss_all(), IGRAPH_UNDIRECTED, NULL));
+              igraph_betweenness(&graph, NULL, &betweenness, igraph_vss_all(), IGRAPH_UNDIRECTED, false));
         igraph_destroy(&graph);
         igraph_vector_int_destroy(&dims);
 
         igraph_vector_int_init_int_end(&dims, -1, 10, 10, 10, 10, -1);
         igraph_square_lattice(&graph, &dims, 1, IGRAPH_UNDIRECTED, /* mutual */ 0, /* periodic */ 0);
         BENCH(" 5 Betweenness, Grid(10,10,10,10), cutoff 5",
-              igraph_betweenness_cutoff(&graph, &betweenness, igraph_vss_all(), IGRAPH_UNDIRECTED, NULL, 5));
+              igraph_betweenness_cutoff(&graph, NULL, &betweenness, igraph_vss_all(), IGRAPH_UNDIRECTED, false, 5));
         BENCH(" 6 Betweenness, Grid(10,10,10,10), cutoff 8",
-              igraph_betweenness_cutoff(&graph, &betweenness, igraph_vss_all(), IGRAPH_UNDIRECTED, NULL, 8));
+              igraph_betweenness_cutoff(&graph, NULL, &betweenness, igraph_vss_all(), IGRAPH_UNDIRECTED, false, 8));
         igraph_destroy(&graph);
         igraph_vector_int_destroy(&dims);
     }
 
     igraph_barabasi_game(&graph, 8000, 1, 1, NULL, 1, 0, IGRAPH_UNDIRECTED, IGRAPH_BARABASI_PSUMTREE, NULL);
     BENCH(" 7 Betweenness, Barabasi n=8000 m=1, undirected",
-          igraph_betweenness(&graph, &betweenness, igraph_vss_all(), IGRAPH_UNDIRECTED, NULL));
+          igraph_betweenness(&graph, NULL, &betweenness, igraph_vss_all(), IGRAPH_UNDIRECTED, false));
     BENCH(" 8 Betweenness, Barabasi n=8000 m=1, undirected, cutoff 6",
-          igraph_betweenness_cutoff(&graph, &betweenness, igraph_vss_all(), IGRAPH_UNDIRECTED, NULL, 6));
+          igraph_betweenness_cutoff(&graph, NULL, &betweenness, igraph_vss_all(), IGRAPH_UNDIRECTED, false, 6));
     igraph_destroy(&graph);
 
     igraph_barabasi_game(&graph, 30000, 1, 5, NULL, 1, 0, IGRAPH_DIRECTED, IGRAPH_BARABASI_PSUMTREE, NULL);
     BENCH(" 9 Betweenness, Barabasi n=30000 m=5, directed",
-          igraph_betweenness(&graph, &betweenness, igraph_vss_all(), IGRAPH_DIRECTED, NULL));
+          igraph_betweenness(&graph, NULL, &betweenness, igraph_vss_all(), IGRAPH_DIRECTED, false));
     BENCH("10 Betweenness, Barabasi n=30000 m=5, directed, cutoff 5",
-          igraph_betweenness_cutoff(&graph, &betweenness, igraph_vss_all(), IGRAPH_DIRECTED, NULL, 5));
+          igraph_betweenness_cutoff(&graph, NULL, &betweenness, igraph_vss_all(), IGRAPH_DIRECTED, false, 5));
     igraph_destroy(&graph);
 
     igraph_vector_destroy(&betweenness);

--- a/tests/benchmarks/igraph_betweenness_weighted.c
+++ b/tests/benchmarks/igraph_betweenness_weighted.c
@@ -55,19 +55,19 @@ int main(void) {
 #define REP 100
 
     BENCH(" 1 Betweenness, unweighted, " NAME ", directed, " TOSTR(REP) "x",
-          REPEAT(igraph_betweenness(&graph, &betweenness, igraph_vss_all(), IGRAPH_DIRECTED, NULL), REP)
+          REPEAT(igraph_betweenness(&graph, NULL, &betweenness, igraph_vss_all(), IGRAPH_DIRECTED, false), REP)
     );
     BENCH(" 2 Betweenness, unweighted, " NAME ", undirected, " TOSTR(REP) "x",
-          REPEAT(igraph_betweenness(&graph, &betweenness, igraph_vss_all(), IGRAPH_UNDIRECTED, NULL), REP)
+          REPEAT(igraph_betweenness(&graph, NULL, &betweenness, igraph_vss_all(), IGRAPH_UNDIRECTED, false), REP)
     );
 
     rand_weight_vec(&weight, &graph);
 
     BENCH(" 3 Betweenness, weighted,   " NAME ", directed, " TOSTR(REP) "x",
-          REPEAT(igraph_betweenness(&graph, &betweenness, igraph_vss_all(), IGRAPH_DIRECTED, &weight), REP)
+          REPEAT(igraph_betweenness(&graph, &weight, &betweenness, igraph_vss_all(), IGRAPH_DIRECTED, false), REP)
     );
     BENCH(" 4 Betweenness, weighted,   " NAME ", undirected, " TOSTR(REP) "x",
-          REPEAT(igraph_betweenness(&graph, &betweenness, igraph_vss_all(), IGRAPH_UNDIRECTED, &weight), REP)
+          REPEAT(igraph_betweenness(&graph, &weight, &betweenness, igraph_vss_all(), IGRAPH_UNDIRECTED, false), REP)
     );
 
     igraph_destroy(&graph);
@@ -81,19 +81,19 @@ int main(void) {
     igraph_de_bruijn(&graph, 5, 5);
 
     BENCH(" 5 Betweenness, unweighted, " NAME ", directed, " TOSTR(REP) "x",
-          REPEAT(igraph_betweenness(&graph, &betweenness, igraph_vss_all(), IGRAPH_DIRECTED, NULL), REP)
+          REPEAT(igraph_betweenness(&graph, NULL, &betweenness, igraph_vss_all(), IGRAPH_DIRECTED, false), REP)
     );
     BENCH(" 6 Betweenness, unweighted, " NAME ", undirected, " TOSTR(REP) "x",
-          REPEAT(igraph_betweenness(&graph, &betweenness, igraph_vss_all(), IGRAPH_UNDIRECTED, NULL), REP)
+          REPEAT(igraph_betweenness(&graph, NULL, &betweenness, igraph_vss_all(), IGRAPH_UNDIRECTED, false), REP)
     );
 
     rand_weight_vec(&weight, &graph);
 
     BENCH(" 7 Betweenness, weighted,   " NAME ", directed, " TOSTR(REP) "x",
-          REPEAT(igraph_betweenness(&graph, &betweenness, igraph_vss_all(), IGRAPH_DIRECTED, &weight), REP)
+          REPEAT(igraph_betweenness(&graph, &weight, &betweenness, igraph_vss_all(), IGRAPH_DIRECTED, false), REP)
     );
     BENCH(" 8 Betweenness, weighted,   " NAME ", undirected, " TOSTR(REP) "x",
-          REPEAT(igraph_betweenness(&graph, &betweenness, igraph_vss_all(), IGRAPH_UNDIRECTED, &weight), REP)
+          REPEAT(igraph_betweenness(&graph, &weight, &betweenness, igraph_vss_all(), IGRAPH_UNDIRECTED, false), REP)
     );
 
     igraph_destroy(&graph);
@@ -112,19 +112,19 @@ int main(void) {
     igraph_erdos_renyi_game_gnm(&graph, 3000, 10000, IGRAPH_DIRECTED, IGRAPH_LOOPS, IGRAPH_NO_MULTIPLE);
 
     BENCH(" 9 Betweenness, unweighted, " NAME ", directed, " TOSTR(REP) "x",
-          REPEAT(igraph_betweenness(&graph, &betweenness, igraph_vss_all(), IGRAPH_DIRECTED, NULL), REP)
+          REPEAT(igraph_betweenness(&graph, NULL, &betweenness, igraph_vss_all(), IGRAPH_DIRECTED, false), REP)
     );
     BENCH("10 Betweenness, unweighted, " NAME ", undirected, " TOSTR(REP) "x",
-          REPEAT(igraph_betweenness(&graph, &betweenness, igraph_vss_all(), IGRAPH_UNDIRECTED, NULL), REP)
+          REPEAT(igraph_betweenness(&graph, NULL, &betweenness, igraph_vss_all(), IGRAPH_UNDIRECTED, false), REP)
     );
 
     rand_weight_vec(&weight, &graph);
 
     BENCH("11 Betweenness, weighted,   " NAME ", directed, " TOSTR(REP) "x",
-          REPEAT(igraph_betweenness(&graph, &betweenness, igraph_vss_all(), IGRAPH_DIRECTED, &weight), REP)
+          REPEAT(igraph_betweenness(&graph, &weight, &betweenness, igraph_vss_all(), IGRAPH_DIRECTED, false), REP)
     );
     BENCH("12 Betweenness, weighted,   " NAME ", undirected, " TOSTR(REP) "x",
-          REPEAT(igraph_betweenness(&graph, &betweenness, igraph_vss_all(), IGRAPH_UNDIRECTED, &weight), REP)
+          REPEAT(igraph_betweenness(&graph, &weight, &betweenness, igraph_vss_all(), IGRAPH_UNDIRECTED, false), REP)
     );
 
     igraph_destroy(&graph);
@@ -140,19 +140,19 @@ int main(void) {
     igraph_erdos_renyi_game_gnm(&graph, 3000, 30000, IGRAPH_DIRECTED, IGRAPH_LOOPS, IGRAPH_NO_MULTIPLE);
 
     BENCH("13 Betweenness, unweighted, " NAME ", directed, " TOSTR(REP) "x",
-          REPEAT(igraph_betweenness(&graph, &betweenness, igraph_vss_all(), IGRAPH_DIRECTED, NULL), REP)
+          REPEAT(igraph_betweenness(&graph, NULL, &betweenness, igraph_vss_all(), IGRAPH_DIRECTED, false), REP)
     );
     BENCH("14 Betweenness, unweighted, " NAME ", undirected, " TOSTR(REP) "x",
-          REPEAT(igraph_betweenness(&graph, &betweenness, igraph_vss_all(), IGRAPH_UNDIRECTED, NULL), REP)
+          REPEAT(igraph_betweenness(&graph, NULL, &betweenness, igraph_vss_all(), IGRAPH_UNDIRECTED, false), REP)
     );
 
     rand_weight_vec(&weight, &graph);
 
     BENCH("15 Betweenness, weighted,   " NAME ", directed, " TOSTR(REP) "x",
-          REPEAT(igraph_betweenness(&graph, &betweenness, igraph_vss_all(), IGRAPH_DIRECTED, &weight), REP)
+          REPEAT(igraph_betweenness(&graph, &weight, &betweenness, igraph_vss_all(), IGRAPH_DIRECTED, false), REP)
     );
     BENCH("16 Betweenness, weighted,   " NAME ", undirected, " TOSTR(REP) "x",
-          REPEAT(igraph_betweenness(&graph, &betweenness, igraph_vss_all(), IGRAPH_UNDIRECTED, &weight), REP)
+          REPEAT(igraph_betweenness(&graph, &weight, &betweenness, igraph_vss_all(), IGRAPH_UNDIRECTED, false), REP)
     );
 
     igraph_destroy(&graph);

--- a/tests/unit/igraph_betweenness.c
+++ b/tests/unit/igraph_betweenness.c
@@ -64,10 +64,10 @@ int main(void) {
     igraph_vector_init(&bet, 0);
 
     igraph_betweenness_cutoff(/* graph=     */ &g,
+            /* weights=   */ 0,
             /* res=       */ &bet,
             /* vids=      */ igraph_vss_all(),
-            /* directed = */ 0,
-            /* weights=   */ 0,
+            /* directed = */ 0, false,
             /* cutoff=    */ 2);
 
     igraph_vector_destroy(&bet);
@@ -80,10 +80,10 @@ int main(void) {
     igraph_vector_init(&bet, 0);
 
     igraph_betweenness_cutoff(/* graph=     */ &g,
+            /* weights=   */ 0,
             /* res=       */ &bet,
             /* vids=      */ igraph_vss_all(),
-            /* directed = */ 0,
-            /* weights=   */ 0,
+            /* directed = */ 0, false,
             /* cutoff=    */ 3);
 
     printf("Max betweenness: %f\n", igraph_vector_max(&bet));
@@ -93,10 +93,10 @@ int main(void) {
     igraph_vector_fill(&weights, 1.0);
 
     igraph_betweenness_cutoff(/* graph=     */ &g,
+            /* weights=   */ &weights,
             /* res=       */ &bet2,
             /* vids=      */ igraph_vss_all(),
-            /* directed = */ 0,
-            /* weights=   */ &weights,
+            /* directed = */ 0, false,
             /* cutoff=    */ 3);
 
     IGRAPH_ASSERT(igraph_vector_all_e(&bet, &bet2));
@@ -111,10 +111,10 @@ int main(void) {
     igraph_small(&g, 4, IGRAPH_UNDIRECTED, 0, 1, 1, 2, 1, 2, 1, 1, 2, 3, 3, 0, 3, 3, -1);
     igraph_vector_init(&bet, 0);
     igraph_betweenness(/* graph=     */ &g,
+            /* weights=   */ 0,
             /* res=       */ &bet,
             /* vids=      */ igraph_vss_all(),
-            /* directed = */ 0,
-            /* weights=   */ 0);
+            /* directed = */ 0, false);
     print_vector(&bet);
     igraph_vector_destroy(&bet);
     igraph_destroy(&g);
@@ -127,8 +127,8 @@ int main(void) {
                        sizeof(nontriv_weights) / sizeof(nontriv_weights[0]));
     igraph_vector_init(&bet, 0);
 
-    igraph_betweenness(/*graph=*/ &g, /*res=*/ &bet, /*vids=*/ igraph_vss_all(),
-                                  /*directed=*/0, /*weights=*/ &weights);
+    igraph_betweenness(/*graph=*/ &g, /*weights=*/ &weights, /*res=*/ &bet, /*vids=*/ igraph_vss_all(),
+            /*directed=*/0, false);
 
     print_vector(&bet);
 
@@ -142,18 +142,18 @@ int main(void) {
     /* unweighted */
     igraph_vector_init(&bet, 0);
     igraph_betweenness_cutoff(/* graph=     */ &g,
+            /* weights=   */ 0,
             /* res=       */ &bet,
             /* vids=      */ igraph_vss_all(),
-            /* directed = */ 0,
-            /* weights=   */ 0,
+            /* directed = */ 0, false,
             /* cutoff=    */ 0);
 
     igraph_vector_init(&bet2, 0);
     igraph_betweenness_cutoff(/* graph=     */ &g,
+            /* weights=   */ 0,
             /* res=       */ &bet2,
             /* vids=      */ igraph_vss_all(),
-            /* directed = */ 0,
-            /* weights=   */ 0,
+            /* directed = */ 0, false,
             /* cutoff=    */ -1);
 
     print_vector(&bet);
@@ -168,18 +168,18 @@ int main(void) {
 
     igraph_vector_init(&bet, 0);
     igraph_betweenness_cutoff(/* graph=     */ &g,
+            /* weights=   */ &weights,
             /* res=       */ &bet,
             /* vids=      */ igraph_vss_all(),
-            /* directed = */ 0,
-            /* weights=   */ &weights,
+            /* directed = */ 0, false,
             /* cutoff=    */ 0);
 
     igraph_vector_init(&bet2, 0);
     igraph_betweenness_cutoff(/* graph=     */ &g,
+            /* weights=   */ &weights,
             /* res=       */ &bet2,
             /* vids=      */ igraph_vss_all(),
-            /* directed = */ 0,
-            /* weights=   */ &weights,
+            /* directed = */ 0, false,
             /* cutoff=    */ -1);
 
     print_vector(&bet);
@@ -207,16 +207,16 @@ int main(void) {
     {
         printf("Cutoff %.0f\n", cutoff);
         printf("Unweighted\n");
-        igraph_betweenness_cutoff(&g, &bet,
-                                  igraph_vss_all(), IGRAPH_UNDIRECTED,
-                /* weights */ NULL,
+        igraph_betweenness_cutoff(&g,
+                /* weights */ NULL, &bet,
+                                  igraph_vss_all(), IGRAPH_UNDIRECTED, false,
                 /* cutoff */ cutoff);
         print_vector(&bet);
 
         printf("Weighted\n");
-        igraph_betweenness_cutoff(&g, &bet2,
-                                  igraph_vss_all(), IGRAPH_UNDIRECTED,
-                /* weights */ &weights,
+        igraph_betweenness_cutoff(&g,
+                /* weights */ &weights, &bet2,
+                                  igraph_vss_all(), IGRAPH_UNDIRECTED, false,
                 /* cutoff */ cutoff);
         print_vector(&bet2);
         printf("\n");
@@ -248,16 +248,16 @@ int main(void) {
     {
         printf("Cutoff %.0f\n", cutoff);
         printf("Unweighted\n");
-        igraph_betweenness_cutoff(&g, &bet,
-                                  igraph_vss_all(), IGRAPH_UNDIRECTED,
-                /* weights */ NULL,
+        igraph_betweenness_cutoff(&g,
+                /* weights */ NULL, &bet,
+                                  igraph_vss_all(), IGRAPH_UNDIRECTED, false,
                 /* cutoff */ cutoff);
         print_vector(&bet);
 
         printf("Weighted\n");
-        igraph_betweenness_cutoff(&g, &bet2,
-                                  igraph_vss_all(), IGRAPH_UNDIRECTED,
-                /* weights */ &weights,
+        igraph_betweenness_cutoff(&g,
+                /* weights */ &weights, &bet2,
+                                  igraph_vss_all(), IGRAPH_UNDIRECTED, false,
                 /* cutoff */ cutoff);
         print_vector(&bet2);
         printf("\n");
@@ -273,7 +273,7 @@ int main(void) {
 
     igraph_empty(&g, 0, IGRAPH_UNDIRECTED);
     igraph_vector_init(&bet, 3); /* purposefully larger than zero, as igraph_betweenness must resize it */
-    igraph_betweenness(&g, &bet, igraph_vss_all(), IGRAPH_UNDIRECTED, NULL);
+    igraph_betweenness(&g, NULL, &bet, igraph_vss_all(), IGRAPH_UNDIRECTED, false);
     print_vector(&bet);
 
     igraph_vector_destroy(&bet);
@@ -284,7 +284,7 @@ int main(void) {
 
     igraph_empty(&g, 2, IGRAPH_UNDIRECTED);
     igraph_vector_init(&bet, 0);
-    igraph_betweenness(&g, &bet, igraph_vss_all(), IGRAPH_UNDIRECTED, NULL);
+    igraph_betweenness(&g, NULL, &bet, igraph_vss_all(), IGRAPH_UNDIRECTED, false);
     print_vector(&bet);
 
     igraph_vector_destroy(&bet);
@@ -303,7 +303,7 @@ int main(void) {
         igraph_square_lattice(&g, &dims, 1, IGRAPH_UNDIRECTED, /* mutual */ 0, /* periodic */ 0);
 
         igraph_vector_init(&bet, 0);
-        igraph_betweenness(&g, &bet, igraph_vss_all(), IGRAPH_UNDIRECTED, NULL);
+        igraph_betweenness(&g, NULL, &bet, igraph_vss_all(), IGRAPH_UNDIRECTED, false);
         printf("Max betweenness: %f\n", igraph_vector_max(&bet));
 
         igraph_vector_destroy(&bet);

--- a/tests/unit/igraph_betweenness_subset.c
+++ b/tests/unit/igraph_betweenness_subset.c
@@ -63,12 +63,12 @@ int main(void) {
     igraph_vs_range(&vs_target, 500, 1000);
 
     igraph_betweenness_subset(/* graph=     */ &g,
-        /* res=       */ &bet,
-        /* vids=      */ igraph_vss_all(),
-        /* directed = */ IGRAPH_UNDIRECTED,
-        /* sources = */ vs_source,
-        /* target = */ vs_target,
-        /* weights=   */ NULL);
+            /* weights=   */ NULL,
+            /* res=       */ &bet,
+            /* sources = */ vs_source,
+            /* target = */ vs_target,
+            /* vids=      */ igraph_vss_all(),
+            /* directed = */ IGRAPH_UNDIRECTED, false);
 
     igraph_vector_destroy(&bet);
     igraph_vs_destroy(&vs_source);
@@ -103,14 +103,13 @@ int main(void) {
     igraph_vector_init(&bet, 0);
 
     igraph_betweenness_subset(
-        /* graph=     */ &g,
-        /* res=       */ &bet,
-        /* vids=      */ igraph_vss_all(),
-        /* directed = */ IGRAPH_UNDIRECTED,
-        /* sources =  */ vs_source,
-        /* target =   */ vs_target,
-        /* weights=   */ NULL
-    );
+            /* graph=     */ &g,
+            /* weights=   */ NULL,
+            /* res=       */ &bet,
+            /* sources =  */ vs_source,
+            /* target =   */ vs_target,
+            /* vids=      */ igraph_vss_all(),
+            /* directed = */ IGRAPH_UNDIRECTED, false);
 
     printf("Max betweenness: %f\n", igraph_vector_max(&bet));
 
@@ -159,12 +158,12 @@ int main(void) {
     igraph_vector_fill(&weights, 1.0);
 
     igraph_betweenness_subset(/* graph=     */ &g,
+            /* weights=   */ &weights,
             /* res=       */ &bet2,
-            /* vids=      */ igraph_vss_all(),
-            /* directed = */ IGRAPH_UNDIRECTED,
             /* sources = */ vs_source,
             /* target = */ vs_target,
-            /* weights=   */ &weights);
+            /* vids=      */ igraph_vss_all(),
+            /* directed = */ IGRAPH_UNDIRECTED, false);
 
     IGRAPH_ASSERT(igraph_vector_all_e(&bet, &bet2));
 
@@ -184,12 +183,12 @@ int main(void) {
 
     igraph_vector_init(&bet, 0);
     igraph_betweenness_subset(/* graph=     */ &g,
-        /* res=       */ &bet,
-        /* vids=      */ igraph_vss_all(),
-        /* directed = */ IGRAPH_UNDIRECTED,
-        /* sources = */ igraph_vss_all(),
-        /* target = */ igraph_vss_all(),
-        /* weights=   */ &weights);
+            /* weights=   */ &weights,
+            /* res=       */ &bet,
+            /* sources = */ igraph_vss_all(),
+            /* target = */ igraph_vss_all(),
+            /* vids=      */ igraph_vss_all(),
+            /* directed = */ IGRAPH_UNDIRECTED, false);
 
     print_vector(&bet);
 
@@ -219,22 +218,22 @@ int main(void) {
         printf("subset without %" IGRAPH_PRId "\n", i);
         printf("Unweighted\n");
         igraph_betweenness_subset(/* graph=     */ &g,
-            /* res=       */ &bet,
-            /* vids=      */ vs,
-            /* directed = */ IGRAPH_UNDIRECTED,
-            /* sources = */ vs_source,
-            /* target = */ igraph_vss_all(),
-            /* weights=   */ NULL);
+                /* weights=   */ NULL,
+                /* res=       */ &bet,
+                /* sources = */ vs_source,
+                /* target = */ igraph_vss_all(),
+                /* vids=      */ vs,
+                /* directed = */ IGRAPH_UNDIRECTED, false);
         print_vector(&bet);
 
         printf("Weighted\n");
         igraph_betweenness_subset(/* graph=     */ &g,
-            /* res=       */ &bet2,
-            /* vids=      */ vs,
-            /* directed = */ IGRAPH_UNDIRECTED,
-            /* sources = */ vs_source,
-            /* target = */ igraph_vss_all(),
-            /* weights */ &weights);
+                /* weights */ &weights,
+                /* res=       */ &bet2,
+                /* sources = */ vs_source,
+                /* target = */ igraph_vss_all(),
+                /* vids=      */ vs,
+                /* directed = */ IGRAPH_UNDIRECTED, false);
         print_vector(&bet2);
         printf("\n");
 
@@ -273,22 +272,22 @@ int main(void) {
         printf("subset without %" IGRAPH_PRId "\n", i);
         printf("Unweighted\n");
         igraph_betweenness_subset(/* graph=     */ &g,
-            /* res=       */ &bet,
-            /* vids=      */ igraph_vss_all(),
-            /* directed = */ 0,
-            /* sources = */ igraph_vss_all(),
-            /* target = */ vs_target,
-            /* weights */ NULL);
+                /* weights */ NULL,
+                /* res=       */ &bet,
+                /* sources = */ igraph_vss_all(),
+                /* target = */ vs_target,
+                /* vids=      */ igraph_vss_all(),
+                /* directed = */ 0, false);
         print_vector(&bet);
 
         printf("Weighted\n");
         igraph_betweenness_subset(/* graph=     */ &g,
-            /* res=       */ &bet2,
-            /* vids=      */ igraph_vss_all(),
-            /* directed = */ 0,
-            /* sources = */ igraph_vss_all(),
-            /* target = */ vs_target,
-            /* weights */ &weights);
+                /* weights */ &weights,
+                /* res=       */ &bet2,
+                /* sources = */ igraph_vss_all(),
+                /* target = */ vs_target,
+                /* vids=      */ igraph_vss_all(),
+                /* directed = */ 0, false);
         print_vector(&bet2);
         printf("\n");
 
@@ -305,13 +304,13 @@ int main(void) {
     printf("==========================================================\n");
     igraph_empty(&g, 2, IGRAPH_UNDIRECTED);
     igraph_vector_init(&bet, 0);
-    igraph_betweenness_subset (/* graph=     */ &g,
-        /* res=       */ &bet,
-        /* vids=      */ igraph_vss_all(),
-        /* directed = */ IGRAPH_UNDIRECTED,
-        /* sources = */ igraph_vss_all(),
-        /* target = */ igraph_vss_all(),
-        /* weights=   */ NULL);
+    igraph_betweenness_subset(/* graph=     */ &g,
+            /* weights=   */ NULL,
+            /* res=       */ &bet,
+            /* sources = */ igraph_vss_all(),
+            /* target = */ igraph_vss_all(),
+            /* vids=      */ igraph_vss_all(),
+            /* directed = */ IGRAPH_UNDIRECTED, false);
 
     print_vector(&bet);
 
@@ -338,13 +337,13 @@ int main(void) {
         igraph_vector_int_remove(&source_vec, 0);
         igraph_vs_vector(&vs_source, &source_vec);
 
-        igraph_betweenness_subset (/* graph=     */ &g,
-        /* res=       */ &bet,
-        /* vids=      */ igraph_vss_all(),
-        /* directed = */ IGRAPH_UNDIRECTED,
-        /* sources = */ vs_source,
-        /* target = */ vs_target,
-        /* weights=   */ NULL);;
+        igraph_betweenness_subset(/* graph=     */ &g,
+                /* weights=   */ NULL,
+                /* res=       */ &bet,
+                /* sources = */ vs_source,
+                /* target = */ vs_target,
+                /* vids=      */ igraph_vss_all(),
+                /* directed = */ IGRAPH_UNDIRECTED, false);;
         printf("Max betweenness: %f\n", igraph_vector_max(&bet));
 
         igraph_vector_destroy(&bet);

--- a/tests/unit/igraph_community_optimal_modularity.c
+++ b/tests/unit/igraph_community_optimal_modularity.c
@@ -21,7 +21,7 @@
 
 void prepare_weights_vector(igraph_vector_t *weights, const igraph_t *graph) {
     const igraph_integer_t m = igraph_ecount(graph);
-    igraph_edge_betweenness(graph, NULL, weights, true, false);
+    igraph_edge_betweenness(graph, NULL, weights, igraph_ess_all(IGRAPH_EDGEORDER_ID), true, false);
     for (igraph_integer_t i=0; i < m; i++) {
         VECTOR(*weights)[i] = 1 / VECTOR(*weights)[i];
     }

--- a/tests/unit/igraph_community_optimal_modularity.c
+++ b/tests/unit/igraph_community_optimal_modularity.c
@@ -21,7 +21,7 @@
 
 void prepare_weights_vector(igraph_vector_t *weights, const igraph_t *graph) {
     const igraph_integer_t m = igraph_ecount(graph);
-    igraph_edge_betweenness(graph, weights, true, NULL);
+    igraph_edge_betweenness(graph, NULL, weights, true, false);
     for (igraph_integer_t i=0; i < m; i++) {
         VECTOR(*weights)[i] = 1 / VECTOR(*weights)[i];
     }

--- a/tests/unit/igraph_community_voronoi.c
+++ b/tests/unit/igraph_community_voronoi.c
@@ -60,7 +60,7 @@ int main(void) {
 
         igraph_vector_init(&betw, 0);
 
-        igraph_edge_betweenness(&graph, NULL, &betw, IGRAPH_UNDIRECTED, false);
+        igraph_edge_betweenness(&graph, NULL, &betw, igraph_ess_all(IGRAPH_EDGEORDER_ID), IGRAPH_UNDIRECTED, false);
 
         igraph_integer_t n = igraph_vector_size(&betw);
         igraph_vector_init_copy(&ibetw, &betw);

--- a/tests/unit/igraph_community_voronoi.c
+++ b/tests/unit/igraph_community_voronoi.c
@@ -60,7 +60,7 @@ int main(void) {
 
         igraph_vector_init(&betw, 0);
 
-        igraph_edge_betweenness(&graph, &betw, IGRAPH_UNDIRECTED, NULL);
+        igraph_edge_betweenness(&graph, NULL, &betw, IGRAPH_UNDIRECTED, false);
 
         igraph_integer_t n = igraph_vector_size(&betw);
         igraph_vector_init_copy(&ibetw, &betw);

--- a/tests/unit/igraph_edge_betweenness.c
+++ b/tests/unit/igraph_edge_betweenness.c
@@ -46,7 +46,7 @@ void test_bug950(void) {
 
     igraph_vector_init(&eb, 0);
 
-    igraph_edge_betweenness(&g, &eb, IGRAPH_UNDIRECTED, &weights);
+    igraph_edge_betweenness(&g, &weights, &eb, IGRAPH_UNDIRECTED, false);
     print_vector(&eb);
 
     igraph_vector_destroy(&eb);
@@ -68,8 +68,8 @@ void test_bug1050(void) {
     igraph_vector_init(&eb, igraph_ecount(&g));
     igraph_vector_init(&eb2, igraph_ecount(&g));
 
-    igraph_edge_betweenness_cutoff(&g, &eb, IGRAPH_UNDIRECTED, /* weights */ 0, /* cutoff */ -1);
-    igraph_edge_betweenness_cutoff(&g, &eb2, IGRAPH_UNDIRECTED, /* weights */ 0, /* cutoff */ 0);
+    igraph_edge_betweenness_cutoff(&g, /* weights */ 0, &eb, IGRAPH_UNDIRECTED, false, /* cutoff */ -1);
+    igraph_edge_betweenness_cutoff(&g, /* weights */ 0, &eb2, IGRAPH_UNDIRECTED, false, /* cutoff */ 0);
 
     /* results must differ */
     IGRAPH_ASSERT(! igraph_vector_all_e(&eb, &eb2));
@@ -85,8 +85,8 @@ void test_bug1050(void) {
     igraph_vector_fill(&weights, 1);
     VECTOR(weights)[0] = 2;
 
-    igraph_edge_betweenness_cutoff(&g, &eb, IGRAPH_UNDIRECTED, &weights, /* cutoff */ -1);
-    igraph_edge_betweenness_cutoff(&g, &eb2, IGRAPH_UNDIRECTED, &weights, /* cutoff */ 0);
+    igraph_edge_betweenness_cutoff(&g, &weights, &eb, IGRAPH_UNDIRECTED, false, /* cutoff */ -1);
+    igraph_edge_betweenness_cutoff(&g, &weights, &eb2, IGRAPH_UNDIRECTED, false, /* cutoff */ 0);
 
     /* results must differ */
     IGRAPH_ASSERT(! igraph_vector_all_e(&eb, &eb2));
@@ -107,13 +107,13 @@ int main(void) {
 
     printf("Null graph\n");
     igraph_empty(&g, 0, IGRAPH_UNDIRECTED);
-    igraph_edge_betweenness(&g, &eb, IGRAPH_UNDIRECTED, NULL);
+    igraph_edge_betweenness(&g, NULL, &eb, IGRAPH_UNDIRECTED, false);
     print_vector(&eb);
     igraph_destroy(&g);
 
     printf("\nEdgeless graph on 3 vertices\n");
     igraph_empty(&g, 3, IGRAPH_DIRECTED);
-    igraph_edge_betweenness(&g, &eb, IGRAPH_DIRECTED, NULL);
+    igraph_edge_betweenness(&g, NULL, &eb, IGRAPH_DIRECTED, false);
     print_vector(&eb);
     igraph_destroy(&g);
 
@@ -122,14 +122,14 @@ int main(void) {
     printf("\nNo cutoff, undirected, unweighted\n");
     igraph_famous(&g, "zachary");
     igraph_vector_init(&eb, 0);
-    igraph_edge_betweenness(&g, &eb, IGRAPH_UNDIRECTED, /*weights=*/ 0);
+    igraph_edge_betweenness(&g, /*weights=*/ 0, &eb, IGRAPH_UNDIRECTED, false);
     print_vector(&eb);
 
     printf("\nNo cutoff, undirected, unit weighted\n");
     igraph_vector_init(&eb2, 0);
     igraph_vector_init(&weights, igraph_ecount(&g));
     igraph_vector_fill(&weights, 1.0);
-    igraph_edge_betweenness(&g, &eb2, IGRAPH_UNDIRECTED, &weights);
+    igraph_edge_betweenness(&g, &weights, &eb2, IGRAPH_UNDIRECTED, false);
     print_vector(&eb2);
 
     /* check that weighted and unweighted calculations give the same result */
@@ -148,7 +148,7 @@ int main(void) {
                  1,0, 2,0, 0,3, 3,4, 4,5, 5,0, 5,6,
                  -1);
     igraph_vector_init(&eb, 0);
-    igraph_edge_betweenness(&g, &eb, IGRAPH_DIRECTED, /* weights */ NULL);
+    igraph_edge_betweenness(&g, /* weights */ NULL, &eb, IGRAPH_DIRECTED, false);
     print_vector(&eb);
     igraph_vector_destroy(&eb);
     igraph_destroy(&g);
@@ -157,7 +157,7 @@ int main(void) {
     igraph_small(&g, 0, IGRAPH_UNDIRECTED,
                  0, 1, 0, 2, 0, 3, 1, 4, -1);
     igraph_vector_init(&eb, 0);
-    igraph_edge_betweenness_cutoff(&g, &eb, IGRAPH_UNDIRECTED, /*weights=*/ 0, /*cutoff=*/2);
+    igraph_edge_betweenness_cutoff(&g, /*weights=*/ 0, &eb, IGRAPH_UNDIRECTED, false, /*cutoff=*/2);
     print_vector(&eb);
     igraph_vector_destroy(&eb);
     igraph_destroy(&g);
@@ -167,7 +167,7 @@ int main(void) {
                  0, 1, 0, 3, 1, 2, 1, 4, 2, 5, 3, 4, 3, 6, 4, 5, 4, 7, 5, 8,
                  6, 7, 7, 8, -1);
     igraph_vector_init(&eb, 0);
-    igraph_edge_betweenness_cutoff(&g, &eb, IGRAPH_UNDIRECTED, /*weights=*/ 0, /*cutoff=*/2);
+    igraph_edge_betweenness_cutoff(&g, /*weights=*/ 0, &eb, IGRAPH_UNDIRECTED, false, /*cutoff=*/2);
     print_vector(&eb);
     igraph_vector_destroy(&eb);
     igraph_destroy(&g);
@@ -176,9 +176,9 @@ int main(void) {
     igraph_small(&g, 4, IGRAPH_UNDIRECTED, 0, 1, 1, 2, 1, 2, 1, 1, 2, 3, 3, 0, 3, 3, -1);
     igraph_vector_init(&eb, 0);
     igraph_edge_betweenness(/* graph=     */ &g,
+            /* weights=   */ 0,
             /* res=       */ &eb,
-            /* directed = */ IGRAPH_UNDIRECTED,
-            /* weights=   */ 0);
+            /* directed = */ IGRAPH_UNDIRECTED, false);
     print_vector(&eb);
     igraph_vector_destroy(&eb);
     igraph_destroy(&g);

--- a/tests/unit/igraph_edge_betweenness.c
+++ b/tests/unit/igraph_edge_betweenness.c
@@ -46,7 +46,7 @@ void test_bug950(void) {
 
     igraph_vector_init(&eb, 0);
 
-    igraph_edge_betweenness(&g, &weights, &eb, IGRAPH_UNDIRECTED, false);
+    igraph_edge_betweenness(&g, &weights, &eb, igraph_ess_all(IGRAPH_EDGEORDER_ID), IGRAPH_UNDIRECTED, false);
     print_vector(&eb);
 
     igraph_vector_destroy(&eb);
@@ -68,8 +68,10 @@ void test_bug1050(void) {
     igraph_vector_init(&eb, igraph_ecount(&g));
     igraph_vector_init(&eb2, igraph_ecount(&g));
 
-    igraph_edge_betweenness_cutoff(&g, /* weights */ 0, &eb, IGRAPH_UNDIRECTED, false, /* cutoff */ -1);
-    igraph_edge_betweenness_cutoff(&g, /* weights */ 0, &eb2, IGRAPH_UNDIRECTED, false, /* cutoff */ 0);
+    igraph_edge_betweenness_cutoff(&g, /* weights */ 0, &eb, igraph_ess_all(IGRAPH_EDGEORDER_ID), IGRAPH_UNDIRECTED,
+                                   false, /* cutoff */ -1);
+    igraph_edge_betweenness_cutoff(&g, /* weights */ 0, &eb2, igraph_ess_all(IGRAPH_EDGEORDER_ID), IGRAPH_UNDIRECTED,
+                                   false, /* cutoff */ 0);
 
     /* results must differ */
     IGRAPH_ASSERT(! igraph_vector_all_e(&eb, &eb2));
@@ -85,8 +87,10 @@ void test_bug1050(void) {
     igraph_vector_fill(&weights, 1);
     VECTOR(weights)[0] = 2;
 
-    igraph_edge_betweenness_cutoff(&g, &weights, &eb, IGRAPH_UNDIRECTED, false, /* cutoff */ -1);
-    igraph_edge_betweenness_cutoff(&g, &weights, &eb2, IGRAPH_UNDIRECTED, false, /* cutoff */ 0);
+    igraph_edge_betweenness_cutoff(&g, &weights, &eb, igraph_ess_all(IGRAPH_EDGEORDER_ID), IGRAPH_UNDIRECTED,
+                                   false, /* cutoff */ -1);
+    igraph_edge_betweenness_cutoff(&g, &weights, &eb2, igraph_ess_all(IGRAPH_EDGEORDER_ID), IGRAPH_UNDIRECTED,
+                                   false, /* cutoff */ 0);
 
     /* results must differ */
     IGRAPH_ASSERT(! igraph_vector_all_e(&eb, &eb2));
@@ -107,13 +111,13 @@ int main(void) {
 
     printf("Null graph\n");
     igraph_empty(&g, 0, IGRAPH_UNDIRECTED);
-    igraph_edge_betweenness(&g, NULL, &eb, IGRAPH_UNDIRECTED, false);
+    igraph_edge_betweenness(&g, NULL, &eb, igraph_ess_all(IGRAPH_EDGEORDER_ID), IGRAPH_UNDIRECTED, false);
     print_vector(&eb);
     igraph_destroy(&g);
 
     printf("\nEdgeless graph on 3 vertices\n");
     igraph_empty(&g, 3, IGRAPH_DIRECTED);
-    igraph_edge_betweenness(&g, NULL, &eb, IGRAPH_DIRECTED, false);
+    igraph_edge_betweenness(&g, NULL, &eb, igraph_ess_all(IGRAPH_EDGEORDER_ID), IGRAPH_DIRECTED, false);
     print_vector(&eb);
     igraph_destroy(&g);
 
@@ -122,14 +126,14 @@ int main(void) {
     printf("\nNo cutoff, undirected, unweighted\n");
     igraph_famous(&g, "zachary");
     igraph_vector_init(&eb, 0);
-    igraph_edge_betweenness(&g, /*weights=*/ 0, &eb, IGRAPH_UNDIRECTED, false);
+    igraph_edge_betweenness(&g, /*weights=*/ 0, &eb, igraph_ess_all(IGRAPH_EDGEORDER_ID), IGRAPH_UNDIRECTED, false);
     print_vector(&eb);
 
     printf("\nNo cutoff, undirected, unit weighted\n");
     igraph_vector_init(&eb2, 0);
     igraph_vector_init(&weights, igraph_ecount(&g));
     igraph_vector_fill(&weights, 1.0);
-    igraph_edge_betweenness(&g, &weights, &eb2, IGRAPH_UNDIRECTED, false);
+    igraph_edge_betweenness(&g, &weights, &eb2, igraph_ess_all(IGRAPH_EDGEORDER_ID), IGRAPH_UNDIRECTED, false);
     print_vector(&eb2);
 
     /* check that weighted and unweighted calculations give the same result */
@@ -148,7 +152,7 @@ int main(void) {
                  1,0, 2,0, 0,3, 3,4, 4,5, 5,0, 5,6,
                  -1);
     igraph_vector_init(&eb, 0);
-    igraph_edge_betweenness(&g, /* weights */ NULL, &eb, IGRAPH_DIRECTED, false);
+    igraph_edge_betweenness(&g, /* weights */ NULL, &eb, igraph_ess_all(IGRAPH_EDGEORDER_ID), IGRAPH_DIRECTED, false);
     print_vector(&eb);
     igraph_vector_destroy(&eb);
     igraph_destroy(&g);
@@ -157,7 +161,8 @@ int main(void) {
     igraph_small(&g, 0, IGRAPH_UNDIRECTED,
                  0, 1, 0, 2, 0, 3, 1, 4, -1);
     igraph_vector_init(&eb, 0);
-    igraph_edge_betweenness_cutoff(&g, /*weights=*/ 0, &eb, IGRAPH_UNDIRECTED, false, /*cutoff=*/2);
+    igraph_edge_betweenness_cutoff(&g, /*weights=*/ 0, &eb, igraph_ess_all(IGRAPH_EDGEORDER_ID), IGRAPH_UNDIRECTED,
+                                   false, /*cutoff=*/2);
     print_vector(&eb);
     igraph_vector_destroy(&eb);
     igraph_destroy(&g);
@@ -167,7 +172,8 @@ int main(void) {
                  0, 1, 0, 3, 1, 2, 1, 4, 2, 5, 3, 4, 3, 6, 4, 5, 4, 7, 5, 8,
                  6, 7, 7, 8, -1);
     igraph_vector_init(&eb, 0);
-    igraph_edge_betweenness_cutoff(&g, /*weights=*/ 0, &eb, IGRAPH_UNDIRECTED, false, /*cutoff=*/2);
+    igraph_edge_betweenness_cutoff(&g, /*weights=*/ 0, &eb, igraph_ess_all(IGRAPH_EDGEORDER_ID), IGRAPH_UNDIRECTED,
+                                   false, /*cutoff=*/2);
     print_vector(&eb);
     igraph_vector_destroy(&eb);
     igraph_destroy(&g);
@@ -177,7 +183,7 @@ int main(void) {
     igraph_vector_init(&eb, 0);
     igraph_edge_betweenness(/* graph=     */ &g,
             /* weights=   */ 0,
-            /* res=       */ &eb,
+            /* res=       */ &eb, igraph_ess_all(IGRAPH_EDGEORDER_ID),
             /* directed = */ IGRAPH_UNDIRECTED, false);
     print_vector(&eb);
     igraph_vector_destroy(&eb);

--- a/tests/unit/igraph_edge_betweenness.out
+++ b/tests/unit/igraph_edge_betweenness.out
@@ -26,3 +26,11 @@ Testing bug 950, tolerances
 ( 0 0 2.33333 2.33333 2.33333 0 2.33333 2.33333 2.33333 2.33333 2.33333 2.33333 0 0 0 )
 
 Testing bug 1050, cutoff values
+
+Testing eids parameter edge selection
+Full edge betweenness: ( 4 6 6 4 )
+Range selection (edges 1-3): ( 6 6 4 )
+Single edge selection (edge 2): ( 6 )
+Vector selection (edges 0, 2, 3): ( 4 6 4 )
+Vector selection with duplicates (edges 0, 2, 0, 2): ( 4 6 4 6 )
+Empty edge selection: ( )

--- a/tests/unit/igraph_edge_betweenness_subset.c
+++ b/tests/unit/igraph_edge_betweenness_subset.c
@@ -49,12 +49,12 @@ void test_bug950_edge(void) {
     igraph_vector_init(&eb, 0);
 
     igraph_edge_betweenness_subset(/* graph=     */ &g,
-        /* res=       */ &eb,
-        /* eids=      */ igraph_ess_all(IGRAPH_EDGEORDER_ID),
-        /* directed = */ IGRAPH_UNDIRECTED,
-        /* sources = */ igraph_vss_all(),
-        /* target = */ igraph_vss_all(),
-        /* weights=   */ &weights);
+            /* weights=   */ &weights,
+            /* res=       */ &eb,
+            /* sources = */ igraph_vss_all(),
+            /* target = */ igraph_vss_all(),
+            /* eids=      */ igraph_ess_all(IGRAPH_EDGEORDER_ID),
+            /* directed = */ IGRAPH_UNDIRECTED, false);
 
     print_vector(&eb);
     igraph_vector_destroy(&eb);
@@ -103,14 +103,13 @@ int main(void) {
     igraph_vector_init(&bet, 0);
 
     igraph_edge_betweenness_subset(
-        /* graph=     */ &g,
-        /* res=       */ &bet,
-        /* eids=      */ igraph_ess_all(IGRAPH_EDGEORDER_ID),
-        /* directed = */ IGRAPH_UNDIRECTED,
-        /* sources =  */ vs_source,
-        /* target =   */ vs_target,
-        /* weights=   */ NULL
-    );
+            /* graph=     */ &g,
+            /* weights=   */ NULL,
+            /* res=       */ &bet,
+            /* sources =  */ vs_source,
+            /* target =   */ vs_target,
+            /* eids=      */ igraph_ess_all(IGRAPH_EDGEORDER_ID),
+            /* directed = */ IGRAPH_UNDIRECTED, false);
 
     printf("Max edge betweenness: %f\n", igraph_vector_max(&bet));
 
@@ -161,14 +160,13 @@ int main(void) {
     igraph_vector_fill(&weights, 1.0);
 
     igraph_edge_betweenness_subset(
-        /* graph=     */ &g,
-        /* res=       */ &bet2,
-        /* eids=      */ igraph_ess_all(IGRAPH_EDGEORDER_ID),
-        /* directed = */ IGRAPH_UNDIRECTED,
-        /* sources = */ vs_source,
-        /* target = */ vs_target,
-        /* weights=   */ &weights
-    );
+            /* graph=     */ &g,
+            /* weights=   */ &weights,
+            /* res=       */ &bet2,
+            /* sources = */ vs_source,
+            /* target = */ vs_target,
+            /* eids=      */ igraph_ess_all(IGRAPH_EDGEORDER_ID),
+            /* directed = */ IGRAPH_UNDIRECTED, false);
 
     IGRAPH_ASSERT(igraph_vector_all_e(&bet, &bet2));
 
@@ -188,13 +186,13 @@ int main(void) {
     igraph_vs_vector(&vs_target, &target_vec);
     igraph_vector_init(&eb, 0);
 
-    igraph_edge_betweenness_subset (/* graph=     */ &g,
-    /* res=       */ &eb,
-    /* eids=      */ igraph_ess_all(IGRAPH_EDGEORDER_ID),
-    /* directed = */ IGRAPH_UNDIRECTED,
-    /* sources = */ vs_source,
-    /* target = */ vs_target,
-    /* weights=   */ NULL);
+    igraph_edge_betweenness_subset(/* graph=     */ &g,
+            /* weights=   */ NULL,
+            /* res=       */ &eb,
+            /* sources = */ vs_source,
+            /* target = */ vs_target,
+            /* eids=      */ igraph_ess_all(IGRAPH_EDGEORDER_ID),
+            /* directed = */ IGRAPH_UNDIRECTED, false);
 
     print_vector(&eb);
     igraph_vector_destroy(&eb);
@@ -214,13 +212,13 @@ int main(void) {
     igraph_es_vector(&es, &node_vec);
     igraph_vector_int_init_range(&target_vec, 1, 5);
     igraph_vs_vector(&vs_target, &target_vec);
-    igraph_edge_betweenness_subset (/* graph=     */ &g,
-        /* res=       */ &eb,
-        /* eids=      */ es,
-        /* directed = */ IGRAPH_UNDIRECTED,
-        /* sources = */ igraph_vss_all(),
-        /* target = */ vs_target,
-        /* weights=   */ NULL);
+    igraph_edge_betweenness_subset(/* graph=     */ &g,
+            /* weights=   */ NULL,
+            /* res=       */ &eb,
+            /* sources = */ igraph_vss_all(),
+            /* target = */ vs_target,
+            /* eids=      */ es,
+            /* directed = */ IGRAPH_UNDIRECTED, false);
 
     print_vector(&eb);
     igraph_vector_destroy(&eb);
@@ -239,13 +237,13 @@ int main(void) {
     igraph_vector_int_init_range(&source_vec, 1, 9);
     igraph_vs_vector(&vs_source, &source_vec);
 
-    igraph_edge_betweenness_subset (/* graph=     */ &g,
-        /* res=       */ &eb,
-        /* eids=      */ igraph_ess_all(IGRAPH_EDGEORDER_ID),
-        /* directed = */ IGRAPH_UNDIRECTED,
-        /* sources = */ vs_source,
-        /* target = */ igraph_vss_all(),
-        /* weights=   */ NULL);
+    igraph_edge_betweenness_subset(/* graph=     */ &g,
+            /* weights=   */ NULL,
+            /* res=       */ &eb,
+            /* sources = */ vs_source,
+            /* target = */ igraph_vss_all(),
+            /* eids=      */ igraph_ess_all(IGRAPH_EDGEORDER_ID),
+            /* directed = */ IGRAPH_UNDIRECTED, false);
     print_vector(&eb);
     igraph_vector_destroy(&eb);
     igraph_vs_destroy(&vs_source);
@@ -259,13 +257,13 @@ int main(void) {
     igraph_empty(&g, 2, IGRAPH_UNDIRECTED);
 
     igraph_vector_init(&bet, 0);
-    igraph_edge_betweenness_subset (/* graph=     */ &g,
-        /* res=       */ &bet,
-        /* eids=      */ igraph_ess_all(IGRAPH_EDGEORDER_ID),
-        /* directed = */ IGRAPH_UNDIRECTED,
-        /* sources = */ igraph_vss_all(),
-        /* target = */ igraph_vss_all(),
-        /* weights=   */ NULL);
+    igraph_edge_betweenness_subset(/* graph=     */ &g,
+            /* weights=   */ NULL,
+            /* res=       */ &bet,
+            /* sources = */ igraph_vss_all(),
+            /* target = */ igraph_vss_all(),
+            /* eids=      */ igraph_ess_all(IGRAPH_EDGEORDER_ID),
+            /* directed = */ IGRAPH_UNDIRECTED, false);
     print_vector(&bet);
     igraph_vector_destroy(&bet);
 
@@ -291,13 +289,13 @@ int main(void) {
         igraph_vector_int_remove(&source_vec, 0);
         igraph_vs_vector(&vs_source, &source_vec);
 
-        igraph_edge_betweenness_subset (/* graph=     */ &g,
-        /* res=       */ &bet,
-        /* eids=      */ igraph_ess_all(IGRAPH_EDGEORDER_ID),
-        /* directed = */ IGRAPH_UNDIRECTED,
-        /* sources = */ vs_source,
-        /* target = */ vs_target,
-        /* weights=   */ NULL);
+        igraph_edge_betweenness_subset(/* graph=     */ &g,
+                /* weights=   */ NULL,
+                /* res=       */ &bet,
+                /* sources = */ vs_source,
+                /* target = */ vs_target,
+                /* eids=      */ igraph_ess_all(IGRAPH_EDGEORDER_ID),
+                /* directed = */ IGRAPH_UNDIRECTED, false);
         printf("Max edge betweenness: %f\n", igraph_vector_max(&bet));
 
         igraph_vector_destroy(&bet);

--- a/tests/unit/igraph_voronoi.c
+++ b/tests/unit/igraph_voronoi.c
@@ -101,7 +101,7 @@ int main(void) {
     printf("\n\nKarate club, betweenness weighted.\n");
 
     igraph_vector_init(&weights, 0);
-    igraph_edge_betweenness(&g, NULL, &weights, IGRAPH_UNDIRECTED, false);
+    igraph_edge_betweenness(&g, NULL, &weights, igraph_ess_all(IGRAPH_EDGEORDER_ID), IGRAPH_UNDIRECTED, false);
 
     printf("\nTiebreaking: 'first'\n");
     igraph_voronoi(&g, &membership, &distances, &generators, &weights, IGRAPH_ALL, IGRAPH_VORONOI_FIRST);

--- a/tests/unit/igraph_voronoi.c
+++ b/tests/unit/igraph_voronoi.c
@@ -101,7 +101,7 @@ int main(void) {
     printf("\n\nKarate club, betweenness weighted.\n");
 
     igraph_vector_init(&weights, 0);
-    igraph_edge_betweenness(&g, &weights, IGRAPH_UNDIRECTED, NULL);
+    igraph_edge_betweenness(&g, NULL, &weights, IGRAPH_UNDIRECTED, false);
 
     printf("\nTiebreaking: 'first'\n");
     igraph_voronoi(&g, &membership, &distances, &generators, &weights, IGRAPH_ALL, IGRAPH_VORONOI_FIRST);


### PR DESCRIPTION
 - Adds a normalization parameter for betweenness, without implementing the feature _yet_.
 - Given that the function signatures were changed, reordered parameters to conform to our guidelines.

Up for discussion.

Interfaces (Stimulus) not yet updated.

See #1797

Question: Do we want an `eids` parameter for edge betweenness, to achieve full consistency with other betweenness functions?