### PR TITLE
feat: limit result count and set sizes for independent set functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,7 +116,8 @@ This section gives detailed on breaking changes you need to consider when updati
 
 #### Cliques and independent sets
 
- - `igraph_cliques()`, `igraph_weighed_cliques()`, `igraph_maximal_cliques()`, `igraph_maximal_cliques_file()`, and `igraph_maximal_cliques_subset()` received a `max_results` parameter to limit the number of returned results. Pass `1` to return a single result, or `IGRAPH_UNLIMITED` to return all results.
+ - `igraph_cliques()`, `igraph_weighed_cliques()`, `igraph_maximal_cliques()`, `igraph_maximal_cliques_file()`, `igraph_maximal_cliques_subset()`, `igraph_independent_sets()` and `igraph_maximal_independent_sets()` received a `max_results` parameter to limit the number of returned results. Pass `1` to return a single result, or `IGRAPH_UNLIMITED` to return all results.
+ - `igraph_maximal_independent_sets()` received `min_size` and `max_size` parameters that control the range of independent set sizes that are returned.
  - `igraph_weighted_cliques()` had its parameter ordering standardized: the `igraph_bool_t maximal` parameter now comes before the `min_weight` / `max_weight` parameters.
  - `igraph_maximal_cliques_callback()` had its parameter ordering standardized: the `igraph_clique_handler_t *cliquehandler_fn, void *arg` parameter pair now comes at the end, making this function consistent with `igraph_cliques_callback()`.
 

