### PR TITLE
Count successful swaps in igraph_rewire

### DIFF
--- a/examples/simple/igraph_assortativity_degree.c
+++ b/examples/simple/igraph_assortativity_degree.c
@@ -26,7 +26,7 @@ int main(void){
         printf("Assortativity before rewiring = %g\n", assortativity);
 
         /* Randomize the graph while preserving the degrees. */
-        igraph_rewire(&g, NULL, 20 * igraph_ecount(&g), IGRAPH_SIMPLE_SW);
+        igraph_rewire(&g, 20 * igraph_ecount(&g), IGRAPH_SIMPLE_SW, NULL);
 
         /* Re-compute assortativity. Did it change? */
         igraph_assortativity_degree(&g, &assortativity, /* ignore edge directions */ IGRAPH_UNDIRECTED);

--- a/examples/simple/igraph_assortativity_degree.c
+++ b/examples/simple/igraph_assortativity_degree.c
@@ -26,7 +26,7 @@ int main(void){
         printf("Assortativity before rewiring = %g\n", assortativity);
 
         /* Randomize the graph while preserving the degrees. */
-        igraph_rewire(&g, 20 * igraph_ecount(&g), IGRAPH_SIMPLE_SW);
+        igraph_rewire(&g, NULL, 20 * igraph_ecount(&g), IGRAPH_SIMPLE_SW);
 
         /* Re-compute assortativity. Did it change? */
         igraph_assortativity_degree(&g, &assortativity, /* ignore edge directions */ IGRAPH_UNDIRECTED);

--- a/examples/simple/igraph_assortativity_nominal.c
+++ b/examples/simple/igraph_assortativity_nominal.c
@@ -34,7 +34,7 @@ int main(void) {
         printf("Assortativity before rewiring = %g\n", assortativity);
 
         /* Rewire graph */
-        igraph_rewire(&g, NULL, 10 * igraph_ecount(&g), IGRAPH_SIMPLE_SW);
+        igraph_rewire(&g, 10 * igraph_ecount(&g), IGRAPH_SIMPLE_SW, NULL);
 
         igraph_assortativity_nominal(&g, NULL, &node_type_vec, &assortativity, IGRAPH_UNDIRECTED, 1);
         printf("Assortativity after rewiring = %g\n\n", assortativity);

--- a/examples/simple/igraph_assortativity_nominal.c
+++ b/examples/simple/igraph_assortativity_nominal.c
@@ -34,7 +34,7 @@ int main(void) {
         printf("Assortativity before rewiring = %g\n", assortativity);
 
         /* Rewire graph */
-        igraph_rewire(&g, 10 * igraph_ecount(&g), IGRAPH_SIMPLE_SW);
+        igraph_rewire(&g, NULL, 10 * igraph_ecount(&g), IGRAPH_SIMPLE_SW);
 
         igraph_assortativity_nominal(&g, NULL, &node_type_vec, &assortativity, IGRAPH_UNDIRECTED, 1);
         printf("Assortativity after rewiring = %g\n\n", assortativity);

--- a/fuzzing/linear_algos_directed.cpp
+++ b/fuzzing/linear_algos_directed.cpp
@@ -209,7 +209,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
         igraph_delete_edges(&graph, igraph_ess_1(0));
 
         if (igraph_vcount(&graph) >= 4) {
-            igraph_rewire(&graph, igraph_ecount(&graph) + 1, IGRAPH_SIMPLE_SW);
+            igraph_rewire(&graph, NULL, igraph_ecount(&graph) + 1, IGRAPH_SIMPLE_SW);
         }
 
         igraph_matrix_destroy(&m);

--- a/fuzzing/linear_algos_directed.cpp
+++ b/fuzzing/linear_algos_directed.cpp
@@ -209,7 +209,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
         igraph_delete_edges(&graph, igraph_ess_1(0));
 
         if (igraph_vcount(&graph) >= 4) {
-            igraph_rewire(&graph, NULL, igraph_ecount(&graph) + 1, IGRAPH_SIMPLE_SW);
+            igraph_rewire(&graph, igraph_ecount(&graph) + 1, IGRAPH_SIMPLE_SW, NULL);
         }
 
         igraph_matrix_destroy(&m);

--- a/fuzzing/linear_algos_undirected.cpp
+++ b/fuzzing/linear_algos_undirected.cpp
@@ -252,7 +252,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
         igraph_delete_edges(&graph, igraph_ess_1(0));
 
         if (igraph_vcount(&graph) >= 4) {
-            igraph_rewire(&graph, igraph_ecount(&graph) + 1, IGRAPH_SIMPLE_SW);
+            igraph_rewire(&graph, NULL, igraph_ecount(&graph) + 1, IGRAPH_SIMPLE_SW);
         }
 
         igraph_matrix_destroy(&m);

--- a/fuzzing/linear_algos_undirected.cpp
+++ b/fuzzing/linear_algos_undirected.cpp
@@ -252,7 +252,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
         igraph_delete_edges(&graph, igraph_ess_1(0));
 
         if (igraph_vcount(&graph) >= 4) {
-            igraph_rewire(&graph, NULL, igraph_ecount(&graph) + 1, IGRAPH_SIMPLE_SW);
+            igraph_rewire(&graph, igraph_ecount(&graph) + 1, IGRAPH_SIMPLE_SW, NULL);
         }
 
         igraph_matrix_destroy(&m);

--- a/include/igraph_operators.h
+++ b/include/igraph_operators.h
@@ -69,7 +69,7 @@ IGRAPH_EXPORT igraph_error_t igraph_connect_neighborhood(igraph_t *graph, igraph
                                               igraph_neimode_t mode);
 IGRAPH_EXPORT igraph_error_t igraph_graph_power(const igraph_t *graph, igraph_t *res,
                                                 igraph_int_t order, igraph_bool_t directed);
-IGRAPH_EXPORT igraph_error_t igraph_rewire(igraph_t *graph, igraph_int_t n, igraph_edge_type_sw_t allowed_edge_types);
+IGRAPH_EXPORT igraph_error_t igraph_rewire(igraph_t *graph, igraph_int_t *successful_swaps, igraph_int_t n, igraph_edge_type_sw_t allowed_edge_types);
 IGRAPH_EXPORT igraph_error_t igraph_simplify(igraph_t *graph,
                                              igraph_bool_t remove_multiple, igraph_bool_t remove_loops,
                                              const igraph_attribute_combination_t *edge_comb);

--- a/include/igraph_operators.h
+++ b/include/igraph_operators.h
@@ -36,6 +36,17 @@ IGRAPH_BEGIN_C_DECLS
 /* Graph operators                                    */
 /* -------------------------------------------------- */
 
+/**
+ * \typedef igraph_rewiring_stats_t
+ * \brief Data structure holding statistics from graph rewiring.
+ *
+ * \param successful_swaps Number of successful rewiring trials (successful swaps).
+ */
+
+typedef struct {
+    igraph_int_t successful_swaps;
+} igraph_rewiring_stats_t;
+
 IGRAPH_EXPORT igraph_error_t igraph_add_edge(igraph_t *graph, igraph_int_t from, igraph_int_t to);
 IGRAPH_EXPORT igraph_error_t igraph_disjoint_union(igraph_t *res,
                                         const igraph_t *left, const igraph_t *right);
@@ -69,7 +80,8 @@ IGRAPH_EXPORT igraph_error_t igraph_connect_neighborhood(igraph_t *graph, igraph
                                               igraph_neimode_t mode);
 IGRAPH_EXPORT igraph_error_t igraph_graph_power(const igraph_t *graph, igraph_t *res,
                                                 igraph_int_t order, igraph_bool_t directed);
-IGRAPH_EXPORT igraph_error_t igraph_rewire(igraph_t *graph, igraph_int_t *successful_swaps, igraph_int_t n, igraph_edge_type_sw_t allowed_edge_types);
+IGRAPH_EXPORT igraph_error_t igraph_rewire(igraph_t *graph, igraph_int_t n, igraph_edge_type_sw_t allowed_edge_types,
+                                        igraph_rewiring_stats_t *stats);
 IGRAPH_EXPORT igraph_error_t igraph_simplify(igraph_t *graph,
                                              igraph_bool_t remove_multiple, igraph_bool_t remove_loops,
                                              const igraph_attribute_combination_t *edge_comb);

--- a/interfaces/functions.yaml
+++ b/interfaces/functions.yaml
@@ -755,7 +755,7 @@ igraph_rewire:
     PARAMS: INOUT GRAPH rewire, INTEGER n, EDGE_TYPE_SW allowed_edge_types=SIMPLE
 
 igraph_induced_subgraph:
-    PARAMS: GRAPH graph, OUT GRAPH res, VERTEX_SELECTOR vids, SUBGRAPH_IMPL impl=AUTO
+    PARAMS: GRAPH graph, OUT GRAPH res, VERTEX_SELECTOR vids, SUBGRAPH_IMPL impl=AUTO, OPTIONAL OUT REWIRING_STATS stats
     DEPS: vids ON graph
 
 igraph_subgraph_from_edges:

--- a/interfaces/functions.yaml
+++ b/interfaces/functions.yaml
@@ -752,10 +752,10 @@ igraph_personalized_pagerank_vs:
         options ON algo
 
 igraph_rewire:
-    PARAMS: INOUT GRAPH rewire, INTEGER n, EDGE_TYPE_SW allowed_edge_types=SIMPLE
+    PARAMS: INOUT GRAPH rewire, INTEGER n, EDGE_TYPE_SW allowed_edge_types=SIMPLE, OPTIONAL OUT REWIRING_STATS stats
 
 igraph_induced_subgraph:
-    PARAMS: GRAPH graph, OUT GRAPH res, VERTEX_SELECTOR vids, SUBGRAPH_IMPL impl=AUTO, OPTIONAL OUT REWIRING_STATS stats
+    PARAMS: GRAPH graph, OUT GRAPH res, VERTEX_SELECTOR vids, SUBGRAPH_IMPL impl=AUTO
     DEPS: vids ON graph
 
 igraph_subgraph_from_edges:

--- a/interfaces/types.yaml
+++ b/interfaces/types.yaml
@@ -640,6 +640,11 @@ PLFIT:
     CTYPE: igraph_plfit_result_t
     FLAGS: BY_REF
 
+REWIRING_STATS:
+    # Structure storing statistics about degree-preserving edge rewiring
+    CTYPE: igraph_rewiring_stats_t
+    FLAGS: BY_REF
+
 VERTEX_ATTRIBUTE_COMBINATION:
     # Structure specifying how the attributes of vertices should be combined
     # during graph operations that may merge multiple vertices into a single one

--- a/src/games/degree_sequence.c
+++ b/src/games/degree_sequence.c
@@ -716,7 +716,7 @@ igraph_error_t edge_switching(
 
     IGRAPH_CHECK(igraph_realize_degree_sequence(graph, out_seq, in_seq, IGRAPH_SIMPLE_SW, IGRAPH_REALIZE_DEGSEQ_INDEX));
     IGRAPH_FINALLY(igraph_destroy, graph);
-    IGRAPH_CHECK(igraph_rewire(graph, 10 * igraph_ecount(graph), IGRAPH_SIMPLE_SW));
+    IGRAPH_CHECK(igraph_rewire(graph, NULL, 10 * igraph_ecount(graph), IGRAPH_SIMPLE_SW));
     IGRAPH_FINALLY_CLEAN(1);
     return IGRAPH_SUCCESS;
 }

--- a/src/games/degree_sequence.c
+++ b/src/games/degree_sequence.c
@@ -716,7 +716,7 @@ igraph_error_t edge_switching(
 
     IGRAPH_CHECK(igraph_realize_degree_sequence(graph, out_seq, in_seq, IGRAPH_SIMPLE_SW, IGRAPH_REALIZE_DEGSEQ_INDEX));
     IGRAPH_FINALLY(igraph_destroy, graph);
-    IGRAPH_CHECK(igraph_rewire(graph, NULL, 10 * igraph_ecount(graph), IGRAPH_SIMPLE_SW));
+    IGRAPH_CHECK(igraph_rewire(graph, 10 * igraph_ecount(graph), IGRAPH_SIMPLE_SW, NULL));
     IGRAPH_FINALLY_CLEAN(1);
     return IGRAPH_SUCCESS;
 }

--- a/src/operators/rewire.c
+++ b/src/operators/rewire.c
@@ -38,7 +38,7 @@
 #define REWIRE_ADJLIST_THRESHOLD 10
 
 /* Not declared static so that the testsuite can use it, but not part of the public API. */
-igraph_error_t igraph_i_rewire(igraph_t *graph, igraph_int_t *successful_swaps, igraph_int_t n, igraph_bool_t loops, igraph_bool_t use_adjlist) {
+igraph_error_t igraph_i_rewire(igraph_t *graph, igraph_int_t n, igraph_bool_t loops, igraph_bool_t use_adjlist, igraph_rewiring_stats_t *stats) {
     const igraph_int_t no_of_edges = igraph_ecount(graph);
     char message[256];
     igraph_int_t a, b, c, d, dummy, num_swaps, num_successful_swaps;
@@ -184,8 +184,8 @@ igraph_error_t igraph_i_rewire(igraph_t *graph, igraph_int_t *successful_swaps, 
         num_swaps++;
     }
 
-    if (successful_swaps) {
-        *successful_swaps = num_successful_swaps;
+    if (stats) {
+        stats->successful_swaps = num_successful_swaps;
     }
 
     if (use_adjlist) {
@@ -228,7 +228,6 @@ igraph_error_t igraph_i_rewire(igraph_t *graph, igraph_int_t *successful_swaps, 
  * constraints specified by \p mode.
  *
  * \param graph The graph object to be rewired.
- * \param successful_swaps Number of successful rewiring trials (successful swaps).
  * \param n Number of rewiring trials to perform.
  * \param allowed_edge_types The types of edges that rewiring may create in the graph.
  *    See \ref igraph_edge_type_sw_t for details.
@@ -240,6 +239,8 @@ igraph_error_t igraph_i_rewire(igraph_t *graph, igraph_int_t *successful_swaps, 
  *      single self-loops are allowed, but not multi-edges.
  *    \endclist
  *    Multigraphs are not yet supported.
+ * \param stats Counts of the number of different operations
+ *        performed by the algorithm are stored here.
  *
  * \return Error code:
  *         \clist
@@ -251,7 +252,7 @@ igraph_error_t igraph_i_rewire(igraph_t *graph, igraph_int_t *successful_swaps, 
  *
  * Time complexity: TODO.
  */
-igraph_error_t igraph_rewire(igraph_t *graph, igraph_int_t *successful_swaps, igraph_int_t n, igraph_edge_type_sw_t allowed_edge_types) {
+igraph_error_t igraph_rewire(igraph_t *graph, igraph_int_t n, igraph_edge_type_sw_t allowed_edge_types, igraph_rewiring_stats_t *stats) {
     igraph_bool_t use_adjlist = n >= REWIRE_ADJLIST_THRESHOLD;
 
     if ((allowed_edge_types & IGRAPH_I_MULTI_EDGES_SW) ||
@@ -259,5 +260,5 @@ igraph_error_t igraph_rewire(igraph_t *graph, igraph_int_t *successful_swaps, ig
         IGRAPH_ERROR("Rewiring multigraphs is not yet implemented.", IGRAPH_UNIMPLEMENTED);
     }
 
-    return igraph_i_rewire(graph, successful_swaps, n, allowed_edge_types & IGRAPH_LOOPS_SW, use_adjlist);
+    return igraph_i_rewire(graph, n, allowed_edge_types & IGRAPH_LOOPS_SW, use_adjlist, stats);
 }

--- a/src/operators/rewire.c
+++ b/src/operators/rewire.c
@@ -38,7 +38,7 @@
 #define REWIRE_ADJLIST_THRESHOLD 10
 
 /* Not declared static so that the testsuite can use it, but not part of the public API. */
-igraph_error_t igraph_i_rewire(igraph_t *graph, igraph_int_t n, igraph_bool_t loops, igraph_bool_t use_adjlist) {
+igraph_error_t igraph_i_rewire(igraph_t *graph, igraph_int_t *successful_swaps, igraph_int_t n, igraph_bool_t loops, igraph_bool_t use_adjlist) {
     const igraph_int_t no_of_edges = igraph_ecount(graph);
     char message[256];
     igraph_int_t a, b, c, d, dummy, num_swaps, num_successful_swaps;
@@ -184,6 +184,10 @@ igraph_error_t igraph_i_rewire(igraph_t *graph, igraph_int_t n, igraph_bool_t lo
         num_swaps++;
     }
 
+    if (successful_swaps) {
+        *successful_swaps = num_successful_swaps;
+    }
+
     if (use_adjlist) {
         /* Replace graph edges with the adjlist current state */
         IGRAPH_CHECK(igraph_delete_edges(graph, igraph_ess_all(IGRAPH_EDGEORDER_ID)));
@@ -224,6 +228,7 @@ igraph_error_t igraph_i_rewire(igraph_t *graph, igraph_int_t n, igraph_bool_t lo
  * constraints specified by \p mode.
  *
  * \param graph The graph object to be rewired.
+ * \param successful_swaps Number of successful rewiring trials (successful swaps).
  * \param n Number of rewiring trials to perform.
  * \param allowed_edge_types The types of edges that rewiring may create in the graph.
  *    See \ref igraph_edge_type_sw_t for details.
@@ -246,7 +251,7 @@ igraph_error_t igraph_i_rewire(igraph_t *graph, igraph_int_t n, igraph_bool_t lo
  *
  * Time complexity: TODO.
  */
-igraph_error_t igraph_rewire(igraph_t *graph, igraph_int_t n, igraph_edge_type_sw_t allowed_edge_types) {
+igraph_error_t igraph_rewire(igraph_t *graph, igraph_int_t *successful_swaps, igraph_int_t n, igraph_edge_type_sw_t allowed_edge_types) {
     igraph_bool_t use_adjlist = n >= REWIRE_ADJLIST_THRESHOLD;
 
     if ((allowed_edge_types & IGRAPH_I_MULTI_EDGES_SW) ||
@@ -254,5 +259,5 @@ igraph_error_t igraph_rewire(igraph_t *graph, igraph_int_t n, igraph_edge_type_s
         IGRAPH_ERROR("Rewiring multigraphs is not yet implemented.", IGRAPH_UNIMPLEMENTED);
     }
 
-    return igraph_i_rewire(graph, n, allowed_edge_types & IGRAPH_LOOPS_SW, use_adjlist);
+    return igraph_i_rewire(graph, successful_swaps, n, allowed_edge_types & IGRAPH_LOOPS_SW, use_adjlist);
 }

--- a/src/operators/rewire_internal.h
+++ b/src/operators/rewire_internal.h
@@ -9,7 +9,8 @@
 IGRAPH_BEGIN_C_DECLS
 
 IGRAPH_PRIVATE_EXPORT igraph_error_t igraph_i_rewire(
-    igraph_t *graph, igraph_int_t n, igraph_bool_t loops,
+    igraph_t *graph, igraph_int_t *successful_swaps,
+    igraph_int_t n, igraph_bool_t loops,
     igraph_bool_t use_adjlist);
 
 IGRAPH_END_C_DECLS

--- a/src/operators/rewire_internal.h
+++ b/src/operators/rewire_internal.h
@@ -9,9 +9,8 @@
 IGRAPH_BEGIN_C_DECLS
 
 IGRAPH_PRIVATE_EXPORT igraph_error_t igraph_i_rewire(
-    igraph_t *graph, igraph_int_t *successful_swaps,
-    igraph_int_t n, igraph_bool_t loops,
-    igraph_bool_t use_adjlist);
+    igraph_t *graph, igraph_int_t n, igraph_bool_t loops,
+    igraph_bool_t use_adjlist, igraph_rewiring_stats_t *stats);
 
 IGRAPH_END_C_DECLS
 

--- a/tests/benchmarks/igraph_average_path_length_unweighted.c
+++ b/tests/benchmarks/igraph_average_path_length_unweighted.c
@@ -56,7 +56,7 @@ int main(void) {
         igraph_square_lattice(&graph, &dims, 1, IGRAPH_UNDIRECTED, 0, &periodic);
         igraph_vector_int_destroy(&dims);
         igraph_vector_bool_destroy(&periodic);
-        igraph_rewire(&graph, 100, IGRAPH_SIMPLE_SW);
+        igraph_rewire(&graph, NULL, 100, IGRAPH_SIMPLE_SW);
         igraph_matrix_resize(&mat, igraph_vcount(&graph), igraph_vcount(&graph)); /* preallocate matrix */
     }
 

--- a/tests/benchmarks/igraph_average_path_length_unweighted.c
+++ b/tests/benchmarks/igraph_average_path_length_unweighted.c
@@ -56,7 +56,7 @@ int main(void) {
         igraph_square_lattice(&graph, &dims, 1, IGRAPH_UNDIRECTED, 0, &periodic);
         igraph_vector_int_destroy(&dims);
         igraph_vector_bool_destroy(&periodic);
-        igraph_rewire(&graph, NULL, 100, IGRAPH_SIMPLE_SW);
+        igraph_rewire(&graph, 100, IGRAPH_SIMPLE_SW, NULL);
         igraph_matrix_resize(&mat, igraph_vcount(&graph), igraph_vcount(&graph)); /* preallocate matrix */
     }
 

--- a/tests/benchmarks/igraph_rewire.c
+++ b/tests/benchmarks/igraph_rewire.c
@@ -29,7 +29,7 @@ void bench(const char *name, igraph_t *graph, int rep) {
              "%s, |V|=%6" IGRAPH_PRId ", |E|=%6" IGRAPH_PRId ", %6" IGRAPH_PRId " swaps, %dx",
              name, vcount, ecount, trials, rep);
 
-    BENCH(msg, REPEAT(igraph_rewire(graph, NULL, trials, IGRAPH_SIMPLE_SW), rep));
+    BENCH(msg, REPEAT(igraph_rewire(graph, trials, IGRAPH_SIMPLE_SW, NULL), rep));
 }
 
 void bench_er(igraph_int_t n, igraph_int_t m, int rep) {

--- a/tests/benchmarks/igraph_rewire.c
+++ b/tests/benchmarks/igraph_rewire.c
@@ -29,7 +29,7 @@ void bench(const char *name, igraph_t *graph, int rep) {
              "%s, |V|=%6" IGRAPH_PRId ", |E|=%6" IGRAPH_PRId ", %6" IGRAPH_PRId " swaps, %dx",
              name, vcount, ecount, trials, rep);
 
-    BENCH(msg, REPEAT(igraph_rewire(graph, trials, IGRAPH_SIMPLE_SW), rep));
+    BENCH(msg, REPEAT(igraph_rewire(graph, NULL, trials, IGRAPH_SIMPLE_SW), rep));
 }
 
 void bench_er(igraph_int_t n, igraph_int_t m, int rep) {

--- a/tests/unit/igraph_rewire.c
+++ b/tests/unit/igraph_rewire.c
@@ -34,7 +34,7 @@ static void check_rewiring(igraph_tree_mode_t tree_mode, igraph_bool_t use_adjli
     igraph_degree(&g, &indegree_before, igraph_vss_all(), IGRAPH_IN, IGRAPH_LOOPS);
     igraph_degree(&g, &outdegree_before, igraph_vss_all(), IGRAPH_OUT, IGRAPH_LOOPS);
 
-    igraph_i_rewire(&g, 1000, allow_loops ? IGRAPH_LOOPS_SW : IGRAPH_SIMPLE_SW, use_adjlist);
+    igraph_i_rewire(&g, NULL, 1000, allow_loops ? IGRAPH_LOOPS_SW : IGRAPH_SIMPLE_SW, use_adjlist);
 
     igraph_vector_int_init(&indegree_after, 0);
     igraph_vector_int_init(&outdegree_after, 0);
@@ -65,7 +65,7 @@ int main(void) {
     {
         igraph_t graph;
         igraph_cycle_graph(&graph, 12, IGRAPH_UNDIRECTED, /* mutual= */ false);
-        igraph_rewire(&graph, 50, IGRAPH_SIMPLE_SW);
+        igraph_rewire(&graph, NULL, 50, IGRAPH_SIMPLE_SW);
         igraph_destroy(&graph);
     }
 

--- a/tests/unit/igraph_rewire.c
+++ b/tests/unit/igraph_rewire.c
@@ -34,7 +34,7 @@ static void check_rewiring(igraph_tree_mode_t tree_mode, igraph_bool_t use_adjli
     igraph_degree(&g, &indegree_before, igraph_vss_all(), IGRAPH_IN, IGRAPH_LOOPS);
     igraph_degree(&g, &outdegree_before, igraph_vss_all(), IGRAPH_OUT, IGRAPH_LOOPS);
 
-    igraph_i_rewire(&g, NULL, 1000, allow_loops ? IGRAPH_LOOPS_SW : IGRAPH_SIMPLE_SW, use_adjlist);
+    igraph_i_rewire(&g, 1000, allow_loops ? IGRAPH_LOOPS_SW : IGRAPH_SIMPLE_SW, use_adjlist, NULL);
 
     igraph_vector_int_init(&indegree_after, 0);
     igraph_vector_int_init(&outdegree_after, 0);
@@ -65,7 +65,7 @@ int main(void) {
     {
         igraph_t graph;
         igraph_cycle_graph(&graph, 12, IGRAPH_UNDIRECTED, /* mutual= */ false);
-        igraph_rewire(&graph, NULL, 50, IGRAPH_SIMPLE_SW);
+        igraph_rewire(&graph, 50, IGRAPH_SIMPLE_SW, NULL);
         igraph_destroy(&graph);
     }
 


### PR DESCRIPTION
`igraph_rewire` now has `successful_swaps` as an output parameter, which records the number of successful rewiring trials.

Closes #2848.

This is my first contribution to this repository, so any feedback is appreciated. I would also like some advice on how to include this parameter in the unit tests, since I believe that the number of successful swaps will differ between each run.

- [x] By submitting this pull request, I assign the copyright of my contribution to _The igraph development team_.
