### PR TITLE
Feat/induced vf2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 - `igraph_hamming()` creates a Hamming graph (experimental function). Thanks to @zxawry for contributing this functionality in #2890!
 - `igraph_is_triangle_free()` determines whether a graph contains no triangles (experimental function).
+- The VF2 subgraph-isomorphism functions can now restrict matches to induced
+  subgraphs using the new `induced` argument. Non-induced matching remains
+  available by passing `false`.
 
 ### Fixed
 

--- a/examples/simple/igraph_isomorphic_vf2.c
+++ b/examples/simple/igraph_isomorphic_vf2.c
@@ -82,7 +82,7 @@ int main(void) {
         VECTOR(color2)[i + 1] = 1;
     }
     igraph_count_subisomorphisms_vf2(&ring1, &ring2, &color1, &color2, 0, 0,
-                                     &count, 0, 0, 0);
+                                     &count, 0, 0, 0, false);
     if (count != 21) {
         fprintf(stderr, "Count with two colors failed, expected 21, got %" IGRAPH_PRId ".\n", count);
         return 3;

--- a/include/igraph_isomorphism.h
+++ b/include/igraph_isomorphism.h
@@ -164,7 +164,8 @@ IGRAPH_EXPORT igraph_error_t igraph_subisomorphic_vf2(const igraph_t *graph1, co
                                            igraph_vector_int_t *map21,
                                            igraph_isocompat_t *node_compat_fn,
                                            igraph_isocompat_t *edge_compat_fn,
-                                           void *arg);
+                                           void *arg,
+                                           igraph_bool_t induced);
 IGRAPH_EXPORT igraph_error_t igraph_count_subisomorphisms_vf2(const igraph_t *graph1, const igraph_t *graph2,
                                                    const igraph_vector_int_t *vertex_color1,
                                                    const igraph_vector_int_t *vertex_color2,
@@ -173,7 +174,8 @@ IGRAPH_EXPORT igraph_error_t igraph_count_subisomorphisms_vf2(const igraph_t *gr
                                                    igraph_int_t *count,
                                                    igraph_isocompat_t *node_compat_fn,
                                                    igraph_isocompat_t *edge_compat_fn,
-                                                   void *arg);
+                                                   void *arg,
+                                                   igraph_bool_t induced);
 IGRAPH_EXPORT igraph_error_t igraph_get_subisomorphisms_vf2(const igraph_t *graph1,
                                                  const igraph_t *graph2,
                                                  const igraph_vector_int_t *vertex_color1,
@@ -183,14 +185,15 @@ IGRAPH_EXPORT igraph_error_t igraph_get_subisomorphisms_vf2(const igraph_t *grap
                                                  igraph_vector_int_list_t *maps,
                                                  igraph_isocompat_t *node_compat_fn,
                                                  igraph_isocompat_t *edge_compat_fn,
-                                                 void *arg);
+                                                 void *arg,
+                                                 igraph_bool_t induced);
 IGRAPH_EXPORT igraph_error_t igraph_get_subisomorphisms_vf2_callback(
     const igraph_t *graph1, const igraph_t *graph2,
     const igraph_vector_int_t *vertex_color1, const igraph_vector_int_t *vertex_color2,
     const igraph_vector_int_t *edge_color1, const igraph_vector_int_t *edge_color2,
     igraph_vector_int_t *map12, igraph_vector_int_t *map21,
     igraph_isohandler_t *isohandler_fn, igraph_isocompat_t *node_compat_fn,
-    igraph_isocompat_t *edge_compat_fn, void *arg
+    igraph_isocompat_t *edge_compat_fn, void *arg, igraph_bool_t induced
 );
 
 /* BLISS family */

--- a/interfaces/functions.yaml
+++ b/interfaces/functions.yaml
@@ -2416,7 +2416,8 @@ igraph_subisomorphic_vf2:
         OPTIONAL OUT INDEX_VECTOR map12, OPTIONAL OUT INDEX_VECTOR map21,
         OPTIONAL ISOCOMPAT_FUNC node_compat_fn,
         OPTIONAL ISOCOMPAT_FUNC edge_compat_fn,
