### PR TITLE
Use subcomponents to more accurately determine where to search cycles for

### DIFF
--- a/src/cycles/simple_cycles.c
+++ b/src/cycles/simple_cycles.c
@@ -136,6 +136,12 @@ static igraph_error_t simple_cycles_unblock(
     return IGRAPH_SUCCESS;
 }
 
+/**
+ * Marks the strongly connected component of 
+ * 
+ * the start vertex as exhausted, using the existing subcomponent
+ * implementation from igraph.
+ */
 static igraph_int_t simple_cycles_vertex_degree(simple_cycle_search_state_t *state, igraph_int_t v) {
     igraph_int_t degree = igraph_vector_int_size(igraph_adjlist_get(&state->AK, v));
 
@@ -406,13 +412,14 @@ static igraph_error_t simple_cycle_search_state_init(
 
     IGRAPH_VECTOR_INT_INIT_FINALLY(&state->edge_stack, 8);
     igraph_vector_int_clear(&state->edge_stack);
-    IGRAPH_VECTOR_INT_INIT_FINALLY(&state->component_stack, 8);
-    igraph_vector_int_clear(&state->component_stack);
 
     // by default false
     IGRAPH_BITSET_INIT_FINALLY(&state->v_blocked, state->N);
 
     IGRAPH_BITSET_INIT_FINALLY(&state->v_exhausted, state->N);
+
+    IGRAPH_VECTOR_INT_INIT_FINALLY(&state->component_stack, 8);
+    igraph_vector_int_clear(&state->component_stack);
 
     IGRAPH_BITSET_INIT_FINALLY(&state->component_forward_seen, state->N);
 
@@ -455,11 +462,12 @@ static igraph_error_t simple_cycle_search_state_init(
  */
 static void simple_cycle_search_state_destroy(simple_cycle_search_state_t *state) {
 
-    igraph_bitset_destroy(&state->component_forward_seen);
-    igraph_bitset_destroy(&state->v_exhausted);
-    igraph_adjlist_destroy(&state->AK);
+    igraph_adjlist_destroy(&state->B);
     igraph_adjlist_destroy(&state->AK_reverse);
+    igraph_adjlist_destroy(&state->AK);
+    igraph_bitset_destroy(&state->component_forward_seen);
     igraph_vector_int_destroy(&state->component_stack);
+    igraph_bitset_destroy(&state->v_exhausted);
     igraph_inclist_destroy(&state->IK);
     igraph_bitset_destroy(&state->v_blocked);
     igraph_vector_int_destroy(&state->edge_stack);
@@ -525,12 +533,12 @@ static igraph_error_t append_simple_cycle_result(
  * https://epubs.siam.org/doi/epdf/10.1137/0204007
  */
 static igraph_error_t simple_cycles_search_callback_from_one_vertex(
-        simple_cycle_search_state_t *state,
-        igraph_int_t s,
-        igraph_int_t min_cycle_length,
-        igraph_int_t max_cycle_length,
-        igraph_cycle_handler_t *callback,
-        void *arg) {
+    simple_cycle_search_state_t *state,
+    igraph_int_t s,
+    igraph_int_t min_cycle_length,
+    igraph_int_t max_cycle_length,
+    igraph_cycle_handler_t *callback,
+    void *arg) {
 
     // L3:
     for (igraph_int_t i = s; i < state->N; ++i) {

--- a/src/cycles/simple_cycles.c
+++ b/src/cycles/simple_cycles.c
@@ -61,9 +61,18 @@ typedef struct {
     /* Boolean vector indicating which vertices are blocked */
     igraph_bitset_t v_blocked;
 
-    /* Boolean vector indicating which vertices have ever been checked.
-     * The bigger picture here is that this allows a "lazy" community decomposition */
-    igraph_bitset_t v_visited;
+    /* Boolean vector indicating which vertices belong to components that were
+     * already processed as starting points. */
+    igraph_bitset_t v_exhausted;
+
+    /* Scratch stack for component traversal. */
+    igraph_vector_int_t component_stack;
+
+    /* Scratch bitset for forward reachability within a component. */
+    igraph_bitset_t component_forward_seen;
+
+    /* Reverse adjacency list used only for directed component marking. */
+    igraph_adjlist_t AK_reverse;
 
     /* Whether the graph is directed */
     igraph_bool_t directed;
@@ -127,6 +136,60 @@ static igraph_error_t simple_cycles_unblock(
     return IGRAPH_SUCCESS;
 }
 
+static igraph_int_t simple_cycles_vertex_degree(simple_cycle_search_state_t *state, igraph_int_t v) {
+    igraph_int_t degree = igraph_vector_int_size(igraph_adjlist_get(&state->AK, v));
+
+    if (state->directed) {
+        degree += igraph_vector_int_size(igraph_adjlist_get(&state->AK_reverse, v));
+    }
+
+    return degree;
+}
+
+/**
+ * Marks low-degree vertices reachable from the start vertex as exhausted,
+ * using the cached adjacency lists.
+ */
+static igraph_error_t simple_cycles_mark_exhausted_component(
+        simple_cycle_search_state_t *state,
+        igraph_int_t s) {
+
+    igraph_vector_int_t *neighbors;
+    igraph_int_t n_neighbors;
+    igraph_int_t degree;
+
+    degree = simple_cycles_vertex_degree(state, s);
+    if (degree >= 3) {
+        return IGRAPH_SUCCESS;
+    }
+
+    igraph_vector_int_clear(&state->component_stack);
+    igraph_bitset_fill(&state->component_forward_seen, false);
+
+    IGRAPH_CHECK(igraph_vector_int_push_back(&state->component_stack, s));
+    IGRAPH_BIT_SET(state->component_forward_seen, s);
+
+    while (igraph_vector_int_size(&state->component_stack) > 0) {
+        const igraph_int_t v = igraph_vector_int_pop_back(&state->component_stack);
+
+        if (simple_cycles_vertex_degree(state, v) < 3) {
+            IGRAPH_BIT_SET(state->v_exhausted, v);
+            neighbors = igraph_adjlist_get(&state->AK, v);
+            n_neighbors = igraph_vector_int_size(neighbors);
+            for (igraph_int_t i = 0; i < n_neighbors; ++i) {
+                const igraph_int_t w = VECTOR(*neighbors)[i];
+                if (!IGRAPH_BIT_TEST(state->component_forward_seen, w) &&
+                    simple_cycles_vertex_degree(state, w) < 3) {
+                    IGRAPH_BIT_SET(state->component_forward_seen, w);
+                    IGRAPH_CHECK(igraph_vector_int_push_back(&state->component_stack, w));
+                }
+            }
+        }
+    }
+
+    return IGRAPH_SUCCESS;
+}
+
 /**
  * The implementation of procedure CIRCUIT from Johnson's paper
  *
@@ -168,8 +231,6 @@ static igraph_error_t simple_cycles_circuit(
     while ((recurse_deeper ||
             igraph_stack_int_size(&neigh_iteration_progress) > 0) &&
             !state->stop_search) {
-        IGRAPH_BIT_SET(state->v_visited, V);
-
         IGRAPH_ASSERT(igraph_stack_int_size(&neigh_iteration_progress) ==
                       igraph_stack_int_size(&e_stack));
         IGRAPH_ASSERT(igraph_stack_int_size(&v_stack) ==
@@ -345,11 +406,15 @@ static igraph_error_t simple_cycle_search_state_init(
 
     IGRAPH_VECTOR_INT_INIT_FINALLY(&state->edge_stack, 8);
     igraph_vector_int_clear(&state->edge_stack);
+    IGRAPH_VECTOR_INT_INIT_FINALLY(&state->component_stack, 8);
+    igraph_vector_int_clear(&state->component_stack);
 
     // by default false
     IGRAPH_BITSET_INIT_FINALLY(&state->v_blocked, state->N);
 
-    IGRAPH_BITSET_INIT_FINALLY(&state->v_visited, state->N);
+    IGRAPH_BITSET_INIT_FINALLY(&state->v_exhausted, state->N);
+
+    IGRAPH_BITSET_INIT_FINALLY(&state->component_forward_seen, state->N);
 
     IGRAPH_CHECK(igraph_inclist_init(
                      graph, &state->IK, mode,
@@ -360,10 +425,19 @@ static igraph_error_t simple_cycle_search_state_init(
     IGRAPH_CHECK(igraph_adjlist_init_from_inclist(graph, &state->AK, &state->IK));
     IGRAPH_FINALLY(igraph_adjlist_destroy, &state->AK);
 
+    if (state->directed) {
+        igraph_neimode_t reverse_mode = (mode == IGRAPH_OUT) ? IGRAPH_IN : IGRAPH_OUT;
+        IGRAPH_CHECK(igraph_adjlist_init(graph, &state->AK_reverse, reverse_mode,
+                                         IGRAPH_NO_LOOPS, IGRAPH_MULTIPLE));
+    } else {
+        IGRAPH_CHECK(igraph_adjlist_init_empty(&state->AK_reverse, state->N));
+    }
+    IGRAPH_FINALLY(igraph_adjlist_destroy, &state->AK_reverse);
+
     IGRAPH_CHECK(igraph_adjlist_init_empty(&state->B, state->N));
     IGRAPH_FINALLY(igraph_adjlist_destroy, &state->B);
 
-    IGRAPH_FINALLY_CLEAN(7);
+    IGRAPH_FINALLY_CLEAN(10);
 
     return IGRAPH_SUCCESS;
 }
@@ -381,10 +455,12 @@ static igraph_error_t simple_cycle_search_state_init(
  */
 static void simple_cycle_search_state_destroy(simple_cycle_search_state_t *state) {
 
-    igraph_adjlist_destroy(&state->B);
+    igraph_bitset_destroy(&state->component_forward_seen);
+    igraph_bitset_destroy(&state->v_exhausted);
     igraph_adjlist_destroy(&state->AK);
+    igraph_adjlist_destroy(&state->AK_reverse);
+    igraph_vector_int_destroy(&state->component_stack);
     igraph_inclist_destroy(&state->IK);
-    igraph_bitset_destroy(&state->v_visited);
     igraph_bitset_destroy(&state->v_blocked);
     igraph_vector_int_destroy(&state->edge_stack);
     igraph_vector_int_destroy(&state->vertex_stack);
@@ -465,6 +541,8 @@ static igraph_error_t simple_cycles_search_callback_from_one_vertex(
     IGRAPH_CHECK(simple_cycles_circuit(state, s, max_cycle_length,
                  min_cycle_length, callback, arg));
 
+    IGRAPH_CHECK(simple_cycles_mark_exhausted_component(state, s));
+
     for (igraph_int_t i = 0; i < state->N; ++i) {
         // We want to remove the vertex with value s, not at position s.
         // It's fine to use binary search since we never add to, only remove from
@@ -539,24 +617,11 @@ igraph_error_t igraph_simple_cycles_callback(
     IGRAPH_CHECK(simple_cycle_search_state_init(&state, graph, mode));
     IGRAPH_FINALLY(simple_cycle_search_state_destroy, &state);
 
-    // Depending on the graph, it is rather unreasonable to search cycles
-    // from each and every node. Instead, we expect that each cycle must involve
-    // either:
-    // - a vertex with degree > 2
-    // - or, if it's a freestanding cycle, be any vertex of this connected component;
-    //   components are identified via the `state->v_visited` boolean mask.
-    //
-    // Thus, we iterate over the vertices, and check if they can be skipped as
-    // a starting point according to the rules laid out above.
+    // Depending on the graph, it is rather unreasonable to search cycles from
+    // every vertex. Instead, once a component has been searched from any one
+    // start vertex, all of its vertices are marked as exhausted and skipped.
     for (igraph_int_t i = 0; i < state.N; i++) {
-        // Check if the vertex is a candidate for a cycle.
-        // Note that we call igraph_degree_1() here instead of retrieving the
-        // neighbor count from igraph_adjlist_get(&state.AK, i) because:
-        //  - we need to the undirected degree in all cases, and
-        //  - our algorithm modifies the adjlist state.AK
-        igraph_int_t degree;
-        IGRAPH_CHECK(igraph_degree_1(graph, &degree, i, IGRAPH_ALL, true));
-        if (degree < 3 && IGRAPH_BIT_TEST(state.v_visited, i)) {
+        if (IGRAPH_BIT_TEST(state.v_exhausted, i)) {
             continue;
         }
         // Check if we find a cycle starting from this vertex.

--- a/tests/unit/igraph_simple_cycles.c
+++ b/tests/unit/igraph_simple_cycles.c
@@ -83,10 +83,10 @@ int main(void) {
     check_cycles(&g, IGRAPH_OUT, 1);
     igraph_destroy(&g);
 
-    // printf("\nTesting large directed cycle graph\n");
-    // igraph_ring(&g, 10000, IGRAPH_DIRECTED, /*mutual=*/ false, /*circular=*/ true);
-    // check_cycles(&g, 1);
-    // igraph_destroy(&g);
+    printf("\nTesting large directed cycle graph\n");
+    igraph_ring(&g, 10000, IGRAPH_DIRECTED, /*mutual=*/ false, /*circular=*/ true);
+    check_cycles(&g, IGRAPH_OUT, 1);
+    igraph_destroy(&g);
 
     printf("\nTesting directed star\n");
     igraph_star(&g, 7, IGRAPH_STAR_OUT, 1);
@@ -374,6 +374,32 @@ int main(void) {
     check_cycles_max(&g, IGRAPH_OUT, 1, 4);
     check_cycles_max(&g, IGRAPH_OUT, 1, 5);
     check_cycles_max(&g, IGRAPH_OUT, 2, 6);
+    igraph_destroy(&g);
+
+    // Regression test for directed 2-cycle detection in a larger graph.
+    // This graph looks like this:
+    // 0 --> 1
+    // |  /  |
+    // vy    v
+    // 5 <-> 2
+    // ^  \
+    // |    v
+    // 4 --> 3
+    igraph_small(&g, 0, IGRAPH_DIRECTED,
+                 0, 1,
+                 0, 5,
+                 1, 5,
+                 2, 5,
+                 4, 3,
+                 4, 5,
+                 5, 2,
+                 5, 3,
+                 -1);
+    check_cycles(&g, IGRAPH_OUT, 1);
+
+    // check same graph, but undirected
+    igraph_to_undirected(&g, IGRAPH_TO_UNDIRECTED_EACH, NULL);
+    check_cycles(&g, IGRAPH_OUT, 3);
     igraph_destroy(&g);
 
     printf("\nTesting undirected graph of type 'Mickey'\n");

--- a/tests/unit/igraph_simple_cycles.c
+++ b/tests/unit/igraph_simple_cycles.c
@@ -64,23 +64,44 @@ void check_cycles(const igraph_t *graph, igraph_neimode_t mode, igraph_int_t exp
     check_cycles_max(graph, mode, expected, -1);
 }
 
+void check_cycles_permuted(const igraph_t *graph, igraph_neimode_t mode, igraph_int_t expected) {
+    igraph_t permuted;
+    igraph_vector_int_t permutation;
+
+    igraph_vector_int_init_range(&permutation, 0, igraph_vcount(graph));
+    if (igraph_vector_int_size(&permutation) > 1) {
+        igraph_vector_int_shuffle(&permutation);
+    }
+    igraph_permute_vertices(graph, &permuted, &permutation);
+
+    check_cycles(&permuted, mode, expected);
+
+    igraph_destroy(&permuted);
+    igraph_vector_int_destroy(&permutation);
+}
+
 int main(void) {
     igraph_t g;
     igraph_t g_ring_undirected, g_star_undirected;
 
+    igraph_rng_seed(igraph_rng_default(), 293847);
+
     printf("Testing null graph\n");
     igraph_empty(&g, 0, IGRAPH_UNDIRECTED);
     check_cycles(&g, IGRAPH_OUT, 0);
+    check_cycles_permuted(&g, IGRAPH_OUT, 0);
     igraph_destroy(&g);
 
     printf("\nTesting edgeless graph\n");
     igraph_empty(&g, 5, IGRAPH_UNDIRECTED);
     check_cycles(&g, IGRAPH_OUT, 0);
+    check_cycles_permuted(&g, IGRAPH_OUT, 0);
     igraph_destroy(&g);
 
     printf("\nTesting directed cycle graph\n");
     igraph_ring(&g, 10, IGRAPH_DIRECTED, /*mutual=*/ false, /*circular=*/ true);
     check_cycles(&g, IGRAPH_OUT, 1);
+    check_cycles_permuted(&g, IGRAPH_OUT, 1);
     igraph_destroy(&g);
 
     printf("\nTesting large directed cycle graph\n");
@@ -98,6 +119,7 @@ int main(void) {
     check_cycles(&g, IGRAPH_OUT, 1);
     check_cycles(&g, IGRAPH_IN, 1);
     check_cycles(&g, IGRAPH_ALL, 43);
+    check_cycles_permuted(&g, IGRAPH_ALL, 43);
     igraph_destroy(&g);
 
     printf("\nTesting undirected ring\n");
@@ -111,10 +133,12 @@ int main(void) {
     igraph_disjoint_union(&g, &g_ring_undirected, &g_star_undirected);
     printf("\nTesting union of undirected wheel and star\n");
     check_cycles(&g, IGRAPH_OUT, 1);
+    check_cycles_permuted(&g, IGRAPH_OUT, 1);
 
     printf("\nTesting union of undirected wheel, star and a single edge\n");
     igraph_add_edge(&g, 7, 13); // add a random edge between the two structures to make them connected
     check_cycles(&g, IGRAPH_OUT, 1);
+    check_cycles_permuted(&g, IGRAPH_OUT, 1);
     igraph_destroy(&g);
     igraph_destroy(&g_star_undirected);
     igraph_destroy(&g_ring_undirected);
@@ -123,12 +147,14 @@ int main(void) {
     igraph_kary_tree(&g, 20, 3, IGRAPH_TREE_OUT);
     check_cycles(&g, IGRAPH_OUT, 0);
     check_cycles(&g, IGRAPH_ALL, 0);
+    check_cycles_permuted(&g, IGRAPH_OUT, 0);
     igraph_destroy(&g);
 
     printf("\nTesting a complete DAG\n");
     igraph_full_citation(&g, 5, IGRAPH_DIRECTED);
     check_cycles(&g, IGRAPH_OUT, 0);
     check_cycles(&g, IGRAPH_ALL, 37);
+    check_cycles_permuted(&g, IGRAPH_ALL, 37);
     igraph_destroy(&g);
 
     igraph_t g_wheel_undirected_2;
@@ -145,6 +171,7 @@ int main(void) {
     // 9 cycles of 3 nodes,
     // )
     check_cycles(&g_wheel_undirected_2, IGRAPH_OUT, 73);
+    check_cycles_permuted(&g_wheel_undirected_2, IGRAPH_OUT, 73);
     // test the max_cycle_length parameter
     check_cycles_max(&g_wheel_undirected_2, IGRAPH_OUT, 9, 3);
     check_cycles_max(&g_wheel_undirected_2, IGRAPH_OUT, 18, 4);
@@ -328,6 +355,7 @@ int main(void) {
         4, 2,
         -1);
     check_cycles(&g, IGRAPH_OUT, 2);
+    check_cycles_permuted(&g, IGRAPH_OUT, 2);
     check_cycles_max(&g, IGRAPH_OUT, 0, 3);
     check_cycles_max(&g, IGRAPH_OUT, 1, 4);
     check_cycles_max(&g, IGRAPH_OUT, 2, 5);
@@ -346,6 +374,7 @@ int main(void) {
          4, 3,
         -1);
     check_cycles(&g, IGRAPH_OUT, 4);
+    check_cycles_permuted(&g, IGRAPH_OUT, 4);
     check_cycles_max(&g, IGRAPH_OUT, 1, 2);
     check_cycles_max(&g, IGRAPH_OUT, 2, 3);
     check_cycles_max(&g, IGRAPH_OUT, 3, 4);
@@ -356,6 +385,7 @@ int main(void) {
                  0, 2, 0, 3, 1, 2, 1, 4, 2, 3, 2, 4, 3, 1, 4, 0, 4, 2,
                  -1);
     check_cycles(&g, IGRAPH_OUT, 7);
+    check_cycles_permuted(&g, IGRAPH_OUT, 7);
     check_cycles_max(&g, IGRAPH_OUT, 0, 1);
     check_cycles_max(&g, IGRAPH_OUT, 1, 2);
     check_cycles_max(&g, IGRAPH_OUT, 3, 3);
@@ -368,6 +398,7 @@ int main(void) {
                  0, 2, 0, 4, 1, 3, 2, 5, 3, 0, 4, 1, 5, 4,
                  -1);
     check_cycles(&g, IGRAPH_OUT, 2);
+    check_cycles_permuted(&g, IGRAPH_OUT, 2);
     check_cycles_max(&g, IGRAPH_OUT, 0, 1);
     check_cycles_max(&g, IGRAPH_OUT, 0, 2);
     check_cycles_max(&g, IGRAPH_OUT, 0, 3);
@@ -396,10 +427,12 @@ int main(void) {
                  5, 3,
                  -1);
     check_cycles(&g, IGRAPH_OUT, 1);
+    check_cycles_permuted(&g, IGRAPH_OUT, 1);
 
     // check same graph, but undirected
     igraph_to_undirected(&g, IGRAPH_TO_UNDIRECTED_EACH, NULL);
     check_cycles(&g, IGRAPH_OUT, 3);
+    check_cycles_permuted(&g, IGRAPH_OUT, 3);
     igraph_destroy(&g);
 
     printf("\nTesting undirected graph of type 'Mickey'\n");
@@ -414,6 +447,7 @@ int main(void) {
                      5,0,
                      -1);
     check_cycles(&g, IGRAPH_ALL, 3);
+    check_cycles_permuted(&g, IGRAPH_ALL, 3);
     igraph_destroy(&g);
 
     printf("\nTesting undirected graph of type 'Mickey2'\n");
@@ -428,6 +462,7 @@ int main(void) {
                      5,0,
                      -1);
     check_cycles(&g, IGRAPH_ALL, 3);
+    check_cycles_permuted(&g, IGRAPH_ALL, 3);
     igraph_destroy(&g);
     igraph_small(&g, 7, IGRAPH_DIRECTED,
                      0,1,
@@ -459,6 +494,7 @@ int main(void) {
                      5, 5,
                      -1);
     check_cycles(&g, IGRAPH_ALL, 6);
+    check_cycles_permuted(&g, IGRAPH_ALL, 6);
     igraph_destroy(&g);
 
     VERIFY_FINALLY_STACK();

--- a/tests/unit/igraph_simple_cycles.out
+++ b/tests/unit/igraph_simple_cycles.out
@@ -7,8 +7,24 @@ Vertex IDs in cycles:
 Edge IDs in cycles:
 {
 }
+Finished search, found 0 cycles, expected 0 cycles. Max cycle length was -1 vertices.
+
+Vertex IDs in cycles:
+{
+}
+Edge IDs in cycles:
+{
+}
 
 Testing edgeless graph
+Finished search, found 0 cycles, expected 0 cycles. Max cycle length was -1 vertices.
+
+Vertex IDs in cycles:
+{
+}
+Edge IDs in cycles:
+{
+}
 Finished search, found 0 cycles, expected 0 cycles. Max cycle length was -1 vertices.
 
 Vertex IDs in cycles:
@@ -29,6 +45,20 @@ Edge IDs in cycles:
 {
   0: ( 0 1 2 3 4 5 6 7 8 9 )
 }
+Finished search, found 1 cycles, expected 1 cycles. Max cycle length was -1 vertices.
+
+Vertex IDs in cycles:
+{
+  0: ( 0 4 2 8 5 9 7 6 3 1 )
+}
+Edge IDs in cycles:
+{
+  0: ( 0 1 2 3 4 5 6 7 8 9 )
+}
+
+Testing large directed cycle graph
+Finished search, found 1 cycles, expected 1 cycles. Max cycle length was -1 vertices.
+
 
 Testing directed star
 Finished search, found 0 cycles, expected 0 cycles. Max cycle length was -1 vertices.
@@ -155,6 +185,100 @@ Edge IDs in cycles:
   41: ( 5 12 6 )
   42: ( 7 8 9 10 11 12 13 )
 }
+Finished search, found 43 cycles, expected 43 cycles. Max cycle length was -1 vertices.
+
+Vertex IDs in cycles:
+{
+  0: ( 0 1 2 4 7 )
+  1: ( 0 1 2 5 6 3 )
+  2: ( 0 1 3 )
+  3: ( 0 1 3 6 5 2 4 7 )
+  4: ( 0 1 4 2 5 6 3 )
+  5: ( 0 1 4 7 )
+  6: ( 0 1 5 2 4 7 )
+  7: ( 0 1 5 6 3 )
+  8: ( 0 1 6 3 )
+  9: ( 0 1 6 5 2 4 7 )
+  10: ( 0 1 7 )
+  11: ( 0 1 7 4 2 5 6 3 )
+  12: ( 0 7 1 2 5 6 3 )
+  13: ( 0 7 1 3 )
+  14: ( 0 7 1 4 2 5 6 3 )
+  15: ( 0 7 1 5 6 3 )
+  16: ( 0 7 1 6 3 )
+  17: ( 0 7 4 1 2 5 6 3 )
+  18: ( 0 7 4 1 3 )
+  19: ( 0 7 4 1 5 6 3 )
+  20: ( 0 7 4 1 6 3 )
+  21: ( 0 7 4 2 1 3 )
+  22: ( 0 7 4 2 1 5 6 3 )
+  23: ( 0 7 4 2 1 6 3 )
+  24: ( 0 7 4 2 5 1 3 )
+  25: ( 0 7 4 2 5 1 6 3 )
+  26: ( 0 7 4 2 5 6 1 3 )
+  27: ( 0 7 4 2 5 6 3 )
+  28: ( 1 2 4 )
+  29: ( 1 2 4 7 )
+  30: ( 1 2 5 )
+  31: ( 1 2 5 6 )
+  32: ( 1 2 5 6 3 )
+  33: ( 1 3 6 )
+  34: ( 1 3 6 5 )
+  35: ( 1 4 2 5 )
+  36: ( 1 4 2 5 6 )
+  37: ( 1 4 2 5 6 3 )
+  38: ( 1 4 7 )
+  39: ( 1 6 5 )
+  40: ( 1 7 4 2 5 )
+  41: ( 1 7 4 2 5 6 )
+  42: ( 1 7 4 2 5 6 3 )
+}
+Edge IDs in cycles:
+{
+  0: ( 3 0 7 8 9 )
+  1: ( 3 0 13 12 11 10 )
+  2: ( 3 4 10 )
+  3: ( 3 4 11 12 13 7 8 9 )
+  4: ( 3 1 7 13 12 11 10 )
+  5: ( 3 1 8 9 )
+  6: ( 3 6 13 7 8 9 )
+  7: ( 3 6 12 11 10 )
+  8: ( 3 5 11 10 )
+  9: ( 3 5 12 13 7 8 9 )
+  10: ( 3 2 9 )
+  11: ( 3 2 8 7 13 12 11 10 )
+  12: ( 9 2 0 13 12 11 10 )
+  13: ( 9 2 4 10 )
+  14: ( 9 2 1 7 13 12 11 10 )
+  15: ( 9 2 6 12 11 10 )
+  16: ( 9 2 5 11 10 )
+  17: ( 9 8 1 0 13 12 11 10 )
+  18: ( 9 8 1 4 10 )
+  19: ( 9 8 1 6 12 11 10 )
+  20: ( 9 8 1 5 11 10 )
+  21: ( 9 8 7 0 4 10 )
+  22: ( 9 8 7 0 6 12 11 10 )
+  23: ( 9 8 7 0 5 11 10 )
+  24: ( 9 8 7 13 6 4 10 )
+  25: ( 9 8 7 13 6 5 11 10 )
+  26: ( 9 8 7 13 12 5 4 10 )
+  27: ( 9 8 7 13 12 11 10 )
+  28: ( 0 7 1 )
+  29: ( 0 7 8 2 )
+  30: ( 0 13 6 )
+  31: ( 0 13 12 5 )
+  32: ( 0 13 12 11 4 )
+  33: ( 4 11 5 )
+  34: ( 4 11 12 6 )
+  35: ( 1 7 13 6 )
+  36: ( 1 7 13 12 5 )
+  37: ( 1 7 13 12 11 4 )
+  38: ( 1 8 2 )
+  39: ( 5 12 6 )
+  40: ( 2 8 7 13 6 )
+  41: ( 2 8 7 13 12 5 )
+  42: ( 2 8 7 13 12 11 4 )
+}
 
 Testing undirected ring
 Finished search, found 1 cycles, expected 1 cycles. Max cycle length was -1 vertices.
@@ -189,6 +313,16 @@ Edge IDs in cycles:
 {
   0: ( 0 1 2 3 4 5 6 7 8 9 )
 }
+Finished search, found 1 cycles, expected 1 cycles. Max cycle length was -1 vertices.
+
+Vertex IDs in cycles:
+{
+  0: ( 0 4 16 2 14 12 8 13 6 11 )
+}
+Edge IDs in cycles:
+{
+  0: ( 8 7 6 5 4 3 2 1 0 9 )
+}
 
 Testing union of undirected wheel, star and a single edge
 Finished search, found 1 cycles, expected 1 cycles. Max cycle length was -1 vertices.
@@ -201,8 +335,26 @@ Edge IDs in cycles:
 {
   0: ( 0 1 2 3 4 5 6 7 8 9 )
 }
+Finished search, found 1 cycles, expected 1 cycles. Max cycle length was -1 vertices.
+
+Vertex IDs in cycles:
+{
+  0: ( 0 14 9 6 3 5 7 1 15 2 )
+}
+Edge IDs in cycles:
+{
+  0: ( 6 5 4 3 2 1 0 9 8 7 )
+}
 
 Testing a tree
+Finished search, found 0 cycles, expected 0 cycles. Max cycle length was -1 vertices.
+
+Vertex IDs in cycles:
+{
+}
+Edge IDs in cycles:
+{
+}
 Finished search, found 0 cycles, expected 0 cycles. Max cycle length was -1 vertices.
 
 Vertex IDs in cycles:
@@ -310,6 +462,88 @@ Edge IDs in cycles:
   34: ( 4 5 8 7 )
   35: ( 4 9 7 )
   36: ( 5 9 8 )
+}
+Finished search, found 37 cycles, expected 37 cycles. Max cycle length was -1 vertices.
+
+Vertex IDs in cycles:
+{
+  0: ( 0 1 2 3 )
+  1: ( 0 1 2 3 4 )
+  2: ( 0 1 2 4 )
+  3: ( 0 1 2 4 3 )
+  4: ( 0 1 3 )
+  5: ( 0 1 3 2 4 )
+  6: ( 0 1 3 4 )
+  7: ( 0 1 4 )
+  8: ( 0 1 4 2 3 )
+  9: ( 0 1 4 3 )
+  10: ( 0 2 1 )
+  11: ( 0 2 1 3 )
+  12: ( 0 2 1 3 4 )
+  13: ( 0 2 1 4 )
+  14: ( 0 2 1 4 3 )
+  15: ( 0 2 3 )
+  16: ( 0 2 3 1 )
+  17: ( 0 2 3 1 4 )
+  18: ( 0 2 3 4 )
+  19: ( 0 2 3 4 1 )
+  20: ( 0 2 4 )
+  21: ( 0 2 4 1 )
+  22: ( 0 2 4 1 3 )
+  23: ( 0 2 4 3 )
+  24: ( 0 2 4 3 1 )
+  25: ( 0 3 1 2 4 )
+  26: ( 0 3 1 4 )
+  27: ( 0 3 2 1 4 )
+  28: ( 0 3 2 4 )
+  29: ( 0 3 4 )
+  30: ( 1 2 3 )
+  31: ( 1 2 3 4 )
+  32: ( 1 2 4 )
+  33: ( 1 2 4 3 )
+  34: ( 1 3 2 4 )
+  35: ( 1 3 4 )
+  36: ( 2 3 4 )
+}
+Edge IDs in cycles:
+{
+  0: ( 4 0 1 5 )
+  1: ( 4 0 1 8 9 )
+  2: ( 4 0 6 9 )
+  3: ( 4 0 6 8 5 )
+  4: ( 4 2 5 )
+  5: ( 4 2 1 6 9 )
+  6: ( 4 2 8 9 )
+  7: ( 4 7 9 )
+  8: ( 4 7 6 1 5 )
+  9: ( 4 7 8 5 )
+  10: ( 3 0 4 )
+  11: ( 3 0 2 5 )
+  12: ( 3 0 2 8 9 )
+  13: ( 3 0 7 9 )
+  14: ( 3 0 7 8 5 )
+  15: ( 3 1 5 )
+  16: ( 3 1 2 4 )
+  17: ( 3 1 2 7 9 )
+  18: ( 3 1 8 9 )
+  19: ( 3 1 8 7 4 )
+  20: ( 3 6 9 )
+  21: ( 3 6 7 4 )
+  22: ( 3 6 7 2 5 )
+  23: ( 3 6 8 5 )
+  24: ( 3 6 8 2 4 )
+  25: ( 5 2 0 6 9 )
+  26: ( 5 2 7 9 )
+  27: ( 5 1 0 7 9 )
+  28: ( 5 1 6 9 )
+  29: ( 5 8 9 )
+  30: ( 0 1 2 )
+  31: ( 0 1 8 7 )
+  32: ( 0 6 7 )
+  33: ( 0 6 8 2 )
+  34: ( 2 1 6 7 )
+  35: ( 2 8 7 )
+  36: ( 1 8 6 )
 }
 
 Created undirected wheel
@@ -466,6 +700,160 @@ Edge IDs in cycles:
   70: ( 7 15 14 13 12 11 10 9 17 8 )
   71: ( 7 16 8 )
   72: ( 9 10 11 12 13 14 15 16 17 )
+}
+Finished search, found 73 cycles, expected 73 cycles. Max cycle length was -1 vertices.
+
+Vertex IDs in cycles:
+{
+  0: ( 0 3 5 6 4 7 8 1 2 )
+  1: ( 0 3 5 6 4 7 8 2 )
+  2: ( 0 3 5 6 4 7 8 9 1 2 )
+  3: ( 0 3 5 6 4 7 9 1 2 )
+  4: ( 0 3 5 6 4 7 9 1 8 2 )
+  5: ( 0 3 5 6 4 7 9 8 1 2 )
+  6: ( 0 3 5 6 4 7 9 8 2 )
+  7: ( 0 3 5 6 4 8 1 2 )
+  8: ( 0 3 5 6 4 8 2 )
+  9: ( 0 3 5 6 4 8 7 9 1 2 )
+  10: ( 0 3 5 6 4 8 9 1 2 )
+  11: ( 0 3 5 6 8 1 2 )
+  12: ( 0 3 5 6 8 2 )
+  13: ( 0 3 5 6 8 4 7 9 1 2 )
+  14: ( 0 3 5 6 8 7 9 1 2 )
+  15: ( 0 3 5 6 8 9 1 2 )
+  16: ( 0 3 5 8 1 2 )
+  17: ( 0 3 5 8 2 )
+  18: ( 0 3 5 8 4 7 9 1 2 )
+  19: ( 0 3 5 8 6 4 7 9 1 2 )
+  20: ( 0 3 5 8 7 9 1 2 )
+  21: ( 0 3 5 8 9 1 2 )
+  22: ( 0 3 8 1 2 )
+  23: ( 0 3 8 2 )
+  24: ( 0 3 8 4 7 9 1 2 )
+  25: ( 0 3 8 5 6 4 7 9 1 2 )
+  26: ( 0 3 8 6 4 7 9 1 2 )
+  27: ( 0 3 8 7 9 1 2 )
+  28: ( 0 3 8 9 1 2 )
+  29: ( 0 8 1 2 )
+  30: ( 0 8 1 9 7 4 6 5 3 )
+  31: ( 0 8 2 )
+  32: ( 0 8 2 1 9 7 4 6 5 3 )
+  33: ( 0 8 3 )
+  34: ( 0 8 3 5 6 4 7 9 1 2 )
+  35: ( 0 8 4 6 5 3 )
+  36: ( 0 8 4 7 9 1 2 )
+  37: ( 0 8 5 3 )
+  38: ( 0 8 5 6 4 7 9 1 2 )
+  39: ( 0 8 6 4 7 9 1 2 )
+  40: ( 0 8 6 5 3 )
+  41: ( 0 8 7 4 6 5 3 )
+  42: ( 0 8 7 9 1 2 )
+  43: ( 0 8 9 1 2 )
+  44: ( 0 8 9 7 4 6 5 3 )
+  45: ( 1 2 8 3 5 6 4 7 9 )
+  46: ( 1 2 8 4 7 9 )
+  47: ( 1 2 8 5 6 4 7 9 )
+  48: ( 1 2 8 6 4 7 9 )
+  49: ( 1 2 8 7 9 )
+  50: ( 1 2 8 9 )
+  51: ( 1 8 2 )
+  52: ( 1 8 3 5 6 4 7 9 )
+  53: ( 1 8 4 7 9 )
+  54: ( 1 8 5 6 4 7 9 )
+  55: ( 1 8 6 4 7 9 )
+  56: ( 1 8 7 9 )
+  57: ( 1 8 9 )
+  58: ( 3 8 4 6 5 )
+  59: ( 3 8 5 )
+  60: ( 3 8 6 5 )
+  61: ( 3 8 7 4 6 5 )
+  62: ( 3 8 9 7 4 6 5 )
+  63: ( 4 7 8 5 6 )
+  64: ( 4 7 8 6 )
+  65: ( 4 7 9 8 5 6 )
+  66: ( 4 7 9 8 6 )
+  67: ( 4 8 5 6 )
+  68: ( 4 8 6 )
+  69: ( 4 8 7 )
+  70: ( 4 8 9 7 )
+  71: ( 5 8 6 )
+  72: ( 7 8 9 )
+}
+Edge IDs in cycles:
+{
+  0: ( 13 12 11 10 9 0 7 15 14 )
+  1: ( 13 12 11 10 9 0 6 14 )
+  2: ( 13 12 11 10 9 0 8 16 15 14 )
+  3: ( 13 12 11 10 9 17 16 15 14 )
+  4: ( 13 12 11 10 9 17 16 7 6 14 )
+  5: ( 13 12 11 10 9 17 8 7 15 14 )
+  6: ( 13 12 11 10 9 17 8 6 14 )
+  7: ( 13 12 11 10 1 7 15 14 )
+  8: ( 13 12 11 10 1 6 14 )
+  9: ( 13 12 11 10 1 0 17 16 15 14 )
+  10: ( 13 12 11 10 1 8 16 15 14 )
+  11: ( 13 12 11 2 7 15 14 )
+  12: ( 13 12 11 2 6 14 )
+  13: ( 13 12 11 2 1 9 17 16 15 14 )
+  14: ( 13 12 11 2 0 17 16 15 14 )
+  15: ( 13 12 11 2 8 16 15 14 )
+  16: ( 13 12 3 7 15 14 )
+  17: ( 13 12 3 6 14 )
+  18: ( 13 12 3 1 9 17 16 15 14 )
+  19: ( 13 12 3 2 10 9 17 16 15 14 )
+  20: ( 13 12 3 0 17 16 15 14 )
+  21: ( 13 12 3 8 16 15 14 )
+  22: ( 13 4 7 15 14 )
+  23: ( 13 4 6 14 )
+  24: ( 13 4 1 9 17 16 15 14 )
+  25: ( 13 4 3 11 10 9 17 16 15 14 )
+  26: ( 13 4 2 10 9 17 16 15 14 )
+  27: ( 13 4 0 17 16 15 14 )
+  28: ( 13 4 8 16 15 14 )
+  29: ( 5 7 15 14 )
+  30: ( 5 7 16 17 9 10 11 12 13 )
+  31: ( 5 6 14 )
+  32: ( 5 6 15 16 17 9 10 11 12 13 )
+  33: ( 5 4 13 )
+  34: ( 5 4 12 11 10 9 17 16 15 14 )
+  35: ( 5 1 10 11 12 13 )
+  36: ( 5 1 9 17 16 15 14 )
+  37: ( 5 3 12 13 )
+  38: ( 5 3 11 10 9 17 16 15 14 )
+  39: ( 5 2 10 9 17 16 15 14 )
+  40: ( 5 2 11 12 13 )
+  41: ( 5 0 9 10 11 12 13 )
+  42: ( 5 0 17 16 15 14 )
+  43: ( 5 8 16 15 14 )
+  44: ( 5 8 17 9 10 11 12 13 )
+  45: ( 15 6 4 12 11 10 9 17 16 )
+  46: ( 15 6 1 9 17 16 )
+  47: ( 15 6 3 11 10 9 17 16 )
+  48: ( 15 6 2 10 9 17 16 )
+  49: ( 15 6 0 17 16 )
+  50: ( 15 6 8 16 )
+  51: ( 7 6 15 )
+  52: ( 7 4 12 11 10 9 17 16 )
+  53: ( 7 1 9 17 16 )
+  54: ( 7 3 11 10 9 17 16 )
+  55: ( 7 2 10 9 17 16 )
+  56: ( 7 0 17 16 )
+  57: ( 7 8 16 )
+  58: ( 4 1 10 11 12 )
+  59: ( 4 3 12 )
+  60: ( 4 2 11 12 )
+  61: ( 4 0 9 10 11 12 )
+  62: ( 4 8 17 9 10 11 12 )
+  63: ( 9 0 3 11 10 )
+  64: ( 9 0 2 10 )
+  65: ( 9 17 8 3 11 10 )
+  66: ( 9 17 8 2 10 )
+  67: ( 1 3 11 10 )
+  68: ( 1 2 10 )
+  69: ( 1 0 9 )
+  70: ( 1 8 17 9 )
+  71: ( 3 2 11 )
+  72: ( 0 8 17 )
 }
 Finished search, found 9 cycles, expected 9 cycles. Max cycle length was 3 vertices.
 
@@ -1569,6 +1957,18 @@ Edge IDs in cycles:
   0: ( 0 1 2 3 )
   1: ( 0 4 5 2 3 )
 }
+Finished search, found 2 cycles, expected 2 cycles. Max cycle length was -1 vertices.
+
+Vertex IDs in cycles:
+{
+  0: ( 0 1 3 2 4 )
+  1: ( 0 1 3 4 )
+}
+Edge IDs in cycles:
+{
+  0: ( 3 0 4 5 2 )
+  1: ( 3 0 1 2 )
+}
 Finished search, found 0 cycles, expected 0 cycles. Max cycle length was 3 vertices.
 
 Vertex IDs in cycles:
@@ -1615,6 +2015,22 @@ Edge IDs in cycles:
   0: ( 0 4 5 6 3 )
   1: ( 1 5 6 3 )
   2: ( 2 6 3 )
+  3: ( 5 7 )
+}
+Finished search, found 4 cycles, expected 4 cycles. Max cycle length was -1 vertices.
+
+Vertex IDs in cycles:
+{
+  0: ( 0 4 1 2 )
+  1: ( 0 4 2 )
+  2: ( 0 4 3 1 2 )
+  3: ( 1 2 )
+}
+Edge IDs in cycles:
+{
+  0: ( 3 1 5 6 )
+  1: ( 3 2 6 )
+  2: ( 3 0 4 5 6 )
   3: ( 5 7 )
 }
 Finished search, found 1 cycles, expected 1 cycles. Max cycle length was 2 vertices.
@@ -1676,6 +2092,28 @@ Edge IDs in cycles:
   4: ( 2 4 6 )
   5: ( 3 8 4 6 )
   6: ( 5 8 )
+}
+Finished search, found 7 cycles, expected 7 cycles. Max cycle length was -1 vertices.
+
+Vertex IDs in cycles:
+{
+  0: ( 0 3 1 )
+  1: ( 0 3 1 2 4 )
+  2: ( 0 3 2 1 )
+  3: ( 0 3 2 4 )
+  4: ( 0 3 2 4 1 )
+  5: ( 1 2 )
+  6: ( 1 2 4 )
+}
+Edge IDs in cycles:
+{
+  0: ( 6 2 4 )
+  1: ( 6 2 5 7 1 )
+  2: ( 6 3 8 4 )
+  3: ( 6 3 7 1 )
+  4: ( 6 3 7 0 4 )
+  5: ( 5 8 )
+  6: ( 5 7 0 )
 }
 Finished search, found 0 cycles, expected 0 cycles. Max cycle length was 1 vertices.
 
@@ -1763,6 +2201,18 @@ Edge IDs in cycles:
   0: ( 0 3 6 5 2 4 )
   1: ( 1 5 2 4 )
 }
+Finished search, found 2 cycles, expected 2 cycles. Max cycle length was -1 vertices.
+
+Vertex IDs in cycles:
+{
+  0: ( 0 5 2 4 1 3 )
+  1: ( 1 3 2 4 )
+}
+Edge IDs in cycles:
+{
+  0: ( 3 6 5 2 4 0 )
+  1: ( 4 1 5 2 )
+}
 Finished search, found 0 cycles, expected 0 cycles. Max cycle length was 1 vertices.
 
 Vertex IDs in cycles:
@@ -1819,6 +2269,54 @@ Edge IDs in cycles:
   0: ( 0 3 6 5 2 4 )
   1: ( 1 5 2 4 )
 }
+Finished search, found 1 cycles, expected 1 cycles. Max cycle length was -1 vertices.
+
+Vertex IDs in cycles:
+{
+  0: ( 2 5 )
+}
+Edge IDs in cycles:
+{
+  0: ( 3 6 )
+}
+Finished search, found 1 cycles, expected 1 cycles. Max cycle length was -1 vertices.
+
+Vertex IDs in cycles:
+{
+  0: ( 3 4 )
+}
+Edge IDs in cycles:
+{
+  0: ( 3 6 )
+}
+Finished search, found 3 cycles, expected 3 cycles. Max cycle length was -1 vertices.
+
+Vertex IDs in cycles:
+{
+  0: ( 0 1 5 )
+  1: ( 2 5 )
+  2: ( 3 4 5 )
+}
+Edge IDs in cycles:
+{
+  0: ( 0 2 1 )
+  1: ( 3 6 )
+  2: ( 4 5 7 )
+}
+Finished search, found 3 cycles, expected 3 cycles. Max cycle length was -1 vertices.
+
+Vertex IDs in cycles:
+{
+  0: ( 0 2 1 )
+  1: ( 0 3 )
+  2: ( 0 5 4 )
+}
+Edge IDs in cycles:
+{
+  0: ( 1 0 2 )
+  1: ( 3 6 )
+  2: ( 5 4 7 )
+}
 
 Testing undirected graph of type 'Mickey'
 Finished search, found 3 cycles, expected 3 cycles. Max cycle length was -1 vertices.
@@ -1835,6 +2333,20 @@ Edge IDs in cycles:
   1: ( 0 1 2 )
   2: ( 4 5 6 7 )
 }
+Finished search, found 3 cycles, expected 3 cycles. Max cycle length was -1 vertices.
+
+Vertex IDs in cycles:
+{
+  0: ( 0 5 3 4 )
+  1: ( 1 6 5 )
+  2: ( 5 )
+}
+Edge IDs in cycles:
+{
+  0: ( 4 7 6 5 )
+  1: ( 1 0 2 )
+  2: ( 3 )
+}
 
 Testing undirected graph of type 'Mickey2'
 Finished search, found 3 cycles, expected 3 cycles. Max cycle length was -1 vertices.
@@ -1849,6 +2361,20 @@ Edge IDs in cycles:
 {
   0: ( 0 1 2 )
   1: ( 4 5 6 7 )
+  2: ( 3 )
+}
+Finished search, found 3 cycles, expected 3 cycles. Max cycle length was -1 vertices.
+
+Vertex IDs in cycles:
+{
+  0: ( 0 1 6 5 )
+  1: ( 0 2 3 )
+  2: ( 2 )
+}
+Edge IDs in cycles:
+{
+  0: ( 4 5 6 7 )
+  1: ( 0 1 2 )
   2: ( 3 )
 }
 Finished search, found 3 cycles, expected 3 cycles. Max cycle length was -1 vertices.
@@ -1886,4 +2412,24 @@ Edge IDs in cycles:
   3: ( 11 )
   4: ( 10 )
   5: ( 8 9 )
+}
+Finished search, found 6 cycles, expected 6 cycles. Max cycle length was -1 vertices.
+
+Vertex IDs in cycles:
+{
+  0: ( 0 1 6 )
+  1: ( 1 )
+  2: ( 2 )
+  3: ( 2 )
+  4: ( 2 3 )
+  5: ( 2 4 5 6 )
+}
+Edge IDs in cycles:
+{
+  0: ( 1 0 2 )
+  1: ( 7 )
+  2: ( 11 )
+  3: ( 10 )
+  4: ( 8 9 )
+  5: ( 5 4 3 6 )
 }


### PR DESCRIPTION
Fixes issue #2911.

I am not yet happy with the implementation, but it would be ok I guess; I submit here and now to show that I am working on it.

What I do currently is to replace the apparently too simplified way I used previously to detect components with a more real component detection. The alternative, using `igraph_subcomponent`, was decided against since it would require an additional pointer to the graph on the current search state; I don't remember why we don't have one, but tried to keep at it.

<!-- Please disclose any use of LLMs (ChatGPT, Copilot, Gemini, etc.) during the preparation of this PR. -->
GitHub Copilot was used during the preparation of this PR.

<!-- The following text must be left intact and the box checked before the PR can be merged. -->

- [X] By submitting this pull request, I assign the copyright of my contribution to _The igraph development team_.