--- a/examples/simple/igraph_independent_sets.c
+++ b/examples/simple/igraph_independent_sets.c
@@ -52,9 +52,16 @@ int main(void) {
     igraph_destroy(&g);
 
     igraph_kary_tree(&g, 10, 2, IGRAPH_TREE_OUT);
-    igraph_maximal_independent_vertex_sets(&g, &result);
+    igraph_maximal_independent_vertex_sets(&g, &result, IGRAPH_UNLIMITED, IGRAPH_UNLIMITED, IGRAPH_UNLIMITED);
     n = igraph_vector_int_list_size(&result);
     printf("%" IGRAPH_PRId " maximal independent sets found\n", n);
+    for (igraph_int_t i = 0; i < n; i++) {
+        igraph_vector_int_print(igraph_vector_int_list_get_ptr(&result, i));
+    }
+
+    igraph_maximal_independent_vertex_sets(&g, &result, 4, 5, IGRAPH_UNLIMITED);
+    n = igraph_vector_int_list_size(&result);
+    printf("%" IGRAPH_PRId " maximal independent sets between sizes 4 and 5 found\n", n);
     for (igraph_int_t i = 0; i < n; i++) {
         igraph_vector_int_print(igraph_vector_int_list_get_ptr(&result, i));
     }

--- a/examples/simple/igraph_independent_sets.c
+++ b/examples/simple/igraph_independent_sets.c
@@ -39,7 +39,7 @@ int main(void) {
     igraph_kary_tree(&g, 5, 2, IGRAPH_TREE_OUT);
     for (size_t j = 0; j < sizeof(params) / (2 * sizeof(params[0])); j++) {
         if (params[2 * j + 1] != 0) {
-            igraph_independent_vertex_sets(&g, &result, params[2 * j], params[2 * j + 1]);
+            igraph_independent_vertex_sets(&g, &result, params[2 * j], params[2 * j + 1], IGRAPH_UNLIMITED);
         } else {
             igraph_largest_independent_vertex_sets(&g, &result);
         }

--- a/examples/simple/igraph_independent_sets.out
+++ b/examples/simple/igraph_independent_sets.out
@@ -33,4 +33,9 @@
 2 3 4
 2 3 9
 2 4 7 8
+4 maximal independent sets between sizes 4 and 5 found
+0 3 4 5 6
+0 3 5 6 9
+1 2 7 8 9
+2 4 7 8
 alpha=6

--- a/include/igraph_cliques.h
+++ b/include/igraph_cliques.h
@@ -100,7 +100,9 @@ IGRAPH_EXPORT igraph_error_t igraph_largest_independent_vertex_sets(
 
 IGRAPH_EXPORT igraph_error_t igraph_maximal_independent_vertex_sets(
         const igraph_t *graph,
-        igraph_vector_int_list_t *res);
+        igraph_vector_int_list_t *res,
+        igraph_int_t min_size, igraph_int_t max_size,
+        igraph_int_t max_results);
 
 IGRAPH_EXPORT igraph_error_t igraph_independence_number(const igraph_t *graph, igraph_int_t *no);
 

--- a/include/igraph_cliques.h
+++ b/include/igraph_cliques.h
@@ -91,7 +91,8 @@ IGRAPH_EXPORT igraph_error_t igraph_weighted_clique_number(
 IGRAPH_EXPORT igraph_error_t igraph_independent_vertex_sets(
         const igraph_t *graph,
         igraph_vector_int_list_t *res,
-        igraph_int_t min_size, igraph_int_t max_size);
+        igraph_int_t min_size, igraph_int_t max_size,
+        igraph_int_t max_results);
 
 IGRAPH_EXPORT igraph_error_t igraph_largest_independent_vertex_sets(
         const igraph_t *graph,

--- a/interfaces/functions.yaml
+++ b/interfaces/functions.yaml
@@ -1404,8 +1404,9 @@ igraph_is_independent_vertex_set:
 
 igraph_independent_vertex_sets:
     PARAMS: |-
-        GRAPH graph, OUT VERTEX_INDICES_LIST res, INTEGER min_size=0,
-        INTEGER max_size=0
+        GRAPH graph, OUT VERTEX_INDICES_LIST res, 
+        INTEGER min_size=UNLIMITED, INTEGER max_size=UNLIMITED,
+        INTEGER max_results=UNLIMITED
     DEPS: res ON graph
 
 igraph_largest_independent_vertex_sets:
@@ -1413,7 +1414,10 @@ igraph_largest_independent_vertex_sets:
     DEPS: res ON graph
 
 igraph_maximal_independent_vertex_sets:
-    PARAMS: GRAPH graph, OUT VERTEX_INDICES_LIST res
+    PARAMS: |-
+        GRAPH graph, OUT VERTEX_INDICES_LIST res,
+        INTEGER min_size=UNLIMITED, INTEGER max_size=UNLIMITED,
+        INTEGER max_results=UNLIMITED
     DEPS: res ON graph
 
 igraph_independence_number:

--- a/tests/unit/max_results.c
+++ b/tests/unit/max_results.c
@@ -104,6 +104,35 @@ int main(void) {
     igraph_vector_int_list_resize(&results_full, max_results);
     IGRAPH_ASSERT(veclist_is_equal(&results_limited, &results_full));
 
+    /* Independent vertex sets */
+
+    igraph_vector_int_list_clear(&results_full);
+    igraph_vector_int_list_clear(&results_limited);
+    max_results = 0;
+    igraph_independent_vertex_sets(&graph, &results_full, IGRAPH_UNLIMITED, 3, IGRAPH_UNLIMITED);
+    igraph_independent_vertex_sets(&graph, &results_limited, IGRAPH_UNLIMITED, 3, max_results);
+    IGRAPH_ASSERT(igraph_vector_int_list_size(&results_limited) == max_results);
+    igraph_vector_int_list_resize(&results_full, max_results);
+    IGRAPH_ASSERT(veclist_is_equal(&results_limited, &results_full));
+
+    igraph_vector_int_list_clear(&results_full);
+    igraph_vector_int_list_clear(&results_limited);
+    max_results = 10;
+    igraph_independent_vertex_sets(&graph, &results_full, IGRAPH_UNLIMITED, 4, IGRAPH_UNLIMITED);
+    igraph_independent_vertex_sets(&graph, &results_limited, IGRAPH_UNLIMITED, 4, max_results);
+    IGRAPH_ASSERT(igraph_vector_int_list_size(&results_limited) == max_results);
+    igraph_vector_int_list_resize(&results_full, max_results);
+    IGRAPH_ASSERT(veclist_is_equal(&results_limited, &results_full));
+
+    igraph_vector_int_list_clear(&results_full);
+    igraph_vector_int_list_clear(&results_limited);
+    max_results = 7;
+    igraph_independent_vertex_sets(&graph, &results_full, 2, 4, IGRAPH_UNLIMITED);
+    igraph_independent_vertex_sets(&graph, &results_limited, 2, 4, max_results);
+    IGRAPH_ASSERT(igraph_vector_int_list_size(&results_limited) == max_results);
+    igraph_vector_int_list_resize(&results_full, max_results);
+    IGRAPH_ASSERT(veclist_is_equal(&results_limited, &results_full));
+
     igraph_vector_destroy(&vertex_weights);
     igraph_destroy(&graph);
     igraph_vector_int_list_destroy(&results_limited);

--- a/tests/unit/max_results.c
+++ b/tests/unit/max_results.c
@@ -133,6 +133,35 @@ int main(void) {
     igraph_vector_int_list_resize(&results_full, max_results);
     IGRAPH_ASSERT(veclist_is_equal(&results_limited, &results_full));
 
+    /* Maximal independent vertex sets */
+
+    igraph_vector_int_list_clear(&results_full);
+    igraph_vector_int_list_clear(&results_limited);
+    max_results = 0;
+    igraph_maximal_independent_vertex_sets(&graph, &results_full, IGRAPH_UNLIMITED, 8, IGRAPH_UNLIMITED);
+    igraph_maximal_independent_vertex_sets(&graph, &results_limited, IGRAPH_UNLIMITED, 8, max_results);
+    IGRAPH_ASSERT(igraph_vector_int_list_size(&results_limited) == max_results);
+    igraph_vector_int_list_resize(&results_full, max_results);
+    IGRAPH_ASSERT(veclist_is_equal(&results_limited, &results_full));
+
+    igraph_vector_int_list_clear(&results_full);
+    igraph_vector_int_list_clear(&results_limited);
+    max_results = 5;
+    igraph_maximal_independent_vertex_sets(&graph, &results_full, IGRAPH_UNLIMITED, 9, IGRAPH_UNLIMITED);
+    igraph_maximal_independent_vertex_sets(&graph, &results_limited, IGRAPH_UNLIMITED, 9, max_results);
+    IGRAPH_ASSERT(igraph_vector_int_list_size(&results_limited) == max_results);
+    igraph_vector_int_list_resize(&results_full, max_results);
+    IGRAPH_ASSERT(veclist_is_equal(&results_limited, &results_full));
+
+    igraph_vector_int_list_clear(&results_full);
+    igraph_vector_int_list_clear(&results_limited);
+    max_results = 4;
+    igraph_maximal_independent_vertex_sets(&graph, &results_full, 7, 10, IGRAPH_UNLIMITED);
+    igraph_maximal_independent_vertex_sets(&graph, &results_limited, 7, 10, max_results);
+    IGRAPH_ASSERT(igraph_vector_int_list_size(&results_limited) == max_results);
+    igraph_vector_int_list_resize(&results_full, max_results);
+    IGRAPH_ASSERT(veclist_is_equal(&results_limited, &results_full));
+
     igraph_vector_destroy(&vertex_weights);
     igraph_destroy(&graph);
     igraph_vector_int_list_destroy(&results_limited);


### PR DESCRIPTION
- `igraph_independent_vertex_sets()` got a `max_results` parameter.
- `igraph_maximal_independent_vertex_sets()` got `min_size`, `max_size` and `max_results` parameters. There is no concern for efficiency for these, it just makes the function consistent with the rest and paves the way for improvements. This one needs a more careful review.