-        OPTIONAL EXTRA extra
+        OPTIONAL EXTRA extra,
+        BOOLEAN induced=False
     DEPS: |-
         vertex_color1 ON graph1, vertex_color2 ON graph2,
         edge_color1 ON graph1, edge_color2 ON graph2
@@ -2430,7 +2431,8 @@ igraph_get_subisomorphisms_vf2_callback:
         ISOMORPHISM_FUNC ishohandler_fn,
         OPTIONAL ISOCOMPAT_FUNC node_compat_fn,
         OPTIONAL ISOCOMPAT_FUNC edge_compat_fn,
-        OPTIONAL EXTRA arg
+        OPTIONAL EXTRA arg,
+        BOOLEAN induced=False
     DEPS: |-
         vertex_color1 ON graph1, vertex_color2 ON graph2,
         edge_color1 ON graph1, edge_color2 ON graph2
@@ -2443,7 +2445,8 @@ igraph_count_subisomorphisms_vf2:
         OUT INTEGER count,
         OPTIONAL ISOCOMPAT_FUNC node_compat_fn,
         OPTIONAL ISOCOMPAT_FUNC edge_compat_fn,
-        OPTIONAL EXTRA extra
+        OPTIONAL EXTRA extra,
+        BOOLEAN induced=False
     DEPS: |-
         vertex_color1 ON graph1, vertex_color2 ON graph2,
         edge_color1 ON graph1, edge_color2 ON graph2
@@ -2456,7 +2459,8 @@ igraph_get_subisomorphisms_vf2:
         OUT VECTOR_INT_LIST maps,
         OPTIONAL ISOCOMPAT_FUNC node_compat_fn,
         OPTIONAL ISOCOMPAT_FUNC edge_compat_fn,
-        OPTIONAL EXTRA extra
+        OPTIONAL EXTRA extra,
+        BOOLEAN induced=False
     DEPS: |-
         vertex_color1 ON graph1, vertex_color2 ON graph2,
         edge_color1 ON graph1, edge_color2 ON graph2

