### PR TITLE
perf: optimize vector_scale() by 1 and vector_add_constant() with 0

### DIFF
--- a/src/core/vector.pmt
+++ b/src/core/vector.pmt
@@ -2356,8 +2356,18 @@ igraph_bool_t FUNCTION(igraph_vector, binsearch2)(const TYPE(igraph_vector) *v,
  */
 
 void FUNCTION(igraph_vector, scale)(TYPE(igraph_vector) *v, BASE by) {
-    igraph_integer_t i;
-    for (i = 0; i < FUNCTION(igraph_vector, size)(v); i++) {
+    const igraph_integer_t n = FUNCTION(igraph_vector, size)(v);
+#ifdef EQ
+    const BASE one = ONE;
+    if (EQ(by, one)) {
+        return;
+    }
+#else
+    if (by == ONE) {
+        return;
+    }
+#endif
+    for (igraph_integer_t i = 0; i < n; i++) {
 #ifdef PROD
         PROD(VECTOR(*v)[i], VECTOR(*v)[i], by);
 #else
@@ -2379,8 +2389,18 @@ void FUNCTION(igraph_vector, scale)(TYPE(igraph_vector) *v, BASE by) {
  */
 
 void FUNCTION(igraph_vector, add_constant)(TYPE(igraph_vector) *v, BASE plus) {
-    igraph_integer_t i, n = FUNCTION(igraph_vector, size)(v);
-    for (i = 0; i < n; i++) {
+    const igraph_integer_t n = FUNCTION(igraph_vector, size)(v);
+#ifdef EQ
+    const BASE zero = ZERO;
+    if (EQ(plus, zero)) {
+        return;
+    }
+#else
+    if (plus == ZERO) {
+        return;
+    }
+#endif
+    for (igraph_integer_t i = 0; i < n; i++) {
 #ifdef SUM
         SUM(VECTOR(*v)[i], VECTOR(*v)[i], plus);
 #else


### PR DESCRIPTION
@ntamas I need a sanity check please. I'd find it convenient when implementing betweenness normalization, to have simpler code without an unnecessary pass over the vector. But perhaps I didn't sleep enough and this is not good for long-term maintainability.

`igraph_vector_scale()` now checks if the scaling factor is 1, and if so it skips scaling. Same for `igraph_vector_add_constant()`.