### PR TITLE
refactor!: igraph_isoclass_subgraph() takes an igraph_vs_t instead of…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,7 @@ This section gives detailed on breaking changes you need to consider when updati
  - `igraph_subisomorphic_lad()` does not have a CPU time limit parameter any more. If you wish to stop the calculation from another thread or a higher level interface, use igraph's interruption mechanism.
  - The semantics of the `igraph_permute_vertices()` permutation argument has changed: the i-th element of the vector now contains the index of the _original_ vertex that will be mapped to the i-th vertex in the new graph. This is now consistent with how other igraph functions treat permutations and vertex index vectors; for instance, you can now pass the result of `igraph_topological_sorting()` directly to `igraph_permute_vertices()` to obtain a new graph where the vertices are sorted topologically.
  - As a consequence to the change in the semantics of the `igraph_permute_vertices()` permutation argument, the semantics of the permutations returned from `igraph_canonical_permutation()` and `igraph_canonical_permutation_bliss()` have also been inverted to maintain the invariant that the output of these functions can be fed into `igraph_permute_vertices()` directly.
+ - `igraph_isoclass_subgraph()` now takes a parameter of type `igraph_vs_t vids` instead of `igraph_vector_int_t vids`. Apply `igraph_vss_vector()` to the vector of vertex IDs to convert it to an `igraph_vs_t`.
 
 #### Centralities
 

--- a/include/igraph_isomorphism.h
+++ b/include/igraph_isomorphism.h
@@ -22,6 +22,7 @@
 #include "igraph_decls.h"
 #include "igraph_datatype.h"
 #include "igraph_error.h"
+#include "igraph_iterators.h"
 #include "igraph_types.h"
 #include "igraph_vector_list.h"
 
@@ -269,7 +270,7 @@ IGRAPH_EXPORT igraph_error_t igraph_automorphism_group_bliss(
 
 /* Functions for small graphs (<= 4 vertices for directed graphs, <= 6 for undirected graphs) */
 IGRAPH_EXPORT igraph_error_t igraph_isoclass(const igraph_t *graph, igraph_int_t *isoclass);
-IGRAPH_EXPORT igraph_error_t igraph_isoclass_subgraph(const igraph_t *graph, const igraph_vector_int_t *vids,
+IGRAPH_EXPORT igraph_error_t igraph_isoclass_subgraph(const igraph_t *graph, igraph_vs_t vids,
                                            igraph_int_t *isoclass);
 IGRAPH_EXPORT igraph_error_t igraph_isoclass_create(igraph_t *graph, igraph_int_t size,
                                          igraph_int_t number, igraph_bool_t directed);

--- a/interfaces/functions.yaml
+++ b/interfaces/functions.yaml
@@ -2319,7 +2319,7 @@ igraph_count_automorphisms:
     DEPS: colors ON graph
 
 igraph_isoclass_subgraph:
-    PARAMS: GRAPH graph, VECTOR_INT vids, OUT INTEGER isoclass
+    PARAMS: GRAPH graph, VERTEX_SELECTOR vids, OUT INTEGER isoclass
     DEPS: vids ON graph
 
 igraph_isoclass_create:

--- a/tests/unit/isoclasses.c
+++ b/tests/unit/isoclasses.c
@@ -28,7 +28,7 @@ int main(void) {
 
     igraph_t g;
     igraph_vector_int_t edges;
-    igraph_vector_int_t vids;
+    igraph_vs_t vids;
     igraph_int_t class;
 
     igraph_vector_int_init_int_end(&edges, -1,
@@ -39,25 +39,25 @@ int main(void) {
     igraph_create(&g, &edges, 0, IGRAPH_DIRECTED);
     igraph_vector_int_destroy(&edges);
 
-    igraph_vector_int_init_int_end(&vids, -1, 1, 4, 6, -1);
-    igraph_isoclass_subgraph(&g, &vids, &class);
-    printf("class: %i\n", (int)class);
-    igraph_vector_int_destroy(&vids);
+    igraph_vs_vector_small(&vids, 1, 4, 6, -1);
+    igraph_isoclass_subgraph(&g, vids, &class);
+    printf("class: %d\n", (int) class);
+    igraph_vs_destroy(&vids);
 
-    igraph_vector_int_init_int_end(&vids, -1, 0, 1, 3, -1);
-    igraph_isoclass_subgraph(&g, &vids, &class);
-    printf("class: %i\n", (int)class);
-    igraph_vector_int_destroy(&vids);
+    igraph_vs_vector_small(&vids, 0, 1, 3, -1);
+    igraph_isoclass_subgraph(&g, vids, &class);
+    printf("class: %d\n", (int) class);
+    igraph_vs_destroy(&vids);
 
-    igraph_vector_int_init_int_end(&vids, -1, 7, 8, 9, -1);
-    igraph_isoclass_subgraph(&g, &vids, &class);
-    printf("class: %i\n", (int)class);
-    igraph_vector_int_destroy(&vids);
+    igraph_vs_vector_small(&vids, 7, 8, 9, -1);
+    igraph_isoclass_subgraph(&g, vids, &class);
+    printf("class: %d\n", (int) class);
+    igraph_vs_destroy(&vids);
 
-    igraph_vector_int_init_int_end(&vids, -1, 0, 2, 5, -1);
-    igraph_isoclass_subgraph(&g, &vids, &class);
-    printf("class: %i\n", (int)class);
-    igraph_vector_int_destroy(&vids);
+    igraph_vs_vector_small(&vids, 0, 2, 5, -1);
+    igraph_isoclass_subgraph(&g, vids, &class);
+    printf("class: %d\n", (int) class);
+    igraph_vs_destroy(&vids);
 
     igraph_destroy(&g);
 

--- a/tests/unit/isoclasses2.c
+++ b/tests/unit/isoclasses2.c
@@ -126,7 +126,7 @@ void random_subgraph_test(void) {
             igraph_bool_t iso;
 
             igraph_random_sample(&vids, 0, igraph_vcount(&graph) - 1, size);
-            igraph_isoclass_subgraph(&graph, &vids, &class);
+            igraph_isoclass_subgraph(&graph, igraph_vss_vector(&vids), &class);
             igraph_isoclass_create(&sg1, size, class, igraph_is_directed(&graph));
             igraph_induced_subgraph(&graph, &sg2, igraph_vss_vector(&vids), IGRAPH_SUBGRAPH_CREATE_FROM_SCRATCH);
 
@@ -151,7 +151,7 @@ void random_subgraph_test(void) {
             igraph_bool_t iso;
 
             igraph_random_sample(&vids, 0, igraph_vcount(&graph) - 1, size);
-            igraph_isoclass_subgraph(&graph, &vids, &class);
+            igraph_isoclass_subgraph(&graph, igraph_vss_vector(&vids), &class);
             igraph_isoclass_create(&sg1, size, class, igraph_is_directed(&graph));
             igraph_induced_subgraph(&graph, &sg2, igraph_vss_vector(&vids), IGRAPH_SUBGRAPH_CREATE_FROM_SCRATCH);
 


### PR DESCRIPTION
… an igraph_vector_int_t

Closes #2859

There's a note in the docs that each vertex must appear at most once. There is no check for this. It's be nice to add one, but we can do that at a later time.