--- a/src/isomorphism/queries.c
+++ b/src/isomorphism/queries.c
@@ -211,5 +211,5 @@ igraph_error_t igraph_i_isomorphic_small(
 igraph_error_t igraph_subisomorphic(const igraph_t *graph1, const igraph_t *graph2,
                          igraph_bool_t *iso) {
 
-    return igraph_subisomorphic_vf2(graph1, graph2, NULL, NULL, NULL, NULL, iso, NULL, NULL, NULL, NULL, NULL);
+    return igraph_subisomorphic_vf2(graph1, graph2, NULL, NULL, NULL, NULL, iso, NULL, NULL, NULL, NULL, NULL, false);
 }

--- a/src/isomorphism/vf2.c
+++ b/src/isomorphism/vf2.c
@@ -45,6 +45,15 @@
  * </para>
  *
  * <para>
+ * VF2 subgraph searches support both induced and non-induced matching.
+ * Non-induced matching permits additional edges between the matched vertices
+ * of the larger graph. Induced matching requires the matched vertices to have
+ * exactly the same adjacency relationships as the smaller graph. Use the
+ * <code>induced</code> argument of the subgraph-isomorphism functions to select
+ * the desired behavior.
+ * </para>
+ *
+ * <para>
  * VF2 works with both directed and undirected graphs. Only simple graphs are supported.
  * Self-loops or multi-edges must not be present in the graphs. Currently, the VF2
  * functions do not check that the input graph is simple: it is the responsibility
@@ -1015,7 +1024,11 @@ igraph_error_t igraph_get_isomorphisms_vf2(const igraph_t *graph1,
  *   determine whether two edges are compatible.
  * \param arg Extra argument to supply to functions \p isohandler_fn, \p
  *   node_compat_fn and \p edge_compat_fn.
- * \param induced Whether to require the matched subgraph to be induced.
+ * \param induced Whether to require induced subgraph isomorphisms. If false,
+ *   additional edges between matched vertices of \p graph1 are allowed. If
+ *   true, two matched vertices are adjacent in \p graph1 if and only if their
+ *   corresponding vertices are adjacent in \p graph2. For directed graphs,
+ *   edge direction is taken into account.
  * \return Error code.
  *
  * Time complexity: exponential.

--- a/src/isomorphism/vf2.c
+++ b/src/isomorphism/vf2.c
@@ -1015,6 +1015,7 @@ igraph_error_t igraph_get_isomorphisms_vf2(const igraph_t *graph1,
  *   determine whether two edges are compatible.
  * \param arg Extra argument to supply to functions \p isohandler_fn, \p
  *   node_compat_fn and \p edge_compat_fn.
+ * \param induced Whether to require the matched subgraph to be induced.
  * \return Error code.
  *
  * Time complexity: exponential.
@@ -1026,7 +1027,7 @@ igraph_error_t igraph_get_subisomorphisms_vf2_callback(
     const igraph_vector_int_t *edge_color1, const igraph_vector_int_t *edge_color2,
     igraph_vector_int_t *map12, igraph_vector_int_t *map21,
     igraph_isohandler_t *isohandler_fn, igraph_isocompat_t *node_compat_fn,
-    igraph_isocompat_t *edge_compat_fn, void *arg
+    igraph_isocompat_t *edge_compat_fn, void *arg, igraph_bool_t induced
 ) {
 
     igraph_int_t no_of_nodes1 = igraph_vcount(graph1),
@@ -1313,7 +1314,13 @@ igraph_error_t igraph_get_subisomorphisms_vf2_callback(
             vsize = igraph_vector_int_size(inneis_1);
             for (i = 0; !end && i < vsize; i++) {
                 igraph_int_t node = VECTOR(*inneis_1)[i];
-                if (VECTOR(*core_1)[node] < 0) {
+                if (induced && VECTOR(*core_1)[node] >= 0) {
+                    igraph_int_t node2 = VECTOR(*core_1)[node];
+                    /* Reject target edges absent from the pattern. */
+                    if (!igraph_vector_int_contains_sorted(inneis_2, node2)) {
+                        end = true;
+                    }
+                } else if (VECTOR(*core_1)[node] < 0) {
                     if (VECTOR(in_1)[node] != 0) {
                         xin1++;
                     }
@@ -1325,7 +1332,13 @@ igraph_error_t igraph_get_subisomorphisms_vf2_callback(
             vsize = igraph_vector_int_size(outneis_1);
             for (i = 0; !end && i < vsize; i++) {
                 igraph_int_t node = VECTOR(*outneis_1)[i];
-                if (VECTOR(*core_1)[node] < 0) {
+                if (induced && VECTOR(*core_1)[node] >= 0) {
+                    igraph_int_t node2 = VECTOR(*core_1)[node];
+                    /* Reject target edges absent from the pattern. */
+                    if (!igraph_vector_int_contains_sorted(outneis_2, node2)) {
+                        end = true;
+                    }
+                } else if (VECTOR(*core_1)[node] < 0) {
                     if (VECTOR(in_1)[node] != 0) {
                         xin1++;
                     }
@@ -1562,6 +1575,7 @@ static igraph_error_t igraph_i_subisomorphic_vf2_cb(
  *   determine whether two edges are compatible.
  * \param arg Extra argument to supply to functions \p node_compat_fn
  *   and \p edge_compat_fn.
+ * \param induced Whether to require the matched subgraph to be induced.
  * \return Error code.
  *
  * Time complexity: exponential.
@@ -1576,7 +1590,8 @@ igraph_error_t igraph_subisomorphic_vf2(const igraph_t *graph1, const igraph_t *
                              igraph_vector_int_t *map21,
                              igraph_isocompat_t *node_compat_fn,
                              igraph_isocompat_t *edge_compat_fn,
-                             void *arg) {
+                             void *arg,
+                             igraph_bool_t induced) {
 
     igraph_i_iso_cb_data_t data = { node_compat_fn, edge_compat_fn, iso, arg };
     igraph_isocompat_t *ncb = node_compat_fn ? igraph_i_isocompat_node_cb : 0;
@@ -1588,7 +1603,7 @@ igraph_error_t igraph_subisomorphic_vf2(const igraph_t *graph1, const igraph_t *
                  edge_color1, edge_color2,
                  map12, map21,
                  (igraph_isohandler_t *) igraph_i_subisomorphic_vf2_cb,
-                 ncb, ecb, &data));
+                 ncb, ecb, &data, induced));
     if (! *iso) {
         if (map12) {
             igraph_vector_int_clear(map12);
@@ -1644,6 +1659,7 @@ static igraph_error_t igraph_i_count_subisomorphisms_vf2_cb(
  *   determine whether two edges are compatible.
  * \param arg Extra argument to supply to functions \p node_compat_fn and
  *   \p edge_compat_fn.
+ * \param induced Whether to count only induced subgraph isomorphisms.
  * \return Error code.
  *
  * Time complexity: exponential.
@@ -1657,7 +1673,8 @@ igraph_error_t igraph_count_subisomorphisms_vf2(const igraph_t *graph1, const ig
                                      igraph_int_t *count,
                                      igraph_isocompat_t *node_compat_fn,
                                      igraph_isocompat_t *edge_compat_fn,
-                                     void *arg) {
+                                     void *arg,
+                                     igraph_bool_t induced) {
 
     igraph_i_iso_cb_data_t data = { node_compat_fn, edge_compat_fn,
                                     count, arg
@@ -1670,7 +1687,7 @@ igraph_error_t igraph_count_subisomorphisms_vf2(const igraph_t *graph1, const ig
                  edge_color1, edge_color2,
                  0, 0,
                  (igraph_isohandler_t*) igraph_i_count_subisomorphisms_vf2_cb,
-                 ncb, ecb, &data));
+                 ncb, ecb, &data, induced));
     return IGRAPH_SUCCESS;
 }
 
@@ -1709,6 +1726,7 @@ igraph_error_t igraph_count_subisomorphisms_vf2(const igraph_t *graph1, const ig
  *   determine whether two edges are compatible.
  * \param arg Extra argument to supply to functions \p node_compat_fn
  *   and \p edge_compat_fn.
+ * \param induced Whether to return only induced subgraph isomorphisms.
  * \return Error code.
  *
  * Time complexity: exponential.
@@ -1723,7 +1741,8 @@ igraph_error_t igraph_get_subisomorphisms_vf2(const igraph_t *graph1,
                                    igraph_vector_int_list_t *maps,
                                    igraph_isocompat_t *node_compat_fn,
                                    igraph_isocompat_t *edge_compat_fn,
-                                   void *arg) {
+                                   void *arg,
+                                   igraph_bool_t induced) {
 
     igraph_i_iso_cb_data_t data = { node_compat_fn, edge_compat_fn, maps, arg };
     igraph_isocompat_t *ncb = node_compat_fn ? igraph_i_isocompat_node_cb : NULL;
@@ -1735,7 +1754,7 @@ igraph_error_t igraph_get_subisomorphisms_vf2(const igraph_t *graph1,
                  edge_color1, edge_color2,
                  NULL, NULL,
                  (igraph_isohandler_t*) igraph_i_store_mapping_vf2_cb,
-                 ncb, ecb, &data));
+                 ncb, ecb, &data, induced));
 
     return IGRAPH_SUCCESS;
 }

--- a/tests/unit/VF2-compat.c
+++ b/tests/unit/VF2-compat.c
@@ -157,7 +157,7 @@ int match_rings_open_closed(void) {
     igraph_subisomorphic_vf2(&rc, &ro, /*colors(4x)*/ 0, 0, 0, 0,
                              &iso, /*map12=*/ 0, /*map21=*/ 0,
                              /*node_compat_fn=*/ 0, /*edge_compat_fn=*/ 0,
-                             /*arg=*/ 0);
+                             /*arg=*/ 0, /*induced=*/ false);
     if (!iso) {
         exit(31);
     }
@@ -165,7 +165,7 @@ int match_rings_open_closed(void) {
     igraph_subisomorphic_vf2(&rc, &ro, /*colors(4x)*/ 0, 0, 0, 0,
                              &iso, /*map12=*/ 0, /*map21=*/ 0,
                              compat_parity, /*edge_compat_fn=*/ 0,
-                             /*arg=*/ 0);
+                             /*arg=*/ 0, /*induced=*/ false);
     if (!iso) {
         exit(32);
     }
@@ -173,7 +173,7 @@ int match_rings_open_closed(void) {
     igraph_subisomorphic_vf2(&rc, &ro, /*colors(4x)*/ 0, 0, 0, 0,
                              &iso, /*map12=*/ 0, /*map21=*/ 0,
                              compat_not0, /*edge_compat_fn=*/ 0,
-                             /*arg=*/ 0);
+                             /*arg=*/ 0, /*induced=*/ false);
     if (iso) {
         exit(33);
     }
@@ -183,7 +183,7 @@ int match_rings_open_closed(void) {
     igraph_subisomorphic_vf2(&rc, &ro, /*colors(4x)*/ 0, 0, 0, 0,
                              &iso, /*map12=*/ 0, /*map21=*/ 0,
                              /*node_compat_fn=*/ 0, compat_parity,
-                             /*arg=*/ 0);
+                             /*arg=*/ 0, /*induced=*/ false);
     if (!iso) {
         exit(34);
     }
@@ -191,7 +191,7 @@ int match_rings_open_closed(void) {
     igraph_subisomorphic_vf2(&rc, &ro, /*colors(4x)*/ 0, 0, 0, 0,
                              &iso, /*map12=*/ 0, /*map21=*/ 0,
                              /*node_compat_fn=*/ 0, compat_not0,
-                             /*arg=*/ 0);
+                             /*arg=*/ 0, /*induced=*/ false);
     if (!iso) {
         exit(35);
     }
@@ -200,7 +200,8 @@ int match_rings_open_closed(void) {
 
     igraph_count_subisomorphisms_vf2(&rc, &ro, /*colors(4x)*/ 0, 0, 0, 0,
                                      &count, /*node_compat_fn=*/ 0,
-                                     /*edge_compat_fn=*/ 0, /*arg=*/ 0);
+                                     /*edge_compat_fn=*/ 0, /*arg=*/ 0,
+                                     /*induced=*/ false);
 
     if (count != 20) {
         exit(36);
@@ -208,7 +209,8 @@ int match_rings_open_closed(void) {
 
     igraph_count_subisomorphisms_vf2(&rc, &ro, /*colors(4x)*/ 0, 0, 0, 0,
                                      &count, compat_parity,
-                                     /*edge_compat_fn=*/ 0, /*arg=*/ 0);
+                                     /*edge_compat_fn=*/ 0, /*arg=*/ 0,
+                                     /*induced=*/ false);
 
     if (count != 10) {
         exit(37);
@@ -216,7 +218,7 @@ int match_rings_open_closed(void) {
 
     igraph_count_subisomorphisms_vf2(&rc, &ro, /*colors(4x)*/ 0, 0, 0, 0,
                                      &count, compat_not0, /*edge_compat_fn=*/ 0,
-                                     /*arg=*/ 0);
+                                     /*arg=*/ 0, /*induced=*/ false);
 
     if (count != 0) {
         exit(38);
@@ -226,7 +228,8 @@ int match_rings_open_closed(void) {
 
     igraph_count_subisomorphisms_vf2(&rc, &ro, /*colors(4x)*/ 0, 0, 0, 0,
                                      &count, /*node_compat_fn=*/ 0,
-                                     compat_parity, /*arg=*/ 0);
+                                     compat_parity, /*arg=*/ 0,
+                                     /*induced=*/ false);
 
     if (count != 10) {
         exit(39);
@@ -234,7 +237,7 @@ int match_rings_open_closed(void) {
 
     igraph_count_subisomorphisms_vf2(&rc, &ro, /*colors(4x)*/ 0, 0, 0, 0,
                                      &count, /*node_compat_fn=*/ 0, compat_not0,
-                                     /*arg=*/ 0);
+                                     /*arg=*/ 0, /*induced=*/ false);
 
     if (count != 2) {
         exit(40);

--- a/tests/unit/igraph_get_subisomorphisms_vf2.c
+++ b/tests/unit/igraph_get_subisomorphisms_vf2.c
@@ -59,7 +59,7 @@ void check_print_destroy(igraph_t *g1,
                          int error) {
     igraph_vector_int_list_t maps;
     igraph_vector_int_list_init(&maps, 0);
-    IGRAPH_ASSERT(igraph_get_subisomorphisms_vf2(g1, g2, vertex_color1, vertex_color2, edge_color1, edge_color2, &maps, node_compat_fn, edge_compat_fn, arg) == error);
+    IGRAPH_ASSERT(igraph_get_subisomorphisms_vf2(g1, g2, vertex_color1, vertex_color2, edge_color1, edge_color2, &maps, node_compat_fn, edge_compat_fn, arg, false) == error);
     print_and_destroy_maps(&maps);
     printf("\n");
 }
@@ -72,7 +72,10 @@ int main(void) {
     igraph_t ring, ring_dir;
     igraph_t ring_plus, ring_plus_dir;
     igraph_t ring_loop;
+    igraph_t triangle, path3, path4;
+    igraph_t transitive_triangle, directed_path3;
     igraph_t g_0, g_1;
+    igraph_int_t count;
     igraph_vector_int_t coloring;
     igraph_vector_int_t plus_edge_coloring;
     igraph_vector_int_t plus_vertex_coloring;
@@ -89,6 +92,38 @@ int main(void) {
     igraph_ring(&ring_dir, 5, /*directed*/ 1, /*mutual*/ 0, /*circular*/ 1);
     igraph_ring(&ring_loop, 5, /*directed*/ 0, /*mutual*/ 0, /*circular*/ 1);
     igraph_add_edge(&ring_loop, 2, 2);
+    igraph_small(&triangle, 3, IGRAPH_UNDIRECTED, 0,1, 1,2, 0,2, -1);
+    igraph_small(&path3, 3, IGRAPH_UNDIRECTED, 0,1, 1,2, -1);
+    igraph_small(&path4, 4, IGRAPH_UNDIRECTED, 0,1, 1,2, 2,3, -1);
+    igraph_small(&transitive_triangle, 3, IGRAPH_DIRECTED, 0,1, 1,2, 0,2, -1);
+    igraph_small(&directed_path3, 3, IGRAPH_DIRECTED, 0,1, 1,2, -1);
+
+    igraph_count_subisomorphisms_vf2(
+        &triangle, &path3, NULL, NULL, NULL, NULL, &count, NULL, NULL, NULL, false
+    );
+    IGRAPH_ASSERT(count == 6);
+
+    igraph_count_subisomorphisms_vf2(
+        &triangle, &path3, NULL, NULL, NULL, NULL, &count, NULL, NULL, NULL, true
+    );
+    IGRAPH_ASSERT(count == 0);
+
+    igraph_count_subisomorphisms_vf2(
+        &path4, &path3, NULL, NULL, NULL, NULL, &count, NULL, NULL, NULL, true
+    );
+    IGRAPH_ASSERT(count == 4);
+
+    igraph_count_subisomorphisms_vf2(
+        &transitive_triangle, &directed_path3,
+        NULL, NULL, NULL, NULL, &count, NULL, NULL, NULL, false
+    );
+    IGRAPH_ASSERT(count == 1);
+
+    igraph_count_subisomorphisms_vf2(
+        &transitive_triangle, &directed_path3,
+        NULL, NULL, NULL, NULL, &count, NULL, NULL, NULL, true
+    );
+    IGRAPH_ASSERT(count == 0);
 
     printf("Two empty graphs:\n");
     check_print_destroy_simple(&g_0, &g_0);
@@ -142,6 +177,11 @@ int main(void) {
     igraph_destroy(&ring_plus);
     igraph_destroy(&ring_plus_dir);
     igraph_destroy(&ring_loop);
+    igraph_destroy(&triangle);
+    igraph_destroy(&path3);
+    igraph_destroy(&path4);
+    igraph_destroy(&transitive_triangle);
+    igraph_destroy(&directed_path3);
     igraph_vector_int_destroy(&coloring);
     igraph_vector_int_destroy(&plus_edge_coloring);
     igraph_vector_int_destroy(&plus_vertex_coloring);

--- a/tests/unit/igraph_isomorphic_vf2.c
+++ b/tests/unit/igraph_isomorphic_vf2.c
@@ -103,7 +103,7 @@ int main(void) {
     igraph_vector_int_init(&color1, igraph_vcount(&ring1));
     igraph_vector_int_init(&color2, igraph_vcount(&ring2));
     igraph_count_subisomorphisms_vf2(&ring1, &ring2, &color1, &color2, 0, 0,
-                                     &count, 0, 0, 0);
+                                     &count, 0, 0, 0, false);
     if (count != 42) {
         fprintf(stderr, "Count with one color failed, expected 42, got %" IGRAPH_PRId ".\n", count);
         return 31;
@@ -195,7 +195,7 @@ int main(void) {
     igraph_vector_int_init(&color1, igraph_ecount(&ring1));
     igraph_vector_int_init(&color2, igraph_ecount(&ring2));
     igraph_count_subisomorphisms_vf2(&ring1, &ring2, 0, 0, &color1, &color2,
-                                     &count, 0, 0, 0);
+                                     &count, 0, 0, 0, false);
     if (count != 42) {
         fprintf(stderr, "Count with one edge color failed, expected 42, got %" IGRAPH_PRId ".\n", count);
         return 51;
@@ -211,7 +211,7 @@ int main(void) {
         VECTOR(color2)[i + 1] = 1;
     }
     igraph_count_subisomorphisms_vf2(&ring1, &ring2, 0, 0, &color1, &color2,
-                                     &count, 0, 0, 0);
+                                     &count, 0, 0, 0, false);
     if (count != 22) {
         fprintf(stderr, "Count with two edge colors failed, expected 22, got %" IGRAPH_PRId ".\n", count);
         return 52;

--- a/tests/unit/igraph_subisomorphic_lad.c
+++ b/tests/unit/igraph_subisomorphic_lad.c
@@ -43,7 +43,7 @@ void test_k_motifs(const igraph_t *graph, const int k, const int class_count, ig
 
         igraph_subisomorphic_lad(&pattern, graph, NULL, NULL, NULL, &maps, /* induced = */ true);
 
-        igraph_count_subisomorphisms_vf2(&pattern, &pattern, NULL, NULL, NULL, NULL, &nAutomorphisms, NULL, NULL, NULL);
+        igraph_count_subisomorphisms_vf2(&pattern, &pattern, NULL, NULL, NULL, NULL, &nAutomorphisms, NULL, NULL, NULL, false);
 
         VECTOR(lad_counts)[i] = igraph_vector_int_list_size(&maps) / nAutomorphisms;
 


### PR DESCRIPTION
## Summary

Add opt-in induced-subgraph semantics to the VF2 subisomorphism APIs while preserving non-induced matching as the default at interface-generator level.

The feasibility check now rejects target edges between already mapped vertices when the corresponding pattern edge is absent. Tests cover undirected and directed induced matching and retain existing non-induced behavior.

## Context 

I was comparing the results of iGraph's VF2 implementation with that of NetworkX on the [SI dataset](https://perso.liris.cnrs.fr/christine.solnon/SIP.html) and noticed that for a subset of problems iGraph reported significantly more matches than NetworkX. Further digging revealed that NetworkX's VF2 implementation returns only induced subgraphs, while iGraph returns non-induced subgraphs. Adding an induced option similar to the LAD is relatively straightforward. And significantly improves runtime on affected problems if only induced subgraphs are desired.

## API note

This draft appends an `igraph_bool_t induced` argument to four public C functions. That is source-incompatible for existing C callers (python-igraph and rigraph) and should implemented in tandem across the repositories. PR for python-igraph prepared. A PR for rigraph can be prepared as well if this PR is deemed desirable.

## Validation

- Configured and built with GCC/G++ 13.3.0
- Built the affected library, unit-test, and example targets
- Passed `example::igraph_isomorphic_vf2`
- Passed `test::igraph_get_subisomorphisms_vf2`
- Passed `test::igraph_isomorphic_vf2`
- Passed `test::igraph_subisomorphic_lad`
- Passed `test::VF2-compat`
- `git diff --check` passes
- Also validated on the previously mismatching SI benchmarks to verify that the same number of induced subgraphs is found as NetworkX.

## Disclosure

This change was prepared with assistance from OpenAI Codex. The implementation and tests were reviewed and executed in the contributor's local environment.

- [x] By submitting this pull request, I assign the copyright of my contribution to _The igraph development team_.
