### PR TITLE
Feature: A even faster CD-index

### DIFF
--- a/doc/structural.xxml
+++ b/doc/structural.xxml
@@ -126,6 +126,7 @@
 <!-- doxrox-include igraph_eigenvector_centrality -->
 <!-- doxrox-include igraph_hub_and_authority_scores -->
 <!-- doxrox-include igraph_convergence_degree -->
+<!-- doxrox-include igraph_cd_index -->
 </section>
 
 <section id="range-limited-centrality-measures"><title>Range-limited centrality measures</title>

--- a/include/igraph_centrality.h
+++ b/include/igraph_centrality.h
@@ -152,6 +152,15 @@ IGRAPH_EXPORT igraph_error_t igraph_constraint(const igraph_t *graph, igraph_vec
 IGRAPH_EXPORT igraph_error_t igraph_convergence_degree(const igraph_t *graph, igraph_vector_t *result,
                                             igraph_vector_t *ins, igraph_vector_t *outs);
 
+IGRAPH_EXPORT igraph_error_t igraph_cd_index(
+        const igraph_t *graph,
+        const igraph_vector_int_t *timestamps,
+        igraph_vector_t *res,
+        igraph_vector_t *i_index,
+        igraph_vector_t *mcd_index,
+        const igraph_vs_t vids,
+        igraph_int_t time_window);
+
 IGRAPH_EXPORT IGRAPH_FUNCATTR_PURE igraph_real_t igraph_centralization(const igraph_vector_t *scores,
                                                   igraph_real_t theoretical_max,
                                                   igraph_bool_t normalized);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -141,6 +141,7 @@ add_library(
   games/watts_strogatz.c
 
   centrality/betweenness.c
+  centrality/cd_index.c
   centrality/centrality_other.c
   centrality/centralization.c
   centrality/closeness.c
@@ -422,6 +423,10 @@ endif()
 
 if(PLFIT_LIBRARIES)
   target_link_libraries(igraph PRIVATE ${PLFIT_LIBRARIES})
+endif()
+
+if(IGRAPH_OPENMP_SUPPORT)
+  target_link_libraries(igraph PRIVATE OpenMP::OpenMP_C)
 endif()
 
 # Link igraph statically to some of the libraries from the subdirectories

--- a/src/centrality/cd_index.c
+++ b/src/centrality/cd_index.c
@@ -156,18 +156,20 @@ igraph_error_t igraph_cd_index(
     #pragma omp parallel
     #endif
     {
-        igraph_int_t *marker = IGRAPH_CALLOC(no_of_nodes, igraph_int_t);
+        /* marker[v] == 0 means "v not yet seen for the current focal vertex".
+         * A nonzero value packs a per-focal tag in the upper bits with two
+         * set-membership flags in the low bits (bit 0: v is a citer of focal
+         * itself, i.e. Set A below; bit 1: v is a citer of one of focal's
+         * references, i.e. Set B below). Calloc's zero-fill already means
+         * "untouched", so -- unlike a sentinel of -1 -- no per-thread
+         * initialization pass over the array is needed at all. */
+        igraph_uint_t *marker = IGRAPH_CALLOC(no_of_nodes, igraph_uint_t);
         if (marker == NULL) {
             #ifdef _OPENMP
             #pragma omp atomic write
             #endif
             oom_occurred = true;
         } else {
-            igraph_int_t i;
-            for (i = 0; i < no_of_nodes; i++) {
-                marker[i] = -1;
-            }
-
             #ifdef _OPENMP
             #pragma omp for
             #endif
@@ -188,46 +190,29 @@ igraph_error_t igraph_cd_index(
                 const igraph_vector_int_t *focal_in = igraph_adjlist_get(&in_adj, focal);
                 igraph_int_t n_focal_out = igraph_vector_int_size(focal_out);
                 igraph_int_t n_focal_in = igraph_vector_int_size(focal_in);
-                igraph_int_t candidate_count = 0;
-                igraph_real_t sum = 0.0;
+                igraph_uint_t tag = ((igraph_uint_t) idx + 1) << 2;
+                igraph_int_t count_a = 0, count_b = 0, n_distinct = 0;
+                igraph_real_t sum;
                 igraph_int_t i_count = 0;
                 igraph_int_t r, j;
 
-                /* Candidates are vertices timestamped within the window that either
-                 * cite one of focal's own references (found by walking the in-lists
-                 * of focal's out-neighbors), or cite focal directly (focal's own
-                 * in-list). Each candidate is scored and counted exactly once, the
-                 * first time it is encountered, using `marker` (stamped with `focal`)
-                 * to detect duplicates without ever needing to clear the array. */
-                for (r = 0; r < n_focal_out; r++) {
-                    igraph_int_t ref = VECTOR(*focal_out)[r];
-                    const igraph_vector_int_t *ref_in = igraph_adjlist_get(&in_adj, ref);
-                    igraph_int_t n_ref_in = igraph_vector_int_size(ref_in);
-                    for (j = 0; j < n_ref_in; j++) {
-                        igraph_int_t cand = VECTOR(*ref_in)[j];
-                        igraph_int_t t_cand = VECTOR(*timestamps)[cand];
-                        if (t_cand > t_focal && t_cand <= window_end && marker[cand] != focal) {
-                            marker[cand] = focal;
-                            candidate_count++;
-                            /* fbit: does cand cite focal directly? */
-                            if (igraph_vector_int_contains_sorted(igraph_adjlist_get(&out_adj, cand), focal)) {
-                                /* bbit: does cand also cite one of focal's own references? */
-                                const igraph_vector_int_t *cand_out = igraph_adjlist_get(&out_adj, cand);
-                                igraph_int_t n_cand_out = igraph_vector_int_size(cand_out);
-                                igraph_int_t k;
-                                igraph_bool_t bbit = false;
-                                for (k = 0; k < n_cand_out; k++) {
-                                    if (igraph_vector_int_contains_sorted(focal_out, VECTOR(*cand_out)[k])) {
-                                        bbit = true;
-                                        break;
-                                    }
-                                }
-                                sum += bbit ? -1.0 : 1.0;
-                            }
-                        }
-                    }
-                }
+                /* Sixt & Pasin's (2024) reformulation of the CD index: rather than
+                 * building one candidate set and, for each member, cross-checking
+                 * whether it cites both focal and a reference (the fbit/bbit
+                 * approach), decompose it into two independent set-membership
+                 * counts that never need to look at each other:
+                 *   Set A = vertices citing focal directly;
+                 *   Set B = vertices citing any of focal's own references.
+                 * CD = (-|A| - 2|B|) / |A union B| + 2, which is algebraically
+                 * identical to the classic per-candidate sum/|C| formulation
+                 * (s'(c) = -1 for c in A, s''(c) = -2 for c in B, and summing
+                 * s'+s'' over the union telescopes to -|A|-2|B| regardless of
+                 * overlap, since s' is 0 outside A and s'' is 0 outside B).
+                 * This removes the need to ever look up a candidate's own
+                 * out-edges, which is where the earlier fbit/bbit version spent
+                 * most of its time. */
 
+                /* Set A: focal's own citers. */
                 for (j = 0; j < n_focal_in; j++) {
                     igraph_int_t cand = VECTOR(*focal_in)[j];
                     igraph_int_t t_cand = VECTOR(*timestamps)[cand];
@@ -239,28 +224,49 @@ igraph_error_t igraph_cd_index(
                         i_count++;
                     }
 
-                    /* CD-index candidate set additionally requires t_cand to be
-                     * strictly later than focal's own timestamp. */
-                    if (t_cand > t_focal && t_cand <= window_end && marker[cand] != focal) {
-                        marker[cand] = focal;
-                        candidate_count++;
-                        /* cand cites focal directly by construction (fbit = 1);
-                         * check whether it also cites one of focal's references. */
-                        const igraph_vector_int_t *cand_out = igraph_adjlist_get(&out_adj, cand);
-                        igraph_int_t n_cand_out = igraph_vector_int_size(cand_out);
-                        igraph_int_t k;
-                        igraph_bool_t bbit = false;
-                        for (k = 0; k < n_cand_out; k++) {
-                            if (igraph_vector_int_contains_sorted(focal_out, VECTOR(*cand_out)[k])) {
-                                bbit = true;
-                                break;
-                            }
+                    /* Set A additionally requires t_cand to be strictly later
+                     * than focal's own timestamp. */
+                    if (t_cand > t_focal && t_cand <= window_end) {
+                        igraph_uint_t val = marker[cand];
+                        if ((val & ~(igraph_uint_t) 3) != tag) {
+                            val = tag;
                         }
-                        sum += bbit ? -1.0 : 1.0;
+                        if (!(val & 1)) {
+                            if ((val & 3) == 0) {
+                                n_distinct++;
+                            }
+                            marker[cand] = val | 1;
+                            count_a++;
+                        }
                     }
                 }
 
-                VECTOR(*res)[idx] = candidate_count > 0 ? sum / candidate_count : IGRAPH_NAN;
+                /* Set B: citers of any of focal's own references. */
+                for (r = 0; r < n_focal_out; r++) {
+                    igraph_int_t ref = VECTOR(*focal_out)[r];
+                    const igraph_vector_int_t *ref_in = igraph_adjlist_get(&in_adj, ref);
+                    igraph_int_t n_ref_in = igraph_vector_int_size(ref_in);
+                    for (j = 0; j < n_ref_in; j++) {
+                        igraph_int_t cand = VECTOR(*ref_in)[j];
+                        igraph_int_t t_cand = VECTOR(*timestamps)[cand];
+                        if (t_cand > t_focal && t_cand <= window_end) {
+                            igraph_uint_t val = marker[cand];
+                            if ((val & ~(igraph_uint_t) 3) != tag) {
+                                val = tag;
+                            }
+                            if (!(val & 2)) {
+                                if ((val & 3) == 0) {
+                                    n_distinct++;
+                                }
+                                marker[cand] = val | 2;
+                                count_b++;
+                            }
+                        }
+                    }
+                }
+
+                sum = -(igraph_real_t) count_a - 2.0 * count_b;
+                VECTOR(*res)[idx] = n_distinct > 0 ? sum / n_distinct + 2.0 : IGRAPH_NAN;
                 if (i_index) {
                     VECTOR(*i_index)[idx] = i_count;
                 }

--- a/src/centrality/cd_index.c
+++ b/src/centrality/cd_index.c
@@ -53,9 +53,10 @@
  *
  * </para><para>
  * The I-index of \c f is simply the number of vertices citing \c f directly
- * that are timestamped in <code>(t_f, t_f + W]</code>. The mCD-index is the
- * product of the CD index and the I-index, a magnitude-weighted variant of
- * the CD index.
+ * that are timestamped at most <code>t_f + W</code> (note that unlike \c C,
+ * this is not bounded below by <code>t_f</code>, matching the original
+ * definition). The mCD-index is the product of the CD index and the
+ * I-index, a magnitude-weighted variant of the CD index.
  *
  * </para><para>
  * This is a port of the algorithm implemented by the fast-cdindex library
@@ -230,25 +231,32 @@ igraph_error_t igraph_cd_index(
                 for (j = 0; j < n_focal_in; j++) {
                     igraph_int_t cand = VECTOR(*focal_in)[j];
                     igraph_int_t t_cand = VECTOR(*timestamps)[cand];
-                    if (t_cand > t_focal && t_cand <= window_end) {
+
+                    /* I-index: bounded above only, by construction (matches
+                     * both the original cdindex and fast-cdindex, neither of
+                     * which excludes in-edges timestamped at or before t_focal). */
+                    if (t_cand <= window_end) {
                         i_count++;
-                        if (marker[cand] != focal) {
-                            marker[cand] = focal;
-                            candidate_count++;
-                            /* cand cites focal directly by construction (fbit = 1);
-                             * check whether it also cites one of focal's references. */
-                            const igraph_vector_int_t *cand_out = igraph_adjlist_get(&out_adj, cand);
-                            igraph_int_t n_cand_out = igraph_vector_int_size(cand_out);
-                            igraph_int_t k;
-                            igraph_bool_t bbit = false;
-                            for (k = 0; k < n_cand_out; k++) {
-                                if (igraph_vector_int_contains_sorted(focal_out, VECTOR(*cand_out)[k])) {
-                                    bbit = true;
-                                    break;
-                                }
+                    }
+
+                    /* CD-index candidate set additionally requires t_cand to be
+                     * strictly later than focal's own timestamp. */
+                    if (t_cand > t_focal && t_cand <= window_end && marker[cand] != focal) {
+                        marker[cand] = focal;
+                        candidate_count++;
+                        /* cand cites focal directly by construction (fbit = 1);
+                         * check whether it also cites one of focal's references. */
+                        const igraph_vector_int_t *cand_out = igraph_adjlist_get(&out_adj, cand);
+                        igraph_int_t n_cand_out = igraph_vector_int_size(cand_out);
+                        igraph_int_t k;
+                        igraph_bool_t bbit = false;
+                        for (k = 0; k < n_cand_out; k++) {
+                            if (igraph_vector_int_contains_sorted(focal_out, VECTOR(*cand_out)[k])) {
+                                bbit = true;
+                                break;
                             }
-                            sum += bbit ? -1.0 : 1.0;
                         }
+                        sum += bbit ? -1.0 : 1.0;
                     }
                 }
 

--- a/src/centrality/cd_index.c
+++ b/src/centrality/cd_index.c
@@ -1,0 +1,278 @@
+/*
+   igraph library.
+   Copyright (C) 2026  The igraph development team <igraph@igraph.org>
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "igraph_centrality.h"
+
+#include "igraph_adjlist.h"
+#include "igraph_interface.h"
+#include "igraph_memory.h"
+#include "igraph_structural.h"
+
+#include "core/interruption.h"
+
+/**
+ * \function igraph_cd_index
+ * \brief The CD index, I-index and mCD-index of citation disruption.
+ *
+ * \experimental
+ *
+ * These measures characterize how a focal vertex in a timestamped, directed
+ * citation network is used by subsequent work. An edge \c u -&gt; \c v is
+ * interpreted as "\c u cites \c v", i.e. \c v is the earlier, cited work.
+ *
+ * </para><para>
+ * For a focal vertex \c f with timestamp <code>t_f</code> and a time window
+ * \c W, let \c C be the set of vertices timestamped in the interval
+ * <code>(t_f, t_f + W]</code> that either cite \c f directly, or cite some
+ * vertex that \c f itself cites. For each <code>c \in C</code>, let
+ * <code>fbit(c) = 1</code> if \c c cites \c f directly, and let
+ * <code>bbit(c) = 1</code> if \c c also cites at least one of \c f's own
+ * references (i.e. \c c "backs up" through \c f rather than displacing it).
+ * The CD index of \c f is then
+ * <code>sum_{c \in C} (fbit(c) - 2 fbit(c) bbit(c)) / |C|</code>: each
+ * citing vertex contributes +1 if it displaces \c f's references
+ * (disruptive), -1 if it cites both \c f and its references
+ * (consolidating), and 0 if it does not cite \c f directly. The CD index
+ * is \c NaN for vertices with an empty \c C (no relevant future
+ * citations).
+ *
+ * </para><para>
+ * The I-index of \c f is simply the number of vertices citing \c f directly
+ * that are timestamped in <code>(t_f, t_f + W]</code>. The mCD-index is the
+ * product of the CD index and the I-index, a magnitude-weighted variant of
+ * the CD index.
+ *
+ * </para><para>
+ * This is a port of the algorithm implemented by the fast-cdindex library
+ * (itself based on Funk &amp; Owen-Smith, 2017), reimplemented using igraph's
+ * own data structures. When igraph is compiled with OpenMP support, the
+ * computation is parallelized across the focal vertices in \p vids; the
+ * number of threads used is controlled through the standard OpenMP
+ * mechanisms (e.g. the \c OMP_NUM_THREADS environment variable).
+ *
+ * \param graph The input graph. It must be directed and must not contain
+ *    self-loops.
+ * \param timestamps A vector containing a timestamp for each vertex, in
+ *    vertex ID order. Its length must equal the number of vertices.
+ * \param res An initialized vector. The CD index of each vertex in \p vids
+ *    will be stored here, in the order given by \p vids.
+ * \param i_index An initialized vector, or \c NULL. If not \c NULL, the
+ *    I-index of each vertex in \p vids will be stored here.
+ * \param mcd_index An initialized vector, or \c NULL. If not \c NULL, the
+ *    mCD-index of each vertex in \p vids will be stored here.
+ * \param vids The vertices to compute the indices for.
+ * \param time_window The width of the time window following each vertex's
+ *    own timestamp within which citing vertices are taken into account.
+ *    Must not be negative.
+ * \return Error code.
+ *
+ * \sa \ref igraph_convergence_degree() for a related, non-temporal
+ *    edge-based disruption-like measure.
+ *
+ * Time complexity: O(|V| + |E| + sum of local neighborhood products around
+ * the vertices in \p vids).
+ */
+igraph_error_t igraph_cd_index(
+        const igraph_t *graph,
+        const igraph_vector_int_t *timestamps,
+        igraph_vector_t *res,
+        igraph_vector_t *i_index,
+        igraph_vector_t *mcd_index,
+        const igraph_vs_t vids,
+        igraph_int_t time_window) {
+
+    igraph_int_t no_of_nodes = igraph_vcount(graph);
+    igraph_adjlist_t out_adj, in_adj;
+    igraph_vit_t vit;
+    igraph_vector_int_t focal_ids;
+    igraph_int_t no_of_focal;
+    igraph_bool_t has_loops;
+    igraph_bool_t oom_occurred = false;
+    igraph_int_t idx;
+
+    if (!igraph_is_directed(graph)) {
+        IGRAPH_ERROR("The CD index is only defined for directed graphs.", IGRAPH_EINVAL);
+    }
+
+    if (!timestamps) {
+        IGRAPH_ERROR("Vertex timestamps must be given.", IGRAPH_EINVAL);
+    }
+    if (igraph_vector_int_size(timestamps) != no_of_nodes) {
+        IGRAPH_ERROR("Invalid timestamp vector length.", IGRAPH_EINVAL);
+    }
+
+    if (time_window < 0) {
+        IGRAPH_ERROR("Time window must not be negative.", IGRAPH_EINVAL);
+    }
+
+    IGRAPH_CHECK(igraph_has_loop(graph, &has_loops));
+    if (has_loops) {
+        IGRAPH_ERROR("The CD index does not support graphs with self-loops.", IGRAPH_EINVAL);
+    }
+
+    IGRAPH_CHECK(igraph_adjlist_init(graph, &out_adj, IGRAPH_OUT, IGRAPH_LOOPS_ONCE, IGRAPH_MULTIPLE));
+    IGRAPH_FINALLY(igraph_adjlist_destroy, &out_adj);
+    IGRAPH_CHECK(igraph_adjlist_init(graph, &in_adj, IGRAPH_IN, IGRAPH_LOOPS_ONCE, IGRAPH_MULTIPLE));
+    IGRAPH_FINALLY(igraph_adjlist_destroy, &in_adj);
+
+    IGRAPH_CHECK(igraph_vit_create(graph, vids, &vit));
+    IGRAPH_FINALLY(igraph_vit_destroy, &vit);
+
+    no_of_focal = IGRAPH_VIT_SIZE(vit);
+    IGRAPH_VECTOR_INT_INIT_FINALLY(&focal_ids, no_of_focal);
+    for (idx = 0; !IGRAPH_VIT_END(vit); IGRAPH_VIT_NEXT(vit), idx++) {
+        VECTOR(focal_ids)[idx] = IGRAPH_VIT_GET(vit);
+    }
+    igraph_vit_destroy(&vit);
+    IGRAPH_FINALLY_CLEAN(1);
+
+    IGRAPH_CHECK(igraph_vector_resize(res, no_of_focal));
+    if (i_index) {
+        IGRAPH_CHECK(igraph_vector_resize(i_index, no_of_focal));
+    }
+    if (mcd_index) {
+        IGRAPH_CHECK(igraph_vector_resize(mcd_index, no_of_focal));
+    }
+
+    IGRAPH_ALLOW_INTERRUPTION();
+
+    #ifdef _OPENMP
+    #pragma omp parallel
+    #endif
+    {
+        igraph_int_t *marker = IGRAPH_CALLOC(no_of_nodes, igraph_int_t);
+        if (marker == NULL) {
+            #ifdef _OPENMP
+            #pragma omp atomic write
+            #endif
+            oom_occurred = true;
+        } else {
+            igraph_int_t i;
+            for (i = 0; i < no_of_nodes; i++) {
+                marker[i] = -1;
+            }
+
+            #ifdef _OPENMP
+            #pragma omp for
+            #endif
+            for (idx = 0; idx < no_of_focal; idx++) {
+                igraph_bool_t skip;
+                #ifdef _OPENMP
+                #pragma omp atomic read
+                #endif
+                skip = oom_occurred;
+                if (skip) {
+                    continue;
+                }
+
+                igraph_int_t focal = VECTOR(focal_ids)[idx];
+                igraph_int_t t_focal = VECTOR(*timestamps)[focal];
+                igraph_int_t window_end = t_focal + time_window;
+                const igraph_vector_int_t *focal_out = igraph_adjlist_get(&out_adj, focal);
+                const igraph_vector_int_t *focal_in = igraph_adjlist_get(&in_adj, focal);
+                igraph_int_t n_focal_out = igraph_vector_int_size(focal_out);
+                igraph_int_t n_focal_in = igraph_vector_int_size(focal_in);
+                igraph_int_t candidate_count = 0;
+                igraph_real_t sum = 0.0;
+                igraph_int_t i_count = 0;
+                igraph_int_t r, j;
+
+                /* Candidates are vertices timestamped within the window that either
+                 * cite one of focal's own references (found by walking the in-lists
+                 * of focal's out-neighbors), or cite focal directly (focal's own
+                 * in-list). Each candidate is scored and counted exactly once, the
+                 * first time it is encountered, using `marker` (stamped with `focal`)
+                 * to detect duplicates without ever needing to clear the array. */
+                for (r = 0; r < n_focal_out; r++) {
+                    igraph_int_t ref = VECTOR(*focal_out)[r];
+                    const igraph_vector_int_t *ref_in = igraph_adjlist_get(&in_adj, ref);
+                    igraph_int_t n_ref_in = igraph_vector_int_size(ref_in);
+                    for (j = 0; j < n_ref_in; j++) {
+                        igraph_int_t cand = VECTOR(*ref_in)[j];
+                        igraph_int_t t_cand = VECTOR(*timestamps)[cand];
+                        if (t_cand > t_focal && t_cand <= window_end && marker[cand] != focal) {
+                            marker[cand] = focal;
+                            candidate_count++;
+                            /* fbit: does cand cite focal directly? */
+                            if (igraph_vector_int_contains_sorted(igraph_adjlist_get(&out_adj, cand), focal)) {
+                                /* bbit: does cand also cite one of focal's own references? */
+                                const igraph_vector_int_t *cand_out = igraph_adjlist_get(&out_adj, cand);
+                                igraph_int_t n_cand_out = igraph_vector_int_size(cand_out);
+                                igraph_int_t k;
+                                igraph_bool_t bbit = false;
+                                for (k = 0; k < n_cand_out; k++) {
+                                    if (igraph_vector_int_contains_sorted(focal_out, VECTOR(*cand_out)[k])) {
+                                        bbit = true;
+                                        break;
+                                    }
+                                }
+                                sum += bbit ? -1.0 : 1.0;
+                            }
+                        }
+                    }
+                }
+
+                for (j = 0; j < n_focal_in; j++) {
+                    igraph_int_t cand = VECTOR(*focal_in)[j];
+                    igraph_int_t t_cand = VECTOR(*timestamps)[cand];
+                    if (t_cand > t_focal && t_cand <= window_end) {
+                        i_count++;
+                        if (marker[cand] != focal) {
+                            marker[cand] = focal;
+                            candidate_count++;
+                            /* cand cites focal directly by construction (fbit = 1);
+                             * check whether it also cites one of focal's references. */
+                            const igraph_vector_int_t *cand_out = igraph_adjlist_get(&out_adj, cand);
+                            igraph_int_t n_cand_out = igraph_vector_int_size(cand_out);
+                            igraph_int_t k;
+                            igraph_bool_t bbit = false;
+                            for (k = 0; k < n_cand_out; k++) {
+                                if (igraph_vector_int_contains_sorted(focal_out, VECTOR(*cand_out)[k])) {
+                                    bbit = true;
+                                    break;
+                                }
+                            }
+                            sum += bbit ? -1.0 : 1.0;
+                        }
+                    }
+                }
+
+                VECTOR(*res)[idx] = candidate_count > 0 ? sum / candidate_count : IGRAPH_NAN;
+                if (i_index) {
+                    VECTOR(*i_index)[idx] = i_count;
+                }
+                if (mcd_index) {
+                    VECTOR(*mcd_index)[idx] = VECTOR(*res)[idx] * i_count;
+                }
+            }
+
+            IGRAPH_FREE(marker);
+        }
+    }
+
+    igraph_vector_int_destroy(&focal_ids);
+    igraph_adjlist_destroy(&in_adj);
+    igraph_adjlist_destroy(&out_adj);
+    IGRAPH_FINALLY_CLEAN(3);
+
+    if (oom_occurred) {
+        IGRAPH_ERROR("Cannot calculate CD index.", IGRAPH_ENOMEM); /* LCOV_EXCL_LINE */
+    }
+
+    return IGRAPH_SUCCESS;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -301,6 +301,7 @@ add_legacy_tests(
   igraph_average_path_length_dijkstra
   igraph_betweenness
   igraph_betweenness_subset
+  cd_index
   igraph_closeness
   igraph_constraint
   igraph_convergence_degree

--- a/tests/unit/cd_index.c
+++ b/tests/unit/cd_index.c
@@ -63,6 +63,31 @@ int main(void) {
     printf("I index:   "); print_vector(&i_index);
     printf("mCD index: "); print_vector(&mcd);
 
+    /* I-index is bounded above only (t_cand <= t_focal + time_window), with
+     * no lower bound, matching cdindex/fast-cdindex exactly -- unlike the
+     * CD-index candidate set, which additionally requires t_cand > t_focal.
+     * Vertex 0 is cited by vertex 1 at the same timestamp and by vertex 2
+     * at an earlier timestamp; both count towards I-index but neither
+     * qualifies as a CD-index candidate, so CD/mCD are NaN while I-index
+     * is 2. */
+    {
+        igraph_t bg;
+        igraph_vector_int_t bts;
+        static const igraph_int_t raw_bts[] = {1000, 1000, 900};
+
+        igraph_small(&bg, 3, IGRAPH_DIRECTED, 1, 0, 2, 0, -1);
+        igraph_vector_int_init_array(&bts, raw_bts, 3);
+
+        igraph_cd_index(&bg, &bts, &cd, &i_index, &mcd, igraph_vss_1(0), 500);
+        printf("\nSame/earlier-timestamp in-edges (vertex 0):\n");
+        printf("CD index:  "); print_vector(&cd);
+        printf("I index:   "); print_vector(&i_index);
+        printf("mCD index: "); print_vector(&mcd);
+
+        igraph_vector_int_destroy(&bts);
+        igraph_destroy(&bg);
+    }
+
     /* Error: undirected graph. */
     {
         igraph_t ug;

--- a/tests/unit/cd_index.c
+++ b/tests/unit/cd_index.c
@@ -1,0 +1,101 @@
+/*
+   igraph library.
+   Copyright (C) 2026  The igraph development team <igraph@igraph.org>
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include <igraph.h>
+
+#include "test_utilities.h"
+
+/* This is the exact 11-vertex, 13-edge toy citation graph used by
+ * fast-cdindex's own regression tests (tests/tests.py's ctimes/cedges,
+ * also used by src/main.cpp), with vertex IDs 0..10 matching igraph's
+ * natural numbering. The expected CD-index and mCD-index values below are
+ * taken verbatim from fast-cdindex's own golden output (tests/py.ok /
+ * tests/bin.ok) for time_window = 157680000. The I-index has no golden
+ * value upstream (fast-cdindex's own tests never print iindex()); the
+ * expected values here were derived by hand from the same timestamps and
+ * window, and cross-checked against mCD-index / CD-index from py.ok
+ * wherever CD-index is nonzero. */
+
+int main(void) {
+    igraph_t g;
+    igraph_vector_int_t timestamps;
+    igraph_vector_t cd, i_index, mcd;
+    static const igraph_int_t ts[] = {
+        694224000, 694224000, 725846400, 725846400, 788918400,
+        852098400, 883612800, 915148800, 915148800, 883612800, 852076800
+    };
+    const igraph_int_t time_window = 157680000;
+
+    igraph_small(&g, 11, IGRAPH_DIRECTED,
+                 4, 2, 4, 0, 4, 1, 4, 3, 5, 2, 6, 2, 6, 4, 7, 4, 8, 4, 9, 4, 9, 1, 9, 3, 10, 4,
+                 -1);
+    igraph_vector_int_init_array(&timestamps, ts, sizeof(ts) / sizeof(ts[0]));
+
+    igraph_vector_init(&cd, 0);
+    igraph_vector_init(&i_index, 0);
+    igraph_vector_init(&mcd, 0);
+
+    /* All vertices at once. */
+    igraph_cd_index(&g, &timestamps, &cd, &i_index, &mcd, igraph_vss_all(), time_window);
+    printf("CD index:  "); print_vector(&cd);
+    printf("I index:   "); print_vector(&i_index);
+    printf("mCD index: "); print_vector(&mcd);
+
+    /* Single vertex via a vs selector; must match the vertex-4 entries above. */
+    igraph_cd_index(&g, &timestamps, &cd, &i_index, &mcd, igraph_vss_1(4), time_window);
+    printf("\nVertex 4 only:\n");
+    printf("CD index:  "); print_vector(&cd);
+    printf("I index:   "); print_vector(&i_index);
+    printf("mCD index: "); print_vector(&mcd);
+
+    /* Error: undirected graph. */
+    {
+        igraph_t ug;
+        igraph_copy(&ug, &g);
+        igraph_to_undirected(&ug, IGRAPH_TO_UNDIRECTED_EACH, NULL);
+        CHECK_ERROR(igraph_cd_index(&ug, &timestamps, &cd, NULL, NULL, igraph_vss_all(), time_window), IGRAPH_EINVAL);
+        igraph_destroy(&ug);
+    }
+
+    /* Error: timestamp vector length mismatch. */
+    {
+        igraph_vector_int_t bad_ts;
+        igraph_vector_int_init(&bad_ts, 3);
+        CHECK_ERROR(igraph_cd_index(&g, &bad_ts, &cd, NULL, NULL, igraph_vss_all(), time_window), IGRAPH_EINVAL);
+        igraph_vector_int_destroy(&bad_ts);
+    }
+
+    /* Error: self-loop present. */
+    {
+        igraph_t lg;
+        igraph_copy(&lg, &g);
+        igraph_add_edge(&lg, 0, 0);
+        CHECK_ERROR(igraph_cd_index(&lg, &timestamps, &cd, NULL, NULL, igraph_vss_all(), time_window), IGRAPH_EINVAL);
+        igraph_destroy(&lg);
+    }
+
+    igraph_vector_destroy(&mcd);
+    igraph_vector_destroy(&i_index);
+    igraph_vector_destroy(&cd);
+    igraph_vector_int_destroy(&timestamps);
+    igraph_destroy(&g);
+
+    VERIFY_FINALLY_STACK();
+
+    return 0;
+}

--- a/tests/unit/cd_index.out
+++ b/tests/unit/cd_index.out
@@ -6,3 +6,8 @@ Vertex 4 only:
 CD index:  ( 0.166667 )
 I index:   ( 5 )
 mCD index: ( 0.833333 )
+
+Same/earlier-timestamp in-edges (vertex 0):
+CD index:  ( NaN )
+I index:   ( 2 )
+mCD index: ( NaN )

--- a/tests/unit/cd_index.out
+++ b/tests/unit/cd_index.out
@@ -1,0 +1,8 @@
+CD index:  ( 1 1 1 1 0.166667 0 0 NaN NaN 0 0 )
+I index:   ( 1 1 2 1 5 0 0 0 0 0 0 )
+mCD index: ( 1 1 2 1 0.833333 0 0 NaN NaN 0 0 )
+
+Vertex 4 only:
+CD index:  ( 0.166667 )
+I index:   ( 5 )
+mCD index: ( 0.833333 )


### PR DESCRIPTION
This is a optimized and OpenMP parallel CD-index ported from `fast-cdindex` by Claude Sonnet 5

Original CD-index by @russellfunk  https://github.com/russellfunk/cdindex
fast-cdindex: https://github.com/dspinellis/fast-cdindex

Further improvement by Sixt and Pasin @lambdamusic - track membership in two sets independently as each is discovered — Set A = vertices citing focal directly, Set B = vertices citing any of focal's own references — and compute CD = (−|A| − 2|B|) / |A ∪ B| + 2 directly.

> Sixt, Joerg, and Michele Pasin. “Dimensions: Calculating Disruption Indices at Scale.” Quantitative Science Studies 5, no. 4 (2024): 975–90. https://doi.org/10.1162/qss_a_00328.

Unit test is matching `fast-cdindex` unit test data. 

## Benchmark 

Data: https://networks.skewed.de/net/arxiv_citation
(SNAP cit-HepPh)  Network: 30,558 papers, 347,229 citations, 1993–2003 (after filtering empty dates)
Hardware: AMD Ryzen 9 5900X / 64Gb RAM

Implementation | mean | std dev | min | max | rate
-- | -- | -- | -- | -- | --
cdindex (2017, Python) | 5.385 s | 8.8 ms | 5.373 s | 5.402 s | 5,675 v/s
cdindex (2017, C, 1 thread) | 5.354 s | 31.2 ms | 5.319 s | 5.413 s | 5,707 v/s
cdindex (2017, C, 24 threads, OpenMP) | 635.9 ms | 12.5 ms | 621.8 ms | 654.6 ms | 48,058 v/s
fast-cdindex (2023, Python) | 1.493 s | 12.2 ms | 1.479 s | 1.513 s | 20,461 v/s
fast-cdindex (2023, C++, 1 thread) | 1.430 s | 11.0 ms | 1.418 s | 1.450 s | 21,370 v/s
fast-cdindex (2023, C++, 24 threads, OpenMP) | 148.0 ms | 4.7 ms | 142.7 ms | 160.0 ms | 206,447 v/s
igraph_cd_index (2026, 1 thread) | 74.0 ms | 0.5 ms | 73.1 ms | 74.9 ms | 412,724 v/s
igraph_cd_index (2026, 24 threads) | 14.7 ms | 2.2 ms | 12.4 ms | 19.5 ms | 2,081,652 v/s

Benchmark code not included here, but all implementation results are identical on all 30,558 vertices (tol 1e-9)

<!-- The following text must be left intact and the box checked before the PR can be merged. -->

- [x] By submitting this pull request, I assign the copyright of my contribution to _The igraph development team_.
