### PR TITLE
fix: eliminate references to exit() from igraph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [main]
 
+### Fixed
+
+ - Eliminated references to `exit()` from the igraph shared library. These were accidentally introduces into igraph 1.0.0 through Qhull and Infomap.
+
 ### Other
 
 - Documentation improvements.

--- a/vendor/infomap/src/io/ProgramInterface.cpp
+++ b/vendor/infomap/src/io/ProgramInterface.cpp
@@ -10,6 +10,8 @@
 #include "ProgramInterface.h"
 #include "../utils/Log.h"
 
+#include "igraph_error.h"
+
 #include <iostream>
 #include <cstdlib>
 #include <map>
@@ -45,6 +47,9 @@ ProgramInterface::ProgramInterface(std::string name, std::string shortDescriptio
   addOptionArgument(m_printJsonParameters, "print-json-parameters", "Print Infomap parameters in JSON.", "About").setHidden(true);
 }
 
+/* Modification for igraph: Disable functions that call forbidden
+ * functions such as exit(). */
+#if 0
 void ProgramInterface::exitWithUsage(bool showAdvanced) const
 {
   Log() << "Name:\n";
@@ -125,9 +130,16 @@ void ProgramInterface::exitWithVersionInformation() const
   Log() << "See www.mapequation.org for terms of use.\n";
   std::exit(0);
 }
+#endif
 
 void ProgramInterface::exitWithError(const std::string& message) const
 {
+    /* Modification for igraph: This function must never be called
+     * when using Infomap through igraph. The function is disabled
+     * to eliminate forbidden references to exit() and std::cerr. */
+    IGRAPH_FATALF("Infomap called exitWithError() with message '%s'.",
+                  message.c_str());
+#if 0
   Log() << m_programName << " version " << m_programVersion;
 #ifdef _OPENMP
   Log() << " compiled with OpenMP";
@@ -142,6 +154,7 @@ void ProgramInterface::exitWithError(const std::string& message) const
     Log() << " [options]";
   Log() << ". Run with option '-h' for more information.\n";
   std::exit(1);
+#endif
 }
 
 std::string toJson(const std::string& key, const std::string& value)
@@ -178,6 +191,9 @@ std::string toJson(const Option& opt)
                    << " }";
 }
 
+/* Modification for igraph: Disable functions that call forbidden
+ * functions such as exit(). */
+#if 0
 void ProgramInterface::exitWithJsonParameters() const
 {
   Log() << "{\n  \"parameters\": [\n";
@@ -197,6 +213,7 @@ void ProgramInterface::exitWithJsonParameters() const
 
   std::exit(0);
 }
+#endif
 
 void ProgramInterface::parseArgs(const std::string& args)
 {
@@ -298,12 +315,16 @@ void ProgramInterface::parseArgs(const std::string& args)
           }
         }
       }
+    /* Modification for igraph: Disable calls to functions that
+     * needed to be removed because they referenced exit().  */
+#if 0
       if (m_displayHelp > 0)
         exitWithUsage(m_displayHelp > 1);
       if (m_displayVersion)
         exitWithVersionInformation();
       if (m_printJsonParameters)
         exitWithJsonParameters();
+#endif
     }
   } catch (std::exception& e) {
     exitWithError(e.what());

--- a/vendor/infomap/src/io/ProgramInterface.h
+++ b/vendor/infomap/src/io/ProgramInterface.h
@@ -392,10 +392,16 @@ public:
   unsigned int numRequiredArguments() const { return m_nonOptionArguments.size() - m_numOptionalNonOptionArguments; }
 
 private:
+/* Modification for igraph: Disable functions that call forbidden
+ * functions such as exit(). */
+#if 0
   void exitWithUsage(bool showAdvanced) const;
   void exitWithVersionInformation() const;
+#endif
   void exitWithError(const std::string& message) const;
+#if 0
   void exitWithJsonParameters() const;
+#endif
 
   std::deque<std::unique_ptr<Option>> m_optionArguments;
   std::deque<std::unique_ptr<TargetBase>> m_nonOptionArguments;

--- a/vendor/qhull/CHANGES.md
+++ b/vendor/qhull/CHANGES.md
@@ -2,7 +2,9 @@ Modifying from https://github.com/qhull/qhull on commit d1c2fc0caa5f644f3a0f2202
 
 Changed `userprintf_r.c` to not print when passed a null pointer as file handle.
 
-Changes the following settings in `user_r.h`:
+Changed `usermem_r.c` to not reference `exit()`. Even though this `exit()` is never called, it is necessary to keep igraph free of any references to it to satisfy CRAN requirements and comply with Debian guidelines.
+
+Changed the following settings in `user_r.h`:
 
  - `#define qh_KEEPstatistics 0`, do not incude statistics gathering code
  - `#define qh_NOtrace`, do not include tracing code

--- a/vendor/qhull/libqhull_r/usermem_r.c
+++ b/vendor/qhull/libqhull_r/usermem_r.c
@@ -20,6 +20,8 @@
 
 #include "libqhull_r.h"
 
+#include "igraph_error.h"
+
 #include <stdarg.h>
 #include <stdlib.h>
 
@@ -38,7 +40,10 @@
     To replace qh_exit with 'throw', see libqhullcpp/usermem_r-cpp.cpp
 */
 void qh_exit(int exitcode) {
-    exit(exitcode);
+    /* exit(exitcode); */
+    /* This code is not reachable. We comment out exit() to ensure
+     * that the igraph shared library does not reference it. */
+    IGRAPH_FATALF("Qhull called exit() with exit code %d.", exitcode);
 } /* exit */
 
 /*-<a                             href="qh-user_r.htm#TOC"


### PR DESCRIPTION
Eliminate references to `exit()` from igraph. These got added to igraph 1.0.0 through Infomap and Qhull.

Refs #2847

Thanks for reporting this @jgmbenoit! I think we're good now. `nm -g src/libigraph.dylib | grep exit` finds nothing on my machine (not even when building with all-vendored libraries).

Calls to `exit()` are either eliminated or replaced with `IGRAPH_FATAL()`, which will emit some useful information and tell the user to report the occurrence as a bug. These calls to `IGRAPH_FATAL()` should all be unreachable—they effectively serve as assertions of unreachability here.

While `flex` generates code that references `exit()`, this code is never called so the linker eliminates it from the shared library. We do not need to worry about the flex-generated code.