### PR TITLE
feat: add support for marking experimental functions in a structured way

### DIFF
--- a/include/igraph_bipartite.h
+++ b/include/igraph_bipartite.h
@@ -95,7 +95,7 @@ IGRAPH_EXPORT igraph_error_t igraph_bipartite_game_gnm(igraph_t *graph, igraph_v
                                             igraph_integer_t m, igraph_bool_t directed,
                                             igraph_neimode_t mode, igraph_bool_t multiple);
 
-IGRAPH_EXPORT igraph_error_t igraph_bipartite_iea_game(
+IGRAPH_EXPERIMENTAL IGRAPH_EXPORT igraph_error_t igraph_bipartite_iea_game(
     igraph_t *graph, igraph_vector_bool_t *types,
     igraph_integer_t n1, igraph_integer_t n2, igraph_integer_t m,
     igraph_bool_t directed, igraph_neimode_t mode);

--- a/include/igraph_coloring.h
+++ b/include/igraph_coloring.h
@@ -48,9 +48,9 @@ typedef enum {
 
 IGRAPH_EXPORT igraph_error_t igraph_vertex_coloring_greedy(const igraph_t *graph, igraph_vector_int_t *colors, igraph_coloring_greedy_t heuristic);
 
-IGRAPH_EXPORT igraph_error_t igraph_is_vertex_coloring(const igraph_t *graph, const igraph_vector_int_t *types, igraph_bool_t *res);
-IGRAPH_EXPORT igraph_error_t igraph_is_bipartite_coloring(const igraph_t *graph, const igraph_vector_bool_t *types, igraph_bool_t *res, igraph_neimode_t *mode);
-IGRAPH_EXPORT igraph_error_t igraph_is_edge_coloring(const igraph_t *graph, const igraph_vector_int_t *types, igraph_bool_t *res);
+IGRAPH_EXPERIMENTAL IGRAPH_EXPORT igraph_error_t igraph_is_vertex_coloring(const igraph_t *graph, const igraph_vector_int_t *types, igraph_bool_t *res);
+IGRAPH_EXPERIMENTAL IGRAPH_EXPORT igraph_error_t igraph_is_bipartite_coloring(const igraph_t *graph, const igraph_vector_bool_t *types, igraph_bool_t *res, igraph_neimode_t *mode);
+IGRAPH_EXPERIMENTAL IGRAPH_EXPORT igraph_error_t igraph_is_edge_coloring(const igraph_t *graph, const igraph_vector_int_t *types, igraph_bool_t *res);
 
 IGRAPH_END_C_DECLS
 

--- a/include/igraph_community.h
+++ b/include/igraph_community.h
@@ -132,7 +132,7 @@ IGRAPH_EXPORT igraph_error_t igraph_le_community_to_membership(const igraph_matr
                                                     igraph_vector_int_t *membership,
                                                     igraph_vector_int_t *csize);
 
-IGRAPH_EXPORT igraph_error_t igraph_community_voronoi(
+IGRAPH_EXPERIMENTAL IGRAPH_EXPORT igraph_error_t igraph_community_voronoi(
     const igraph_t *graph,
     igraph_vector_int_t *membership, igraph_vector_int_t *generators, igraph_real_t *modularity,
     const igraph_vector_t *lengths, const igraph_vector_t *weights,

--- a/include/igraph_components.h
+++ b/include/igraph_components.h
@@ -54,17 +54,17 @@ IGRAPH_EXPORT igraph_error_t igraph_biconnected_components(const igraph_t *graph
 IGRAPH_EXPORT igraph_error_t igraph_is_biconnected(const igraph_t *graph, igraph_bool_t *result);
 IGRAPH_EXPORT igraph_error_t igraph_bridges(const igraph_t *graph, igraph_vector_int_t *bridges);
 
-IGRAPH_EXPORT igraph_error_t igraph_bond_percolation(
+IGRAPH_EXPERIMENTAL IGRAPH_EXPORT igraph_error_t igraph_bond_percolation(
         const igraph_t *graph,
         igraph_vector_int_t *giant_size,
         igraph_vector_int_t *vertex_count,
         const igraph_vector_int_t *edge_order);
-IGRAPH_EXPORT igraph_error_t igraph_site_percolation(
+IGRAPH_EXPERIMENTAL IGRAPH_EXPORT igraph_error_t igraph_site_percolation(
         const igraph_t *graph,
         igraph_vector_int_t *giant_size,
         igraph_vector_int_t *edge_count,
         const igraph_vector_int_t *vertex_order);
-IGRAPH_EXPORT igraph_error_t igraph_edgelist_percolation(
+IGRAPH_EXPERIMENTAL IGRAPH_EXPORT igraph_error_t igraph_edgelist_percolation(
         const igraph_vector_int_t *edges,
         igraph_vector_int_t *giant_size,
         igraph_vector_int_t *vertex_count);

--- a/include/igraph_constructors.h
+++ b/include/igraph_constructors.h
@@ -97,8 +97,8 @@ IGRAPH_EXPORT igraph_error_t igraph_realize_degree_sequence(igraph_t *graph,
                                                  igraph_realize_degseq_t method);
 IGRAPH_EXPORT igraph_error_t igraph_triangular_lattice(igraph_t *graph, const igraph_vector_int_t *dims, igraph_bool_t directed, igraph_bool_t mutual);
 IGRAPH_EXPORT igraph_error_t igraph_hexagonal_lattice(igraph_t *graph, const igraph_vector_int_t *dims, igraph_bool_t directed, igraph_bool_t mutual);
-IGRAPH_EXPORT igraph_error_t igraph_realize_bipartite_degree_sequence(igraph_t *graph, const igraph_vector_int_t *deg1, const igraph_vector_int_t *deg2, igraph_edge_type_sw_t allowed_edge_types, igraph_realize_degseq_t method);
-IGRAPH_EXPORT igraph_error_t igraph_mycielski_graph(igraph_t *graph, igraph_integer_t k);
+IGRAPH_EXPERIMENTAL IGRAPH_EXPORT igraph_error_t igraph_realize_bipartite_degree_sequence(igraph_t *graph, const igraph_vector_int_t *deg1, const igraph_vector_int_t *deg2, igraph_edge_type_sw_t allowed_edge_types, igraph_realize_degseq_t method);
+IGRAPH_EXPERIMENTAL IGRAPH_EXPORT igraph_error_t igraph_mycielski_graph(igraph_t *graph, igraph_integer_t k);
 
 IGRAPH_END_C_DECLS
 

--- a/include/igraph_cycles.h
+++ b/include/igraph_cycles.h
@@ -41,18 +41,18 @@ IGRAPH_EXPORT igraph_error_t igraph_is_dag(const igraph_t *graph, igraph_bool_t 
 /* Cycle bases                                        */
 /* -------------------------------------------------- */
 
-IGRAPH_EXPORT igraph_error_t igraph_fundamental_cycles(
+IGRAPH_EXPERIMENTAL IGRAPH_EXPORT igraph_error_t igraph_fundamental_cycles(
         const igraph_t *graph, const igraph_vector_t *weights,
         igraph_vector_int_list_t *result,
         igraph_integer_t start_vid, igraph_real_t bfs_cutoff);
 
-IGRAPH_EXPORT igraph_error_t igraph_minimum_cycle_basis(
+IGRAPH_EXPERIMENTAL IGRAPH_EXPORT igraph_error_t igraph_minimum_cycle_basis(
         const igraph_t *graph, const igraph_vector_t *weights,
         igraph_vector_int_list_t *result,
         igraph_real_t bfs_cutoff,
         igraph_bool_t complete, igraph_bool_t use_cycle_order);
 
-IGRAPH_EXPORT igraph_error_t igraph_find_cycle(
+IGRAPH_EXPERIMENTAL IGRAPH_EXPORT igraph_error_t igraph_find_cycle(
         const igraph_t *graph,
         igraph_vector_int_t *vertices,
         igraph_vector_int_t *edges,
@@ -76,14 +76,14 @@ typedef igraph_error_t igraph_cycle_handler_t(
         const igraph_vector_int_t *edges,
         void *arg);
 
-IGRAPH_EXPORT igraph_error_t igraph_simple_cycles_callback(
+IGRAPH_EXPERIMENTAL IGRAPH_EXPORT igraph_error_t igraph_simple_cycles_callback(
         const igraph_t *graph,
         igraph_neimode_t mode,
         igraph_integer_t min_cycle_length,
         igraph_integer_t max_cycle_length,
         igraph_cycle_handler_t *callback, void *arg);
 
-IGRAPH_EXPORT igraph_error_t igraph_simple_cycles(
+IGRAPH_EXPERIMENTAL IGRAPH_EXPORT igraph_error_t igraph_simple_cycles(
         const igraph_t *graph,
         igraph_vector_int_list_t *vertices,
         igraph_vector_int_list_t *edges,

--- a/include/igraph_decls.h
+++ b/include/igraph_decls.h
@@ -76,3 +76,12 @@
 /* Used instead of IGRAPH_EXPORT with functions that need to be tested,
  * but are not part of the public API. */
 #define IGRAPH_PRIVATE_EXPORT IGRAPH_EXPORT
+
+/* Marks experimental functions. If IGRAPH_WARN_EXPERIMENTAL is defined to a
+ * nonzero value, supported compilers will emit a warning when these functions
+ * are used. */
+#if defined(__GNUC__) && IGRAPH_WARN_EXPERIMENTAL
+#define IGRAPH_EXPERIMENTAL __attribute__((__warning__("Experimental function.")))
+#else
+#define IGRAPH_EXPERIMENTAL /* empty */
+#endif

--- a/include/igraph_games.h
+++ b/include/igraph_games.h
@@ -49,7 +49,7 @@ IGRAPH_EXPORT igraph_error_t igraph_erdos_renyi_game_gnp(igraph_t *graph, igraph
                                               igraph_bool_t directed, igraph_bool_t loops);
 IGRAPH_EXPORT igraph_error_t igraph_erdos_renyi_game_gnm(igraph_t *graph, igraph_integer_t n, igraph_integer_t m,
                                               igraph_bool_t directed, igraph_bool_t loops, igraph_bool_t multiple);
-IGRAPH_EXPORT igraph_error_t igraph_iea_game(igraph_t *graph,
+IGRAPH_EXPERIMENTAL IGRAPH_EXPORT igraph_error_t igraph_iea_game(igraph_t *graph,
                                              igraph_integer_t n, igraph_integer_t m,
                                              igraph_bool_t directed, igraph_bool_t loops);
 IGRAPH_EXPORT igraph_error_t igraph_degree_sequence_game(igraph_t *graph, const igraph_vector_int_t *out_deg,
@@ -169,7 +169,7 @@ IGRAPH_EXPORT igraph_error_t igraph_static_power_law_game(igraph_t *graph,
                                                igraph_bool_t loops, igraph_bool_t multiple,
                                                igraph_bool_t finite_size_correction);
 
-IGRAPH_EXPORT igraph_error_t igraph_chung_lu_game(igraph_t *graph,
+IGRAPH_EXPERIMENTAL IGRAPH_EXPORT igraph_error_t igraph_chung_lu_game(igraph_t *graph,
                                                   const igraph_vector_t *expected_out_deg,
                                                   const igraph_vector_t *expected_in_deg,
                                                   igraph_bool_t loops,

--- a/include/igraph_layout.h
+++ b/include/igraph_layout.h
@@ -133,7 +133,7 @@ IGRAPH_EXPORT igraph_error_t igraph_layout_bipartite(const igraph_t *graph,
                                           igraph_matrix_t *res, igraph_real_t hgap,
                                           igraph_real_t vgap, igraph_integer_t maxiter);
 
-IGRAPH_EXPORT igraph_error_t igraph_layout_umap(const igraph_t *graph,
+IGRAPH_EXPERIMENTAL IGRAPH_EXPORT igraph_error_t igraph_layout_umap(const igraph_t *graph,
                                                 igraph_matrix_t *res,
                                                 igraph_bool_t use_seed,
                                                 const igraph_vector_t *distances,
@@ -141,7 +141,7 @@ IGRAPH_EXPORT igraph_error_t igraph_layout_umap(const igraph_t *graph,
                                                 igraph_integer_t epochs,
                                                 igraph_bool_t distances_are_weights);
 
-IGRAPH_EXPORT igraph_error_t igraph_layout_umap_3d(const igraph_t *graph,
+IGRAPH_EXPERIMENTAL IGRAPH_EXPORT igraph_error_t igraph_layout_umap_3d(const igraph_t *graph,
                                                 igraph_matrix_t *res,
                                                 igraph_bool_t use_seed,
                                                 const igraph_vector_t *distances,
@@ -149,7 +149,7 @@ IGRAPH_EXPORT igraph_error_t igraph_layout_umap_3d(const igraph_t *graph,
                                                 igraph_integer_t epochs,
                                                 igraph_bool_t distances_are_weights);
 
-IGRAPH_EXPORT igraph_error_t igraph_layout_umap_compute_weights(const igraph_t *graph,
+IGRAPH_EXPERIMENTAL IGRAPH_EXPORT igraph_error_t igraph_layout_umap_compute_weights(const igraph_t *graph,
                                                 const igraph_vector_t *distances,
                                                 igraph_vector_t *weights);
 
@@ -287,7 +287,7 @@ IGRAPH_EXPORT igraph_error_t igraph_roots_for_tree_layout(
         igraph_vector_int_t *roots,
         igraph_root_choice_t use_eccentricity);
 
-IGRAPH_EXPORT igraph_error_t igraph_layout_align(const igraph_t *graph, igraph_matrix_t *layout);
+IGRAPH_EXPERIMENTAL IGRAPH_EXPORT igraph_error_t igraph_layout_align(const igraph_t *graph, igraph_matrix_t *layout);
 
 IGRAPH_END_C_DECLS
 

--- a/include/igraph_operators.h
+++ b/include/igraph_operators.h
@@ -85,15 +85,15 @@ IGRAPH_EXPORT igraph_error_t igraph_induced_subgraph_edges(
 IGRAPH_EXPORT igraph_error_t igraph_subgraph_from_edges(const igraph_t *graph, igraph_t *res,
                                         igraph_es_t eids, igraph_bool_t delete_vertices);
 IGRAPH_EXPORT igraph_error_t igraph_reverse_edges(igraph_t *graph, igraph_es_t eids);
-IGRAPH_EXPORT igraph_error_t igraph_product(igraph_t *res,
+IGRAPH_EXPERIMENTAL IGRAPH_EXPORT igraph_error_t igraph_product(igraph_t *res,
                                             const igraph_t *g1,
                                             const igraph_t *g2,
                                             igraph_product_t type);
-IGRAPH_EXPORT igraph_error_t igraph_rooted_product(igraph_t *res,
+IGRAPH_EXPERIMENTAL IGRAPH_EXPORT igraph_error_t igraph_rooted_product(igraph_t *res,
                                                    const igraph_t *g1,
                                                    const igraph_t *g2,
                                                    const igraph_integer_t root);
-IGRAPH_EXPORT igraph_error_t igraph_mycielskian(const igraph_t *graph, igraph_t *res, igraph_integer_t k);
+IGRAPH_EXPERIMENTAL IGRAPH_EXPORT igraph_error_t igraph_mycielskian(const igraph_t *graph, igraph_t *res, igraph_integer_t k);
 
 IGRAPH_END_C_DECLS
 

--- a/include/igraph_paths.h
+++ b/include/igraph_paths.h
@@ -208,12 +208,12 @@ IGRAPH_EXPORT igraph_error_t igraph_eccentricity(
     igraph_vs_t vids, igraph_neimode_t mode
 );
 
-IGRAPH_EXPORT igraph_error_t igraph_radius(
+IGRAPH_EXPERIMENTAL IGRAPH_EXPORT igraph_error_t igraph_radius(
     const igraph_t *graph, const igraph_vector_t *weights, igraph_real_t *radius,
     igraph_neimode_t mode
 );
 
-IGRAPH_EXPORT igraph_error_t igraph_graph_center(
+IGRAPH_EXPERIMENTAL IGRAPH_EXPORT igraph_error_t igraph_graph_center(
     const igraph_t *graph, const igraph_vector_t *weights,
     igraph_vector_int_t *res, igraph_neimode_t mode
 );
@@ -284,7 +284,7 @@ IGRAPH_EXPORT igraph_error_t igraph_widest_path_widths_dijkstra(const igraph_t *
                                              igraph_vs_t to,
                                              const igraph_vector_t *weights,
                                              igraph_neimode_t mode);
-IGRAPH_EXPORT igraph_error_t igraph_voronoi(const igraph_t *graph,
+IGRAPH_EXPERIMENTAL IGRAPH_EXPORT igraph_error_t igraph_voronoi(const igraph_t *graph,
                                             igraph_vector_int_t *membership,
                                             igraph_vector_t *distances,
                                             const igraph_vector_int_t *generators,

--- a/include/igraph_reachability.h
+++ b/include/igraph_reachability.h
@@ -27,7 +27,7 @@
 
 IGRAPH_BEGIN_C_DECLS
 
-IGRAPH_EXPORT igraph_error_t igraph_reachability(
+IGRAPH_EXPERIMENTAL IGRAPH_EXPORT igraph_error_t igraph_reachability(
             const igraph_t *graph,
             igraph_vector_int_t *membership,
             igraph_vector_int_t *csize,
@@ -35,7 +35,7 @@ IGRAPH_EXPORT igraph_error_t igraph_reachability(
             igraph_bitset_list_t *reach,
             igraph_neimode_t mode);
 
-IGRAPH_EXPORT igraph_error_t igraph_count_reachable(
+IGRAPH_EXPERIMENTAL IGRAPH_EXPORT igraph_error_t igraph_count_reachable(
             const igraph_t *graph,
             igraph_vector_int_t *counts,
             igraph_neimode_t mode);

--- a/include/igraph_spatial.h
+++ b/include/igraph_spatial.h
@@ -27,7 +27,7 @@
 
 IGRAPH_BEGIN_C_DECLS
 
-IGRAPH_EXPORT igraph_error_t igraph_delaunay_graph(igraph_t *graph, const igraph_matrix_t *points);
+IGRAPH_EXPERIMENTAL IGRAPH_EXPORT igraph_error_t igraph_delaunay_graph(igraph_t *graph, const igraph_matrix_t *points);
 
 /**
  * \typedef igraph_metric_t
@@ -51,7 +51,7 @@ IGRAPH_EXPORT igraph_error_t igraph_nearest_neighbor_graph(
     igraph_real_t cutoff,
     igraph_bool_t directed);
 
-IGRAPH_EXPORT igraph_error_t igraph_spatial_edge_lengths(
+IGRAPH_EXPERIMENTAL IGRAPH_EXPORT igraph_error_t igraph_spatial_edge_lengths(
     const igraph_t *graph,
     igraph_vector_t *lengths,
     const igraph_matrix_t *points,

--- a/include/igraph_structural.h
+++ b/include/igraph_structural.h
@@ -81,7 +81,7 @@ IGRAPH_EXPORT igraph_error_t igraph_is_perfect(const igraph_t *graph, igraph_boo
 /* Structural properties                              */
 /* -------------------------------------------------- */
 
-IGRAPH_EXPORT igraph_error_t igraph_is_complete(const igraph_t *graph, igraph_bool_t *res);
+IGRAPH_EXPERIMENTAL IGRAPH_EXPORT igraph_error_t igraph_is_complete(const igraph_t *graph, igraph_bool_t *res);
 IGRAPH_EXPORT igraph_error_t igraph_is_clique(const igraph_t *graph, igraph_vs_t candidate,
                                               igraph_bool_t directed, igraph_bool_t *res);
 IGRAPH_EXPORT igraph_error_t igraph_is_independent_vertex_set(const igraph_t *graph, igraph_vs_t candidate,
@@ -115,7 +115,7 @@ IGRAPH_EXPORT igraph_error_t igraph_avg_nearest_neighbor_degree(const igraph_t *
                                                      igraph_vector_t *knn,
                                                      igraph_vector_t *knnk,
                                                      const igraph_vector_t *weights);
-IGRAPH_EXPORT igraph_error_t igraph_degree_correlation_vector(
+IGRAPH_EXPERIMENTAL IGRAPH_EXPORT igraph_error_t igraph_degree_correlation_vector(
         const igraph_t *graph, const igraph_vector_t *weights,
         igraph_vector_t *knnk,
         igraph_neimode_t from_mode, igraph_neimode_t to_mode,
@@ -125,11 +125,11 @@ IGRAPH_EXPORT igraph_error_t igraph_feedback_arc_set(
     const igraph_t *graph, igraph_vector_int_t *result,
     const igraph_vector_t *weights, igraph_fas_algorithm_t algo);
 
-IGRAPH_EXPORT igraph_error_t igraph_feedback_vertex_set(
+IGRAPH_EXPERIMENTAL IGRAPH_EXPORT igraph_error_t igraph_feedback_vertex_set(
     const igraph_t *graph, igraph_vector_int_t *result,
     const igraph_vector_t *vertex_weights, igraph_fvs_algorithm_t algo);
 
-IGRAPH_EXPORT igraph_error_t igraph_rich_club_sequence(
+IGRAPH_EXPERIMENTAL IGRAPH_EXPORT igraph_error_t igraph_rich_club_sequence(
     const igraph_t *graph,
     const igraph_vector_t *weights,
     igraph_vector_t *res,

--- a/include/igraph_transitivity.h
+++ b/include/igraph_transitivity.h
@@ -42,7 +42,7 @@ IGRAPH_EXPORT igraph_error_t igraph_transitivity_barrat(const igraph_t *graph,
                                              igraph_vs_t vids,
                                              const igraph_vector_t *weights,
                                              igraph_transitivity_mode_t mode);
-IGRAPH_EXPORT igraph_error_t igraph_ecc(const igraph_t *graph,
+IGRAPH_EXPERIMENTAL IGRAPH_EXPORT igraph_error_t igraph_ecc(const igraph_t *graph,
                                         igraph_vector_t *res,
                                         igraph_es_t eids,
                                         igraph_integer_t k,

--- a/include/igraph_vector_pmt.h
+++ b/include/igraph_vector_pmt.h
@@ -299,7 +299,7 @@ IGRAPH_EXPORT igraph_error_t FUNCTION(igraph_vector, difference_sorted)(const TY
                                                              const TYPE(igraph_vector) *v2, TYPE(igraph_vector) *result);
 IGRAPH_EXPORT igraph_error_t FUNCTION(igraph_vector, intersect_sorted)(const TYPE(igraph_vector) *v1,
                                                             const TYPE(igraph_vector) *v2, TYPE(igraph_vector) *result);
-IGRAPH_EXPORT IGRAPH_FUNCATTR_PURE igraph_integer_t FUNCTION(igraph_vector, intersection_size_sorted)(
+IGRAPH_EXPERIMENTAL IGRAPH_EXPORT IGRAPH_FUNCATTR_PURE igraph_integer_t FUNCTION(igraph_vector, intersection_size_sorted)(
         const TYPE(igraph_vector) *v1,
         const TYPE(igraph_vector) *v2);
 #endif

--- a/src/core/bitset.c
+++ b/src/core/bitset.c
@@ -146,8 +146,6 @@ igraph_integer_t igraph_i_clz64(igraph_uint_t x) {
  * \function igraph_bitset_init
  * \brief Initializes a bitset object (constructor).
  *
- * \experimental
- *
  * </para><para>
  * Every bitset needs to be initialized before it can be used, and
  * there are a number of initialization functions or otherwise called
@@ -186,8 +184,6 @@ igraph_error_t igraph_bitset_init(igraph_bitset_t *bitset, igraph_integer_t size
  * \function igraph_bitset_destroy
  * \brief Destroys a bitset object.
  *
- * \experimental
- *
  * All bitsets initialized by \ref igraph_bitset_init() should be properly
  * destroyed by this function. A destroyed bitset needs to be
  * reinitialized by \ref igraph_bitset_init() or
@@ -209,8 +205,6 @@ void igraph_bitset_destroy(igraph_bitset_t *bitset) {
  * \ingroup bitset
  * \function igraph_bitset_init_copy
  * \brief Initializes a bitset from another bitset object (constructor).
- *
- * \experimental
  *
  * The contents of the existing bitset object will be copied to
  * the new one.
@@ -241,8 +235,6 @@ igraph_error_t igraph_bitset_init_copy(igraph_bitset_t *dest, const igraph_bitse
  * \function igraph_bitset_update
  * \brief Update a bitset from another one.
  *
- * \experimental
- *
  * The size and contents of \p dest will be identical to that of \p src.
  *
  * \param dest Pointer to an initialized bitset object. This will be updated.
@@ -272,8 +264,6 @@ igraph_error_t igraph_bitset_update(igraph_bitset_t *dest, const igraph_bitset_t
  * \function igraph_bitset_capacity
  * \brief Returns the allocated capacity of the bitset.
  *
- * \experimental
- *
  * Note that this might be different from the size of the bitset (as
  * queried by \ref igraph_bitset_size()), and specifies how many elements
  * the bitset can hold, without reallocation.
@@ -296,8 +286,6 @@ igraph_integer_t igraph_bitset_capacity(const igraph_bitset_t *bitset) {
  * \function igraph_bitset_size
  * \brief Returns the length of the bitset.
  *
- * \experimental
- *
  * \param bitset The bitset object
  * \return The size of the bitset.
  *
@@ -312,8 +300,6 @@ igraph_integer_t igraph_bitset_size(const igraph_bitset_t *bitset) {
  * \ingroup bitset
  * \function igraph_bitset_reserve
  * \brief Reserves memory for a bitset.
- *
- * \experimental
  *
  * \a igraph bitsets are flexible, they can grow and
  * shrink. Growing
@@ -367,8 +353,6 @@ igraph_error_t igraph_bitset_reserve(igraph_bitset_t *bitset, igraph_integer_t c
  * \function igraph_bitset_resize
  * \brief Resizes the bitset.
  *
- * \experimental
- *
  * Note that this function does not free any memory, just sets the
  * size of the bitset to the given one. It may, on the other hand,
  * allocate more memory if the new size is larger than the previous
@@ -414,8 +398,6 @@ igraph_error_t igraph_bitset_resize(igraph_bitset_t *bitset, igraph_integer_t ne
  * \function igraph_bitset_popcount
  * \brief The population count of the bitset.
  *
- * \experimental
- *
  * Returns the number of set bits, also called the population count,
  * of the bitset.
  *
@@ -446,8 +428,6 @@ igraph_integer_t igraph_bitset_popcount(const igraph_bitset_t *bitset) {
  * \ingroup bitset
  * \function igraph_bitset_countl_zero
  * \brief The number of leading zeros in the bitset.
- *
- * \experimental
  *
  * Returns the number of leading (starting at the most significant bit)
  * zeros in the bitset before the first one is encountered. If the bitset
@@ -483,8 +463,6 @@ igraph_integer_t igraph_bitset_countl_zero(const igraph_bitset_t *bitset) {
  * \function igraph_bitset_countl_one
  * \brief The number of leading ones in the bitset.
  *
- * \experimental
- *
  * Returns the number of leading ones (starting at the most significant bit)
  * in the bitset before the first zero is encountered.
  * If the bitset is all ones, then its size is returned.
@@ -519,8 +497,6 @@ igraph_integer_t igraph_bitset_countl_one(const igraph_bitset_t *bitset) {
  * \function igraph_bitset_countr_zero
  * \brief The number of trailing zeros in the bitset.
  *
- * \experimental
- *
  * Returns the number of trailing (starting at the least significant bit)
  * zeros in the bitset before the first one is encountered.
  * If the bitset is all zeros, then its size is returned.
@@ -553,8 +529,6 @@ igraph_integer_t igraph_bitset_countr_zero(const igraph_bitset_t *bitset) {
  * \ingroup bitset
  * \function igraph_bitset_countr_one
  * \brief The number of trailing ones in the bitset.
- *
- * \experimental
  *
  * Returns the number of trailing ones (starting at the least significant bit)
  * in the bitset before the first zero is encountered.
@@ -589,8 +563,6 @@ igraph_integer_t igraph_bitset_countr_one(const igraph_bitset_t *bitset) {
  * \function igraph_bitset_is_all_zero
  * \brief Are all bits zeros?
  *
- * \experimental
- *
  * \param bitset The bitset object to test.
  * \return True if none of the bits are set.
  *
@@ -618,8 +590,6 @@ igraph_bool_t igraph_bitset_is_all_zero(const igraph_bitset_t *bitset) {
  * \ingroup bitset
  * \function igraph_bitset_is_all_one
  * \brief Are all bits ones?
- *
- * \experimental
  *
  * \param bitset The bitset object to test.
  * \return True if all of the bits are set.
@@ -649,8 +619,6 @@ igraph_bool_t igraph_bitset_is_all_one(const igraph_bitset_t *bitset) {
  * \function igraph_bitset_is_any_zero
  * \brief Are any bits zeros?
  *
- * \experimental
- *
  * \param bitset The bitset object to test.
  * \return True if at least one bit is zero.
  *
@@ -666,8 +634,6 @@ igraph_bool_t igraph_bitset_is_any_zero(const igraph_bitset_t *bitset) {
  * \function igraph_bitset_is_any_one
  * \brief Are any bits ones?
  *
- * \experimental
- *
  * \param bitset The bitset object to test.
  * \return True if at least one bit is one.
  *
@@ -682,8 +648,6 @@ igraph_bool_t igraph_bitset_is_any_one(const igraph_bitset_t *bitset) {
  * \ingroup bitset
  * \function igraph_bitset_or
  * \brief Bitwise OR of two bitsets.
- *
- * \experimental
  *
  * Applies a bitwise or to the contents of two bitsets and stores it in an
  * already initialized bitset. The destination bitset may be equal to one
@@ -711,8 +675,6 @@ void igraph_bitset_or(igraph_bitset_t *dest,
  * \function igraph_bitset_and
  * \brief Bitwise AND of two bitsets.
  *
- * \experimental
- *
  * Applies a bitwise and to the contents of two bitsets and stores it in an
  * already initialized bitset. The destination bitset may be equal to one
  * (or even both) of the sources. When working with bitsets, it is common
@@ -737,8 +699,6 @@ void igraph_bitset_and(igraph_bitset_t *dest, const igraph_bitset_t *src1, const
  * \ingroup bitset
  * \function igraph_bitset_xor
  * \brief Bitwise XOR of two bitsets.
- *
- * \experimental
  *
  * Applies a bitwise xor to the contents of two bitsets and stores it in
  * an already initialized bitset. The destination bitset may be equal to
@@ -766,8 +726,6 @@ void igraph_bitset_xor(igraph_bitset_t *dest,
  * \function igraph_bitset_not
  * \brief Bitwise negation of a bitset.
  *
- * \experimental
- *
  * Applies a bitwise not to the contents of a bitset and stores it in an
  * already initialized bitset. The destination bitset may be equal to the
  * source. When working with bitsets, it is common that those created are
@@ -791,8 +749,6 @@ void igraph_bitset_not(igraph_bitset_t *dest, const igraph_bitset_t *src) {
  * \function igraph_bitset_fill
  * \brief Fills a bitset with a constant value.
  *
- * \experimental
- *
  * Sets all bits of a bitset to the same value.
  *
  * \param bitset The bitset object to modify.
@@ -814,8 +770,6 @@ void igraph_bitset_fill(igraph_bitset_t *bitset, igraph_bool_t value) {
  * \function igraph_bitset_null
  * \brief Clears all bits in a bitset.
  *
- * \experimental
- *
  * \param bitset The bitset object to clear all bits in.
  *
  * \sa \ref igraph_bitset_fill()
@@ -831,8 +785,6 @@ void igraph_bitset_null(igraph_bitset_t *bitset) {
  * \ingroup bitset
  * \function igraph_bitset_fprint
  * \brief Prints the bits of a bitset.
- *
- * \experimental
  *
  * Outputs the contents of a bitset to a file.
  * The bitset is written from index n-1 to index 0, left to right,


### PR DESCRIPTION
Closes #2841 

This PR changes how experimental functions are marked. Instead of only relying on the documentation, now there is an `IGRAPH_EXPERIMENTAL` macro, to be used in declarations in a similar way to `IGRAPH_DEPRECATED`.

If the user defines the macro `IGRAPH_WARN_EXPERIMENTAL` to a nonzero value, supported compilers will issue when this function is used and is not eliminated through dead code elimination.  Currently this is GCC-like compilers like GCC itself and Clang.

Thus is a project that uses igraph does not wish to rely on experimental functions, they can use `-DIGRAPH_WARN_EXPERIMENTAL` when compiling.

I proposed this in #2643.

I did not update the documentation yet—that will come after there's a decision both on this PR and on #2643.

This PR also makes bitset functions final (i.e. no longer experimental). I updated #2576 for discussing what (not) to keep experimental for 1.0, and I need comments in that issue.