### PR TITLE
fix: more robust compilation on some Apple systems

### DIFF
--- a/etc/cmake/compilers.cmake
+++ b/etc/cmake/compilers.cmake
@@ -8,6 +8,17 @@ include(CheckCCompilerFlag)
 #  - https://www.gnu.org/software/libc/manual/html_node/Feature-Test-Macros.html
 add_compile_definitions(_POSIX_C_SOURCE=200809L)
 
+# On some Apple systems, with some compilers, defining _POSIX_C_SOURCE causes compilation
+# failures when including C++ headers. Defining _DARWIN_C_SOURCE explicitly usually fixes
+# this. Refs: https://trac.macports.org/ticket/60655 and https://trac.macports.org/ticket/73145
+# This is claimed to be due to _POSIX_C_SOURCE disabling APIs that C++ headers rely on
+# on some systems. _DARWIN_C_SOURCE re-enables these APIs, but _GNU_SOURCE alone does not 
+# necessarily do so. Using different global defined for C and C++ is problematic with CMake,
+# so instead of restricting _POSIX_C_SOURCE to C, we define _DARWIN_C_SOURCE.
+if(APPLE)
+  add_compile_definitions(_DARWIN_C_SOURCE)
+endif()
+
 if(MSVC)
   add_compile_options(/FS)
   add_compile_definitions(_CRT_SECURE_NO_WARNINGS) # necessary to compile for UWP


### PR DESCRIPTION
This defines `_DARWIN_C_SOURCE` to improve compilation robustness on misbehaving Apple systems.

On some old Apple systems, as well as with MacPorts's GCC, defining `_POSIX_C_SOURCE` can break some standard C++ headers (i.e. including them triggers errors). This is unfortunate as `_POSIX_C_SOURCE` is the standard way to enable POSIX features, which improve igraph functionality/performance. It seems that defining `_DARWIN_C_SOURCE` explicitly fixes these types of issues.  There are many discussions on GitHub about this, going back over 10 years. 

@ntamas Can you please try to build igraph with Homebrew's GCC _without_ this patch, and see if it works? I don't have Homebrew. If it does not work, can you test with this patch as well to see if it fixes it?

Let's not merge this yet, as it's unclear if defining `_DARWIN_C_SOURCE` can have negative effects in some circumstances. Let's wait for https://github.com/macports/macports-ports/pull/29711 first, and see how compilation goes.